### PR TITLE
fix(speech): play prompts with hardware ringer switch off (#136)

### DIFF
--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -8,6 +8,19 @@ final class SpeechService {
     private var lastUtteranceID = UUID()
     var hasSpokenSessionIntro = false
 
+    init() {
+        // Use .playback category so prompts are audible even when the hardware
+        // ringer/silent switch is off. .spokenAudio mode pauses other audio
+        // during speech; .duckOthers lowers (rather than cuts) background audio.
+        // The in-app audio toggle (speak(_:enabled:)) remains the parent's control.
+        try? AVAudioSession.sharedInstance().setCategory(
+            .playback,
+            mode: .spokenAudio,
+            options: .duckOthers
+        )
+        try? AVAudioSession.sharedInstance().setActive(true)
+    }
+
     func speak(_ text: String, enabled: Bool) {
         guard enabled, !text.isEmpty else { return }
         synthesizer.stopSpeaking(at: .immediate)


### PR DESCRIPTION
## Summary

`AVSpeechSynthesizer` with no `AVAudioSession` configuration uses the ambient category, which the iOS hardware ringer/silent switch mutes. On a shared family iPad where the ringer is commonly off, all spoken prompts were silently suppressed even though the in-app speaker button showed as active.

Sets the audio session to `.playback` / `.spokenAudio` / `.duckOthers` in `SpeechService.init()` — the same approach used by podcast and audiobook apps. This category is exempt from the ringer switch.

The parent's in-app audio toggle continues to gate `synthesizer.speak(...)` calls as the deliberate mute control.

## Root cause evidence

The TestFlight screenshot for build 19 shows 🔇 in the device status bar while the in-app speaker icon appears active — confirming the hardware silent switch was the trigger.

## Test plan

- [ ] CI passes
- [ ] With hardware ringer switch **OFF**: spoken prompts play during a session
- [ ] With in-app audio toggle **OFF**: prompts are silent (parent mute respected)
- [ ] Background audio on device is ducked (not cut) during prompts

Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)