### PR TITLE
fix: surface multiple saved sessions in parent history

### DIFF
--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -9,7 +9,9 @@ struct MatherApp: App {
     init() {
         do {
             container = try ModelContainer(for: StoredSessionSummary.self)
-            _appModel = State(initialValue: AppModel(modelContext: container.mainContext))
+            let appModel = AppModel(modelContext: container.mainContext)
+            Self.seedSessionHistoryIfRequested(using: appModel)
+            _appModel = State(initialValue: appModel)
         } catch {
             fatalError("Failed to create model container: \(error)")
         }
@@ -19,6 +21,35 @@ struct MatherApp: App {
         WindowGroup {
             RootView(appModel: appModel)
                 .modelContainer(container)
+        }
+    }
+}
+
+private extension MatherApp {
+    static func seedSessionHistoryIfRequested(using appModel: AppModel) {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let flagIndex = arguments.firstIndex(of: "-uiTest.seedHistory"),
+              arguments.indices.contains(flagIndex + 1),
+              let requestedCount = Int(arguments[flagIndex + 1]) else { return }
+
+        appModel.historyStore.clearAll()
+
+        for index in 0..<max(requestedCount, 0) {
+            let startedAt = Date.now.addingTimeInterval(TimeInterval(-index * 3_600))
+            let sessionId = "ui-test-seeded-\(index)"
+            let draft = SessionSummaryDraft(
+                sessionId: sessionId,
+                startedAt: startedAt,
+                endedAt: startedAt.addingTimeInterval(300),
+                objectiveTitle: "Make & Break to 10",
+                problemsCompleted: 4 + index,
+                firstAttemptAccuracy: index == 0 ? 0.75 : 0.5,
+                transferCorrectCount: 2 + (index % 2),
+                medianLatencyMs: 90_000 + (index * 15_000),
+                nextTargetHint: "UI test seeded session history.",
+                exportFileName: "session-\(sessionId).jsonl"
+            )
+            appModel.historyStore.save(draft)
         }
     }
 }

--- a/Features/ParentSummary/ParentSummaryView.swift
+++ b/Features/ParentSummary/ParentSummaryView.swift
@@ -7,11 +7,12 @@ struct ParentSummaryView: View {
 
     var body: some View {
         let digest = appModel.telemetryWriter.digest(from: summaries)
+        let recentSummaries = Array(summaries.prefix(5))
 
         ZStack {
             MatherTheme.background.ignoresSafeArea()
             ScrollView {
-                VStack(spacing: 20) {
+                VStack(spacing: 16) {
                     CardSurface {
                         VStack(alignment: .leading, spacing: 8) {
                             Text("Parent Summary")
@@ -71,29 +72,18 @@ struct ParentSummaryView: View {
                         }
 
                         CardSurface {
-                            HStack(alignment: .top, spacing: 12) {
-                                Image(systemName: "lightbulb.fill")
-                                    .foregroundStyle(MatherTheme.warm)
-                                    .font(.title3)
-                                Text(digest.nextTargetHint)
+                            VStack(alignment: .leading, spacing: 10) {
+                                Text("Recent sessions")
+                                    .font(.title3.weight(.bold))
+                                Text(historyCaption(totalCount: summaries.count, visibleCount: recentSummaries.count))
                                     .font(.subheadline.weight(.medium))
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
-                        }
-                    }
-
-                    CardSurface {
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text("Recent sessions")
-                                .font(.title3.weight(.bold))
-                            if summaries.isEmpty {
-                                Text("No history yet. Run a session to start.")
-                                    .font(.subheadline)
                                     .foregroundStyle(.secondary)
-                            } else {
-                                ForEach(Array(summaries.prefix(5))) { summary in
+                                ForEach(Array(recentSummaries.enumerated()), id: \.element.sessionId) { index, summary in
                                     HStack {
                                         VStack(alignment: .leading, spacing: 4) {
+                                            Text("Session \(index + 1)")
+                                                .font(.caption.weight(.bold))
+                                                .foregroundStyle(MatherTheme.accent)
                                             Text(summary.startedAt.formatted(date: .abbreviated, time: .shortened))
                                                 .font(.subheadline.weight(.semibold))
                                             Text("\(summary.problemsCompleted) problems · \(Int(summary.firstAttemptAccuracy * 100))% first try")
@@ -111,10 +101,23 @@ struct ParentSummaryView: View {
                                                 .clipShape(Capsule())
                                         }
                                     }
-                                    .padding(12)
+                                    .padding(10)
                                     .background(summary.sessionId == summaries.first?.sessionId ? MatherTheme.warm.opacity(0.2) : Color.secondary.opacity(0.06))
                                     .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                                    .accessibilityElement(children: .combine)
+                                    .accessibilityIdentifier("parent-summary-session-\(index)")
                                 }
+                            }
+                        }
+
+                        CardSurface {
+                            HStack(alignment: .top, spacing: 12) {
+                                Image(systemName: "lightbulb.fill")
+                                    .foregroundStyle(MatherTheme.warm)
+                                    .font(.title3)
+                                Text(digest.nextTargetHint)
+                                    .font(.subheadline.weight(.medium))
+                                    .fixedSize(horizontal: false, vertical: true)
                             }
                         }
                     }
@@ -141,6 +144,14 @@ struct ParentSummaryView: View {
         let seconds = ms / 1000
         return seconds < 60 ? "\(seconds)s" : "\(seconds / 60)m \(seconds % 60)s"
     }
+
+    private func historyCaption(totalCount: Int, visibleCount: Int) -> String {
+        guard totalCount > 0 else { return "No saved sessions yet." }
+        if totalCount == visibleCount {
+            return "\(totalCount) saved locally"
+        }
+        return "Showing latest \(visibleCount) of \(totalCount) saved locally"
+    }
 }
 
 private struct StatTile: View {
@@ -162,7 +173,7 @@ private struct StatTile: View {
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 16)
+        .padding(.vertical, 12)
         .background(color.opacity(0.1))
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
     }

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -90,9 +90,15 @@ struct SettingsView: View {
                         VStack(alignment: .leading, spacing: 12) {
                             Text("Session history")
                                 .font(.title2.weight(.bold))
-                            ForEach(summaries.prefix(8)) { summary in
+                            Text("\(summaries.count) saved locally")
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(.secondary)
+                            ForEach(Array(summaries.prefix(8).enumerated()), id: \.element.sessionId) { index, summary in
                                 HStack {
                                     VStack(alignment: .leading) {
+                                        Text("Session \(index + 1)")
+                                            .font(.caption.weight(.bold))
+                                            .foregroundStyle(MatherTheme.accent)
                                         Text(summary.startedAt.formatted(date: .abbreviated, time: .shortened))
                                         Text("Accuracy \(Int(summary.firstAttemptAccuracy * 100))%")
                                             .foregroundStyle(.secondary)
@@ -103,6 +109,8 @@ struct SettingsView: View {
                                         .foregroundStyle(.secondary)
                                 }
                                 .padding(.vertical, 4)
+                                .accessibilityElement(children: .combine)
+                                .accessibilityIdentifier("settings-history-session-\(index)")
                             }
                             if summaries.isEmpty {
                                 Text("No history yet.")

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -153,6 +153,27 @@ final class ScreenshotTests: XCTestCase {
         snapshot(app, "Settings-AfterCancelClear")
     }
 
+    func testSessionHistoryShowsMultipleSavedSessionsInParentSummaryAndSettings() {
+        let app = launchWithSeededHistory(count: 2)
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
+
+        app.buttons["Parent Summary"].tap()
+        _ = app.staticTexts["Parent Summary"].waitForExistence(timeout: 10)
+        XCTAssertTrue(app.staticTexts["2 saved locally"].waitForExistence(timeout: 5))
+
+        let parentSecond = app.staticTexts["Session 2"].firstMatch
+        XCTAssertTrue(parentSecond.waitForExistence(timeout: 5))
+        XCTAssertTrue(parentSecond.isHittable)
+
+        app.buttons["Settings"].tap()
+        _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
+        XCTAssertTrue(app.staticTexts["2 saved locally"].waitForExistence(timeout: 5))
+
+        let settingsSecond = app.staticTexts["Session 2"].firstMatch
+        XCTAssertTrue(settingsSecond.waitForExistence(timeout: 5))
+        XCTAssertTrue(settingsSecond.isHittable)
+    }
+
     // MARK: - iPhone layout / pilot runbook
 
     /// Verifies the full session flow renders without crash and screenshots the
@@ -259,6 +280,19 @@ final class ScreenshotTests: XCTestCase {
             "-feature.hapticsEnabled", "YES",
             "-feature.testModeEnabled", "YES",
             "-feature.verticalSlice1Enabled", "YES"
+        ]
+        app.launch()
+        return app
+    }
+
+    private func launchWithSeededHistory(count: Int) -> XCUIApplication {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.testModeEnabled", "YES",
+            "-uiTest.seedHistory", "\(count)"
         ]
         app.launch()
         return app


### PR DESCRIPTION
## Summary
- seed deterministic session history for UI verification
- move recent sessions higher and make counts explicit in parent surfaces
- add a regression test that proves two saved sessions appear in Parent Summary and Settings

Closes #81