### PR TITLE
style(ui): polish dark mode playfulness and depth

### DIFF
--- a/Features/VerticalSlice1/EquationResolveView.swift
+++ b/Features/VerticalSlice1/EquationResolveView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct EquationResolveView: View {
+    @Environment(\.colorScheme) private var colorScheme
     let target: Int
     let leftInput: String
     let rightInput: String
@@ -77,7 +78,16 @@ struct EquationResolveView: View {
                     Text(value.isEmpty ? "?" : value)
                         .font(.system(size: 40, weight: .black, design: .rounded))
                         .frame(maxWidth: .infinity, minHeight: 84)
-                        .background(selectedSide == side ? MatherTheme.accent.opacity(0.18) : MatherTheme.softBlue.opacity(0.25))
+                        .background(selectedSide == side ? MatherTheme.accent.opacity(colorScheme == .dark ? 0.28 : 0.18) : MatherTheme.softBlue.opacity(colorScheme == .dark ? 0.32 : 0.25))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                                .strokeBorder(
+                                    selectedSide == side
+                                        ? .white.opacity(colorScheme == .dark ? 0.12 : 0)
+                                        : MatherTheme.panelDeep.opacity(colorScheme == .dark ? 0.65 : 0),
+                                    lineWidth: 1
+                                )
+                        )
                         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
                     // Inline clear — always reachable, no scrolling needed
                     if !value.isEmpty {

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct HomeView: View {
+    @Environment(\.colorScheme) private var colorScheme
     @Bindable var appModel: AppModel
 
     var body: some View {
@@ -116,7 +117,11 @@ struct HomeView: View {
                     )
                 )
             }
-            .shadow(color: .black.opacity(0.08), radius: 12, y: 5)
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1)
+            )
+            .shadow(color: colorScheme == .dark ? MatherTheme.coral.opacity(0.12) : .black.opacity(0.08), radius: colorScheme == .dark ? 18 : 12, y: colorScheme == .dark ? 8 : 5)
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("Play")

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -1,13 +1,16 @@
 import SwiftUI
 
 struct SliceSessionView: View {
+    @Environment(\.colorScheme) private var colorScheme
     @Bindable var appModel: AppModel
     @State private var celebrationScale: CGFloat = 0.3
 
     var body: some View {
         ZStack {
             LinearGradient(
-                colors: [MatherTheme.background, Color.white],
+                colors: colorScheme == .dark
+                    ? [MatherTheme.background, MatherTheme.panel]
+                    : [MatherTheme.background, Color.white],
                 startPoint: .topLeading,
                 endPoint: .bottomTrailing
             )
@@ -38,17 +41,23 @@ struct SliceSessionView: View {
             // The engine delays stage transition by 1.5s so the child sees the reward
             // before the screen changes. Non-interactive so taps pass through.
             if appModel.engine.showCelebration {
-                Text(appModel.engine.activeTheme.celebrationEmoji)
-                    .font(.system(size: 120))
-                    .scaleEffect(celebrationScale)
-                    .allowsHitTesting(false)
-                    .transition(.opacity.combined(with: .scale(scale: 0.8)))
-                    .onAppear {
-                        celebrationScale = 0.3
-                        withAnimation(.spring(response: 0.4, dampingFraction: 0.5)) {
-                            celebrationScale = 1.0
-                        }
+                ZStack {
+                    Circle()
+                        .fill(MatherTheme.coral.opacity(colorScheme == .dark ? 0.18 : 0.12))
+                        .frame(width: 180, height: 180)
+                        .blur(radius: 6)
+                    Text(appModel.engine.activeTheme.celebrationEmoji)
+                        .font(.system(size: 120))
+                }
+                .scaleEffect(celebrationScale)
+                .allowsHitTesting(false)
+                .transition(.opacity.combined(with: .scale(scale: 0.8)))
+                .onAppear {
+                    celebrationScale = 0.3
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.5)) {
+                        celebrationScale = 1.0
                     }
+                }
             }
         }
         .navigationBarBackButtonHidden(true)
@@ -127,7 +136,8 @@ struct SliceSessionView: View {
                             .font(.title2.weight(.bold))
                             .foregroundStyle(appModel.featureFlags.audioEnabled ? MatherTheme.softBlue : .secondary)
                             .frame(width: 44, height: 44)
-                            .background(MatherTheme.softBlue.opacity(0.18))
+                            .background(MatherTheme.softBlue.opacity(colorScheme == .dark ? 0.24 : 0.18))
+                            .overlay(Circle().strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1))
                             .clipShape(Circle())
                     }
                     .accessibilityLabel(appModel.featureFlags.audioEnabled ? "Mute audio" : "Enable audio")
@@ -138,7 +148,8 @@ struct SliceSessionView: View {
                             .font(.title2.weight(.bold))
                             .foregroundStyle(MatherTheme.warm)
                             .frame(width: 44, height: 44)
-                            .background(MatherTheme.warm.opacity(0.18))
+                            .background(MatherTheme.warm.opacity(colorScheme == .dark ? 0.24 : 0.18))
+                            .overlay(Circle().strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1))
                             .clipShape(Circle())
                     }
                     .accessibilityLabel("Replay prompt")
