### PR TITLE
feat(theme): wire theme vocabulary through engine speech prompts (#92)

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -106,13 +106,13 @@ final class VerticalSliceEngine {
         equationRightInput = ""
         transferLeftCount = 0
         transferRightCount = 0
-        feedbackMessage = "Make the target number with the big counters."
+        feedbackMessage = activeTheme.sessionStartFeedback()
         showCelebration = false
         completedSummary = nil
         sessionStartedAt = .now
         problemStartedAt = .now
         speechService.resetSession()
-        speechService.speakSessionIntroIfNeeded()
+        speechService.speakSessionIntro(activeTheme.sessionIntroPhrase())
 
         do {
             try telemetryWriter.beginSession(sessionId: currentSession.sessionId, featureFlags: featureFlags)
@@ -319,7 +319,7 @@ final class VerticalSliceEngine {
         )
         saveSummary(summary)
         completedSummary = summary
-        feedbackMessage = "Session complete. Great job showing the same number in different ways."
+        feedbackMessage = activeTheme.sessionEndPhrase()
         route = .sessionSummary
     }
 
@@ -447,31 +447,23 @@ final class VerticalSliceEngine {
         guard let currentProblem else { return "Start a session to play." }
         switch currentStage {
         case .concrete:
-            return "Make \(currentProblem.target) with the counters."
+            return activeTheme.concretePrompt(target: currentProblem.target)
         case .pictorial:
-            return "Break \(currentProblem.target) into two groups."
+            return activeTheme.pictorialPrompt(target: currentProblem.target)
         case .abstract:
-            return "Type the same split as an equation."
+            return activeTheme.abstractPrompt()
         case .transfer:
-            return "Show the same equation with counters again. Put \(currentProblem.decompositionA) on the left and \(currentProblem.decompositionB) on the right."
+            return activeTheme.transferPrompt(
+                decompositionA: currentProblem.decompositionA,
+                decompositionB: currentProblem.decompositionB
+            )
         case .done:
             return "Nice work."
         }
     }
 
     private func successMessage(for stage: SliceStage, problem: SliceProblem) -> String {
-        switch stage {
-        case .concrete:
-            return "Yes. You made \(problem.target)."
-        case .pictorial:
-            return "That break still makes \(problem.target)."
-        case .abstract:
-            return "Your equation matches the split."
-        case .transfer:
-            return "You matched the same equation with counters."
-        case .done:
-            return "Problem complete."
-        }
+        activeTheme.stageSuccessPhrase(for: stage, target: problem.target)
     }
 
     private func feedbackMessageForFailure(stage: SliceStage, problem: SliceProblem) -> String {

--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -21,10 +21,10 @@ final class SpeechService {
     // Always speaks the session intro regardless of the audio toggle — the child
     // should always hear a spoken start cue. The parent's mute toggle applies to
     // in-session prompts only (via speak(_:enabled:)).
-    func speakSessionIntroIfNeeded() {
+    func speakSessionIntro(_ phrase: String) {
         guard !hasSpokenSessionIntro else { return }
         hasSpokenSessionIntro = true
-        speak("Let's make and break numbers to ten.", enabled: true)
+        speak(phrase, enabled: true)
     }
 
     func resetSession() {

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -2,6 +2,23 @@ import Foundation
 import Testing
 @testable import Mather
 
+// MARK: - Test helpers
+
+private struct RocketTheme: SliceTheme {
+    var counterKind: CounterKind { .circle }
+    var celebrationEmoji: String { "🚀" }
+    func concretePrompt(target: Int) -> String { "Launch \(target) rockets." }
+    func pictorialPrompt(target: Int) -> String { "Split the rockets into two pads." }
+    func abstractPrompt() -> String { "Type the rocket equation." }
+    func transferPrompt(decompositionA: Int, decompositionB: Int) -> String {
+        "Relaunch \(decompositionA) and \(decompositionB) rockets."
+    }
+    func stageSuccessPhrase(for stage: SliceStage, target: Int) -> String { "Blast off!" }
+    func sessionIntroPhrase() -> String { "Let's count rockets." }
+    func sessionEndPhrase() -> String { "Mission complete." }
+    func sessionStartFeedback() -> String { "Place the rockets on the pad." }
+}
+
 struct ThemeTests {
 
     // MARK: - ClassicTheme
@@ -79,5 +96,58 @@ struct ThemeTests {
             saveSummary: { _ in }
         )
         #expect(engine.activeTheme.celebrationEmoji == "⭐️")
+    }
+
+    // MARK: - Engine vocabulary routing (PR2)
+
+    @MainActor
+    @Test func engineUsesInjectedThemeSessionStartFeedback() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            activeTheme: RocketTheme(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        #expect(engine.feedbackMessage == "Place the rockets on the pad.")
+    }
+
+    @MainActor
+    @Test func engineUsesClassicThemeSessionStartFeedbackByDefault() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        #expect(engine.feedbackMessage == "Make the target number with the big counters.")
+    }
+
+    @MainActor
+    @Test func engineConcretePromptComesFromTheme() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            activeTheme: RocketTheme(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        // After advancing to pictorial, feedbackMessage should use theme pictorialPrompt
+        engine.adjustConcrete(by: engine.currentProblem?.target ?? 0)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(engine.feedbackMessage == "Split the rockets into two pads.")
     }
 }


### PR DESCRIPTION
## Summary
- Replaces all hardcoded speech strings in `VerticalSliceEngine` with `activeTheme.*` calls — `promptForCurrentStage()`, `successMessage()`, `startSession()`, `endSession()`
- Renames `SpeechService.speakSessionIntroIfNeeded()` → `speakSessionIntro(_:)` so the intro phrase comes from the theme
- `ClassicTheme` returns the identical strings — **zero change to audio or feedback messages when default theme is active**
- Adds 3 new engine-vocabulary tests in `ThemeTests.swift` covering session-start routing and stage-prompt routing via injected theme

## Test plan
- [ ] All existing `VerticalSliceEngineTests` pass unchanged
- [ ] New `ThemeTests` (vocabulary routing) pass
- [ ] CI green on this branch

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)