### PR TITLE
fix: cap counter cells at 72pt and compact ConcreteBuildView layout

### DIFF
--- a/Features/VerticalSlice1/ConcreteBuildView.swift
+++ b/Features/VerticalSlice1/ConcreteBuildView.swift
@@ -15,22 +15,25 @@ struct ConcreteBuildView: View {
 
     var body: some View {
         CardSurface {
-            VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 14) {
                 HStack(alignment: .firstTextBaseline, spacing: 10) {
                     Text("Make")
                         .font(.title.weight(.bold))
                         .foregroundStyle(.secondary)
                     Text("\(target)")
-                        .font(.system(size: 56, weight: .black, design: .rounded))
+                        .font(.system(size: 44, weight: .black, design: .rounded))
                         .foregroundStyle(MatherTheme.accent)
                 }
 
                 // Color.clear with aspectRatio is the reliable SwiftUI idiom for
                 // square grid cells — it constrains height = width without fighting
                 // the grid's flexible column width calculation.
+                // Cells are capped at 72pt so on wide screens (iPad) they don't grow
+                // to 130pt+ — "bigger circles" feedback and scrolling are eliminated.
                 LazyVGrid(columns: columns, spacing: 10) {
                     ForEach(0..<10, id: \.self) { index in
                         counterCell(index: index)
+                            .frame(maxWidth: 72, maxHeight: 72)
                             .accessibilityIdentifier("counter-cell-\(index)")
                             .accessibilityLabel("Counter \(index + 1)")
                             .onTapGesture {
@@ -43,28 +46,30 @@ struct ConcreteBuildView: View {
                             }
                     }
                 }
+                .frame(maxWidth: 400)
+                .frame(maxWidth: .infinity)
 
                 // Number-bond display: live A + B = target as circles are tapped.
                 // Numerals and symbols only — no words, consistent with the no-reading principle.
                 // Connects the concrete ten-frame action to the abstract equation (CPA bridge).
                 HStack(spacing: 8) {
                     Text("\(warmCount)")
-                        .font(.system(size: 44, weight: .black, design: .rounded))
+                        .font(.system(size: 36, weight: .black, design: .rounded))
                         .foregroundStyle(MatherTheme.warm)
                         .accessibilityIdentifier("warm-count-label")
                         .contentTransition(.numericText())
                         .animation(.spring(response: 0.3), value: warmCount)
                     Text("+")
-                        .font(.system(size: 32, weight: .bold, design: .rounded))
+                        .font(.system(size: 24, weight: .bold, design: .rounded))
                         .foregroundStyle(.secondary)
                     Text("\(accentCount)")
-                        .font(.system(size: 44, weight: .black, design: .rounded))
+                        .font(.system(size: 36, weight: .black, design: .rounded))
                         .foregroundStyle(MatherTheme.accent)
                         .accessibilityIdentifier("accent-count-label")
                         .contentTransition(.numericText())
                         .animation(.spring(response: 0.3), value: accentCount)
                     Text("= \(warmCount + accentCount)")
-                        .font(.system(size: 32, weight: .bold, design: .rounded))
+                        .font(.system(size: 24, weight: .bold, design: .rounded))
                         .foregroundStyle(.secondary)
                 }
                 .frame(maxWidth: .infinity, alignment: .center)


### PR DESCRIPTION
## Summary
On iPad the `LazyVGrid` flexible columns expand each counter cell to ~130pt, producing visually oversized circles and pushing the card height beyond the screen — requiring the child to scroll to reach the submit button.

- **Cell cap**: `.frame(maxWidth: 72, maxHeight: 72)` — child-friendly size on all screens
- **Grid centred**: `.frame(maxWidth: 400).frame(maxWidth: .infinity)` prevents left-alignment when cells are capped on wide screens
- **Title number**: 56pt → 44pt (saves ~14pt)
- **Equation numerals**: 44pt/32pt → 36pt/24pt (saves ~10pt)
- **VStack spacing**: 20 → 14 (saves 18pt)
- **Net savings ≈ 140pt on iPad** — concrete stage now fits without scrolling

## Test plan
- [ ] iPad simulator (iPad mini, 744pt wide) — concrete stage fits on screen without scrolling
- [ ] iPhone 16 — concrete stage unchanged in appearance, still fits
- [ ] Vehicle theme — car/truck cells capped at 72pt and centred
- [ ] Tap "That is X" button is visible without scrolling
- [ ] All existing unit tests pass

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)