### PR TITLE
feat(m5): haptic feedback on success and failure

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -33,17 +33,20 @@ final class VerticalSliceEngine {
     private let telemetryWriter: TelemetryWriter
     private let featureFlags: FeatureFlagService
     private let speechService: SpeechService
+    private let hapticsService: HapticsService
     private let saveSummary: (SessionSummaryDraft) -> Void
 
     init(
         featureFlags: FeatureFlagService,
         telemetryWriter: TelemetryWriter,
         speechService: SpeechService,
+        hapticsService: HapticsService = HapticsService(),
         saveSummary: @escaping (SessionSummaryDraft) -> Void
     ) {
         self.featureFlags = featureFlags
         self.telemetryWriter = telemetryWriter
         self.speechService = speechService
+        self.hapticsService = hapticsService
         self.saveSummary = saveSummary
     }
 
@@ -164,6 +167,7 @@ final class VerticalSliceEngine {
         } else {
             feedbackMessage = feedbackMessageForFailure(stage: currentStage, problem: currentProblem)
             speechService.speak(feedbackMessage, enabled: featureFlags.audioEnabled)
+            hapticsService.failure(enabled: featureFlags.hapticsEnabled)
         }
     }
 
@@ -180,6 +184,7 @@ final class VerticalSliceEngine {
         showCelebration = true
         feedbackMessage = successMessage
         speechService.speak(successMessage, enabled: featureFlags.audioEnabled)
+        hapticsService.success(enabled: featureFlags.hapticsEnabled)
 
         let next = SliceStateMachine.nextStage(after: currentStage, success: true, showTransfer: config.showTransfer)
         recordStageTransition(from: currentStage, to: next)

--- a/Services/HapticsService.swift
+++ b/Services/HapticsService.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+@MainActor
+final class HapticsService {
+    private(set) var successFiredCount = 0
+    private(set) var failureFiredCount = 0
+
+    func success(enabled: Bool) {
+        guard enabled else { return }
+        successFiredCount += 1
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+    }
+
+    func failure(enabled: Bool) {
+        guard enabled else { return }
+        failureFiredCount += 1
+        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+    }
+
+    func resetCounts() {
+        successFiredCount = 0
+        failureFiredCount = 0
+    }
+}

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -27,4 +27,93 @@ struct VerticalSliceEngineTests {
         engine.submitCurrentStage()
         #expect(engine.currentStage == .abstract)
     }
+
+    @Test
+    func hapticsSuccessFiredOnCorrectAnswer() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.hapticsEnabled = true
+        let haptics = HapticsService()
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            hapticsService: haptics,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        engine.adjustConcrete(by: engine.currentProblem?.target ?? 0)
+        engine.submitCurrentStage()
+
+        #expect(haptics.successFiredCount == 1)
+        #expect(haptics.failureFiredCount == 0)
+    }
+
+    @Test
+    func hapticsSuccessNotFiredWhenDisabled() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.hapticsEnabled = false
+        let haptics = HapticsService()
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            hapticsService: haptics,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        engine.adjustConcrete(by: engine.currentProblem?.target ?? 0)
+        engine.submitCurrentStage()
+
+        #expect(haptics.successFiredCount == 0)
+    }
+
+    @Test
+    func hapticsFailureFiredOnWrongAnswer() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.hapticsEnabled = true
+        let haptics = HapticsService()
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            hapticsService: haptics,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        // Leave count at 0 — wrong answer for any target > 0
+        engine.submitCurrentStage()
+
+        #expect(haptics.failureFiredCount == 1)
+        #expect(haptics.successFiredCount == 0)
+    }
+
+    @Test
+    func hapticsFailureNotFiredWhenDisabled() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.hapticsEnabled = false
+        let haptics = HapticsService()
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            hapticsService: haptics,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        engine.submitCurrentStage()
+
+        #expect(haptics.failureFiredCount == 0)
+    }
 }

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -79,6 +79,46 @@ final class ScreenshotTests: XCTestCase {
         snapshot(app, "ConcreteBuild-Initial")
     }
 