@@ -150,7 +161,8 @@ struct SliceSessionView: View {
                             .font(.title2.weight(.bold))
                             .foregroundStyle(.secondary)
                             .frame(width: 44, height: 44)
-                            .background(Color.secondary.opacity(0.12))
+                            .background(Color.secondary.opacity(colorScheme == .dark ? 0.18 : 0.12))
+                            .overlay(Circle().strokeBorder(.white.opacity(colorScheme == .dark ? 0.06 : 0), lineWidth: 1))
                             .clipShape(Circle())
                     }
                     .accessibilityLabel("Go to Home")
@@ -190,6 +202,15 @@ struct SliceSessionView: View {
             .padding(.top, 12)
             .padding(.bottom, 8)
         }
-        .background(.ultraThinMaterial)
+        .background(persistentSubmitBarBackground)
+    }
+
+    @ViewBuilder
+    private var persistentSubmitBarBackground: some View {
+        if colorScheme == .dark {
+            MatherTheme.panel.opacity(0.98)
+        } else {
+            Rectangle().fill(.ultraThinMaterial)
+        }
     }
 }

--- a/Features/VerticalSlice1/TransferCheckView.swift
+++ b/Features/VerticalSlice1/TransferCheckView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct TransferCheckView: View {
+    @Environment(\.colorScheme) private var colorScheme
     let problem: SliceProblem
     let leftCount: Int
     let rightCount: Int
@@ -61,7 +62,10 @@ struct TransferCheckView: View {
     }
 
     private func transferBucket(title: String, targetCount: Int, count: Int, fill: Color, side: TransferSide) -> some View {
-        VStack(spacing: 8) {
+        let bucketBackground = colorScheme == .dark ? MatherTheme.panel.opacity(0.94) : MatherTheme.card
+        let bucketBorder = colorScheme == .dark ? MatherTheme.panelDeep.opacity(0.78) : fill.opacity(0.18)
+
+        return VStack(spacing: 8) {
             HStack {
                 Text(title)
                     .font(.caption.weight(.bold))
@@ -118,6 +122,19 @@ struct TransferCheckView: View {
             }
             .foregroundStyle(fill)
         }
+        .padding(12)
         .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(bucketBackground)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .strokeBorder(bucketBorder, lineWidth: 1)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .strokeBorder(.white.opacity(colorScheme == .dark ? 0.06 : 0), lineWidth: 1)
+        )
     }
 }


### PR DESCRIPTION
## Summary
- make dark mode feel warmer and more playful on the home and session surfaces
- improve dark-mode depth and separation for session controls, transfer buckets, and equation inputs
- add a livelier celebration glow during session progress

## Validation
- on `ganesh@mba`: `xcodegen generate`
- on `ganesh@mba`: `xcodebuild build-for-testing -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17 Pro" CODE_SIGNING_ALLOWED=NO`
- on `ganesh@mba`: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:MatherTests CODE_SIGNING_ALLOWED=NO`
