### PR TITLE
feat(theme): selectedThemeId in FeatureFlags + theme_id telemetry (#93)

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -304,7 +304,7 @@ final class VerticalSliceEngine {
     private func endSession() {
         currentSession.endedAt = .now
         let digest = buildDigest()
-        let export = try? telemetryWriter.finishSession(session: currentSession, digest: digest)
+        let export = try? telemetryWriter.finishSession(session: currentSession, digest: digest, themeId: featureFlags.selectedThemeId)
         let summary = SessionSummaryDraft(
             sessionId: currentSession.sessionId.uuidString,
             startedAt: currentSession.startedAt,

--- a/Persistence/TelemetryWriter.swift
+++ b/Persistence/TelemetryWriter.swift
@@ -39,7 +39,8 @@ final class TelemetryWriter {
                     "schema_version": String(Self.schemaVersion),
                     "feature_verticalSlice1Enabled": String(featureFlags.verticalSlice1Enabled),
                     "feature_testModeEnabled": String(featureFlags.testModeEnabled),
-                    "feature_audioEnabled": String(featureFlags.audioEnabled)
+                    "feature_audioEnabled": String(featureFlags.audioEnabled),
+                    "theme_id": featureFlags.selectedThemeId
                 ]
             )
         )
@@ -60,7 +61,7 @@ final class TelemetryWriter {
     }
 
     @discardableResult
-    func finishSession(session: SliceSession, digest: ParentDigest) throws -> ExportArtifact? {
+    func finishSession(session: SliceSession, digest: ParentDigest, themeId: String = "classic") throws -> ExportArtifact? {
         try append(
             SliceEvent(
                 type: .sessionEnd,
@@ -69,7 +70,8 @@ final class TelemetryWriter {
                     "problems_completed": String(digest.problemsCompleted),
                     "first_attempt_accuracy": String(format: "%.2f", digest.firstAttemptAccuracy),
                     "median_latency_ms": String(digest.medianLatencyMs),
-                    "transfer_correct": String(digest.transferCorrectCount)
+                    "transfer_correct": String(digest.transferCorrectCount),
+                    "theme_id": themeId
                 ]
             )
         )

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -8,6 +8,7 @@ final class FeatureFlagService {
         static let testModeEnabled = "feature.testModeEnabled"
         static let audioEnabled = "feature.audioEnabled"
         static let hapticsEnabled = "feature.hapticsEnabled"
+        static let selectedThemeId = "feature.selectedThemeId"
     }
 
     var verticalSlice1Enabled: Bool {
@@ -26,6 +27,13 @@ final class FeatureFlagService {
         didSet { defaults.set(hapticsEnabled, forKey: Keys.hapticsEnabled) }
     }
 
+    /// Identifies the active theme for the next session.
+    /// Valid values: `"classic"` (default), `"vehicle"`.
+    /// Injected via launch argument `-feature.selectedThemeId classic` in UI tests.
+    var selectedThemeId: String {
+        didSet { defaults.set(selectedThemeId, forKey: Keys.selectedThemeId) }
+    }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -39,10 +47,12 @@ final class FeatureFlagService {
             Keys.testModeEnabled: true,
             Keys.audioEnabled: true,
             Keys.hapticsEnabled: true,
+            Keys.selectedThemeId: "classic",
         ])
         verticalSlice1Enabled = defaults.bool(forKey: Keys.verticalSlice1Enabled)
         testModeEnabled = defaults.bool(forKey: Keys.testModeEnabled)
         audioEnabled = defaults.bool(forKey: Keys.audioEnabled)
         hapticsEnabled = defaults.bool(forKey: Keys.hapticsEnabled)
+        selectedThemeId = defaults.string(forKey: Keys.selectedThemeId) ?? "classic"
     }
 }

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import Mather
+
+struct FeatureFlagTests {
+
+    @Test func selectedThemeIdDefaultsToClassic() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        #expect(flags.selectedThemeId == "classic")
+    }
+
+    @Test func selectedThemeIdPersistsAcrossInstances() {
+        let defaults = UserDefaults(suiteName: #function)!
+        let flags1 = FeatureFlagService(defaults: defaults)
+        flags1.selectedThemeId = "vehicle"
+
+        let flags2 = FeatureFlagService(defaults: defaults)
+        #expect(flags2.selectedThemeId == "vehicle")
+    }
+
+    @Test func selectedThemeIdCanBeResetToClassic() {
+        let defaults = UserDefaults(suiteName: #function)!
+        let flags = FeatureFlagService(defaults: defaults)
+        flags.selectedThemeId = "vehicle"
+        flags.selectedThemeId = "classic"
+        #expect(flags.selectedThemeId == "classic")
+    }
+
+    @Test func otherFlagsUnaffectedByThemeIdChange() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.selectedThemeId = "vehicle"
+        // Defaults should still be what FeatureFlagService registers
+        #expect(flags.testModeEnabled == true)
+        #expect(flags.audioEnabled == true)
+        #expect(flags.hapticsEnabled == true)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `selectedThemeId: String` to `FeatureFlagService` — UserDefaults key `"feature.selectedThemeId"`, default `"classic"`, injectable via launch arg `-feature.selectedThemeId vehicle`
- Adds `theme_id` field to both `session_start` and `session_end` telemetry JSONL events (read from `featureFlags.selectedThemeId`)
- Adds `FeatureFlagTests.swift` with 4 tests covering default value, persistence, reset, and flag isolation

## Test plan
- [ ] `FeatureFlagTests` all pass
- [ ] All existing engine / theme tests pass unchanged
- [ ] CI green on this branch

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)