### PR TITLE
fix(tests): increase async sleep and scroll for Xcode Cloud compatibility

### DIFF
--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -23,11 +23,11 @@ struct VerticalSliceEngineTests {
 
         engine.adjustConcrete(by: engine.currentProblem?.target ?? 0)
         engine.submitCurrentStage()
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(for: .milliseconds(200))
         #expect(engine.currentStage == .pictorial)
 
         engine.submitCurrentStage()
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(for: .milliseconds(200))
         #expect(engine.currentStage == .abstract)
     }
 
@@ -79,16 +79,16 @@ struct VerticalSliceEngineTests {
         // stage-advance Task (which runs after celebrationDuration: 0) can fire.
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()    // concrete → pictorial (stageSuccess)
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(for: .milliseconds(200))
         engine.submitCurrentStage()    // pictorial → abstract (stageSuccess)
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(for: .milliseconds(200))
         engine.equationLeftInput = String(problem.decompositionA)
         engine.equationRightInput = String(problem.decompositionB)
         engine.submitCurrentStage()    // abstract → transfer (stageSuccess)
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(for: .milliseconds(200))
         engine.adjustTransfer(by: problem.target)
         engine.submitCurrentStage()    // transfer → done (success — problem complete)
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(for: .milliseconds(200))
 
         #expect(haptics.successFiredCount == 1)
         #expect(haptics.stageSuccessFiredCount == 3)
@@ -163,9 +163,9 @@ struct VerticalSliceEngineTests {
         // Advance to abstract stage — await after each submit so the stage-advance Task fires.
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage() // → pictorial
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(for: .milliseconds(200))
         engine.submitCurrentStage() // → abstract
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(for: .milliseconds(200))
 
         #expect(engine.currentStage == .abstract)
 
@@ -176,7 +176,7 @@ struct VerticalSliceEngineTests {
         engine.equationLeftInput = String(altLeft)
         engine.equationRightInput = String(altRight)
         engine.submitCurrentStage()
-        try await Task.sleep(for: .milliseconds(10))
+        try await Task.sleep(for: .milliseconds(200))
 
         // Should advance past abstract regardless of which valid decomposition was entered
         #expect(engine.currentStage != .abstract)

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -110,7 +110,11 @@ final class ScreenshotTests: XCTestCase {
         // Fill to correct target by tapping the last counter cell (index 9).
         // The engine clamps the count to the problem target, so tapping cell 9
         // always reaches the target regardless of what it is (6–10).
+        // Scroll down first — on compact/small simulators the second grid row can be off-screen.
         let lastCell = app.otherElements["counter-cell-9"]
+        if !lastCell.waitForExistence(timeout: 3) {
+            app.scrollViews.firstMatch.swipeUp()
+        }
         _ = lastCell.waitForExistence(timeout: 5)
         lastCell.tap()
         submitButton.tap()
@@ -178,8 +182,12 @@ final class ScreenshotTests: XCTestCase {
         _ = app.staticTexts.element(matching: makePredicate).waitForExistence(timeout: 15)
         snapshot(app, "iPhone-ConcreteBuild-AdaptiveGrid")
 
-        // Fill to correct target and submit to reach pictorial stage
+        // Fill to correct target and submit to reach pictorial stage.
+        // Scroll down first — on compact/small simulators the second grid row can be off-screen.
         let lastCell = app.otherElements["counter-cell-9"]
+        if !lastCell.waitForExistence(timeout: 3) {
+            app.scrollViews.firstMatch.swipeUp()
+        }
         _ = lastCell.waitForExistence(timeout: 5)
         lastCell.tap()
 


### PR DESCRIPTION
## Summary

- **Unit tests**: `Task.sleep(.milliseconds(10))` → `.milliseconds(200)` — Xcode Cloud's build infrastructure is slower than GitHub Actions; the stage-advance `Task` (even with `celebrationDuration: 0`) wasn't completing within 10ms, causing 3 async engine tests to fail
- **UI tests**: Add scroll-before-tap for `counter-cell-9` — on compact simulators used by Xcode Cloud, the second row of the `LazyVGrid` ten-frame is off-screen; `LazyVGrid` doesn't render off-screen cells so the element didn't exist at query time

## Test plan
- [ ] CI green on this PR
- [ ] Xcode Cloud build passes all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)