### PR TITLE
ci: increase timeouts and add post-boot pause

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   build-test:
     name: Build & Test
     runs-on: macos-15
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
@@ -69,7 +69,14 @@ jobs:
             STATE=$(xcrun simctl list devices | grep -F "$SIM_ID" \
               | grep -oE 'Booted|Shutdown|Booting' | head -1 || echo "Unknown")
             echo "[$i/40] $STATE"
-            [[ "$STATE" == "Booted" ]] && { echo "Simulator ready: $SIM_ID"; exit 0; }
+            [[ "$STATE" == "Booted" ]] && {
+              echo "Simulator booted: $SIM_ID"
+              # Wait for SpringBoard to finish initialising before handing off to
+              # xcodebuild — the OS reports Booted before the UI is fully ready,
+              # which causes the first test run to hang waiting for the app to launch.
+              sleep 10
+              exit 0
+            }
             sleep 5
           done
           echo "Simulator did not reach Booted state after 200s" >&2
@@ -77,7 +84,7 @@ jobs:
           exit 1
 
       - name: Run unit tests
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           xcodebuild test-without-building \
             -project Mather.xcodeproj \


### PR DESCRIPTION
## Problem
Unit tests have timed out 3 times at the 10-minute limit. Each time `gh run rerun --failed` passes on the retry, confirming it's a slow-start issue not a test failure.

Root cause: `xcrun simctl` reports `Booted` before SpringBoard has fully initialised. `xcodebuild` then hangs waiting for the app to launch inside the simulator.

## Fixes
1. **Post-boot `sleep 10`** after the poll loop confirms `Booted` — gives SpringBoard time to finish before handing off to xcodebuild
2. **Unit test timeout 10 → 15 min** — extra headroom on slow runners
3. **Job timeout 45 → 60 min** — keeps budget consistent with the grown test suite (13 unit + 6 UI tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)