### PR TITLE
fix(ux): TransferCheckView button targets + accessibility labels

### DIFF
--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -129,6 +129,7 @@ struct SliceSessionView: View {
                             .background(MatherTheme.softBlue.opacity(0.18))
                             .clipShape(Circle())
                     }
+                    .accessibilityLabel(appModel.featureFlags.audioEnabled ? "Mute audio" : "Enable audio")
                     Button {
                         appModel.engine.replayPrompt()
                     } label: {
@@ -139,6 +140,7 @@ struct SliceSessionView: View {
                             .background(MatherTheme.warm.opacity(0.18))
                             .clipShape(Circle())
                     }
+                    .accessibilityLabel("Replay prompt")
                     // Adult escape hatch — secondary styling so child ignores it
                     Button {
                         appModel.engine.showHome()

--- a/Features/VerticalSlice1/TransferCheckView.swift
+++ b/Features/VerticalSlice1/TransferCheckView.swift
@@ -121,14 +121,18 @@ struct TransferCheckView: View {
             .background(fill.opacity(0.12))
             .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
             .accessibilityIdentifier("transfer-\(side == .left ? "left" : "right")-group")
-            .onTapGesture { onAdjust(1, side) }
 
+            // +/- buttons — primary interaction surface; bucket tap removed to avoid
+            // conflict between two mechanisms triggering the same action.
             HStack(spacing: 10) {
                 Button {
                     onAdjust(-1, side)
                 } label: {
                     Image(systemName: "minus.circle.fill")
                         .font(.title.weight(.bold))
+                        .frame(minWidth: 44, minHeight: 44)
+                        .background(fill.opacity(0.15))
+                        .clipShape(Circle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Remove from \(side == .left ? "left" : "right") group")
@@ -139,6 +143,9 @@ struct TransferCheckView: View {
                 } label: {
                     Image(systemName: "plus.circle.fill")
                         .font(.title.weight(.bold))
+                        .frame(minWidth: 44, minHeight: 44)
+                        .background(fill.opacity(0.15))
+                        .clipShape(Circle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Add to \(side == .left ? "left" : "right") group")


### PR DESCRIPTION
## Summary

Two child UX issues found in the post-milestone review:

- **TransferCheckView +/- buttons** had no hit target (plain SF Symbol icon, ~22pt rendered). Wrapped labels in `.frame(minWidth: 44, minHeight: 44)` with a fill-tinted circle background — gives a visible affordance and meets the 44×44pt minimum.
- **Tap conflict** — bucket background had `.onTapGesture { onAdjust(+1) }` alongside the separate +1 button directly below. Removed the bucket tap; the +/- buttons are the correct interaction surface.
- **Session header accessibility labels** — speaker toggle and replay button had no `.accessibilityLabel()`. VoiceOver now reads "Mute audio"/"Enable audio" and "Replay prompt".

## Test plan
- [ ] All existing tests pass
- [ ] Manual: in VoiceOver, navigate to session header — speaker and replay buttons announce correctly
- [ ] Manual: transfer stage — tapping bucket background no longer increments; only +/- buttons do
- [ ] Manual: +/- buttons are visibly distinct (fill-tinted circle background) and easy to tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)