### PR TITLE
fix(ux): inline clear button in Write It entry cards

### DIFF
--- a/Features/VerticalSlice1/EquationResolveView.swift
+++ b/Features/VerticalSlice1/EquationResolveView.swift
@@ -54,13 +54,6 @@ struct EquationResolveView: View {
                     }
                 }
 
-                HStack(spacing: 16) {
-                    Button("Clear left") { onClear(.left) }
-                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.6)))
-                    Button("Clear right") { onClear(.right) }
-                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.6)))
-                }
-
                 Button("Check equation") {
                     onSubmit()
                 }
@@ -76,11 +69,25 @@ struct EquationResolveView: View {
             VStack(spacing: 8) {
                 Text(title)
                     .font(.headline)
-                Text(value.isEmpty ? "?" : value)
-                    .font(.system(size: 40, weight: .black, design: .rounded))
-                    .frame(maxWidth: .infinity, minHeight: 84)
-                    .background(selectedSide == side ? MatherTheme.accent.opacity(0.18) : MatherTheme.softBlue.opacity(0.25))
-                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                ZStack(alignment: .topTrailing) {
+                    Text(value.isEmpty ? "?" : value)
+                        .font(.system(size: 40, weight: .black, design: .rounded))
+                        .frame(maxWidth: .infinity, minHeight: 84)
+                        .background(selectedSide == side ? MatherTheme.accent.opacity(0.18) : MatherTheme.softBlue.opacity(0.25))
+                        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                    // Inline clear — always reachable, no scrolling needed
+                    if !value.isEmpty {
+                        Button {
+                            onClear(side)
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(.secondary)
+                                .font(.title3)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(8)
+                    }
+                }
             }
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
Fixes #73

## Problem
"Clear left" / "Clear right" buttons sat at the bottom of the screen below the number grid. On compact devices this required scrolling to reach them — poor accessibility for a 5-year-old.

## Fix
- Removed the bottom `HStack` with "Clear left" / "Clear right" buttons
- Added a small `xmark.circle.fill` icon overlaid in the top-right corner of each entry card value area, shown only when the field is non-empty
- Clear is now always immediately visible and reachable without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)