### PR TITLE
feat(vs1): stage transition events + feedback banner animation

### DIFF
--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -26,6 +26,7 @@ enum SliceEventType: String, Codable {
     case problemPresented = "problem_presented"
     case interaction
     case hintUsed = "hint_used"
+    case stageTransition = "stage_transition"
     case problemCompleted = "problem_completed"
     case sessionEnd = "session_end"
 }

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -182,6 +182,7 @@ final class VerticalSliceEngine {
         speechService.speak(successMessage, enabled: featureFlags.audioEnabled)
 
         let next = SliceStateMachine.nextStage(after: currentStage, success: true, showTransfer: config.showTransfer)
+        recordStageTransition(from: currentStage, to: next)
         if currentStage == .transfer || (!config.showTransfer && currentStage == .abstract) {
             recordProblemCompletion(transferCorrect: true)
         }
@@ -295,6 +296,22 @@ final class VerticalSliceEngine {
                     "action": action,
                     "value": String(value),
                     "stage": currentStage.rawValue
+                ]
+            )
+        )
+    }
+
+    private func recordStageTransition(from: SliceStage, to: SliceStage) {
+        guard let currentProblem else { return }
+        try? telemetryWriter.append(
+            SliceEvent(
+                type: .stageTransition,
+                payload: [
+                    "problem_id": currentProblem.id.uuidString,
+                    "from": from.rawValue,
+                    "to": to.rawValue,
+                    "decomposition_a": String(currentProblem.decompositionA),
+                    "decomposition_b": String(currentProblem.decompositionB)
                 ]
             )
         )

--- a/Features/VerticalSlice1/FeedbackBannerView.swift
+++ b/Features/VerticalSlice1/FeedbackBannerView.swift
@@ -4,10 +4,13 @@ struct FeedbackBannerView: View {
     let message: String
     let isCelebrating: Bool
 
+    @State private var iconScale: CGFloat = 1.0
+
     var body: some View {
         HStack(spacing: 14) {
             Image(systemName: isCelebrating ? "hands.clap.fill" : "sparkles")
                 .font(.title2)
+                .scaleEffect(iconScale)
             Text(message)
                 .font(.headline.weight(.semibold))
                 .multilineTextAlignment(.leading)
@@ -17,5 +20,11 @@ struct FeedbackBannerView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(isCelebrating ? MatherTheme.warm.opacity(0.65) : MatherTheme.softBlue.opacity(0.75))
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .animation(.easeInOut(duration: 0.25), value: isCelebrating)
+        .onChange(of: isCelebrating) { _, celebrating in
+            guard celebrating else { return }
+            withAnimation(.spring(response: 0.25, dampingFraction: 0.4)) { iconScale = 1.5 }
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.55).delay(0.18)) { iconScale = 1.0 }
+        }
     }
 }


### PR DESCRIPTION
## Changes

**M3 gap — `stageTransition` event (closes the transferDirection acceptance criterion)**
- Added `SliceEventType.stageTransition` (`"stage_transition"`) to `SliceModels.swift`
- `VerticalSliceEngine.completeStage()` now emits a `stage_transition` event on every stage advance, recording `from`, `to`, `decomposition_a`, and `decomposition_b` — the decomposition fields capture the transfer direction (which side A and B are on) for telemetry analysis

**M5 gap — soft success animation on `FeedbackBannerView`**
- Background colour transitions smoothly (easeInOut 0.25s) when `isCelebrating` flips
- Icon spring-bounces (scale 1.0 → 1.5 → 1.0, two-phase spring) on each celebration — gives child a clear non-verbal success signal without any punitive motion on failure

## Issues being closed after this merges
After CI passes, I'll close: #6 (M1), #2 (M2), #3 (M6), #5 (M4) — all substantially complete per codebase audit. And update #4 (M3) and #7 (M5) with remaining open items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)