### PR TITLE
feat(theme): SliceTheme protocol + CounterKind + ClassicTheme (#91)

### DIFF
--- a/Domain/ClassicTheme.swift
+++ b/Domain/ClassicTheme.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// The default theme — reproduces every hardcoded string and circle counter
+/// from the original engine. Behaviour is unchanged when ClassicTheme is active.
+struct ClassicTheme: SliceTheme {
+    var counterKind: CounterKind { .circle }
+    var celebrationEmoji: String { "⭐️" }
+
+    func concretePrompt(target: Int) -> String {
+        "Make \(target) with the counters."
+    }
+
+    func pictorialPrompt(target: Int) -> String {
+        "Break \(target) into two groups."
+    }
+
+    func abstractPrompt() -> String {
+        "Type the same split as an equation."
+    }
+
+    func transferPrompt(decompositionA: Int, decompositionB: Int) -> String {
+        "Show the same equation with counters again. Put \(decompositionA) on the left and \(decompositionB) on the right."
+    }
+
+    func stageSuccessPhrase(for stage: SliceStage, target: Int) -> String {
+        switch stage {
+        case .concrete:  return "Yes. You made \(target)."
+        case .pictorial: return "That break still makes \(target)."
+        case .abstract:  return "Your equation matches the split."
+        case .transfer:  return "You matched the same equation with counters."
+        case .done:      return "Problem complete."
+        }
+    }
+
+    func sessionIntroPhrase() -> String {
+        "Let's make and break numbers to ten."
+    }
+
+    func sessionEndPhrase() -> String {
+        "Session complete. Great job showing the same number in different ways."
+    }
+
+    func sessionStartFeedback() -> String {
+        "Make the target number with the big counters."
+    }
+}

--- a/Domain/SliceTheme.swift
+++ b/Domain/SliceTheme.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Describes how a counter cell is rendered — shape or SF Symbol.
+enum CounterKind: Equatable {
+    case circle
+    case vehicle(symbolName: String)
+}
+
+/// A theme controls the vocabulary and counter appearance for a VS1 session.
+/// It is a pure value type: no state, no observation, no actor isolation.
+/// The engine freezes the active theme at `startSession()` and holds it for the
+/// duration of the session — themes never change mid-session.
+protocol SliceTheme {
+    /// How counter cells are rendered in the concrete, split, and transfer views.
+    var counterKind: CounterKind { get }
+
+    /// Emoji shown in the fullscreen celebration overlay on a correct stage answer.
+    var celebrationEmoji: String { get }
+
+    // MARK: - Stage prompts (spoken by SpeechService)
+
+    func concretePrompt(target: Int) -> String
+    func pictorialPrompt(target: Int) -> String
+    func abstractPrompt() -> String
+    func transferPrompt(decompositionA: Int, decompositionB: Int) -> String
+
+    // MARK: - Success messages
+
+    /// Spoken when the child completes a stage correctly.
+    func stageSuccessPhrase(for stage: SliceStage, target: Int) -> String
+
+    // MARK: - Session lifecycle phrases
+
+    func sessionIntroPhrase() -> String
+    func sessionEndPhrase() -> String
+    /// Shown as `feedbackMessage` at the start of a session (before first prompt).
+    func sessionStartFeedback() -> String
+}

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -42,12 +42,16 @@ final class VerticalSliceEngine {
     private let saveSummary: (SessionSummaryDraft) -> Void
     // Injected so unit tests can pass 0 to skip the animation delay.
     let celebrationDuration: TimeInterval
+    // Frozen at startSession(); never changes mid-session.
+    // Unit tests can inject any SliceTheme to verify prompt routing.
+    private(set) var activeTheme: any SliceTheme
 
     init(
         featureFlags: FeatureFlagService,
         telemetryWriter: TelemetryWriter,
         speechService: SpeechService,
         hapticsService: HapticsService = HapticsService(),
+        activeTheme: any SliceTheme = ClassicTheme(),
         celebrationDuration: TimeInterval = 1.5,
         saveSummary: @escaping (SessionSummaryDraft) -> Void
     ) {
@@ -55,6 +59,7 @@ final class VerticalSliceEngine {
         self.telemetryWriter = telemetryWriter
         self.speechService = speechService
         self.hapticsService = hapticsService
+        self.activeTheme = activeTheme
         self.celebrationDuration = celebrationDuration
         self.saveSummary = saveSummary
     }

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import Mather
+
+struct ThemeTests {
+
+    // MARK: - ClassicTheme
+
+    @Test func classicThemeCounterKindIsCircle() {
+        let theme = ClassicTheme()
+        #expect(theme.counterKind == .circle)
+    }
+
+    @Test func classicThemeCelebrationEmoji() {
+        #expect(ClassicTheme().celebrationEmoji == "⭐️")
+    }
+
+    @Test func classicThemeConcretePrompt() {
+        #expect(ClassicTheme().concretePrompt(target: 7) == "Make 7 with the counters.")
+    }
+
+    @Test func classicThemePictorialPrompt() {
+        #expect(ClassicTheme().pictorialPrompt(target: 5) == "Break 5 into two groups.")
+    }
+
+    @Test func classicThemeAbstractPrompt() {
+        #expect(ClassicTheme().abstractPrompt() == "Type the same split as an equation.")
+    }
+
+    @Test func classicThemeTransferPrompt() {
+        let prompt = ClassicTheme().transferPrompt(decompositionA: 3, decompositionB: 4)
+        #expect(prompt.contains("3"))
+        #expect(prompt.contains("4"))
+    }
+
+    @Test func classicThemeStageSuccessPhrases() {
+        let theme = ClassicTheme()
+        #expect(theme.stageSuccessPhrase(for: .concrete, target: 6) == "Yes. You made 6.")
+        #expect(theme.stageSuccessPhrase(for: .pictorial, target: 8) == "That break still makes 8.")
+        #expect(theme.stageSuccessPhrase(for: .abstract, target: 5) == "Your equation matches the split.")
+        #expect(theme.stageSuccessPhrase(for: .transfer, target: 7) == "You matched the same equation with counters.")
+    }
+
+    @Test func classicThemeSessionPhrases() {
+        let theme = ClassicTheme()
+        #expect(theme.sessionIntroPhrase() == "Let's make and break numbers to ten.")
+        #expect(!theme.sessionEndPhrase().isEmpty)
+        #expect(!theme.sessionStartFeedback().isEmpty)
+    }
+
+    // MARK: - Engine default theme
+
+    @MainActor
+    @Test func engineDefaultThemeIsClassic() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        // ClassicTheme returns .circle
+        if case .circle = engine.activeTheme.counterKind { } else {
+            Issue.record("Expected .circle counter kind from default theme")
+        }
+        #expect(engine.activeTheme.celebrationEmoji == "⭐️")
+    }
+
+    @MainActor
+    @Test func engineAcceptsInjectedTheme() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            activeTheme: ClassicTheme(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        #expect(engine.activeTheme.celebrationEmoji == "⭐️")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SliceTheme` protocol (pure value type) with `CounterKind` enum in `Domain/SliceTheme.swift`
- Adds `ClassicTheme` struct in `Domain/ClassicTheme.swift` — reproduces all current hardcoded engine strings exactly (zero behaviour change)
- Wires `activeTheme: any SliceTheme` into `VerticalSliceEngine` as a stored property injected at `init` time (defaults to `ClassicTheme()`, no existing call-sites broken)
- Adds `ThemeTests.swift` with 10 unit tests covering protocol prompts, emoji, counter kind, and engine injection

## Test plan
- [ ] All existing `VerticalSliceEngineTests` pass unchanged
- [ ] New `ThemeTests` pass (ClassicTheme prompt strings, engine default theme, injected theme)
- [ ] CI green on this branch

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)