### PR TITLE
feat(theme): activeTheme celebration emoji in SliceSessionView (#98)

### DIFF
--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -38,7 +38,7 @@ struct SliceSessionView: View {
             // The engine delays stage transition by 1.5s so the child sees the reward
             // before the screen changes. Non-interactive so taps pass through.
             if appModel.engine.showCelebration {
-                Text("⭐️")
+                Text(appModel.engine.activeTheme.celebrationEmoji)
                     .font(.system(size: 120))
                     .scaleEffect(celebrationScale)
                     .allowsHitTesting(false)

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -146,6 +146,14 @@ struct ThemeTests {
         #expect(prompt.contains("5"))
     }
 
+    // MARK: - Celebration emoji (PR8)
+
+    @Test func celebrationEmojiDistinctBetweenThemes() {
+        #expect(VehicleTheme().celebrationEmoji != ClassicTheme().celebrationEmoji)
+        #expect(!VehicleTheme().celebrationEmoji.isEmpty)
+        #expect(!ClassicTheme().celebrationEmoji.isEmpty)
+    }
+
     // MARK: - Engine vocabulary routing (PR2)
 
     @MainActor


### PR DESCRIPTION
## Summary
- Replaces hardcoded `"⭐️"` in the fullscreen celebration overlay with `appModel.engine.activeTheme.celebrationEmoji`
- `ClassicTheme` returns `"⭐️"` (visually unchanged), `VehicleTheme` returns `"🚗"`
- Adds 1 new `ThemeTest` verifying emoji distinctness and non-empty for both themes

## Test plan
- [ ] All existing tests pass (celebration emoji still "⭐️" for classic theme)
- [ ] CI green on this branch

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)