### PR TITLE
fix(xcode-cloud): stamp MARKETING_VERSION from git tag before archive

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
-# Xcode Cloud post-clone hook — regenerates the Xcode project from project.yml.
-# Xcode Cloud reads the committed .xcodeproj at workflow-setup time but runs this
-# script after cloning before building, so the generated project is always current.
+# Xcode Cloud post-clone hook — regenerates the Xcode project from project.yml
+# and stamps MARKETING_VERSION from the git tag when triggered by a tag push.
+#
+# Environment variables provided by Xcode Cloud:
+#   CI_TAG          — set when triggered by a tag (e.g. "v0.1.2"), empty otherwise
+#   CI_BUILD_NUMBER — monotonically increasing build number (used for CFBundleVersion)
 #
 # See: https://developer.apple.com/documentation/xcode/writing-custom-build-scripts
 
@@ -9,6 +12,18 @@ set -e
 
 echo "--- ci_post_clone: installing XcodeGen ---"
 brew install xcodegen
+
+# Stamp MARKETING_VERSION from the git tag so Apple accepts the archive.
+# project.yml ships with "0.1.0-dev" as a dev placeholder; release builds
+# must use a clean semver string like "0.1.2" (no -dev suffix).
+if [ -n "${CI_TAG:-}" ]; then
+  VERSION="${CI_TAG#v}"   # strip leading "v": v0.1.2 → 0.1.2
+  echo "--- ci_post_clone: stamping MARKETING_VERSION=${VERSION} from tag ${CI_TAG} ---"
+  sed -i '' "s/MARKETING_VERSION: .*/MARKETING_VERSION: ${VERSION}/" \
+    "$CI_PRIMARY_REPOSITORY_PATH/project.yml"
+else
+  echo "--- ci_post_clone: no tag — keeping MARKETING_VERSION as-is (dev build) ---"
+fi
 
 echo "--- ci_post_clone: regenerating Mather.xcodeproj ---"
 cd "$CI_PRIMARY_REPOSITORY_PATH"


### PR DESCRIPTION
## Summary

Xcode Cloud was failing the Archive action with:
> '0.1.0-dev' is not a valid value for cfBundleShortVersionString

The `project.yml` ships with `MARKETING_VERSION: 0.1.0-dev` as a dev placeholder. Xcode Cloud doesn't know about the git tag, so it was archiving with the raw `-dev` string which Apple rejects.

The `ci_post_clone.sh` hook now:
1. Checks `CI_TAG` (set by Xcode Cloud on tag-triggered builds, e.g. `v0.1.2`)
2. Strips the `v` prefix → `0.1.2`
3. Patches `project.yml` with `sed` before `xcodegen generate`

Branch/PR builds (no `CI_TAG`) keep the `0.1.0-dev` placeholder unchanged.

## Test plan
- [ ] CI green on this PR
- [ ] Merge → tag `v0.1.3` → Xcode Cloud Archive succeeds and TestFlight build appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)