### PR TITLE
test(m7): session history + digest tests, parent summary UI flow

### DIFF
--- a/Tests/MatherTests/SessionHistoryTests.swift
+++ b/Tests/MatherTests/SessionHistoryTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Mather
+
+// MARK: - Helpers
+
+@MainActor
+private func makeInMemoryStore() throws -> (SessionHistoryStore, ModelContext) {
+    let schema = Schema([StoredSessionSummary.self])
+    let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+    let container = try ModelContainer(for: schema, configurations: config)
+    let context = ModelContext(container)
+    return (SessionHistoryStore(modelContext: context), context)
+}
+
+private func makeDraft(
+    sessionId: String = UUID().uuidString,
+    problemsCompleted: Int = 5,
+    accuracy: Double = 0.8,
+    transferCorrect: Int = 3,
+    medianLatencyMs: Int = 1200,
+    startedAt: Date = .now
+) -> SessionSummaryDraft {
+    SessionSummaryDraft(
+        sessionId: sessionId,
+        startedAt: startedAt,
+        endedAt: startedAt.addingTimeInterval(300),
+        objectiveTitle: "Make & Break to 10",
+        problemsCompleted: problemsCompleted,
+        firstAttemptAccuracy: accuracy,
+        transferCorrectCount: transferCorrect,
+        medianLatencyMs: medianLatencyMs,
+        nextTargetHint: "Keep going.",
+        exportFileName: "session-\(sessionId).jsonl"
+    )
+}
+
+// MARK: - SessionHistoryStore tests
+
+@MainActor
+struct SessionHistoryStoreTests {
+    @Test
+    func savePersistsSummary() throws {
+        let (store, context) = try makeInMemoryStore()
+        let draft = makeDraft(problemsCompleted: 6, accuracy: 0.75)
+
+        store.save(draft)
+
+        let fetched = try context.fetch(FetchDescriptor<StoredSessionSummary>())
+        #expect(fetched.count == 1)
+        #expect(fetched[0].problemsCompleted == 6)
+        #expect(fetched[0].firstAttemptAccuracy == 0.75)
+    }
+
+    @Test
+    func clearAllRemovesAllSummaries() throws {
+        let (store, context) = try makeInMemoryStore()
+        store.save(makeDraft())
+        store.save(makeDraft())
+
+        store.clearAll()
+
+        let fetched = try context.fetch(FetchDescriptor<StoredSessionSummary>())
+        #expect(fetched.isEmpty)
+    }
+
+    @Test
+    func saveMultipleSessionsAreAllPersisted() throws {
+        let (store, context) = try makeInMemoryStore()
+        store.save(makeDraft(sessionId: "aaa", problemsCompleted: 3))
+        store.save(makeDraft(sessionId: "bbb", problemsCompleted: 6))
+
+        let fetched = try context.fetch(FetchDescriptor<StoredSessionSummary>())
+        #expect(fetched.count == 2)
+    }
+}
+
+// MARK: - TelemetryWriter.digest tests
+
+@MainActor
+struct TelemetryWriterDigestTests {
+    @Test
+    func digestReturnsDefaultsForEmptyHistory() {
+        let digest = TelemetryWriter().digest(from: [])
+
+        #expect(digest.problemsCompleted == 0)
+        #expect(digest.firstAttemptAccuracy == 0)
+        #expect(digest.transferCorrectCount == 0)
+        #expect(digest.medianLatencyMs == 0)
+    }
+
+    @Test
+    func digestAggregatesTotalsAcrossSessions() throws {
+        let (store, context) = try makeInMemoryStore()
+        store.save(makeDraft(problemsCompleted: 4, accuracy: 1.0, transferCorrect: 4, medianLatencyMs: 1000))
+        store.save(makeDraft(problemsCompleted: 6, accuracy: 0.5, transferCorrect: 2, medianLatencyMs: 2000))
+
+        let summaries = try context.fetch(FetchDescriptor<StoredSessionSummary>())
+        let digest = TelemetryWriter().digest(from: summaries)
+
+        #expect(digest.problemsCompleted == 10)
+        #expect(digest.transferCorrectCount == 6)
+        #expect(digest.firstAttemptAccuracy == 0.75) // (1.0 + 0.5) / 2
+    }
+
+    @Test
+    func digestMedianLatencyPicksMiddleValue() throws {
+        let (store, context) = try makeInMemoryStore()
+        store.save(makeDraft(medianLatencyMs: 1000))
+        store.save(makeDraft(medianLatencyMs: 2000))
+        store.save(makeDraft(medianLatencyMs: 3000))
+
+        let summaries = try context.fetch(FetchDescriptor<StoredSessionSummary>())
+        let digest = TelemetryWriter().digest(from: summaries)
+
+        #expect(digest.medianLatencyMs == 2000)
+    }
+
+    @Test
+    func digestNextHintEncouragesProgressWhenAccuracyHigh() throws {
+        let (store, context) = try makeInMemoryStore()
+        store.save(makeDraft(accuracy: 0.9))
+
+        let summaries = try context.fetch(FetchDescriptor<StoredSessionSummary>())
+        let digest = TelemetryWriter().digest(from: summaries)
+
+        // High accuracy (>= 0.7) should give a "keep going" hint, not a "repeat" hint
+        #expect(!digest.nextTargetHint.contains("Repeat"))
+    }
+
+    @Test
+    func digestNextHintSuggestsRepeatWhenAccuracyLow() throws {
+        let (store, context) = try makeInMemoryStore()
+        store.save(makeDraft(accuracy: 0.4))
+
+        let summaries = try context.fetch(FetchDescriptor<StoredSessionSummary>())
+        let digest = TelemetryWriter().digest(from: summaries)
+
+        #expect(digest.nextTargetHint.contains("Repeat"))
+    }
+}

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -125,8 +125,26 @@ final class ScreenshotTests: XCTestCase {
         let app = launch()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
         app.buttons["Parent Summary"].tap()
-        _ = app.waitForExistence(timeout: 3)
-        snapshot(app, "ParentSummary")
+        _ = app.staticTexts["Parent Summary"].waitForExistence(timeout: 10)
+        snapshot(app, "ParentSummary-Empty")
+
+        // Navigate to Settings from Parent Summary
+        let settingsButton = app.buttons["Settings"]
+        _ = settingsButton.waitForExistence(timeout: 5)
+        settingsButton.tap()
+        _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
+        snapshot(app, "Settings-FromParentSummary")
+
+        // Tap clear — confirm dialog should appear
+        let clearButton = app.buttons["Clear session history"]
+        _ = clearButton.waitForExistence(timeout: 5)
+        clearButton.tap()
+        _ = app.alerts["Clear all session data?"].waitForExistence(timeout: 5)
+        snapshot(app, "Settings-ClearConfirmDialog")
+
+        // Dismiss with Cancel
+        app.alerts["Clear all session data?"].buttons["Cancel"].tap()
+        snapshot(app, "Settings-AfterCancelClear")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
Issue #9's implementation (ParentSummaryView, session history list, clear confirmation, toggles, export ShareLink) was already complete. This PR adds the missing test coverage.

**Unit tests — `SessionHistoryTests.swift` (8 new tests):**

`SessionHistoryStoreTests`:
- `savePersistsSummary` — verifies a draft is stored with correct fields
- `clearAllRemovesAllSummaries` — save two, clear, verify empty
- `saveMultipleSessionsAreAllPersisted` — two sessions coexist

`TelemetryWriterDigestTests`:
- `digestReturnsDefaultsForEmptyHistory` — zeros when no sessions
- `digestAggregatesTotalsAcrossSessions` — completion + transfer totals, mean accuracy
- `digestMedianLatencyPicksMiddleValue` — median of three latencies
- `digestNextHintEncouragesProgressWhenAccuracyHigh` — ≥ 0.7 → no "Repeat" in hint
- `digestNextHintSuggestsRepeatWhenAccuracyLow` — < 0.7 → hint contains "Repeat"

**UI test — `testScreenshot_ParentSummary` extended:**
- Screenshots: `ParentSummary-Empty`, `Settings-FromParentSummary`, `Settings-ClearConfirmDialog`, `Settings-AfterCancelClear`
- Full flow visible in CI screen recording

Closes #9

## Test plan
- [ ] All 13 unit tests green (8 new + 5 existing)
- [ ] Screenshot artifacts include clear confirmation dialog
- [ ] Video shows Settings → clear dialog → cancel flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)