### PR TITLE
test(vehicle): fix post-merge theme rotation expectation

### DIFF
--- a/Tests/MatherTests/VehicleSpecTests.swift
+++ b/Tests/MatherTests/VehicleSpecTests.swift
@@ -115,10 +115,11 @@ struct VehicleSpecTests {
         let firstNoun = engine.activeTheme.counterNoun
         guard let problem = engine.currentProblem else { return }
 
-        // Complete all 4 CPA stages — same pattern as VerticalSliceEngineTests.
+        // Complete all 4 CPA stages.
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()                             // concrete → pictorial
         try await Task.sleep(for: .milliseconds(200))
+        engine.moveSplit(delta: 0)
         engine.submitCurrentStage()                             // pictorial → abstract
         try await Task.sleep(for: .milliseconds(200))
         engine.equationLeftInput = String(problem.decompositionA)


### PR DESCRIPTION
## Summary
- fix the vehicle theme rotation test on main
- complete the pictorial stage before asserting the engine advances to the next themed problem

## Why
Main CI after PR #140 failed because this test assumed pictorial could advance without completing the stage state. The engine behavior is correct, the test was stale.

## Testing
- GitHub Actions