### PR TITLE
fix: improve SessionConfigView text contrast to meet WCAG AA

### DIFF
--- a/Features/VerticalSlice1/SessionConfigView.swift
+++ b/Features/VerticalSlice1/SessionConfigView.swift
@@ -25,7 +25,7 @@ struct SessionConfigView: View {
                             .font(.title.weight(.black))
                         Text("Keep sessions short and consistent.")
                             .font(.headline)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(MatherTheme.ink.opacity(0.6))
                             .fixedSize(horizontal: false, vertical: true)
 
                         Divider()
@@ -91,7 +91,7 @@ struct SessionConfigView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                 Text(option.name)
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(isSelected ? option.color : .secondary)
+                    .foregroundStyle(isSelected ? option.color : MatherTheme.ink.opacity(0.55))
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 14)


### PR DESCRIPTION
## Summary
- Replace `.secondary` foreground (≈3.0:1 contrast ratio) with `MatherTheme.ink.opacity(0.6)` on the setup card subtitle
- Replace `.secondary` with `MatherTheme.ink.opacity(0.55)` on unselected theme card labels
- Both changes bring contrast above the WCAG AA minimum of 4.5:1 on white `CardSurface`

## Test plan
- [ ] Open Session Setup screen — subtitle "Keep sessions short and consistent." is clearly legible (dark charcoal, not washed-out grey)
- [ ] Tap between Classic and Vehicles theme cards — unselected card label is clearly readable in both states
- [ ] All existing unit tests pass

Closes #115, #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)