### PR TITLE
docs(wiki): VS1 Theme Framework spec + ADR-0004 (#100)

### DIFF
--- a/wiki/ADRs/ADR-0004-theme-architecture.md
+++ b/wiki/ADRs/ADR-0004-theme-architecture.md
@@ -1,0 +1,63 @@
+# ADR-0004: VS1 Theme Architecture
+
+**Date:** 2026-04-04
+**Status:** Accepted
+**Context:** VS1 Theme Framework (issues #91–#100, PRs #102–#110)
+
+---
+
+## Context
+
+Issue #79 proposed a vehicle-first playful theme to increase engagement for 5-6 year olds. The implementation needed to:
+
+1. Let a parent choose a theme before a session
+2. Keep the theme stable for the duration of the session
+3. Not change any CPA stage rules, scoring, or engine logic
+4. Be testable with arbitrary theme implementations in unit tests
+
+---
+
+## Decision
+
+**Theme as a session-scoped value type, resolved once at `startSession()`.**
+
+`SliceTheme` is a protocol (not a class, not `@Observable`). Conforming types are value structs. `VerticalSliceEngine` holds `private(set) var activeTheme: any SliceTheme`, which is frozen at `startSession()` by reading `featureFlags.selectedThemeId`.
+
+Key properties:
+
+- `activeTheme` never changes between `startSession()` and `endSession()` — the child cannot switch themes mid-session
+- The engine init accepts `activeTheme: (any SliceTheme)? = nil` — when non-nil, `startSession()` preserves the injected value and does not override from flags. This lets unit tests inject arbitrary themes (e.g. a `RocketTheme` fixture) without registering them in `FeatureFlagService`
+- `SliceTheme` lives in `Domain/` because it is domain logic (vocabulary, counter kind, CPA prompt routing), not a presentation concern
+
+---
+
+## Alternatives considered
+
+### Global `@Observable` theme service
+Rejected. A globally observable theme would add SwiftUI observation overhead for a value that never changes during a session. It would also allow mid-session theme changes, which would confuse a child mid-task.
+
+### Theme as a `@State` variable in views
+Rejected. Domain vocabulary (speech prompts, success phrases) belongs in the engine, not in views. A view-scoped theme could not be used for `SpeechService` calls.
+
+### Theme embedded in `SessionConfig`
+Considered. `SliceConfig` already holds `audioEnabled` and `deterministicMode`. However, the theme is a richer object (a protocol value, not a plain Bool/Int), and would require `SliceConfig` to import domain types it doesn't currently need. Keeping it on the engine is simpler.
+
+---
+
+## Consequences
+
+- All stage prompts, success messages, and session lifecycle strings route through `activeTheme` — hardcoded strings are gone from the engine
+- `ClassicTheme` returns the same strings that were hardcoded before — zero regression risk
+- Adding a new theme requires: new struct, one `startSession()` line, one UI card — no engine changes
+- Telemetry records `theme_id` in both `session_start` and `session_end` JSONL events for future segmentation
+- `CounterView` renders either a `Circle` or SF Symbol based on `theme.counterKind`, and is shared across `ConcreteBuildView`, `SplitView`, and `TransferCheckView` — consistent counter identity throughout a session
+
+---
+
+## Pedagogical rationale
+
+See `wiki/Research/Playful-Themes-for-VS1.md` and issue #79 for the full research grounding. Summary:
+
+- Interest-driven learning (Hidi & Renninger): a vehicle theme triggers situational interest in 5-6 year olds, keeping them on-task through the full CPA loop
+- Self-Determination Theory: theme picker satisfies autonomy and relatedness needs
+- Subitising is structure-dependent, not shape-dependent (Clements, 2002): replacing circles with car icons in the same 2×5 grid preserves all subitising benefits

--- a/wiki/Specs/VS1-Theme-Framework.md
+++ b/wiki/Specs/VS1-Theme-Framework.md
@@ -1,0 +1,99 @@
+# VS1 Theme Framework
+
+**Status:** Implemented (PRs #102–#110)
+**Milestone:** VS1 Theme Framework (#2)
+
+---
+
+## Overview
+
+The VS1 theme framework lets a parent select a visual and vocabulary theme for a session before it starts. The first content pack is **Vehicles** — car SF Symbols and parking-lot vocabulary replace the default abstract circles and neutral prompts.
+
+Themes are a purely additive layer. The CPA learning loop, stage rules, equation logic, and scoring are completely unchanged.
+
+---
+
+## Protocol
+
+`SliceTheme` is defined in `Domain/SliceTheme.swift`:
+
+```swift
+protocol SliceTheme {
+    var counterKind: CounterKind { get }
+    var celebrationEmoji: String { get }
+
+    func concretePrompt(target: Int) -> String
+    func pictorialPrompt(target: Int) -> String
+    func abstractPrompt() -> String
+    func transferPrompt(decompositionA: Int, decompositionB: Int) -> String
+    func stageSuccessPhrase(for stage: SliceStage, target: Int) -> String
+    func sessionIntroPhrase() -> String
+    func sessionEndPhrase() -> String
+    func sessionStartFeedback() -> String
+}
+```
+
+`CounterKind` controls rendering:
+
+```swift
+enum CounterKind: Equatable {
+    case circle                          // filled/empty circle (ClassicTheme)
+    case vehicle(symbolName: String)     // SF Symbol (VehicleTheme uses "car.fill")
+}
+```
+
+---
+
+## Session lifecycle
+
+1. **SessionConfigView** — parent taps a theme card → sets `featureFlags.selectedThemeId`
+2. **startSession()** — engine reads `selectedThemeId`, resolves `ClassicTheme` or `VehicleTheme`, stores as `activeTheme`
+3. **During session** — `activeTheme` is frozen (never changes mid-session)
+4. **Views** — `ConcreteBuildView`, `SplitView`, `TransferCheckView` all receive `theme: any SliceTheme` and pass it to `CounterView`
+5. **Speech** — `promptForCurrentStage()`, `successMessage()`, `startSession()`, `endSession()` all delegate to `activeTheme`
+
+---
+
+## Available themes
+
+| ID | Struct | Counter | Emoji | Intro phrase |
+|---|---|---|---|---|
+| `classic` | `ClassicTheme` | Circle | ⭐️ | "Let's make and break numbers to ten." |
+| `vehicle` | `VehicleTheme` | car.fill SF Symbol | 🚗 | "Let's park and split cars to ten." |
+
+---
+
+## CounterView
+
+`Features/VerticalSlice1/CounterView.swift` — renders a single ten-frame cell.
+
+```swift
+CounterView(
+    index: Int,           // 0-based position in the grid
+    filled: Bool,         // whether this counter is active
+    theme: any SliceTheme,
+    overrideColor: Color? = nil  // bucket colour for SplitView / TransferView
+)
+```
+
+For the two-tone ten-frame: index 0–4 → warm amber, index 5–9 → vivid accent.
+`overrideColor` is used by SplitView and TransferCheckView where each bucket has its own palette colour.
+
+---
+
+## Subitising preservation
+
+Replacing circles with SF Symbols preserves all subitising benefits. Subitising depends on **spatial arrangement**, not object shape (Clements, 2002). The 2×5 ten-frame grid structure is invariant across themes. A child still instantly reads "a full top row of 5 plus 2 in the bottom row = 7" regardless of the counter shape.
+
+---
+
+## Adding a new theme
+
+1. Create `Domain/MyTheme.swift` conforming to `SliceTheme`
+2. Register its ID in `startSession()` in `VerticalSliceEngine.swift`
+3. Add a card to `themeOptions` in `SessionConfigView.swift`
+4. Add vocabulary tests in `ThemeTests.swift`
+
+No changes to `CounterKind`, `SliceStateMachine`, or any engine logic are required for a theme that uses an existing SF Symbol.
+
+To add a new counter shape, extend `CounterKind` and handle the new case in `CounterView.counterShape`.


### PR DESCRIPTION
## Summary
- Adds `wiki/Specs/VS1-Theme-Framework.md` — protocol shape, CounterKind, CounterView API, session lifecycle, available themes, guide for adding new themes
- Adds `wiki/ADRs/ADR-0004-theme-architecture.md` — records session-scoped value-type decision, alternatives rejected, consequences, pedagogical rationale

No code changes. Both docs will auto-sync to the GitHub wiki on merge to main.

## Test plan
- [ ] CI green (build only, no test changes)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)