### PR TITLE
Fix Scorecards workflow permissions

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -10,13 +10,16 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
-  id-token: write
 
 jobs:
   scorecard:
     name: OSSF Scorecard
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      id-token: write
     steps:
       - name: Run Scorecard analysis
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a


### PR DESCRIPTION
## Summary
- move Scorecards write permissions from workflow scope to the scorecard job
- keep workflow-level permissions read-only to satisfy scorecard-action publish restrictions

## Linked Issues
- Refs main CI red status from failed Scorecards run on 2026-03-31

## Type of Change
- [ ] Research / docs only
- [ ] New feature (behind feature flag)
- [ ] New feature (ready to ship)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [x] CI / tooling

## Trunk-Based Dev Checklist
- [x] Branch is short-lived (< 2 days from `main`)
- [x] Incomplete features are behind a feature flag
- [x] No merge commits — rebased onto latest `main`
- [ ] CI passes (build + tests)
- [x] New code has tests (or explain why not)
- [x] No new secrets, unsafe workflow permissions, or unpinned automation were introduced

## Testing
- Reviewed failing GitHub Actions log for Scorecards run 23811730751
- Verified the workflow now matches the current `scorecard-action` restriction: no workflow-level write permissions
- `git diff --check`

## Screenshots / Screen Recording
- N/A