### PR TITLE
fix(theme): close vocabulary bypass gaps (UX review)

### DIFF
--- a/Domain/ClassicTheme.swift
+++ b/Domain/ClassicTheme.swift
@@ -5,6 +5,7 @@ import Foundation
 struct ClassicTheme: SliceTheme {
     var counterKind: CounterKind { .circle }
     var celebrationEmoji: String { "⭐️" }
+    var counterNoun: String { "counters" }
 
     func concretePrompt(target: Int) -> String {
         "Make \(target) with the counters."

--- a/Domain/SliceTheme.swift
+++ b/Domain/SliceTheme.swift
@@ -17,6 +17,10 @@ protocol SliceTheme {
     /// Emoji shown in the fullscreen celebration overlay on a correct stage answer.
     var celebrationEmoji: String { get }
 
+    /// Noun for a single counter — used in failure hint copy so the hint matches
+    /// the active theme's vocabulary (e.g. "counters" vs "cars").
+    var counterNoun: String { get }
+
     // MARK: - Stage prompts (spoken by SpeechService)
 
     func concretePrompt(target: Int) -> String

--- a/Domain/VehicleTheme.swift
+++ b/Domain/VehicleTheme.swift
@@ -12,6 +12,7 @@ import Foundation
 struct VehicleTheme: SliceTheme {
     var counterKind: CounterKind { .vehicle(symbolName: "car.fill") }
     var celebrationEmoji: String { "🚗" }
+    var counterNoun: String { "cars" }
 
     func concretePrompt(target: Int) -> String {
         "Park \(target) cars in the garage."

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -485,7 +485,7 @@ final class VerticalSliceEngine {
             } else if attempts == 2 {
                 return "You have \(concreteCount). How many more do you need to make \(problem.target)?"
             } else {
-                return "Try tapping the circles one by one until you reach \(problem.target)."
+                return "Try tapping the \(activeTheme.counterNoun) one by one until you reach \(problem.target)."
             }
         case .pictorial:
             if attempts == 1 {

--- a/Features/VerticalSlice1/EquationResolveView.swift
+++ b/Features/VerticalSlice1/EquationResolveView.swift
@@ -8,6 +8,7 @@ struct EquationResolveView: View {
     let onClear: (EquationSide) -> Void
     let onSubmit: () -> Void
     var showsInlineSubmit = true
+    var theme: any SliceTheme = ClassicTheme()
 
     @State private var selectedSide: EquationSide = .left
 
@@ -18,7 +19,7 @@ struct EquationResolveView: View {
             VStack(alignment: .leading, spacing: 18) {
                 Text("Write it")
                     .font(.largeTitle.weight(.black))
-                Text("Show the same split as an equation that equals \(target).")
+                Text(theme.abstractPrompt())
                     .font(.headline)
                     .foregroundStyle(.secondary)
 

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -88,7 +88,8 @@ struct SliceSessionView: View {
                 onAppend: appModel.engine.appendEquationDigit,
                 onClear: appModel.engine.clearEquation,
                 onSubmit: appModel.engine.submitCurrentStage,
-                showsInlineSubmit: false
+                showsInlineSubmit: false,
+                theme: appModel.engine.activeTheme
             )
         case .transfer:
             TransferCheckView(

--- a/Features/VerticalSlice1/TransferCheckView.swift
+++ b/Features/VerticalSlice1/TransferCheckView.swift
@@ -11,11 +11,10 @@ struct TransferCheckView: View {
     var body: some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 18) {
-                Text("Show it again")
-                    .font(.largeTitle.weight(.black))
-                Text("Show the same equation with counters again.")
-                    .font(.headline)
+                Text(theme.transferPrompt(decompositionA: problem.decompositionA, decompositionB: problem.decompositionB))
+                    .font(.headline.weight(.bold))
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
                     .accessibilityIdentifier("transfer-instruction")
 
                 HStack(spacing: 10) {

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -7,6 +7,7 @@ import Testing
 private struct RocketTheme: SliceTheme {
     var counterKind: CounterKind { .circle }
     var celebrationEmoji: String { "🚀" }
+    var counterNoun: String { "rockets" }
     func concretePrompt(target: Int) -> String { "Launch \(target) rockets." }
     func pictorialPrompt(target: Int) -> String { "Split the rockets into two pads." }
     func abstractPrompt() -> String { "Type the rocket equation." }
@@ -264,5 +265,37 @@ struct ThemeTests {
         engine.submitCurrentStage()
         try await Task.sleep(for: .milliseconds(200))
         #expect(engine.feedbackMessage == "Split the rockets into two pads.")
+    }
+
+    // MARK: - counterNoun (UX review fix)
+
+    @Test func classicThemeCounterNounIsCounters() {
+        #expect(ClassicTheme().counterNoun == "counters")
+    }
+
+    @Test func vehicleThemeCounterNounIsCars() {
+        #expect(VehicleTheme().counterNoun == "cars")
+    }
+
+    /// After 3 concrete failures with VehicleTheme, the feedback hint must say "cars" not "circles".
+    @MainActor
+    @Test func engineConcreteFailureHintUsesThemeCounterNoun() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            activeTheme: VehicleTheme(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        // Submit wrong answer three times to reach the "tapping the X" hint
+        engine.submitCurrentStage() // attempt 1 — wrong (count is 0)
+        engine.submitCurrentStage() // attempt 2
+        engine.submitCurrentStage() // attempt 3 → counterNoun hint
+        #expect(engine.feedbackMessage.contains("cars"))
+        #expect(!engine.feedbackMessage.contains("circles"))
     }
 }


### PR DESCRIPTION
## Summary

Post-milestone UX audit found three places where the VehicleTheme vocabulary was silently ignored or contradicted by hardcoded strings:

- **`counterNoun` on `SliceTheme`** — failure hint on the 3rd concrete attempt said \"Try tapping the circles one by one…\" even in VehicleTheme. New `counterNoun` property (`"counters"` / `"cars"`) fixes the copy.
- **`EquationResolveView`** — view had no `theme` parameter; its subtitle was hardcoded to \"Show the same split as an equation…\" while the FeedbackBanner above it was already showing `theme.abstractPrompt()`. Now uses `theme.abstractPrompt()` as the subtitle.
- **`TransferCheckView`** — \"Show it again\" / \"Show the same equation with counters again.\" headings were hardcoded; `theme.transferPrompt()` was spoken by the engine but never displayed. Replaced with the theme's transfer prompt.

## Test plan
- [ ] All existing `ThemeTests` and `VerticalSliceEngineTests` pass
- [ ] New `classicThemeCounterNounIsCounters` / `vehicleThemeCounterNounIsCars` unit tests pass
- [ ] New `engineConcreteFailureHintUsesThemeCounterNoun` integration test: 3rd concrete failure with VehicleTheme → feedbackMessage contains \"cars\", not \"circles\"
- [ ] Manual: launch Vehicle theme session, confirm abstract-stage subtitle and transfer heading match vehicle vocabulary

🤖 Generated with [Claude Code](https://claude.com/claude-code)