### PR TITLE
feat: semantic versioned release workflow (#44)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build & Release
+    runs-on: macos-15
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Show toolchain versions
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Parse version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF_NAME}"          # e.g. v1.0.0
+          VERSION="${TAG#v}"                # e.g. 1.0.0
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp version into Info.plist
+        run: |
+          /usr/libexec/PlistBuddy \
+            -c "Set :CFBundleShortVersionString ${{ steps.version.outputs.version }}" \
+            App/Info.plist
+          /usr/libexec/PlistBuddy \
+            -c "Set :CFBundleVersion ${{ github.run_number }}" \
+            App/Info.plist
+
+      - name: Generate project
+        run: xcodegen generate
+
+      - name: Resolve dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project Mather.xcodeproj \
+            -scheme Mather \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Build archive
+        run: |
+          xcodebuild archive \
+            -project Mather.xcodeproj \
+            -scheme Mather \
+            -destination 'generic/platform=iOS Simulator' \
+            -archivePath "$RUNNER_TEMP/Mather.xcarchive" \
+            CODE_SIGNING_ALLOWED=NO \
+            SKIP_INSTALL=NO
+
+      - name: Compress archive
+        run: |
+          cd "$RUNNER_TEMP"
+          zip -r Mather-${{ steps.version.outputs.version }}.zip Mather.xcarchive
+
+      - name: Create GitHub Release
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "Mather ${{ steps.version.outputs.tag }}" \
+            --notes "$(cat <<'EOF'
+          ## Mather ${{ steps.version.outputs.tag }}
+
+          **Sideload instructions**: Clone the repo at this tag and run `xcodebuild` locally, or open in Xcode and deploy to your iPad via USB/WiFi.
+
+          This is a personal/family sideload build — not App Store distributed (see ADR-0002).
+
+          ### What's in this release
+          See the [commit history](https://github.com/${{ github.repository }}/commits/${{ steps.version.outputs.tag }}) for details.
+          EOF
+          )" \
+            "$RUNNER_TEMP/Mather-${{ steps.version.outputs.version }}.zip"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/project.yml
+++ b/project.yml
@@ -9,8 +9,11 @@ settings:
     PRODUCT_NAME: Mather
     DEVELOPMENT_TEAM: ""
     CODE_SIGN_STYLE: Automatic
+    # MARKETING_VERSION is overridden at release time by the release workflow
+    # (.github/workflows/release.yml) from the git tag (e.g. v1.0.0 → 1.0.0).
+    # Local development builds show 0.1.0-dev. See ADR-0003 for the scheme.
     CURRENT_PROJECT_VERSION: 1
-    MARKETING_VERSION: 0.1.0
+    MARKETING_VERSION: 0.1.0-dev
 targets:
   Mather:
     type: application

--- a/wiki/ADRs/ADR-0003-release-workflow.md
+++ b/wiki/ADRs/ADR-0003-release-workflow.md
@@ -1,0 +1,68 @@
+# ADR-0003: Semantic Versioned Release Workflow
+
+**Date**: 2026-04-02
+**Status**: Accepted
+**Deciders**: @ganesh47
+
+---
+
+## Context
+
+Mather is distributed as a personal/family sideload (ADR-0002). Without a defined versioning scheme, it is impossible to know which build a device is running, making it hard to correlate observed child behaviour with specific code changes. Alpha testing with a real child requires build provenance.
+
+---
+
+## Decision
+
+Use **semantic versioning** (`vMAJOR.MINOR.PATCH`) with a GitHub Actions release workflow triggered by git tags.
+
+### Version Scheme
+
+| Component | Meaning | Example |
+|---|---|---|
+| `MAJOR` | Vertical slice milestone | `1` = VS1 Make & Break to 10 |
+| `MINOR` | Feature addition within a milestone | `1` = new problem type added |
+| `PATCH` | Bug fix or polish within a minor | `1` = ten-frame layout fix |
+
+- `CFBundleShortVersionString` (`MARKETING_VERSION`) = `MAJOR.MINOR.PATCH` from the git tag
+- `CFBundleVersion` (`CURRENT_PROJECT_VERSION`) = `GITHUB_RUN_NUMBER` (monotonically increasing integer)
+- Local development builds default to `0.1.0-dev` (defined in `project.yml`)
+
+### Tagging Convention
+
+```bash
+git tag v1.0.0 -m "VS1 Make & Break to 10 — first real-child pilot release"
+git push origin v1.0.0
+```
+
+This triggers `.github/workflows/release.yml`, which:
+1. Stamps `Info.plist` with the version from the tag
+2. Builds an `.xcarchive` targeting the iOS Simulator (no code signing required)
+3. Compresses the archive and attaches it to a GitHub Release
+
+### Why Simulator Archive (Not IPA)
+
+Full IPA export (`xcodebuild -exportArchive`) requires a development certificate and provisioning profile. These are device-specific credentials that cannot be stored in CI without significant setup (Fastlane match, or manual secrets management). Since sideloading is done from the developer's machine via Xcode, the GitHub Release serves as a **source-of-truth marker** — the developer checks out the tag and deploys from Xcode, knowing exactly which code version is on the device.
+
+IPA export can be added later if a paid Apple Developer account and CI-safe certificate management is set up.
+
+### First Release Target
+
+`v1.0.0` — when VS1 polish issues (#44–#49) are all closed.
+
+---
+
+## Consequences
+
+**Positive**:
+- Every build running on the test iPad has a traceable version string in Settings → General → About
+- Telemetry JSONL exports include `appVersion` in `session_start` events — correlating session data with code versions becomes possible
+- GitHub Releases provide a changelog anchor point per milestone
+
+**Negative / Limitations**:
+- The CI archive targets the Simulator (not a real device) — it validates that the build compiles and archives, but the actual device deployment is still manual from Xcode
+- No IPA attached to the release until certificate management is set up
+
+**Neutral**:
+- `project.yml` `MARKETING_VERSION` is overridden at tag time; local builds show `0.1.0-dev`
+- The release workflow does not run on pushes to `main` — it is tag-only


### PR DESCRIPTION
## Summary

Closes #44.

- Adds `.github/workflows/release.yml` — tag-triggered (`v*.*.*`) workflow that stamps `Info.plist` with the semver version, builds an `.xcarchive` for the iOS Simulator, and publishes a GitHub Release with the archive attached
- Adds `wiki/ADRs/ADR-0003-release-workflow.md` — documents the versioning scheme, tagging convention, and why IPA export is deferred
- Updates `project.yml` — `MARKETING_VERSION` changed to `0.1.0-dev` for local builds with a comment explaining the release override

## Versioning scheme (ADR-0003)

| Tag | `CFBundleShortVersionString` | Meaning |
|---|---|---|
| `v1.0.0` | `1.0.0` | VS1 first pilot release |
| `v1.1.0` | `1.1.0` | Feature addition within VS1 |
| `v1.0.1` | `1.0.1` | Bug fix / polish |

`CFBundleVersion` = `GITHUB_RUN_NUMBER` (monotonically increasing).

## Why Simulator archive, not IPA

Full IPA export requires a signing cert + provisioning profile in CI. Since sideloading is done from the developer's Xcode directly, the GitHub Release is a **source-of-truth marker** — check out the tag, deploy from Xcode. IPA export can follow once CI certificate management is configured.

## Test plan

- [ ] CI (build + unit + UI tests) passes on this PR
- [ ] Manually push a test tag `v0.1.0` and verify the release workflow triggers and creates a GitHub Release
- [ ] Confirm `CFBundleShortVersionString` in the archive matches the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)