+    // MARK: - Haptics / feedback flow
+
+    /// Exercises the failure-then-success path so the screen recording captures
+    /// both the failure feedback banner and the celebration state.
+    func testScreenshot_ConcreteBuild_FailureThenSuccess() {
+        let app = launchWithVS1AndHaptics()
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
+
+        let playButton = app.buttons["Play"]
+        _ = playButton.waitForExistence(timeout: 5)
+        playButton.tap()
+        _ = app.staticTexts["Session setup"].waitForExistence(timeout: 10)
+
+        let startButton = app.buttons["Start Session"]
+        _ = startButton.waitForExistence(timeout: 5)
+        startButton.tap()
+
+        let makePredicate = NSPredicate(format: "label BEGINSWITH 'Make '")
+        _ = app.staticTexts.element(matching: makePredicate).waitForExistence(timeout: 15)
+        snapshot(app, "ConcreteBuild-BeforeInput")
+
+        // Submit with count at 0 to trigger failure feedback
+        let submitPredicate = NSPredicate(format: "label BEGINSWITH 'That is '")
+        let submitButton = app.buttons.element(matching: submitPredicate)
+        _ = submitButton.waitForExistence(timeout: 5)
+        submitButton.tap()
+        snapshot(app, "ConcreteBuild-FailureFeedback")
+
+        // Fill to correct target (deterministic mode targets are 6–10; tapping 10 circles covers all)
+        let addButton = app.buttons["Add"]
+        _ = addButton.waitForExistence(timeout: 5)
+        for _ in 0..<10 { addButton.tap() }
+        submitButton.tap()
+
+        // After a correct answer the stage advances to pictorial — wait for it
+        let breakPredicate = NSPredicate(format: "label BEGINSWITH 'Break '")
+        _ = app.staticTexts.element(matching: breakPredicate).waitForExistence(timeout: 10)
+        snapshot(app, "Pictorial-AfterConcreteSuccess")
+    }
+
     // MARK: - Parent Summary screen
 
     func testScreenshot_ParentSummary() {
@@ -136,6 +176,20 @@ final class ScreenshotTests: XCTestCase {
         _ = homeButton.waitForExistence(timeout: 5)
         homeButton.tap()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
+    }
+
+    /// Launches with VS1 pre-enabled and haptics on — use for tests that exercise success/failure feedback.
+    private func launchWithVS1AndHaptics() -> XCUIApplication {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "YES",
+            "-feature.testModeEnabled", "YES",
+            "-feature.verticalSlice1Enabled", "YES"
+        ]
+        app.launch()
+        return app
     }
 
     /// Attaches a full-screen screenshot to the test result with `.keepAlways` lifetime.


### PR DESCRIPTION
## Summary
- New `HapticsService`: fires `UIImpactFeedbackGenerator(.medium)` on correct answers and `UINotificationFeedbackGenerator(.warning)` on wrong answers, gated on `featureFlags.hapticsEnabled`
- Wired into `VerticalSliceEngine.completeStage()` (success) and `submitCurrentStage()` failure branch
- `hapticsService` injected via default parameter — no changes needed to `AppModel`

## Tests
**Unit (4 new cases in `VerticalSliceEngineTests`):**
- `hapticsSuccessFiredOnCorrectAnswer` — verifies `successFiredCount == 1` after correct concrete submit
- `hapticsSuccessNotFiredWhenDisabled` — verifies count stays 0 when `hapticsEnabled = false`
- `hapticsFailureFiredOnWrongAnswer` — verifies `failureFiredCount == 1` after wrong submit
- `hapticsFailureNotFiredWhenDisabled` — verifies count stays 0 when disabled

**UI (new `testScreenshot_ConcreteBuild_FailureThenSuccess`):**
- Launches with haptics ON (`-feature.hapticsEnabled YES`)
- Submits wrong answer → screenshot `ConcreteBuild-FailureFeedback`
- Submits correct answer → screenshot `Pictorial-AfterConcreteSuccess`
- Full flow visible in CI screen recording video

Closes #7

## Test plan
- [ ] CI green — all 8 unit tests pass
- [ ] Screenshot artifact includes `ConcreteBuild-FailureFeedback.png` and `Pictorial-AfterConcreteSuccess.png`
- [ ] Video artifact shows failure feedback banner then stage transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)