### PR TITLE
fix: add .contentShape(Rectangle()) to counter cells for reliable taps

### DIFF
--- a/Features/VerticalSlice1/ConcreteBuildView.swift
+++ b/Features/VerticalSlice1/ConcreteBuildView.swift
@@ -33,6 +33,7 @@ struct ConcreteBuildView: View {
                         counterCell(index: index)
                             .accessibilityIdentifier("counter-cell-\(index)")
                             .accessibilityLabel("Counter \(index + 1)")
+                            .contentShape(Rectangle())
                             .onTapGesture {
                                 let isWarm = index < 5
                                 let rowIndex = index % 5


### PR DESCRIPTION
## Summary
`CounterView` renders as `Color.clear` with a visual shape as an overlay. SwiftUI does not guarantee hit-testing on fully-transparent views — taps landing on the transparent margin between the circle and the cell edge may be silently dropped.

Adding `.contentShape(Rectangle())` explicitly declares the full grid cell rectangle as the tappable region, ensuring first-tap registration is reliable wherever a child's finger lands on the cell.

## Test plan
- [ ] Classic theme: tap each of the 10 counter cells — every tap registers on first press
- [ ] Vehicle theme: same verification with car/truck symbols
- [ ] Tap at the very corner of a cell (transparent area) — registers correctly
- [ ] All existing unit tests pass

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)