### PR TITLE
fix: 5 iPhone layout issues from CI UX review

### DIFF
--- a/Features/VerticalSlice1/ConcreteBuildView.swift
+++ b/Features/VerticalSlice1/ConcreteBuildView.swift
@@ -49,7 +49,7 @@ struct ConcreteBuildView: View {
                     Text("+")
                         .font(.system(size: 32, weight: .bold, design: .rounded))
                         .foregroundStyle(.secondary)
-                    Text("\(target - concreteCount)")
+                    Text(concreteCount > 0 ? "\(target - concreteCount)" : "?")
                         .font(.system(size: 44, weight: .black, design: .rounded))
                         .foregroundStyle(MatherTheme.accent)
                         .contentTransition(.numericText())

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -74,6 +74,7 @@ struct HomeView: View {
                                 .font(.system(size: 36, weight: .black, design: .rounded))
                                 .foregroundStyle(.white)
                         }
+                        .layoutPriority(1)
 
                         Spacer()
                     }
@@ -97,6 +98,7 @@ struct HomeView: View {
                         Text("Tap to start a session")
                             .font(.headline.weight(.bold))
                             .foregroundStyle(MatherTheme.ink)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                     Spacer()
                     Image(systemName: "play.circle.fill")

--- a/Features/VerticalSlice1/SessionConfigView.swift
+++ b/Features/VerticalSlice1/SessionConfigView.swift
@@ -44,8 +44,6 @@ struct SessionConfigView: View {
                     appModel.engine.showHome()
                 }
                 .font(.headline.weight(.semibold))
-
-                Spacer()
             }
             .padding(24)
         }

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -13,18 +13,25 @@ struct SliceSessionView: View {
             )
             .ignoresSafeArea()
 
-            ScrollView {
-                VStack(spacing: 20) {
-                    header
-                    FeedbackBannerView(message: appModel.engine.feedbackMessage, isCelebrating: appModel.engine.showCelebration)
+            VStack(spacing: 0) {
+                header
+                    .padding(.horizontal, 20)
+                    .padding(.top, 20)
 
-                    if let currentProblem = appModel.engine.currentProblem {
-                        stageView(for: currentProblem)
-                    } else {
-                        CardSurface { Text("No problem loaded.") }
+                ScrollView {
+                    VStack(spacing: 20) {
+                        FeedbackBannerView(message: appModel.engine.feedbackMessage, isCelebrating: appModel.engine.showCelebration)
+
+                        if let currentProblem = appModel.engine.currentProblem {
+                            stageView(for: currentProblem)
+                        } else {
+                            CardSurface { Text("No problem loaded.") }
+                        }
                     }
+                    .padding(.horizontal, 20)
+                    .padding(.top, 12)
+                    .padding(.bottom, 20)
                 }
-                .padding(20)
             }
 
             // Fullscreen celebration overlay — appears on every correct stage answer.
@@ -73,6 +80,8 @@ struct SliceSessionView: View {
                         Text(appModel.engine.currentStage.title)
                             .font(.system(size: 28, weight: .black, design: .rounded))
                             .foregroundStyle(stageColour(appModel.engine.currentStage))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
                     }
                     Spacer()
                     Button {
@@ -81,7 +90,7 @@ struct SliceSessionView: View {
                         Image(systemName: appModel.featureFlags.audioEnabled ? "speaker.wave.2.fill" : "speaker.slash.fill")
                             .font(.title2.weight(.bold))
                             .foregroundStyle(appModel.featureFlags.audioEnabled ? MatherTheme.softBlue : .secondary)
-                            .frame(width: 52, height: 52)
+                            .frame(width: 44, height: 44)
                             .background(MatherTheme.softBlue.opacity(0.18))
                             .clipShape(Circle())
                     }
@@ -91,7 +100,7 @@ struct SliceSessionView: View {
                         Image(systemName: "arrow.counterclockwise.circle.fill")
                             .font(.title2.weight(.bold))
                             .foregroundStyle(MatherTheme.warm)
-                            .frame(width: 52, height: 52)
+                            .frame(width: 44, height: 44)
                             .background(MatherTheme.warm.opacity(0.18))
                             .clipShape(Circle())
                     }
@@ -102,7 +111,7 @@ struct SliceSessionView: View {
                         Image(systemName: "house.circle.fill")
                             .font(.title2.weight(.bold))
                             .foregroundStyle(.secondary)
-                            .frame(width: 52, height: 52)
+                            .frame(width: 44, height: 44)
                             .background(Color.secondary.opacity(0.12))
                             .clipShape(Circle())
                     }


### PR DESCRIPTION
Closes #53

## Changes

Five targeted fixes from the CI video UX review (run #79, iPhone 16 simulator).

### 1 + 2 — Session header pinned & title no longer wraps (`SliceSessionView`)
- Moved `header` **outside** the `ScrollView` into a pinned `VStack`. The header (problem counter, progress bar, audio/replay/home buttons) is now always visible even after the feedback banner causes a scroll.
- Reduced the three icon buttons **52 → 44 pt** (still above Apple HIG minimum for adult-only controls).
- Added `.lineLimit(1).minimumScaleFactor(0.75)` to the stage title so "Make it" scales down before wrapping on narrow widths.

### 3 — Hero card text no longer truncates (`HomeView`)
- Added `.layoutPriority(1)` to the text `VStack` inside the gradient hero strip so SwiftUI allocates space to the text before the `Spacer`, preventing "Make..." / "to..." truncation.
- Added `.fixedSize(horizontal: false, vertical: true)` to the CTA subtitle so it wraps rather than truncates.

### 4 — Session config centered on iPhone (`SessionConfigView`)
- Removed the bottom `Spacer()`. The `ZStack` now centers the card/button group vertically, filling the screen more naturally on iPhone instead of leaving a large empty area below.

### 5 — Number bond initial state (`ConcreteBuildView`)
- Changed the complement display to show `"?"` when `concreteCount == 0`. The child now sees `0 + ? = 6` on load, inviting discovery rather than revealing the answer before they have done any work. Switches to the live numeral on the first tap.

## Test plan
- [ ] CI green on iPhone 16 simulator
- [ ] Stage title "Make it" fits on one line in session header screenshots
- [ ] Session header visible in ConcreteBuild-FailureFeedback screenshot (not scrolled off)
- [ ] HomeView hero card shows "Make & Break / to 10" without truncation
- [ ] SessionConfigView card is vertically centered (no black/empty lower half)
- [ ] ConcreteBuild-Initial screenshot shows "0 + ? = 6"

🤖 Generated with [Claude Code](https://claude.com/claude-code)