### PR TITLE
fix: replace ghost car silhouette with dashed parking outline; cap counter size

### DIFF
--- a/Features/VerticalSlice1/CounterView.swift
+++ b/Features/VerticalSlice1/CounterView.swift
@@ -58,15 +58,25 @@ struct CounterView: View {
 
     @ViewBuilder
     private func vehicleCounter(symbolName: String) -> some View {
-        let color: Color = filled ? filledColor : Color.secondary.opacity(0.25)
-        Image(systemName: symbolName)
-            .resizable()
-            .scaledToFit()
-            .foregroundStyle(color)
-            .padding(6)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(filled ? filledColor.opacity(0.12) : Color.secondary.opacity(0.07))
-            )
+        if filled {
+            Image(systemName: symbolName)
+                .resizable()
+                .scaledToFit()
+                .foregroundStyle(filledColor)
+                .padding(6)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(filledColor.opacity(0.12))
+                )
+        } else {
+            // Dashed parking-space outline — clearly signals an empty slot
+            // without the ghost-car silhouette that reads as decorative background.
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(
+                    Color.secondary.opacity(0.3),
+                    style: StrokeStyle(lineWidth: 1.5, dash: [4])
+                )
+                .padding(4)
+        }
     }
 }

--- a/Features/VerticalSlice1/SplitView.swift
+++ b/Features/VerticalSlice1/SplitView.swift
@@ -101,7 +101,7 @@ struct SplitView: View {
                                 theme: theme,
                                 overrideColor: fill
                             )
-                            .frame(minWidth: 18, minHeight: 18)
+                            .frame(minWidth: 18, minHeight: 18, maxWidth: 36, maxHeight: 36)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- **CounterView**: unfilled vehicle slots now show a dashed `RoundedRectangle` parking-space outline instead of a faint car SF Symbol that testers read as decorative background
- **SplitView**: `CounterView` frame gains `maxWidth: 36, maxHeight: 36` to prevent counters growing oversized at small problem counts

## Test plan
- [ ] Start a Vehicle theme session — unfilled counter slots show a dashed outline box, not a ghost car
- [ ] Start a Classic theme session — circle counters unchanged
- [ ] In SplitView, adjust split to a small number (e.g. 1 + 9) — the single filled counter stays ≤36pt

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)