### PR TITLE
feat(theme): CounterView component + vehicle rendering in ConcreteBuildView (#95)

### DIFF
--- a/Features/VerticalSlice1/ConcreteBuildView.swift
+++ b/Features/VerticalSlice1/ConcreteBuildView.swift
@@ -6,6 +6,7 @@ struct ConcreteBuildView: View {
     let accentCount: Int
     let onAdjust: (Int, ConcreteGroup) -> Void
     let onSubmit: () -> Void
+    var theme: any SliceTheme = ClassicTheme()
 
     // Ten-frame is always 5 columns × 2 rows — invariant across device sizes.
     // The 2×5 structure is what enables subitizing: 7 is instantly seen as
@@ -81,26 +82,6 @@ struct ConcreteBuildView: View {
         let isFirstRow = index < 5
         let rowIndex = index % 5
         let filled = isFirstRow ? rowIndex < warmCount : rowIndex < accentCount
-        let fillColor: Color = filled
-            ? (isFirstRow ? MatherTheme.warm : MatherTheme.accent)
-            : .clear
-        let strokeColor: Color = isFirstRow
-            ? MatherTheme.warm.opacity(filled ? 0.0 : 0.55)
-            : MatherTheme.accent.opacity(filled ? 0.0 : 0.45)
-        let bgColor: Color = isFirstRow
-            ? MatherTheme.warm.opacity(filled ? 0.0 : 0.12)
-            : MatherTheme.accent.opacity(filled ? 0.0 : 0.10)
-
-        Color.clear
-            .aspectRatio(1, contentMode: .fit)
-            .overlay(
-                Circle()
-                    .fill(filled ? fillColor : bgColor)
-                    .overlay(
-                        Circle()
-                            .strokeBorder(filled ? fillColor.opacity(0.3) : strokeColor, lineWidth: 2.5)
-                    )
-                    .shadow(color: filled ? fillColor.opacity(0.35) : .clear, radius: 4, y: 2)
-            )
+        CounterView(index: index, filled: filled, theme: theme)
     }
 }

--- a/Features/VerticalSlice1/CounterView.swift
+++ b/Features/VerticalSlice1/CounterView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// A single counter cell in the 2×5 ten-frame grid.
+///
+/// Renders as a filled/empty circle (ClassicTheme) or a car SF Symbol
+/// (VehicleTheme) depending on the active theme's `counterKind`.
+/// The 2×5 grid structure is preserved regardless of theme — subitising
+/// depends on spatial arrangement, not object shape (Clements, 2002).
+///
+/// Row colouring: index 0-4 → warm amber (first row), index 5-9 → vivid
+/// accent (second row). Two-tone structure lets the child instantly see
+/// "5 + N" without counting.
+struct CounterView: View {
+    let index: Int      // 0-based position in the ten-frame (0–9)
+    let filled: Bool
+    let theme: any SliceTheme
+
+    private var isFirstRow: Bool { index < 5 }
+
+    private var filledColor: Color {
+        isFirstRow ? MatherTheme.warm : MatherTheme.accent
+    }
+
+    var body: some View {
+        Color.clear
+            .aspectRatio(1, contentMode: .fit)
+            .overlay(counterShape)
+    }
+
+    @ViewBuilder
+    private var counterShape: some View {
+        switch theme.counterKind {
+        case .circle:
+            circleCounter
+        case .vehicle(let symbolName):
+            vehicleCounter(symbolName: symbolName)
+        }
+    }
+
+    private var circleCounter: some View {
+        let fillColor: Color = filled ? filledColor : .clear
+        let bgColor: Color = isFirstRow
+            ? MatherTheme.warm.opacity(filled ? 0 : 0.12)
+            : MatherTheme.accent.opacity(filled ? 0 : 0.10)
+        let strokeColor: Color = isFirstRow
+            ? MatherTheme.warm.opacity(filled ? 0 : 0.55)
+            : MatherTheme.accent.opacity(filled ? 0 : 0.45)
+
+        return Circle()
+            .fill(filled ? fillColor : bgColor)
+            .overlay(
+                Circle()
+                    .strokeBorder(filled ? fillColor.opacity(0.3) : strokeColor, lineWidth: 2.5)
+            )
+            .shadow(color: filled ? fillColor.opacity(0.35) : .clear, radius: 4, y: 2)
+    }
+
+    @ViewBuilder
+    private func vehicleCounter(symbolName: String) -> some View {
+        let color: Color = filled ? filledColor : Color.secondary.opacity(0.25)
+        Image(systemName: symbolName)
+            .resizable()
+            .scaledToFit()
+            .foregroundStyle(color)
+            .padding(6)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(filled ? filledColor.opacity(0.12) : Color.secondary.opacity(0.07))
+            )
+    }
+}

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -69,7 +69,8 @@ struct SliceSessionView: View {
                 warmCount: appModel.engine.concreteWarmCount,
                 accentCount: appModel.engine.concreteAccentCount,
                 onAdjust: appModel.engine.adjustConcrete,
-                onSubmit: appModel.engine.submitCurrentStage
+                onSubmit: appModel.engine.submitCurrentStage,
+                theme: appModel.engine.activeTheme
             )
         case .pictorial:
             SplitView(target: problem.target, leftCount: appModel.engine.splitLeftCount, onAdjust: appModel.engine.moveSplit, onSubmit: appModel.engine.submitCurrentStage)


### PR DESCRIPTION
## Summary
- Adds `CounterView.swift` — standalone SwiftUI view rendering either a `Circle` (ClassicTheme) or `car.fill` SF Symbol (VehicleTheme) based on `theme.counterKind`
- Refactors `ConcreteBuildView.counterCell()` to delegate to `CounterView` — same two-tone warm/accent grid, same `counter-cell-N` accessibility identifiers, zero behaviour change with ClassicTheme
- Adds `theme: any SliceTheme` parameter to `ConcreteBuildView` (defaults to `ClassicTheme()` — no existing call-sites broken)
- `SliceSessionView` passes `appModel.engine.activeTheme` through to `ConcreteBuildView`

## Test plan
- [ ] All existing UI tests (including `counter-cell-9` tap) pass unchanged
- [ ] All unit tests pass
- [ ] CI green on this branch

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)