### PR TITLE
fix(ux): consistent nav button order + SplitView drag affordance

### DIFF
--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -146,13 +146,13 @@ struct SettingsView: View {
                     .tint(MatherTheme.danger)
 
                     HStack(spacing: 16) {
-                        Button("Home") {
-                            appModel.engine.showHome()
+                        Button("Parent Summary") {
+                            appModel.engine.showParentSummary()
                         }
                         .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.7)))
 
-                        Button("Parent Summary") {
-                            appModel.engine.showParentSummary()
+                        Button("Home") {
+                            appModel.engine.showHome()
                         }
                         .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.7)))
                     }

--- a/Features/VerticalSlice1/SplitView.swift
+++ b/Features/VerticalSlice1/SplitView.swift
@@ -38,6 +38,17 @@ struct SplitView: View {
                         }
                 )
 
+                // Swipe affordance — left/right chevrons hint at the drag gesture.
+                // Tap on each bucket also adjusts the split (no reading required).
+                HStack {
+                    Image(systemName: "chevron.left")
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                }
+                .font(.footnote.weight(.medium))
+                .foregroundStyle(.secondary.opacity(0.45))
+                .padding(.horizontal, 20)
+
                 // Live equation — shows A + B = target as the child adjusts the split.
                 // Bridges the pictorial buckets to the abstract equation (CPA framework).
                 HStack(spacing: 8) {


### PR DESCRIPTION
## Summary

Two remaining polish items from the post-milestone UX review:

- **Navigation button order** — `SettingsView` had `["Home", "Parent Summary"]` while `ParentSummaryView` had `["Settings", "Home"]`. "Home" moved between left and right across screens. Standardised to cross-nav button on the left (blue), "Home" on the right (warm) in both views.
- **SplitView drag affordance** — the drag-to-adjust gesture on the bucket area had no visual hint. Added a pair of subtle left/right chevrons (`‹  ›`) between the buckets and the live equation — icon-only, no reading required, signals swipeable interaction.

## Test plan
- [ ] All existing tests pass
- [ ] Manual: SettingsView bottom row shows "Parent Summary" left, "Home" right
- [ ] Manual: ParentSummaryView bottom row unchanged — "Settings" left, "Home" right
- [ ] Manual: SplitView shows faint ‹ › chevrons; dragging left/right still adjusts the split

🤖 Generated with [Claude Code](https://claude.com/claude-code)