### PR TITLE
Fix 12 research-gap issues from VS1 critical review

### DIFF
--- a/Domain/ProblemGenerator.swift
+++ b/Domain/ProblemGenerator.swift
@@ -1,15 +1,20 @@
 import Foundation
 
 enum ProblemGenerator {
+    // Seed covers varied decomposition patterns:
+    // - spread pairs (large difference: 1+5, 1+6, 2+7) reveal the range of a number
+    // - mid pairs (3+4, 3+6) are the "non-round" preferred by the spec
+    // - symmetric pairs (3+3, 4+4) test understanding that a+a is valid
+    // - reversed pairs (6+2 after 2+6) expose commutativity across problems
     private static let deterministicSeed: [(Int, Int, Int)] = [
-        (6, 1, 5),
-        (7, 2, 5),
-        (8, 3, 5),
-        (9, 4, 5),
-        (10, 5, 5),
-        (6, 2, 4),
-        (7, 3, 4),
-        (8, 4, 4)
+        (6, 3, 3),  // symmetric — 6 = 3+3
+        (7, 3, 4),  // mid spread
+        (8, 2, 6),  // wider spread
+        (9, 4, 5),  // near-equal
+        (10, 4, 6), // non-round, not anchored to 5
+        (6, 1, 5),  // extreme spread
+        (8, 6, 2),  // reversed of (8,2,6) — commutativity
+        (7, 6, 1),  // high-low reversed
     ]
 
     static func generateProblems(config: SliceConfig) -> [SliceProblem] {

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -20,6 +20,9 @@ final class VerticalSliceEngine {
     private(set) var currentSession = SliceSession(sessionId: UUID(), startedAt: .now, endedAt: nil, problems: [], schemaVersion: TelemetryWriter.schemaVersion)
     private(set) var currentStage: SliceStage = .concrete
     private(set) var currentProblemState = ProblemState()
+    private var sessionStartedAt: Date = .now
+    private var problemStartedAt: Date = .now
+    private let sessionTimeLimitSeconds: TimeInterval = 7 * 60
 
     var concreteCount = 0
     var splitLeftCount = 0
@@ -91,8 +94,10 @@ final class VerticalSliceEngine {
         feedbackMessage = "Make the target number with the big counters."
         showCelebration = false
         completedSummary = nil
+        sessionStartedAt = .now
+        problemStartedAt = .now
         speechService.resetSession()
-        speechService.speakSessionIntroIfNeeded(enabled: featureFlags.audioEnabled)
+        speechService.speakSessionIntroIfNeeded()
 
         do {
             try telemetryWriter.beginSession(sessionId: currentSession.sessionId, featureFlags: featureFlags)
@@ -183,19 +188,26 @@ final class VerticalSliceEngine {
 
     private func validateEquation(for problem: SliceProblem) -> Bool {
         guard let left = Int(equationLeftInput), let right = Int(equationRightInput) else { return false }
-        return left + right == problem.target && left == splitLeftCount && right == (problem.target - splitLeftCount)
+        return left + right == problem.target
     }
 
     private func completeStage(successMessage: String) {
-        showCelebration = true
         feedbackMessage = successMessage
         speechService.speak(successMessage, enabled: featureFlags.audioEnabled)
-        hapticsService.success(enabled: featureFlags.hapticsEnabled)
 
         let next = SliceStateMachine.nextStage(after: currentStage, success: true, showTransfer: config.showTransfer)
         recordStageTransition(from: currentStage, to: next)
-        if currentStage == .transfer || (!config.showTransfer && currentStage == .abstract) {
+
+        let isProblemComplete = currentStage == .transfer || (!config.showTransfer && currentStage == .abstract)
+        if isProblemComplete {
             recordProblemCompletion(transferCorrect: true)
+            // Full celebration for completing an entire problem
+            showCelebration = true
+            hapticsService.success(enabled: featureFlags.hapticsEnabled)
+        } else {
+            // Subtle signal for completing an individual CPA stage
+            showCelebration = false
+            hapticsService.stageSuccess(enabled: featureFlags.hapticsEnabled)
         }
 
         currentStage = next
@@ -226,7 +238,9 @@ final class VerticalSliceEngine {
     }
 
     private func advanceProblemOrFinishSession() {
-        if currentProblemIndex + 1 < problems.count {
+        let elapsed = Date.now.timeIntervalSince(sessionStartedAt)
+        let timeCapReached = elapsed >= sessionTimeLimitSeconds
+        if currentProblemIndex + 1 < problems.count && !timeCapReached {
             currentProblemIndex += 1
             currentStage = .concrete
             currentProblemState = ProblemState()
@@ -235,6 +249,7 @@ final class VerticalSliceEngine {
             equationLeftInput = ""
             equationRightInput = ""
             transferCount = 0
+            problemStartedAt = .now
             feedbackMessage = promptForCurrentStage()
             logProblemPresented()
         } else {
@@ -268,8 +283,13 @@ final class VerticalSliceEngine {
         let completed = currentSession.problems.count
         let firstTryCount = currentSession.problems.filter(\.firstTryCorrect).count
         let transferCorrect = currentSession.problems.filter(\.transferCorrect).count
-        let latencySource = currentSession.problems.map { max($0.events.count * 600, 600) }
-        let median = latencySource.sorted().dropFirst(latencySource.count / 2).first ?? 0
+        let latencies = currentSession.problems.compactMap { problem -> Int? in
+            guard let event = problem.events.first(where: { $0.type == .problemCompleted }),
+                  let ms = Int(event.payload["time_ms"] ?? "") else { return nil }
+            return ms
+        }
+        let sorted = latencies.sorted()
+        let median = sorted.isEmpty ? 0 : sorted[sorted.count / 2]
         let accuracy = completed == 0 ? 0 : Double(firstTryCount) / Double(completed)
 
         return ParentDigest(
@@ -278,8 +298,30 @@ final class VerticalSliceEngine {
             medianLatencyMs: median,
             problemsCompleted: completed,
             transferCorrectCount: transferCorrect,
-            nextTargetHint: accuracy < 0.7 ? "Repeat the same range with spoken prompts." : "Increase to 7 or 8 problems when the child stays relaxed."
+            nextTargetHint: nextHint(accuracy: accuracy, transferCorrect: transferCorrect, completed: completed)
         )
+    }
+
+    private func nextHint(accuracy: Double, transferCorrect: Int, completed: Int) -> String {
+        guard completed > 0 else {
+            return "Complete a session to see personalised recommendations here."
+        }
+        let transferRate = Double(transferCorrect) / Double(completed)
+        // Transfer success much lower than overall accuracy → abstract-to-concrete
+        // connection isn't formed yet; suggest home reinforcement
+        if transferRate < accuracy - 0.3 {
+            return "Your child found the reverse (equation → counters) harder. Try this at home: write '3 + 4 =' on paper and ask them to show it with grapes or blocks."
+        }
+        if accuracy < 0.5 {
+            return "The concept is still new. Keep sessions short, use physical objects at home (10 buttons, 10 pebbles), and don't rush to the written equation."
+        }
+        if accuracy < 0.7 {
+            return "Repeat the same range with spoken prompts. At home, practise splitting 6–9 objects into two groups and counting each."
+        }
+        if accuracy < 0.9 {
+            return "Solid progress! Try increasing to 7–8 problems next session when they seem relaxed."
+        }
+        return "Excellent mastery. Try the full 1–10 range or introduce writing the equation on paper first before using the app."
     }
 
     private func logProblemPresented() {
@@ -322,7 +364,9 @@ final class VerticalSliceEngine {
                     "from": from.rawValue,
                     "to": to.rawValue,
                     "decomposition_a": String(currentProblem.decompositionA),
-                    "decomposition_b": String(currentProblem.decompositionB)
+                    "decomposition_b": String(currentProblem.decompositionB),
+                    "entered_left": equationLeftInput,
+                    "entered_right": equationRightInput
                 ]
             )
         )
@@ -330,15 +374,18 @@ final class VerticalSliceEngine {
 
     private func recordProblemCompletion(transferCorrect: Bool) {
         guard let currentProblem else { return }
+        let elapsedMs = Int(Date.now.timeIntervalSince(problemStartedAt) * 1000)
+        currentProblemState.timeSpentMs = elapsedMs
         let problemSession = ProblemSession(
             problemId: currentProblem.id,
-            givenAt: .now,
+            givenAt: problemStartedAt,
             events: [
                 SliceEvent(
                     type: .problemCompleted,
                     payload: [
                         "problem_id": currentProblem.id.uuidString,
                         "attempts": String(currentProblemState.attempts),
+                        "time_ms": String(elapsedMs),
                         "transfer_correct": String(transferCorrect)
                     ]
                 )
@@ -384,15 +431,40 @@ final class VerticalSliceEngine {
     }
 
     private func feedbackMessageForFailure(stage: SliceStage, problem: SliceProblem) -> String {
+        let attempts = currentProblemState.attempts
         switch stage {
         case .concrete:
-            return "Keep counting. Make exactly \(problem.target)."
+            if attempts == 1 {
+                return "Keep counting. Make exactly \(problem.target)."
+            } else if attempts == 2 {
+                return "You have \(concreteCount). How many more do you need to make \(problem.target)?"
+            } else {
+                return "Try tapping the circles one by one until you reach \(problem.target)."
+            }
         case .pictorial:
-            return "Try another break. Both groups together should still make \(problem.target)."
+            if attempts == 1 {
+                return "Try another break. Both groups together should still make \(problem.target)."
+            } else if attempts == 2 {
+                return "You have \(splitLeftCount) on the left and \(problem.target - splitLeftCount) on the right. That makes \(splitLeftCount + (problem.target - splitLeftCount))."
+            } else {
+                return "Any split is fine — left and right just need to add up to \(problem.target)."
+            }
         case .abstract:
-            return "Use the same two parts you just built."
+            if attempts == 1 {
+                return "Use two numbers that add up to \(problem.target)."
+            } else if attempts == 2 {
+                return "Try \(problem.decompositionA) and \(problem.decompositionB). What do they add up to?"
+            } else {
+                return "Type \(problem.decompositionA) on the left and \(problem.decompositionB) on the right."
+            }
         case .transfer:
-            return "Look at the equation and rebuild the whole number."
+            if attempts == 1 {
+                return "Look at the equation and rebuild the whole number."
+            } else if attempts == 2 {
+                return "The equation shows \(problem.decompositionA) + \(problem.decompositionB). How many is that altogether?"
+            } else {
+                return "Tap until you have \(problem.target) counters — that is what \(problem.decompositionA) + \(problem.decompositionB) equals."
+            }
         case .done:
             return "Try again."
         }

--- a/Features/VerticalSlice1/ConcreteBuildView.swift
+++ b/Features/VerticalSlice1/ConcreteBuildView.swift
@@ -6,14 +6,10 @@ struct ConcreteBuildView: View {
     let onAdjust: (Int) -> Void
     let onSubmit: () -> Void
 
-    @Environment(\.horizontalSizeClass) private var sizeClass
-
-    private var columns: [GridItem] {
-        let count = sizeClass == .compact ? 2 : 5
-        return Array(repeating: GridItem(.flexible(), spacing: 12), count: count)
-    }
-
-    private var circleMinHeight: CGFloat { sizeClass == .compact ? 80 : 82 }
+    // Ten-frame is always 5 columns × 2 rows — this fixed 2×5 structure is
+    // what enables subitizing (e.g. "7 = full row of 5 + 2 more").
+    // Circle size scales with available space; the column count is invariant.
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 5)
 
     var body: some View {
         CardSurface {
@@ -24,14 +20,21 @@ struct ConcreteBuildView: View {
                     .font(.headline)
                     .foregroundStyle(.secondary)
 
-                LazyVGrid(columns: columns, spacing: 12) {
+                // Always 10 slots visible: filled slots show as accent circles,
+                // empty slots remain as faint outlines so the ten-frame structure
+                // is always clear and subitizing is always possible.
+                LazyVGrid(columns: columns, spacing: 8) {
                     ForEach(0..<10, id: \.self) { index in
                         Circle()
-                            .fill(index < concreteCount ? MatherTheme.accent : MatherTheme.softBlue.opacity(0.3))
-                            .frame(minHeight: circleMinHeight)
+                            .fill(index < concreteCount ? MatherTheme.accent : MatherTheme.softBlue.opacity(0.15))
                             .overlay {
-                                Circle().stroke(Color.white, lineWidth: 3)
+                                Circle().stroke(
+                                    index < concreteCount ? Color.white : MatherTheme.softBlue.opacity(0.5),
+                                    lineWidth: 2
+                                )
                             }
+                            .aspectRatio(1, contentMode: .fit)
+                            .frame(minWidth: 44, minHeight: 44)
                             .onTapGesture {
                                 let tapped = index + 1
                                 onAdjust(tapped - concreteCount)

--- a/Features/VerticalSlice1/SessionSummaryView.swift
+++ b/Features/VerticalSlice1/SessionSummaryView.swift
@@ -6,21 +6,24 @@ struct SessionSummaryView: View {
     var body: some View {
         ZStack {
             MatherTheme.background.ignoresSafeArea()
-            VStack(spacing: 20) {
-                CardSurface {
-                    VStack(alignment: .leading, spacing: 14) {
-                        Text("Session complete")
-                            .font(.largeTitle.weight(.black))
-                        Text(appModel.engine.feedbackMessage)
-                            .font(.title3)
-                        if let summary = appModel.engine.completedSummary {
-                            Text("Problems completed: \(summary.problemsCompleted)")
-                            Text("First try accuracy: \(Int(summary.firstAttemptAccuracy * 100))%")
-                            Text("Export file: \(summary.exportFileName)")
-                                .foregroundStyle(.secondary)
-                        }
-                    }
+            VStack(spacing: 24) {
+                Spacer()
+
+                VStack(spacing: 16) {
+                    Text("🎉")
+                        .font(.system(size: 80))
+                    Text("Amazing work!")
+                        .font(.largeTitle.weight(.black))
+                    Text("You did it!")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(.secondary)
                 }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 32)
+                .background(MatherTheme.warm.opacity(0.25))
+                .clipShape(RoundedRectangle(cornerRadius: 32, style: .continuous))
+
+                Spacer()
 
                 Button("Play again") {
                     appModel.engine.showSessionConfig()
@@ -38,8 +41,6 @@ struct SessionSummaryView: View {
                     }
                     .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.75)))
                 }
-
-                Spacer()
             }
             .padding(24)
         }

--- a/Features/VerticalSlice1/SplitView.swift
+++ b/Features/VerticalSlice1/SplitView.swift
@@ -19,12 +19,12 @@ struct SplitView: View {
 
                 ViewThatFits {
                     HStack(spacing: 16) {
-                        bucket(title: "Left", count: leftCount, fill: MatherTheme.softBlue, delta: 1)
-                        bucket(title: "Right", count: rightCount, fill: MatherTheme.warm.opacity(0.9), delta: -1)
+                        bucket(title: "Left", count: leftCount, capacity: target, fill: MatherTheme.softBlue, delta: 1)
+                        bucket(title: "Right", count: rightCount, capacity: target, fill: MatherTheme.warm.opacity(0.9), delta: -1)
                     }
                     VStack(spacing: 16) {
-                        bucket(title: "Left", count: leftCount, fill: MatherTheme.softBlue, delta: 1)
-                        bucket(title: "Right", count: rightCount, fill: MatherTheme.warm.opacity(0.9), delta: -1)
+                        bucket(title: "Left", count: leftCount, capacity: target, fill: MatherTheme.softBlue, delta: 1)
+                        bucket(title: "Right", count: rightCount, capacity: target, fill: MatherTheme.warm.opacity(0.9), delta: -1)
                     }
                 }
                 .gesture(
@@ -53,21 +53,31 @@ struct SplitView: View {
         }
     }
 
-    private func bucket(title: String, count: Int, fill: Color, delta: Int) -> some View {
+    private func bucket(title: String, count: Int, capacity: Int, fill: Color, delta: Int) -> some View {
         VStack(spacing: 12) {
             Text(title)
                 .font(.title2.weight(.bold))
             Text("\(count)")
                 .font(.system(size: 44, weight: .black, design: .rounded))
             RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .fill(fill)
-                .frame(maxWidth: .infinity, minHeight: 120)
+                .fill(fill.opacity(0.25))
                 .overlay {
-                    Text(String(repeating: "● ", count: max(count, 1)))
-                        .lineLimit(3)
-                        .minimumScaleFactor(0.5)
-                        .padding()
+                    LazyVGrid(
+                        columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 5),
+                        spacing: 6
+                    ) {
+                        ForEach(0..<capacity, id: \.self) { index in
+                            Circle()
+                                .fill(index < count ? fill : fill.opacity(0.15))
+                                .overlay {
+                                    Circle().stroke(fill.opacity(0.4), lineWidth: 1.5)
+                                }
+                                .aspectRatio(1, contentMode: .fit)
+                        }
+                    }
+                    .padding(12)
                 }
+                .frame(maxWidth: .infinity, minHeight: 100)
                 .onTapGesture {
                     onAdjust(delta)
                 }

--- a/Features/VerticalSlice1/TransferCheckView.swift
+++ b/Features/VerticalSlice1/TransferCheckView.swift
@@ -24,7 +24,7 @@ struct TransferCheckView: View {
                     ForEach(0..<problem.target, id: \.self) { index in
                         Circle()
                             .fill(index < transferCount ? MatherTheme.accent : MatherTheme.softBlue.opacity(0.25))
-                            .frame(minHeight: 48)
+                            .frame(minHeight: 80)
                     }
                 }
 

--- a/Persistence/TelemetryWriter.swift
+++ b/Persistence/TelemetryWriter.swift
@@ -127,7 +127,27 @@ final class TelemetryWriter {
             medianLatencyMs: median,
             problemsCompleted: completed,
             transferCorrectCount: transferCorrect,
-            nextTargetHint: accuracy < 0.7 ? "Repeat targets 6 to 8 with audio prompts enabled." : "Try one more session and watch for faster transfer success."
+            nextTargetHint: digestHint(accuracy: accuracy, transferCorrect: transferCorrect, completed: completed)
         )
+    }
+
+    private func digestHint(accuracy: Double, transferCorrect: Int, completed: Int) -> String {
+        guard completed > 0 else {
+            return "Start with targets 6 to 8 and watch for relaxed repetition."
+        }
+        let transferRate = Double(transferCorrect) / Double(completed)
+        if transferRate < accuracy - 0.3 {
+            return "The reverse direction (equation → counters) is the gap. Practise writing '3 + 4 =' and asking your child to show it with physical objects."
+        }
+        if accuracy < 0.5 {
+            return "Repeat the current range — keep sessions short and use real objects at home (pebbles, pasta) alongside the app."
+        }
+        if accuracy < 0.7 {
+            return "Repeat targets 6 to 8 with audio prompts enabled. Physical practice at home helps consolidate the concept."
+        }
+        if accuracy < 0.9 {
+            return "Good progress. Try one more session and watch for faster, confident transfer responses."
+        }
+        return "Strong mastery. Consider expanding the range or introducing numeral writing on paper."
     }
 }

--- a/Services/HapticsService.swift
+++ b/Services/HapticsService.swift
@@ -4,7 +4,16 @@ import UIKit
 final class HapticsService {
     private(set) var successFiredCount = 0
     private(set) var failureFiredCount = 0
+    private(set) var stageSuccessFiredCount = 0
 
+    /// Light haptic for completing an individual CPA stage (not a full problem).
+    func stageSuccess(enabled: Bool) {
+        guard enabled else { return }
+        stageSuccessFiredCount += 1
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    /// Medium haptic for completing a full problem (all stages done).
     func success(enabled: Bool) {
         guard enabled else { return }
         successFiredCount += 1
@@ -20,5 +29,6 @@ final class HapticsService {
     func resetCounts() {
         successFiredCount = 0
         failureFiredCount = 0
+        stageSuccessFiredCount = 0
     }
 }

--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -18,10 +18,13 @@ final class SpeechService {
         synthesizer.speak(utterance)
     }
 
-    func speakSessionIntroIfNeeded(enabled: Bool) {
+    // Always speaks the session intro regardless of the audio toggle — the child
+    // should always hear a spoken start cue. The parent's mute toggle applies to
+    // in-session prompts only (via speak(_:enabled:)).
+    func speakSessionIntroIfNeeded() {
         guard !hasSpokenSessionIntro else { return }
         hasSpokenSessionIntro = true
-        speak("Let's make and break numbers to ten.", enabled: enabled)
+        speak("Let's make and break numbers to ten.", enabled: true)
     }
 
     func resetSession() {

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -29,7 +29,7 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
-    func hapticsSuccessFiredOnCorrectAnswer() {
+    func hapticsStageSuccessFiredOnConcreteStageClear() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.hapticsEnabled = true
@@ -47,12 +47,47 @@ struct VerticalSliceEngineTests {
         engine.adjustConcrete(by: engine.currentProblem?.target ?? 0)
         engine.submitCurrentStage()
 
-        #expect(haptics.successFiredCount == 1)
+        // Completing an individual stage (not a full problem) fires stageSuccess, not success
+        #expect(haptics.stageSuccessFiredCount == 1)
+        #expect(haptics.successFiredCount == 0)
         #expect(haptics.failureFiredCount == 0)
     }
 
     @Test
-    func hapticsSuccessNotFiredWhenDisabled() {
+    func hapticsSuccessFiredOnProblemComplete() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.hapticsEnabled = true
+        let haptics = HapticsService()
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            hapticsService: haptics,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        guard let problem = engine.currentProblem else { return }
+
+        // Complete all four CPA stages for one problem
+        engine.adjustConcrete(by: problem.target)
+        engine.submitCurrentStage()    // concrete → pictorial (stageSuccess)
+        engine.submitCurrentStage()    // pictorial → abstract (stageSuccess)
+        engine.equationLeftInput = String(problem.decompositionA)
+        engine.equationRightInput = String(problem.decompositionB)
+        engine.submitCurrentStage()    // abstract → transfer (stageSuccess)
+        engine.adjustTransfer(by: problem.target)
+        engine.submitCurrentStage()    // transfer → done (success — problem complete)
+
+        #expect(haptics.successFiredCount == 1)
+        #expect(haptics.stageSuccessFiredCount == 3)
+        #expect(haptics.failureFiredCount == 0)
+    }
+
+    @Test
+    func hapticsStageSuccessNotFiredWhenDisabled() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.hapticsEnabled = false
@@ -70,6 +105,7 @@ struct VerticalSliceEngineTests {
         engine.adjustConcrete(by: engine.currentProblem?.target ?? 0)
         engine.submitCurrentStage()
 
+        #expect(haptics.stageSuccessFiredCount == 0)
         #expect(haptics.successFiredCount == 0)
     }
 
@@ -94,6 +130,44 @@ struct VerticalSliceEngineTests {
 
         #expect(haptics.failureFiredCount == 1)
         #expect(haptics.successFiredCount == 0)
+    }
+
+    @Test
+    func equationAcceptsAlternativeCorrectDecomposition() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.hapticsEnabled = false
+        let haptics = HapticsService()
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            hapticsService: haptics,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        guard let problem = engine.currentProblem else { return }
+
+        // Advance to abstract stage
+        engine.adjustConcrete(by: problem.target)
+        engine.submitCurrentStage() // → pictorial
+        engine.submitCurrentStage() // → abstract
+
+        #expect(engine.currentStage == .abstract)
+
+        // Enter a valid decomposition different from the stored split
+        // e.g. if decompositionA=1, decompositionB=5 for target=6, try 3+3
+        let altLeft = problem.target / 2
+        let altRight = problem.target - altLeft
+        engine.equationLeftInput = String(altLeft)
+        engine.equationRightInput = String(altRight)
+        engine.submitCurrentStage()
+
+        // Should advance past abstract regardless of which valid decomposition was entered
+        #expect(engine.currentStage != .abstract)
+        #expect(haptics.failureFiredCount == 0)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Addresses all 12 issues raised by the critical review of VS1 against the research wiki. Ordered by priority:

**5 critical bugs (pilot blockers):**
- Closes #30 — `SessionSummaryView` no longer shows accuracy % or problem count to child; replaced with celebratory end screen
- Closes #31 — `TransferCheckView` touch targets increased from 48pt to 80pt
- Closes #32 — `validateEquation` relaxed to `a + b == target`; any valid decomposition accepted; entered values recorded in telemetry
- Closes #33 — `speakSessionIntroIfNeeded()` always fires at session start regardless of audio toggle; parent mute applies to in-session prompts only
- Closes #34 — `showCelebration` fires on problem completion only; individual stage completions use a new `stageSuccess()` light haptic; full `.medium` haptic reserved for problem-complete milestone

**1 priority:high enhancement:**
- Closes #35 — `ConcreteBuildView` always uses 5-column ten-frame layout (invariant across device sizes) to support subitizing; empty slots always visible

**6 priority:medium enhancements:**
- Closes #36 — 3-tier ZPD hint escalation: attempt 1 → gentle redirect, attempt 2 → specific scaffold referencing child's current count, attempt 3+ → guided explicit hint
- Closes #37 — 7-minute session time guard in `advanceProblemOrFinishSession`; session ends naturally at time cap without mentioning time
- Closes #38 — Real elapsed-time latency via `problemStartedAt: Date`; written as `time_ms` to JSONL; `buildDigest()` median uses real values
- Closes #39 — Deterministic seed expanded to cover symmetric (3+3), wide-spread (2+6), reversed (6+2) decompositions
- Closes #40 — `SplitView` buckets render discrete `Circle` shapes in a 5-column grid with empty slots visible; replaces `"● "` text string
- Closes #41 — Parent digest hint has 5 tiers: transfer-gap (abstract→concrete gap), low, below-threshold, improving, mastered; includes real-world offline activity suggestions

## Test plan

- [x] All existing unit tests pass (CI)
- [x] New haptics tests: `hapticsStageSuccessFiredOnConcreteStageClear`, `hapticsSuccessFiredOnProblemComplete`, `hapticsStageSuccessNotFiredWhenDisabled`
- [x] New engine test: `equationAcceptsAlternativeCorrectDecomposition`
- [x] UI screenshot tests capture: ten-frame layout (5 cols), SplitView circles, celebratory end screen
- [x] CI video shows no raw scores on child-facing end screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)