### PR TITLE
feat(theme): vehicle counters in TransferCheckView via CounterView (#97)

### DIFF
--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -96,7 +96,8 @@ struct SliceSessionView: View {
                 leftCount: appModel.engine.transferLeftCount,
                 rightCount: appModel.engine.transferRightCount,
                 onAdjust: appModel.engine.adjustTransfer,
-                onSubmit: appModel.engine.submitCurrentStage
+                onSubmit: appModel.engine.submitCurrentStage,
+                theme: appModel.engine.activeTheme
             )
         case .done:
             CardSurface { Text("Moving to the next problem...") }

--- a/Features/VerticalSlice1/TransferCheckView.swift
+++ b/Features/VerticalSlice1/TransferCheckView.swift
@@ -6,6 +6,7 @@ struct TransferCheckView: View {
     let rightCount: Int
     let onAdjust: (Int, TransferSide) -> Void
     let onSubmit: () -> Void
+    var theme: any SliceTheme = ClassicTheme()
 
     var body: some View {
         CardSurface {
@@ -103,12 +104,13 @@ struct TransferCheckView: View {
                     HStack(spacing: 6) {
                         ForEach(rows[rowIndex].indices, id: \.self) { dotIndex in
                             let isFilled = rows[rowIndex][dotIndex]
-                            Circle()
-                                .fill(isFilled ? fill : fill.opacity(0.15))
-                                .overlay(
-                                    Circle().strokeBorder(fill.opacity(isFilled ? 0.2 : 0.35), lineWidth: 1.5)
-                                )
-                                .frame(minWidth: 18, minHeight: 18)
+                            CounterView(
+                                index: dotIndex + rowIndex * 5,
+                                filled: isFilled,
+                                theme: theme,
+                                overrideColor: fill
+                            )
+                            .frame(minWidth: 18, minHeight: 18)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Adds `theme` parameter to `TransferCheckView` (defaults `ClassicTheme()`)
- Replaces `Circle()` dots in `TransferCheckView.transferBucket()` with `CounterView`, using `overrideColor` for bucket fill colour
- `SliceSessionView` passes `appModel.engine.activeTheme` to `TransferCheckView`
- Counter identity is now consistent across all three physical CPA stages (concrete, split, transfer) — child sees the same car icon throughout the session
- **Classic theme: visually identical**

## Test plan
- [ ] All existing unit and UI tests pass unchanged
- [ ] CI green on this branch

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)