### PR TITLE
feat(vs1): Bond Blast sensor-powered finale stage

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -10,21 +10,32 @@ final class AppModel {
     let telemetryWriter: TelemetryWriter
     let historyStore: SessionHistoryStore
     let engine: VerticalSliceEngine
+    let hapticsService: HapticsService
+    let motionService: MotionService
+    let soundDetectionService: SoundDetectionService
 
     init(modelContext: ModelContext) {
         let featureFlags = FeatureFlagService()
         let speechService = SpeechService()
         let telemetryWriter = TelemetryWriter()
         let historyStore = SessionHistoryStore(modelContext: modelContext)
+        let hapticsService = HapticsService()
+        let motionService = MotionService()
+        let soundDetectionService = SoundDetectionService()
 
         self.featureFlags = featureFlags
         self.speechService = speechService
         self.telemetryWriter = telemetryWriter
         self.historyStore = historyStore
+        self.hapticsService = hapticsService
+        self.motionService = motionService
+        self.soundDetectionService = soundDetectionService
+
         engine = VerticalSliceEngine(
             featureFlags: featureFlags,
             telemetryWriter: telemetryWriter,
             speechService: speechService,
+            hapticsService: hapticsService,
             saveSummary: historyStore.save
         )
     }

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -18,6 +18,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Mather listens for claps to celebrate with you! Enable in Settings → Clap reaction.</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/Domain/ClassicTheme.swift
+++ b/Domain/ClassicTheme.swift
@@ -25,11 +25,12 @@ struct ClassicTheme: SliceTheme {
 
     func stageSuccessPhrase(for stage: SliceStage, target: Int) -> String {
         switch stage {
-        case .concrete:  return "Yes. You made \(target)."
-        case .pictorial: return "That break still makes \(target)."
-        case .abstract:  return "Your equation matches the split."
-        case .transfer:  return "You matched the same equation with counters."
-        case .done:      return "Problem complete."
+        case .concrete:   return "Yes. You made \(target)."
+        case .pictorial:  return "That break still makes \(target)."
+        case .abstract:   return "Your equation matches the split."
+        case .transfer:   return "You matched the same equation with counters."
+        case .bondMatch:  return "Bond Blast complete!"
+        case .done:       return "Problem complete."
         }
     }
 

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -6,17 +6,19 @@ enum SliceStage: String, Codable, CaseIterable, Identifiable {
     case pictorial
     case abstract
     case transfer
+    case bondMatch
     case done
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .concrete: "Make it"
+        case .concrete:  "Make it"
         case .pictorial: "Break it"
-        case .abstract: "Write it"
-        case .transfer: "Show it again"
-        case .done: "Done"
+        case .abstract:  "Write it"
+        case .transfer:  "Show it again"
+        case .bondMatch: "Bond Blast!"
+        case .done:      "Done"
         }
     }
 }
@@ -131,6 +133,43 @@ struct SessionSummaryDraft: Equatable {
     var medianLatencyMs: Int
     var nextTargetHint: String
     var exportFileName: String
+}
+
+// MARK: - Bond Blast models
+
+/// One complement pair in the Bond Blast finale stage.
+/// `left + right == target` for all pairs in a `BondMatchState`.
+struct ComplementPair: Identifiable, Equatable {
+    let id: UUID
+    let left: Int
+    let right: Int
+    var isMatched: Bool
+
+    init(left: Int, right: Int, isMatched: Bool = false) {
+        self.id = UUID()
+        self.left = left
+        self.right = right
+        self.isMatched = isMatched
+    }
+}
+
+/// State for the Bond Blast finale stage — held by `VerticalSliceEngine`.
+struct BondMatchState: Equatable {
+    let target: Int
+    /// Canonical pair list ordered by ascending left value.
+    var pairs: [ComplementPair]
+
+    var matchCount: Int { pairs.filter(\.isMatched).count }
+    var isComplete: Bool { pairs.allSatisfy(\.isMatched) }
+
+    /// Generate all unique complement pairs (a, b) where a ≤ b and a + b == target.
+    /// Excludes (0, target) — zero is not a meaningful addend in this context.
+    static func makePairs(for target: Int) -> [ComplementPair] {
+        guard target >= 2 else { return [] }
+        return (1...(target - 1))
+            .filter { $0 <= target - $0 }
+            .map { a in ComplementPair(left: a, right: target - a) }
+    }
 }
 
 @Model

--- a/Domain/SliceStateMachine.swift
+++ b/Domain/SliceStateMachine.swift
@@ -1,7 +1,22 @@
 import Foundation
 
 enum SliceStateMachine {
-    static func nextStage(after stage: SliceStage, success: Bool, showTransfer: Bool) -> SliceStage {
+    /// Compute the next stage after `stage` succeeds.
+    ///
+    /// - Parameters:
+    ///   - stage: The stage that just completed successfully.
+    ///   - success: Must be `true`; failure returns `stage` unchanged.
+    ///   - showTransfer: Whether the Transfer stage is enabled for this session.
+    ///   - showBondMatch: Whether the Bond Blast finale should follow the last
+    ///     transfer (or abstract, when transfer is disabled). The engine passes
+    ///     `true` only on the last problem of the session when
+    ///     `featureFlags.vs1BondMatchEnabled` is set.
+    static func nextStage(
+        after stage: SliceStage,
+        success: Bool,
+        showTransfer: Bool,
+        showBondMatch: Bool = false
+    ) -> SliceStage {
         guard success else { return stage }
 
         switch stage {
@@ -10,15 +25,23 @@ enum SliceStateMachine {
         case .pictorial:
             return .abstract
         case .abstract:
-            return showTransfer ? .transfer : .done
+            if showTransfer { return .transfer }
+            return showBondMatch ? .bondMatch : .done
         case .transfer:
+            return showBondMatch ? .bondMatch : .done
+        case .bondMatch:
             return .done
         case .done:
             return .done
         }
     }
 
-    static func canTransition(from current: SliceStage, to next: SliceStage, showTransfer: Bool) -> Bool {
-        nextStage(after: current, success: true, showTransfer: showTransfer) == next
+    static func canTransition(
+        from current: SliceStage,
+        to next: SliceStage,
+        showTransfer: Bool,
+        showBondMatch: Bool = false
+    ) -> Bool {
+        nextStage(after: current, success: true, showTransfer: showTransfer, showBondMatch: showBondMatch) == next
     }
 }

--- a/Domain/VehicleSpec.swift
+++ b/Domain/VehicleSpec.swift
@@ -36,11 +36,12 @@ extension VehicleSpec {
         transferPromptFn: { "\($0) cars on the left and \($1) on the right." },
         stageSuccessFn: { stage, _ in
             switch stage {
-            case .concrete:  return "You filled the garage!"
-            case .pictorial: return "Both zones together make the same number."
-            case .abstract:  return "Your equation matches the split."
-            case .transfer:  return "You parked them perfectly."
-            case .done:      return "Problem complete."
+            case .concrete:   return "You filled the garage!"
+            case .pictorial:  return "Both zones together make the same number."
+            case .abstract:   return "Your equation matches the split."
+            case .transfer:   return "You parked them perfectly."
+            case .bondMatch:  return "Bond Blast complete!"
+            case .done:       return "Problem complete."
             }
         },
         sessionIntroFn: { "Let's park and split cars to ten." },
@@ -58,11 +59,12 @@ extension VehicleSpec {
         transferPromptFn: { "\($0) trucks on the left and \($1) on the right." },
         stageSuccessFn: { stage, _ in
             switch stage {
-            case .concrete:  return "All trucks loaded!"
-            case .pictorial: return "Both groups add up to the same number."
-            case .abstract:  return "Your equation matches the split."
-            case .transfer:  return "Trucks delivered perfectly."
-            case .done:      return "Problem complete."
+            case .concrete:   return "All trucks loaded!"
+            case .pictorial:  return "Both groups add up to the same number."
+            case .abstract:   return "Your equation matches the split."
+            case .transfer:   return "Trucks delivered perfectly."
+            case .bondMatch:  return "Bond Blast complete!"
+            case .done:       return "Problem complete."
             }
         },
         sessionIntroFn: { "Let's load and split trucks to ten." },
@@ -80,11 +82,12 @@ extension VehicleSpec {
         transferPromptFn: { "\($0) vans on the left and \($1) on the right." },
         stageSuccessFn: { stage, _ in
             switch stage {
-            case .concrete:  return "Warehouse full!"
-            case .pictorial: return "Both routes carry the same total."
-            case .abstract:  return "Your equation matches the split."
-            case .transfer:  return "Vans delivered!"
-            case .done:      return "Problem complete."
+            case .concrete:   return "Warehouse full!"
+            case .pictorial:  return "Both routes carry the same total."
+            case .abstract:   return "Your equation matches the split."
+            case .transfer:   return "Vans delivered!"
+            case .bondMatch:  return "Bond Blast complete!"
+            case .done:       return "Problem complete."
             }
         },
         sessionIntroFn: { "Let's deliver vans to ten." },
@@ -102,11 +105,12 @@ extension VehicleSpec {
         transferPromptFn: { "\($0) buses at the left stop and \($1) at the right." },
         stageSuccessFn: { stage, _ in
             switch stage {
-            case .concrete:  return "All aboard!"
-            case .pictorial: return "Both stops total the same."
-            case .abstract:  return "Your equation matches the split."
-            case .transfer:  return "Buses on route!"
-            case .done:      return "Problem complete."
+            case .concrete:   return "All aboard!"
+            case .pictorial:  return "Both stops total the same."
+            case .abstract:   return "Your equation matches the split."
+            case .transfer:   return "Buses on route!"
+            case .bondMatch:  return "Bond Blast complete!"
+            case .done:       return "Problem complete."
             }
         },
         sessionIntroFn: { "Let's fill buses to ten." },
@@ -124,11 +128,12 @@ extension VehicleSpec {
         transferPromptFn: { "\($0) bulldozers on the left and \($1) on the right." },
         stageSuccessFn: { stage, _ in
             switch stage {
-            case .concrete:  return "Site ready!"
-            case .pictorial: return "Both zones cover the same total."
-            case .abstract:  return "Your equation matches the split."
-            case .transfer:  return "Bulldozers in position!"
-            case .done:      return "Problem complete."
+            case .concrete:   return "Site ready!"
+            case .pictorial:  return "Both zones cover the same total."
+            case .abstract:   return "Your equation matches the split."
+            case .transfer:   return "Bulldozers in position!"
+            case .bondMatch:  return "Bond Blast complete!"
+            case .done:       return "Problem complete."
             }
         },
         sessionIntroFn: { "Let's line up bulldozers to ten." },
@@ -146,11 +151,12 @@ extension VehicleSpec {
         transferPromptFn: { "\($0) helicopters on the left pad and \($1) on the right." },
         stageSuccessFn: { stage, _ in
             switch stage {
-            case .concrete:  return "All landed!"
-            case .pictorial: return "Both pads together hold the same total."
-            case .abstract:  return "Your equation matches the split."
-            case .transfer:  return "Helicopters landed perfectly."
-            case .done:      return "Problem complete."
+            case .concrete:   return "All landed!"
+            case .pictorial:  return "Both pads together hold the same total."
+            case .abstract:   return "Your equation matches the split."
+            case .transfer:   return "Helicopters landed perfectly."
+            case .bondMatch:  return "Bond Blast complete!"
+            case .done:       return "Problem complete."
             }
         },
         sessionIntroFn: { "Let's land helicopters to ten." },
@@ -168,11 +174,12 @@ extension VehicleSpec {
         transferPromptFn: { "\($0) planes at the left terminal and \($1) at the right." },
         stageSuccessFn: { stage, _ in
             switch stage {
-            case .concrete:  return "All planes at the gate!"
-            case .pictorial: return "Both terminals hold the same total."
-            case .abstract:  return "Your equation matches the split."
-            case .transfer:  return "Planes ready for take-off!"
-            case .done:      return "Problem complete."
+            case .concrete:   return "All planes at the gate!"
+            case .pictorial:  return "Both terminals hold the same total."
+            case .abstract:   return "Your equation matches the split."
+            case .transfer:   return "Planes ready for take-off!"
+            case .bondMatch:  return "Bond Blast complete!"
+            case .done:       return "Problem complete."
             }
         },
         sessionIntroFn: { "Let's park planes to ten." },

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -31,6 +31,7 @@ final class VerticalSliceEngine {
     var equationRightInput = ""
     var transferLeftCount = 0
     var transferRightCount = 0
+    private(set) var bondMatchState: BondMatchState? = nil
     var feedbackMessage = "Tap Play to start."
     var showCelebration = false
     var completedSummary: SessionSummaryDraft?
@@ -134,6 +135,7 @@ final class VerticalSliceEngine {
         equationRightInput = ""
         transferLeftCount = 0
         transferRightCount = 0
+        bondMatchState = nil
         feedbackMessage = activeTheme.sessionStartFeedback()
         showCelebration = false
         completedSummary = nil
@@ -235,6 +237,10 @@ final class VerticalSliceEngine {
         case .transfer:
             isCorrect = transferLeftCount == currentProblem.decompositionA
                 && transferRightCount == currentProblem.decompositionB
+        case .bondMatch:
+            // Bond Blast is not submitted via submitCurrentStage — pairs are matched
+            // individually via matchPair(id:). This case is unreachable in practice.
+            isCorrect = bondMatchState?.isComplete == true
         case .done:
             isCorrect = true
         }
@@ -253,6 +259,54 @@ final class VerticalSliceEngine {
         speechService.speak(promptForCurrentStage(), enabled: featureFlags.audioEnabled)
     }
 
+    // MARK: - Bond Blast actions
+
+    /// Called by BondMatchView when the child begins dragging or taps a left card.
+    func bondDragStarted(pairId: UUID) {
+        guard currentStage == .bondMatch else { return }
+        hapticsService.cardPickup(enabled: featureFlags.hapticsEnabled)
+        logBondMatchTelemetry("pair_drag_started", extra: ["pair_id": pairId.uuidString])
+    }
+
+    /// Called by BondMatchView when a dragged card is hovering near a snap target.
+    func bondNearTarget() {
+        guard currentStage == .bondMatch else { return }
+        hapticsService.cardNearSnap(enabled: featureFlags.hapticsEnabled)
+    }
+
+    /// Called when the child successfully matches a complement pair.
+    /// Advances to `.done` when all pairs are matched.
+    func matchPair(id: UUID) {
+        guard currentStage == .bondMatch,
+              let idx = bondMatchState?.pairs.firstIndex(where: { $0.id == id }),
+              let problem = currentProblem else { return }
+
+        bondMatchState?.pairs[idx].isMatched = true
+        let pair = bondMatchState!.pairs[idx]
+
+        logBondMatchTelemetry("pair_matched", extra: [
+            "left": String(pair.left),
+            "right": String(pair.right),
+            "match_count": String(bondMatchState?.matchCount ?? 0)
+        ])
+        hapticsService.cardSnapCorrect(enabled: featureFlags.hapticsEnabled)
+
+        if bondMatchState?.isComplete == true {
+            let msg = "Amazing! You matched all the bonds for \(problem.target)!"
+            completeStage(successMessage: msg)
+        }
+    }
+
+    /// Called when the child drops a card on the wrong target.
+    func mismatchPair() {
+        guard currentStage == .bondMatch, let problem = currentProblem else { return }
+        logBondMatchTelemetry("pair_mismatch", extra: [:])
+        hapticsService.cardSnapMismatch(enabled: featureFlags.hapticsEnabled)
+        let msg = "Try again! Find two numbers that make \(problem.target)."
+        feedbackMessage = msg
+        speechService.speak(msg, enabled: featureFlags.audioEnabled)
+    }
+
     private func validateEquation(for problem: SliceProblem) -> Bool {
         guard let left = Int(equationLeftInput), let right = Int(equationRightInput) else { return false }
         return left + right == problem.target
@@ -262,13 +316,29 @@ final class VerticalSliceEngine {
         feedbackMessage = successMessage
         speechService.speak(successMessage, enabled: featureFlags.audioEnabled)
 
-        let next = SliceStateMachine.nextStage(after: currentStage, success: true, showTransfer: config.showTransfer)
+        // Bond Blast fires only on the last problem of the session.
+        let isLastProblem = currentProblemIndex + 1 >= problems.count
+        let showBondMatch = featureFlags.vs1BondMatchEnabled && isLastProblem
+
+        let next = SliceStateMachine.nextStage(
+            after: currentStage,
+            success: true,
+            showTransfer: config.showTransfer,
+            showBondMatch: showBondMatch
+        )
         recordStageTransition(from: currentStage, to: next)
 
-        let isProblemComplete = currentStage == .transfer || (!config.showTransfer && currentStage == .abstract)
+        // A problem is complete when the next stage is .done (the last meaningful
+        // stage has been cleared). This handles all paths: with/without transfer,
+        // with/without bond match.
+        let isProblemComplete = next == .done
         if isProblemComplete {
             recordProblemCompletion(transferCorrect: true)
-            hapticsService.success(enabled: featureFlags.hapticsEnabled)
+            if currentStage == .bondMatch {
+                hapticsService.bondMatchComplete(enabled: featureFlags.hapticsEnabled)
+            } else {
+                hapticsService.success(enabled: featureFlags.hapticsEnabled)
+            }
         } else {
             hapticsService.stageSuccess(enabled: featureFlags.hapticsEnabled)
         }
@@ -300,6 +370,17 @@ final class VerticalSliceEngine {
         case .transfer:
             transferLeftCount = 0
             transferRightCount = 0
+        case .bondMatch:
+            if let problem = currentProblem {
+                bondMatchState = BondMatchState(
+                    target: problem.target,
+                    pairs: BondMatchState.makePairs(for: problem.target)
+                )
+                logBondMatchTelemetry("bond_match_started", extra: [
+                    "target": String(problem.target),
+                    "pair_count": String(bondMatchState?.pairs.count ?? 0)
+                ])
+            }
         case .concrete, .done:
             break
         }
@@ -488,6 +569,8 @@ final class VerticalSliceEngine {
                 decompositionA: currentProblem.decompositionA,
                 decompositionB: currentProblem.decompositionB
             )
+        case .bondMatch:
+            return "Bond Blast! Match the pairs that make \(currentProblem.target)!"
         case .done:
             return "Nice work."
         }
@@ -532,9 +615,22 @@ final class VerticalSliceEngine {
             } else {
                 return "Keep showing the same equation with counters: \(problem.decompositionA) in the first group and \(problem.decompositionB) in the second group."
             }
+        case .bondMatch:
+            return "Try another pair. Look for two numbers that add up to \(problem.target)."
         case .done:
             return "Try again."
         }
+    }
+
+    private func logBondMatchTelemetry(_ action: String, extra: [String: String]) {
+        guard let currentProblem else { return }
+        var payload = extra
+        payload["problem_id"] = currentProblem.id.uuidString
+        payload["action"] = action
+        payload["stage"] = SliceStage.bondMatch.rawValue
+        try? telemetryWriter.append(
+            SliceEvent(type: .interaction, payload: payload)
+        )
     }
 
     private func appendDigit(to string: String, digit: Int) -> String {

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -35,6 +35,27 @@ struct SettingsView: View {
         )
     }
 
+    private var bondMatchBinding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.vs1BondMatchEnabled },
+            set: { appModel.featureFlags.vs1BondMatchEnabled = $0 }
+        )
+    }
+
+    private var motionBinding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.motionControlsEnabled },
+            set: { appModel.featureFlags.motionControlsEnabled = $0 }
+        )
+    }
+
+    private var soundReactionBinding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.soundReactionEnabled },
+            set: { appModel.featureFlags.soundReactionEnabled = $0 }
+        )
+    }
+
     private func smokeStep(_ text: String) -> some View {
         Label(text, systemImage: "checkmark.circle")
             .font(.subheadline)
@@ -62,6 +83,9 @@ struct SettingsView: View {
                             Toggle("Make & Break to 10", isOn: verticalSliceBinding)
                                 .lineLimit(1)
                                 .minimumScaleFactor(0.85)
+                            Toggle("Bond Blast finale", isOn: bondMatchBinding)
+                            Toggle("Motion controls", isOn: motionBinding)
+                            Toggle("Clap reaction (mic)", isOn: soundReactionBinding)
                             Toggle("Test mode", isOn: testModeBinding)
                             Toggle("Audio prompts", isOn: audioBinding)
                             Toggle("Haptics", isOn: hapticsBinding)

--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -1,0 +1,301 @@
+import SwiftUI
+
+/// Bond Blast — the sensor-powered complement-match finale stage for VS1.
+///
+/// Displays all complement pairs for the session target (e.g. for 7:
+/// 1+6, 2+5, 3+4). The child selects a left card (tap to highlight), then
+/// taps the matching right card to lock the pair. All pairs locked = stage done.
+///
+/// **Sensor integration** (both ambient — tap-only path always works):
+/// - Tilt drift: unselected left cards float ±6 pt with device attitude.
+/// - Shake: shuffles the right column order for unmatched pairs.
+/// - Clap (optional, default off): triggers a celebration response after
+///   all pairs are matched.
+///
+/// Lifecycle: `MotionService` and `SoundDetectionService` are started/stopped
+/// by `SliceSessionView` via `.onAppear` / `.onDisappear` modifiers applied at
+/// the call site, not inside this view.
+struct BondMatchView: View {
+
+    // MARK: - Inputs
+
+    let state: BondMatchState
+    let tiltPitch: Double
+    let tiltRoll: Double
+    let shakeDetected: Bool
+    let clapDetected: Bool
+    /// Called when the child correctly matches a pair (passes the pair's id).
+    let onMatch: (UUID) -> Void
+    /// Called when the child taps a wrong right-column target.
+    let onMismatch: () -> Void
+    /// Called when the child taps or drags a left card (pickup haptic).
+    let onDragStarted: (UUID) -> Void
+    /// Called when a card is near a snap zone (near-snap haptic).
+    let onNearTarget: () -> Void
+    /// Call after consuming a shake event so MotionService can reset.
+    let onShakeHandled: () -> Void
+    /// Call after consuming a clap event so SoundDetectionService can reset.
+    let onClapHandled: () -> Void
+
+    // MARK: - Local state
+
+    /// The left-card pair currently selected (highlighted), waiting for a right-tap.
+    @State private var selectedPairId: UUID? = nil
+    /// Right column display order — shuffled at appear, reshuffled on shake.
+    @State private var shuffledRightValues: [Int] = []
+    /// Right-value that is currently wobbling after a mismatch.
+    @State private var mismatchedRightValue: Int? = nil
+
+    // MARK: - Constants
+
+    private let cardSize: CGFloat = 88
+    private let cardSpacing: CGFloat = 12
+
+    // MARK: - Tilt drift
+
+    /// Subtle positional drift applied to unselected, unmatched left cards.
+    /// Max ±6 pt — perceptible but does not displace cards out of their tap zone.
+    private var tiltDrift: CGSize {
+        CGSize(
+            width:  CGFloat(tiltRoll)  * 6,
+            height: CGFloat(tiltPitch) * 6
+        )
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        CardSurface {
+            VStack(spacing: 20) {
+                headerView
+                pairsGrid
+                progressDots
+            }
+        }
+        .onAppear {
+            setupShuffledOrder()
+        }
+        .onChange(of: shakeDetected) { _, shook in
+            guard shook else { return }
+            withAnimation(.spring(response: 0.4, dampingFraction: 0.65)) {
+                shuffleUnmatchedRight()
+            }
+            onShakeHandled()
+        }
+        .onChange(of: clapDetected) { _, clapped in
+            guard clapped, state.isComplete else { return }
+            onClapHandled()
+        }
+        .sensoryFeedback(.success, trigger: state.matchCount)
+        .accessibilityLabel("Bond Blast matching board. Make \(state.target). \(state.matchCount) of \(state.pairs.count) matched.")
+    }
+
+    // MARK: - Subviews
+
+    private var headerView: some View {
+        VStack(spacing: 6) {
+            Text("Bond Blast!")
+                .font(.system(size: 28, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.accent)
+                .accessibilityAddTraits(.isHeader)
+            Text("Make \(state.target)")
+                .font(.title2.weight(.bold))
+                .foregroundStyle(MatherTheme.warm)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var pairsGrid: some View {
+        HStack(alignment: .top, spacing: 16) {
+            // Left column: selectable source cards
+            VStack(spacing: cardSpacing) {
+                columnLabel("Pick")
+                ForEach(state.pairs) { pair in
+                    leftCard(pair: pair)
+                }
+            }
+
+            // Centre: large "+" separator
+            VStack {
+                columnLabel(" ")  // height spacer to align with labels
+                Text("+")
+                    .font(.system(size: 32, weight: .black, design: .rounded))
+                    .foregroundStyle(Color.secondary.opacity(0.5))
+                    .frame(height: cardSize)
+            }
+
+            // Right column: shuffle targets (complement values)
+            VStack(spacing: cardSpacing) {
+                columnLabel("Match")
+                ForEach(shuffledRightValues, id: \.self) { rightVal in
+                    rightCard(value: rightVal)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var progressDots: some View {
+        HStack(spacing: 10) {
+            ForEach(0..<state.pairs.count, id: \.self) { i in
+                Circle()
+                    .fill(i < state.matchCount ? MatherTheme.accent : Color.secondary.opacity(0.25))
+                    .frame(width: 14, height: 14)
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.6), value: state.matchCount)
+    }
+
+    // MARK: - Card builders
+
+    @ViewBuilder
+    private func leftCard(pair: ComplementPair) -> some View {
+        let isSelected = selectedPairId == pair.id
+        let isMatched  = pair.isMatched
+
+        Button {
+            guard !isMatched else { return }
+            if !isSelected { onDragStarted(pair.id) }
+            withAnimation(.spring(response: 0.2, dampingFraction: 0.65)) {
+                selectedPairId = isSelected ? nil : pair.id
+            }
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                numberCardFill(
+                    value: pair.left,
+                    textColor: isMatched ? MatherTheme.accent : .white,
+                    background: isMatched
+                        ? MatherTheme.accent.opacity(0.15)
+                        : (isSelected ? MatherTheme.warm : MatherTheme.warm.opacity(0.85)),
+                    strokeColor: isSelected ? .white : (isMatched ? MatherTheme.accent : .clear),
+                    strokeWidth: isSelected ? 4 : (isMatched ? 2 : 0),
+                    dashed: false
+                )
+                .shadow(
+                    color: isSelected ? MatherTheme.warm.opacity(0.55) : .clear,
+                    radius: 12
+                )
+                // Tilt drift — only on unselected, unmatched cards
+                .offset((!isSelected && !isMatched) ? tiltDrift : .zero)
+                .animation(.linear(duration: 0.1), value: tiltDrift)
+
+                if isMatched {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(MatherTheme.accent)
+                        .font(.title3.weight(.bold))
+                        .offset(x: 4, y: -4)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .scaleEffect(isSelected ? 1.07 : 1.0)
+        .animation(.spring(response: 0.22, dampingFraction: 0.6), value: isSelected)
+        .frame(width: cardSize, height: cardSize)
+        .accessibilityLabel("\(pair.left)\(isMatched ? ", matched" : isSelected ? ", selected" : "")")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+
+    @ViewBuilder
+    private func rightCard(value: Int) -> some View {
+        let isMatched   = state.pairs.first(where: { $0.right == value })?.isMatched == true
+        let isWobbling  = mismatchedRightValue == value
+        let isActivated = selectedPairId != nil && !isMatched
+
+        Button {
+            guard let selId = selectedPairId,
+                  let pair = state.pairs.first(where: { $0.id == selId }),
+                  !pair.isMatched else { return }
+
+            if value == pair.right {
+                onMatch(selId)
+                withAnimation(.spring(response: 0.2)) { selectedPairId = nil }
+            } else {
+                onMismatch()
+                triggerMismatch(for: value)
+            }
+        } label: {
+            numberCardFill(
+                value: value,
+                textColor: isMatched ? MatherTheme.softBlue : MatherTheme.ink,
+                background: isMatched
+                    ? MatherTheme.softBlue.opacity(0.15)
+                    : (isActivated ? MatherTheme.softBlue.opacity(0.18) : Color.secondary.opacity(0.08)),
+                strokeColor: isMatched
+                    ? MatherTheme.softBlue
+                    : (isActivated ? MatherTheme.softBlue.opacity(0.6) : Color.secondary.opacity(0.3)),
+                strokeWidth: 3,
+                dashed: !isMatched && !isActivated
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(isMatched)
+        .frame(width: cardSize, height: cardSize)
+        .offset(x: isWobbling ? 8 : 0)
+        .animation(
+            isWobbling
+                ? .easeInOut(duration: 0.08).repeatCount(5, autoreverses: true)
+                : .default,
+            value: isWobbling
+        )
+        .accessibilityLabel("\(value)\(isMatched ? ", matched" : "")")
+    }
+
+    // MARK: - Shared card fill
+
+    @ViewBuilder
+    private func numberCardFill(
+        value: Int,
+        textColor: Color,
+        background: Color,
+        strokeColor: Color,
+        strokeWidth: CGFloat,
+        dashed: Bool
+    ) -> some View {
+        Text("\(value)")
+            .font(.system(size: 38, weight: .black, design: .rounded))
+            .foregroundStyle(textColor)
+            .frame(width: cardSize, height: cardSize)
+            .background(background)
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(
+                        strokeColor,
+                        style: StrokeStyle(
+                            lineWidth: strokeWidth,
+                            dash: dashed ? [7, 4] : []
+                        )
+                    )
+            )
+    }
+
+    private func columnLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .frame(height: 20)
+    }
+
+    // MARK: - Private helpers
+
+    private func setupShuffledOrder() {
+        shuffledRightValues = state.pairs.map(\.right).shuffled()
+    }
+
+    /// Re-shuffle only the unmatched right values in place.
+    private func shuffleUnmatchedRight() {
+        let matched   = Set(state.pairs.filter(\.isMatched).map(\.right))
+        var unmatched = shuffledRightValues.filter { !matched.contains($0) }.shuffled()
+        shuffledRightValues = shuffledRightValues.map { val in
+            matched.contains(val) ? val : unmatched.removeFirst()
+        }
+    }
+
+    private func triggerMismatch(for value: Int) {
+        mismatchedRightValue = value
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(450))
+            mismatchedRightValue = nil
+        }
+    }
+}

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -100,6 +100,34 @@ struct SliceSessionView: View {
                 onSubmit: appModel.engine.submitCurrentStage,
                 theme: appModel.engine.activeTheme
             )
+        case .bondMatch:
+            if let bondState = appModel.engine.bondMatchState {
+                BondMatchView(
+                    state: bondState,
+                    tiltPitch: appModel.motionService.tiltPitch,
+                    tiltRoll: appModel.motionService.tiltRoll,
+                    shakeDetected: appModel.motionService.shakeDetected,
+                    clapDetected: appModel.soundDetectionService.clapDetected,
+                    onMatch: appModel.engine.matchPair(id:),
+                    onMismatch: appModel.engine.mismatchPair,
+                    onDragStarted: appModel.engine.bondDragStarted(pairId:),
+                    onNearTarget: appModel.engine.bondNearTarget,
+                    onShakeHandled: appModel.motionService.resetShake,
+                    onClapHandled: appModel.soundDetectionService.resetClap
+                )
+                .onAppear {
+                    if appModel.featureFlags.motionControlsEnabled {
+                        appModel.motionService.startUpdates()
+                    }
+                    if appModel.featureFlags.soundReactionEnabled {
+                        appModel.soundDetectionService.startListening()
+                    }
+                }
+                .onDisappear {
+                    appModel.motionService.stopUpdates()
+                    appModel.soundDetectionService.stopListening()
+                }
+            }
         case .done:
             CardSurface { Text("Moving to the next problem...") }
         }
@@ -165,11 +193,12 @@ struct SliceSessionView: View {
 
     private func stageColour(_ stage: SliceStage) -> Color {
         switch stage {
-        case .concrete: MatherTheme.warm
+        case .concrete:  MatherTheme.warm
         case .pictorial: MatherTheme.softBlue
-        case .abstract: MatherTheme.accent
-        case .transfer: MatherTheme.coral
-        case .done: .secondary
+        case .abstract:  MatherTheme.accent
+        case .transfer:  MatherTheme.coral
+        case .bondMatch: MatherTheme.accent
+        case .done:      .secondary
         }
     }
 

--- a/Services/HapticsService.swift
+++ b/Services/HapticsService.swift
@@ -1,34 +1,226 @@
+import CoreHaptics
 import UIKit
 
+/// Provides tactile feedback throughout the app.
+///
+/// Uses CHHapticEngine for rich, multi-event patterns (Bond Blast card
+/// pickup, near-snap magnetic pull, correct snap, mismatch wobble, and
+/// celebration rhythm). Falls back to UIImpactFeedbackGenerator when the
+/// haptic engine is unavailable (simulator, older hardware).
+///
+/// All methods are safe to call when haptics are disabled — they return
+/// immediately without side effects.
 @MainActor
 final class HapticsService {
+
+    // MARK: - Testability counters
+
     private(set) var successFiredCount = 0
     private(set) var failureFiredCount = 0
     private(set) var stageSuccessFiredCount = 0
+
+    // MARK: - Engine
+
+    private var engine: CHHapticEngine?
+
+    init() {
+        guard CHHapticEngine.capabilitiesForHardware().supportsHaptics else { return }
+        do {
+            engine = try CHHapticEngine()
+            engine?.resetHandler = { [weak self] in
+                try? self?.engine?.start()
+            }
+            engine?.stoppedHandler = { _ in }
+            try engine?.start()
+        } catch {
+            engine = nil
+        }
+    }
+
+    // MARK: - Existing CPA stage feedback
 
     /// Light haptic for completing an individual CPA stage (not a full problem).
     func stageSuccess(enabled: Bool) {
         guard enabled else { return }
         stageSuccessFiredCount += 1
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        playTransient(intensity: 0.5, sharpness: 0.5) {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        }
     }
 
     /// Medium haptic for completing a full problem (all stages done).
     func success(enabled: Bool) {
         guard enabled else { return }
         successFiredCount += 1
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        playTransient(intensity: 0.8, sharpness: 0.7) {
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        }
     }
 
     func failure(enabled: Bool) {
         guard enabled else { return }
         failureFiredCount += 1
-        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        playTransient(intensity: 0.5, sharpness: 0.1) {
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+        }
     }
+
+    // MARK: - Bond Blast haptics
+
+    /// Soft "weight" sensation when a card is picked up / tapped to select.
+    func cardPickup(enabled: Bool) {
+        guard enabled else { return }
+        playTransient(intensity: 0.4, sharpness: 0.6) {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        }
+    }
+
+    /// Intensifying magnetic pull as a card nears the correct snap target.
+    func cardNearSnap(enabled: Bool) {
+        guard enabled else { return }
+        guard let engine else {
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+            return
+        }
+        do {
+            let rampEvent = CHHapticEvent(
+                eventType: .hapticContinuous,
+                parameters: [
+                    CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.2),
+                    CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.4)
+                ],
+                relativeTime: 0,
+                duration: 0.2
+            )
+            let intensityCurve = CHHapticParameterCurve(
+                parameterID: .hapticIntensityControl,
+                controlPoints: [
+                    CHHapticParameterCurve.ControlPoint(relativeTime: 0, value: 0.2),
+                    CHHapticParameterCurve.ControlPoint(relativeTime: 0.2, value: 0.7)
+                ],
+                relativeTime: 0
+            )
+            let pattern = try CHHapticPattern(events: [rampEvent], parameterCurves: [intensityCurve])
+            let player = try engine.makePlayer(with: pattern)
+            try player.start(atTime: CHHapticTimeImmediate)
+        } catch {
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        }
+    }
+
+    /// Satisfying "click + echo" when a pair is correctly matched.
+    func cardSnapCorrect(enabled: Bool) {
+        guard enabled else { return }
+        guard let engine else {
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+            return
+        }
+        do {
+            let click = CHHapticEvent(
+                eventType: .hapticTransient,
+                parameters: [
+                    CHHapticEventParameter(parameterID: .hapticIntensity, value: 1.0),
+                    CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.9)
+                ],
+                relativeTime: 0
+            )
+            let echo = CHHapticEvent(
+                eventType: .hapticTransient,
+                parameters: [
+                    CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.5),
+                    CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.5)
+                ],
+                relativeTime: 0.08
+            )
+            let pattern = try CHHapticPattern(events: [click, echo], parameterCurves: [])
+            let player = try engine.makePlayer(with: pattern)
+            try player.start(atTime: CHHapticTimeImmediate)
+        } catch {
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        }
+    }
+
+    /// Soft, rounded "hmm" when a wrong pair is attempted.
+    func cardSnapMismatch(enabled: Bool) {
+        guard enabled else { return }
+        playTransient(intensity: 0.5, sharpness: 0.1) {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        }
+    }
+
+    /// Four rising taps followed by a short sustain — session-closing celebration.
+    func bondMatchComplete(enabled: Bool) {
+        guard enabled else { return }
+        guard let engine else {
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            return
+        }
+        do {
+            let offsets: [(time: Double, intensity: Float, sharpness: Float)] = [
+                (0.0,  0.5, 0.8),
+                (0.15, 0.65, 0.85),
+                (0.30, 0.80, 0.90),
+                (0.45, 1.0, 1.0)
+            ]
+            var events: [CHHapticEvent] = offsets.map { tap in
+                CHHapticEvent(
+                    eventType: .hapticTransient,
+                    parameters: [
+                        CHHapticEventParameter(parameterID: .hapticIntensity, value: tap.intensity),
+                        CHHapticEventParameter(parameterID: .hapticSharpness, value: tap.sharpness)
+                    ],
+                    relativeTime: tap.time
+                )
+            }
+            events.append(
+                CHHapticEvent(
+                    eventType: .hapticContinuous,
+                    parameters: [
+                        CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.6),
+                        CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.5)
+                    ],
+                    relativeTime: 0.6,
+                    duration: 0.3
+                )
+            )
+            let pattern = try CHHapticPattern(events: events, parameterCurves: [])
+            let player = try engine.makePlayer(with: pattern)
+            try player.start(atTime: CHHapticTimeImmediate)
+        } catch {
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        }
+    }
+
+    // MARK: - Test support
 
     func resetCounts() {
         successFiredCount = 0
         failureFiredCount = 0
         stageSuccessFiredCount = 0
+    }
+
+    // MARK: - Private helpers
+
+    /// Play a single transient event via CHHapticEngine, falling back to a closure.
+    private func playTransient(intensity: Float, sharpness: Float, fallback: () -> Void) {
+        guard let engine else {
+            fallback()
+            return
+        }
+        do {
+            let event = CHHapticEvent(
+                eventType: .hapticTransient,
+                parameters: [
+                    CHHapticEventParameter(parameterID: .hapticIntensity, value: intensity),
+                    CHHapticEventParameter(parameterID: .hapticSharpness, value: sharpness)
+                ],
+                relativeTime: 0
+            )
+            let pattern = try CHHapticPattern(events: [event], parameterCurves: [])
+            let player = try engine.makePlayer(with: pattern)
+            try player.start(atTime: CHHapticTimeImmediate)
+        } catch {
+            fallback()
+        }
     }
 }

--- a/Services/MotionService.swift
+++ b/Services/MotionService.swift
@@ -1,0 +1,83 @@
+import CoreMotion
+import Observation
+
+/// Wraps CMMotionManager with @MainActor isolation.
+///
+/// Delivers device attitude (pitch/roll) for tilt drift and detects
+/// shake gestures for the Bond Blast shuffle mechanic. No permissions
+/// required — CoreMotion device motion is always available.
+///
+/// Start/stop lifecycle is managed by BondMatchView via onAppear/onDisappear.
+@MainActor
+@Observable
+final class MotionService {
+
+    // MARK: - Observable state
+
+    /// Pitch (forward/backward tilt) in radians. Positive = top tilts away.
+    var tiltPitch: Double = 0
+    /// Roll (left/right tilt) in radians. Positive = right side tilts down.
+    var tiltRoll: Double = 0
+    /// Set to true for one shake event, then auto-resets after 500 ms.
+    var shakeDetected: Bool = false
+
+    // MARK: - Private
+
+    // nonisolated(unsafe) avoids a Sendable crossing error: CMMotionManager is not
+    // Sendable, but we only ever access it from @MainActor methods, so it is safe.
+    nonisolated(unsafe) private let manager = CMMotionManager()
+    private var shakeResetTask: Task<Void, Never>?
+
+    // MARK: - Lifecycle
+
+    /// Begin streaming device motion at 30 Hz. Safe to call multiple times.
+    func startUpdates() {
+        guard manager.isDeviceMotionAvailable, !manager.isDeviceMotionActive else { return }
+        manager.deviceMotionUpdateInterval = 1.0 / 30.0
+        manager.startDeviceMotionUpdates(to: .main) { [weak self] motion, _ in
+            guard let motion else { return }
+            MainActor.assumeIsolated {
+                self?.applyMotion(motion)
+            }
+        }
+    }
+
+    /// Stop all device motion updates and reset tilt state.
+    func stopUpdates() {
+        manager.stopDeviceMotionUpdates()
+        shakeResetTask?.cancel()
+        tiltPitch = 0
+        tiltRoll = 0
+        shakeDetected = false
+    }
+
+    /// Call after the view has consumed a shake event to prevent re-triggering.
+    func resetShake() {
+        shakeDetected = false
+        shakeResetTask?.cancel()
+    }
+
+    // MARK: - Private helpers
+
+    private func applyMotion(_ motion: CMDeviceMotion) {
+        tiltPitch = motion.attitude.pitch
+        tiltRoll  = motion.attitude.roll
+
+        // Shake detection: userAcceleration excludes gravity.
+        // A deliberate device shake exceeds 2.5g on at least one axis.
+        let acc = motion.userAcceleration
+        let magnitude = (acc.x * acc.x + acc.y * acc.y + acc.z * acc.z).squareRoot()
+        if magnitude > 2.5 && !shakeDetected {
+            triggerShake()
+        }
+    }
+
+    private func triggerShake() {
+        shakeDetected = true
+        shakeResetTask?.cancel()
+        shakeResetTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(600))
+            self?.shakeDetected = false
+        }
+    }
+}

--- a/Services/SoundDetectionService.swift
+++ b/Services/SoundDetectionService.swift
@@ -1,0 +1,99 @@
+import AVFoundation
+import Observation
+
+/// Detects hand-clap events via microphone RMS spike analysis.
+///
+/// Uses AVAudioEngine (NOT SoundAnalysis) for low latency and zero ML model
+/// overhead. A clap signature is an RMS spike from near-silence (< 0.05) to
+/// above 0.3 within one ~46 ms buffer window.
+///
+/// **Privacy**: Audio data is never stored or transmitted — the tap computes
+/// only an RMS scalar. The service is started only when
+/// `featureFlags.soundReactionEnabled` is true (default: false), and stops
+/// immediately when BondMatchView disappears.
+///
+/// Requires `NSMicrophoneUsageDescription` in Info.plist.
+@MainActor
+@Observable
+final class SoundDetectionService {
+
+    // MARK: - Observable state
+
+    /// Momentarily true when a clap is detected; auto-resets after 500 ms.
+    var clapDetected: Bool = false
+
+    // MARK: - Private
+
+    // nonisolated(unsafe): AVAudioEngine is not Sendable, but we only ever
+    // access it from @MainActor methods (start/stop are both @MainActor).
+    nonisolated(unsafe) private let audioEngine = AVAudioEngine()
+    private var isListening = false
+    private var previousRMS: Float = 0
+    private var clapResetTask: Task<Void, Never>?
+
+    // MARK: - Lifecycle
+
+    /// Request microphone access (if not yet granted) and begin listening.
+    /// Does nothing if already listening.
+    func startListening() {
+        guard !isListening else { return }
+        let inputNode = audioEngine.inputNode
+        let format = inputNode.inputFormat(forBus: 0)
+
+        inputNode.installTap(onBus: 0, bufferSize: 2048, format: format) { [weak self] buffer, _ in
+            guard let channelData = buffer.floatChannelData?[0] else { return }
+            let frameCount = Int(buffer.frameLength)
+            var sumOfSquares: Float = 0
+            for i in 0..<frameCount {
+                sumOfSquares += channelData[i] * channelData[i]
+            }
+            let rms = (sumOfSquares / Float(frameCount)).squareRoot()
+
+            // The audio tap runs on the audio I/O thread — marshal to @MainActor.
+            Task { @MainActor [weak self] in
+                self?.evaluateRMS(rms)
+            }
+        }
+
+        do {
+            try audioEngine.start()
+            isListening = true
+        } catch {
+            // Silently fail: microphone permission may be denied, or the
+            // audio session may be unavailable. Bond Blast still works without clap.
+            inputNode.removeTap(onBus: 0)
+        }
+    }
+
+    /// Stop listening and tear down the audio tap.
+    func stopListening() {
+        guard isListening else { return }
+        audioEngine.inputNode.removeTap(onBus: 0)
+        audioEngine.stop()
+        isListening = false
+        previousRMS = 0
+        clapResetTask?.cancel()
+        clapDetected = false
+    }
+
+    /// Call after the view has consumed the clap event to prevent re-triggering.
+    func resetClap() {
+        clapDetected = false
+        clapResetTask?.cancel()
+    }
+
+    // MARK: - Private helpers
+
+    private func evaluateRMS(_ rms: Float) {
+        // Clap signature: near-silence followed by a sharp spike.
+        if rms > 0.3 && previousRMS < 0.05 && !clapDetected {
+            clapDetected = true
+            clapResetTask?.cancel()
+            clapResetTask = Task { @MainActor [weak self] in
+                try? await Task.sleep(for: .milliseconds(500))
+                self?.clapDetected = false
+            }
+        }
+        previousRMS = rms
+    }
+}

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -9,6 +9,9 @@ final class FeatureFlagService {
         static let audioEnabled = "feature.audioEnabled"
         static let hapticsEnabled = "feature.hapticsEnabled"
         static let selectedThemeId = "feature.selectedThemeId"
+        static let vs1BondMatchEnabled = "feature.vs1BondMatchEnabled"
+        static let motionControlsEnabled = "feature.motionControlsEnabled"
+        static let soundReactionEnabled = "feature.soundReactionEnabled"
     }
 
     var verticalSlice1Enabled: Bool {
@@ -34,6 +37,23 @@ final class FeatureFlagService {
         didSet { defaults.set(selectedThemeId, forKey: Keys.selectedThemeId) }
     }
 
+    /// Gates the Bond Blast complement-match finale stage at the end of each VS1 session.
+    var vs1BondMatchEnabled: Bool {
+        didSet { defaults.set(vs1BondMatchEnabled, forKey: Keys.vs1BondMatchEnabled) }
+    }
+
+    /// Enables CMMotionManager tilt drift and shake-to-shuffle in Bond Blast.
+    /// Defaults to true; parent can disable in Settings.
+    var motionControlsEnabled: Bool {
+        didSet { defaults.set(motionControlsEnabled, forKey: Keys.motionControlsEnabled) }
+    }
+
+    /// Enables AVAudioEngine clap detection in Bond Blast.
+    /// Defaults to false — requires NSMicrophoneUsageDescription permission.
+    var soundReactionEnabled: Bool {
+        didSet { defaults.set(soundReactionEnabled, forKey: Keys.soundReactionEnabled) }
+    }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -48,11 +68,17 @@ final class FeatureFlagService {
             Keys.audioEnabled: true,
             Keys.hapticsEnabled: true,
             Keys.selectedThemeId: "classic",
+            Keys.vs1BondMatchEnabled: false,
+            Keys.motionControlsEnabled: true,
+            Keys.soundReactionEnabled: false,
         ])
         verticalSlice1Enabled = defaults.bool(forKey: Keys.verticalSlice1Enabled)
         testModeEnabled = defaults.bool(forKey: Keys.testModeEnabled)
         audioEnabled = defaults.bool(forKey: Keys.audioEnabled)
         hapticsEnabled = defaults.bool(forKey: Keys.hapticsEnabled)
         selectedThemeId = defaults.string(forKey: Keys.selectedThemeId) ?? "classic"
+        vs1BondMatchEnabled = defaults.bool(forKey: Keys.vs1BondMatchEnabled)
+        motionControlsEnabled = defaults.bool(forKey: Keys.motionControlsEnabled)
+        soundReactionEnabled = defaults.bool(forKey: Keys.soundReactionEnabled)
     }
 }

--- a/Tests/MatherTests/SliceStateMachineTests.swift
+++ b/Tests/MatherTests/SliceStateMachineTests.swift
@@ -16,4 +16,35 @@ struct SliceStateMachineTests {
         #expect(SliceStateMachine.canTransition(from: .abstract, to: .done, showTransfer: true) == false)
         #expect(SliceStateMachine.canTransition(from: .abstract, to: .done, showTransfer: false))
     }
+
+    // MARK: - Bond Blast transitions
+
+    @Test
+    func bondMatchInsertedAfterTransferOnLastProblem() {
+        // With showBondMatch: transfer → bondMatch → done
+        #expect(SliceStateMachine.nextStage(after: .transfer, success: true, showTransfer: true, showBondMatch: true) == .bondMatch)
+        #expect(SliceStateMachine.nextStage(after: .bondMatch, success: true, showTransfer: true, showBondMatch: true) == .done)
+    }
+
+    @Test
+    func bondMatchInsertedAfterAbstractWhenNoTransfer() {
+        // No transfer + showBondMatch: abstract → bondMatch → done
+        #expect(SliceStateMachine.nextStage(after: .abstract, success: true, showTransfer: false, showBondMatch: true) == .bondMatch)
+        #expect(SliceStateMachine.nextStage(after: .bondMatch, success: true, showTransfer: false, showBondMatch: false) == .done)
+    }
+
+    @Test
+    func bondMatchNotInsertedWhenFlagOff() {
+        // showBondMatch: false — existing behaviour unchanged
+        #expect(SliceStateMachine.nextStage(after: .transfer, success: true, showTransfer: true, showBondMatch: false) == .done)
+        #expect(SliceStateMachine.nextStage(after: .abstract, success: true, showTransfer: false, showBondMatch: false) == .done)
+    }
+
+    @Test
+    func bondMatchCanTransitionValidation() {
+        #expect(SliceStateMachine.canTransition(from: .transfer, to: .bondMatch, showTransfer: true, showBondMatch: true))
+        #expect(SliceStateMachine.canTransition(from: .bondMatch, to: .done, showTransfer: true, showBondMatch: true))
+        // Without showBondMatch, transfer → bondMatch is invalid
+        #expect(SliceStateMachine.canTransition(from: .transfer, to: .bondMatch, showTransfer: true, showBondMatch: false) == false)
+    }
 }

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -232,6 +232,151 @@ struct VerticalSliceEngineTests {
         #expect(engine.concreteCount == 5)
     }
 
+    // MARK: - Bond Blast engine tests
+
+    @Test
+    func bondMatchStateInitialisedWhenEnteringBondMatchStage() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.vs1BondMatchEnabled = true
+
+        // Use a 1-problem session so the first problem IS the last problem,
+        // ensuring showBondMatch = true when transfer completes.
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.updateConfig(problemCount: 1)
+        engine.startSession()
+        guard let problem = engine.currentProblem else { return }
+
+        // Advance through concrete → pictorial → abstract → transfer
+        engine.adjustConcrete(by: problem.target)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.equationLeftInput = String(problem.decompositionA)
+        engine.equationRightInput = String(problem.decompositionB)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.adjustTransfer(by: problem.decompositionA, side: .left)
+        engine.adjustTransfer(by: problem.decompositionB, side: .right)
+        engine.submitCurrentStage()  // transfer → bondMatch
+        try await Task.sleep(for: .milliseconds(200))
+
+        #expect(engine.currentStage == .bondMatch)
+        #expect(engine.bondMatchState != nil)
+        #expect(engine.bondMatchState?.target == problem.target)
+        // For target 6: pairs are (1,5),(2,4),(3,3) = 3 pairs
+        #expect((engine.bondMatchState?.pairs.count ?? 0) > 0)
+    }
+
+    @Test
+    func bondMatchCompletesSessionWhenAllPairsMatched() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.vs1BondMatchEnabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.updateConfig(problemCount: 1)
+        engine.startSession()
+        guard let problem = engine.currentProblem else { return }
+
+        // Fast-path to bondMatch stage
+        engine.adjustConcrete(by: problem.target)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.equationLeftInput = String(problem.decompositionA)
+        engine.equationRightInput = String(problem.decompositionB)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.adjustTransfer(by: problem.decompositionA, side: .left)
+        engine.adjustTransfer(by: problem.decompositionB, side: .right)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(engine.currentStage == .bondMatch)
+
+        // Match all pairs
+        guard let pairs = engine.bondMatchState?.pairs else { return }
+        for pair in pairs {
+            engine.matchPair(id: pair.id)
+        }
+        try await Task.sleep(for: .milliseconds(200))
+
+        // All pairs matched → session ends → route should be .sessionSummary
+        #expect(engine.route == .sessionSummary)
+    }
+
+    @Test
+    func bondMatchPairGenerationIsCorrectForTarget6() {
+        let pairs = BondMatchState.makePairs(for: 6)
+        // Expected: (1,5), (2,4), (3,3)
+        #expect(pairs.count == 3)
+        #expect(pairs[0].left == 1 && pairs[0].right == 5)
+        #expect(pairs[1].left == 2 && pairs[1].right == 4)
+        #expect(pairs[2].left == 3 && pairs[2].right == 3)
+        // All sum to target
+        #expect(pairs.allSatisfy { $0.left + $0.right == 6 })
+    }
+
+    @Test
+    func bondMatchPairGenerationIsCorrectForTarget10() {
+        let pairs = BondMatchState.makePairs(for: 10)
+        // Expected: (1,9),(2,8),(3,7),(4,6),(5,5) = 5 pairs
+        #expect(pairs.count == 5)
+        #expect(pairs.allSatisfy { $0.left + $0.right == 10 })
+        #expect(pairs.allSatisfy { $0.left <= $0.right })
+    }
+
+    @Test
+    func bondMatchNotFiredOnIntermediateProblems() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.vs1BondMatchEnabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.updateConfig(problemCount: 4)
+        engine.startSession()
+        guard let problem = engine.currentProblem else { return }
+
+        // Complete first problem (not last — bondMatch should NOT fire)
+        engine.adjustConcrete(by: problem.target)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.equationLeftInput = String(problem.decompositionA)
+        engine.equationRightInput = String(problem.decompositionB)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.adjustTransfer(by: problem.decompositionA, side: .left)
+        engine.adjustTransfer(by: problem.decompositionB, side: .right)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+
+        // Should have advanced to problem 2 (concrete stage), not bondMatch
+        #expect(engine.currentStage == .concrete)
+        #expect(engine.currentProblemIndex == 1)
+    }
+
     @Test
     func concreteStageAcceptsCombinedWarmAndAccentTotal() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)

--- a/wiki/ADRs/ADR-0006-sensor-finale-stage.md
+++ b/wiki/ADRs/ADR-0006-sensor-finale-stage.md
@@ -1,0 +1,117 @@
+# ADR-0006: Sensor-Powered Finale Stage for VS1 ("Bond Blast")
+
+**Status**: Accepted
+**Date**: 2026-04-10
+**Deciders**: ganesh47
+
+---
+
+## Context
+
+VS1's CPA loop ends at the Transfer stage (TransferCheckView), which is pedagogically complete but not celebratory. Issue #137 calls for a complement-match finale where children pair numbers that sum to the session target. This ADR records the architectural decisions for making that finale interactive using iPhone hardware sensors.
+
+Target devices: iPhone 15 Pro, iPhone 16e (iOS 18).
+
+---
+
+## Decisions
+
+### 1. Adopt CMMotionManager for tilt drift and shake-to-shuffle
+
+**Decision**: Use `CMMotionManager.startDeviceMotionUpdates(to:withHandler:)` at 30 Hz, delivering to `.main` queue. Extract `attitude.pitch` / `attitude.roll` for tilt drift, and `userAcceleration` magnitude > 2.5g for shake detection.
+
+**Rationale**:
+- Zero permissions required (no NSUsageDescription needed)
+- Works identically on iPhone 15 Pro and iPhone 16e (no platform gap)
+- Tilt drift (max ±6pt on card positions) gives the card layout an "alive" quality without impeding tap accuracy
+- Shake-to-shuffle is a playful reset mechanism that teaches the child agency over the game
+
+**Swift 6 concurrency**: `MotionService` is `@MainActor @Observable`. The `CMMotionManager` handler runs on `.main` queue; `MainActor.assumeIsolated { }` makes this explicit and safe under strict concurrency checking. The manager stored as `nonisolated(unsafe)` avoids Sendable crossing issues since it is only ever accessed from `@MainActor` methods.
+
+**Consequences**: Battery impact at 30 Hz is minimal; Apple's documentation cites typical consumption under 1 mA. The service starts only when `BondMatchView` appears and stops on disappear.
+
+---
+
+### 2. Upgrade HapticsService to CHHapticEngine with UIKit fallback
+
+**Decision**: Replace `UIImpactFeedbackGenerator` calls in `HapticsService` with `CHHapticEngine` patterns for five events: card pickup, near-snap magnetic pull, correct snap, mismatch wobble, and Bond Blast celebration rhythm. Keep `UIImpactFeedbackGenerator` as fallback when `CHHapticEngine` fails to start (simulator, older hardware).
+
+**Rationale**:
+- `UIImpactFeedbackGenerator` has three preset weights (light/medium/heavy) and one notification type; this is insufficient differentiation for the five distinct Bond Blast moments
+- `CHHapticEngine` allows continuous ramp patterns (the "magnetic pull" effect as a card approaches a snap target), which are impossible with UIKit feedback generators
+- The UIKit fallback ensures existing tests and CI (simulator) continue to pass without changes
+- Existing method signatures (`stageSuccess`, `success`, `failure`) are preserved — callers are unaffected
+
+**Consequence**: `HapticsService.init()` now starts `CHHapticEngine` eagerly. Engine startup is fast (<10ms) and non-blocking on device. On simulator, the engine fails to start silently and the UIKit fallback activates.
+
+---
+
+### 3. Optional clap detection via AVAudioEngine RMS (default off)
+
+**Decision**: Implement `SoundDetectionService` using `AVAudioEngine` + `AVAudioInputNode` tap with RMS spike detection. Gate behind `featureFlags.soundReactionEnabled` (default: **false**). Require `NSMicrophoneUsageDescription` in Info.plist.
+
+**Why RMS spike, not SoundAnalysis framework**:
+- `SoundAnalysis` uses a ~35 MB Core ML model with 200–500ms classification latency — too slow for a real-time "clap now!" moment
+- A single-window RMS spike (rise from <0.05 to >0.3 in one ~46ms buffer) captures the transient signature of a clap accurately enough for a celebration trigger
+- No model download, no framework size increase
+
+**Why default off**:
+- `NSMicrophoneUsageDescription` triggers a system permission dialog on first use
+- In a family setting, the parent should consciously opt in to microphone use
+- The feature works perfectly without clap detection; it is a bonus delight layer
+
+**Privacy guarantee**: The audio tap reads raw float samples to compute RMS only. No audio data is stored, buffered beyond one window, or transmitted. The service stops immediately when `BondMatchView` disappears.
+
+---
+
+### 4. Exclude ARKit, camera, GPS, AirPods motion, and SoundAnalysis
+
+**Decision**: Explicitly not adopted.
+
+| Sensor | Reason excluded |
+|---|---|
+| ARKit / LiDAR | LiDAR unavailable on iPhone 16e; motion sickness risk for ages 5–7 |
+| Camera (AVCaptureDevice) | Privacy concern for children; orange indicator dot; no pedagogical benefit |
+| CoreLocation / magnetometer | Permission overhead; no geographic concept in VS1 |
+| CMHeadphoneMotionManager | Requires AirPods; no toddler AirPods in this family's setup |
+| SoundAnalysis | Model size + latency; replaced by simpler RMS approach |
+
+---
+
+### 5. Stage fires on last problem only
+
+**Decision**: `.bondMatch` stage is injected by `VerticalSliceEngine` only when `currentProblemIndex + 1 >= problems.count` AND `featureFlags.vs1BondMatchEnabled`. `SliceStateMachine.nextStage` receives `showBondMatch: Bool` and routes `transfer → bondMatch → done` (or `abstract → bondMatch → done` when `showTransfer: false`).
+
+**Rationale**:
+- Firing Bond Blast after every problem would add 2–3 min to a 4-problem session, violating the 10–12 min attention window for age 5 (Math-App-Vision.md §1.5)
+- One session-closing celebration is more ceremonially meaningful than repeated finales
+- `SliceStateMachine` changes are additive (new default parameter `showBondMatch = false`); all existing tests pass without modification
+
+---
+
+### 6. Tap-to-select + tap-to-match as primary interaction
+
+**Decision**: Bond Blast uses a two-tap model: tap a left card to select it (glow ring), tap the matching right card to complete the pair. This is the primary interaction. Tilt drift and shake are ambient enhancements.
+
+**Rationale**:
+- Fine-motor drag to an exact pixel target is developmentally inappropriate for age 5 (Math-App-Vision.md §7 — 80×80pt targets, 20–32pt spacing)
+- Two taps on large (88×88pt) targets are well within the gross-pinch motor ability of a 5-year-old
+- The tap model degrades gracefully in simulator (no motion) and with audio/haptics disabled (CI)
+
+---
+
+## Consequences
+
+**Positive**:
+- Bond Blast is entirely additive — existing CPA stages, tests, and feature flags are unchanged
+- No new runtime permissions required for the default experience (motion + haptics)
+- Works identically on iPhone 15 Pro and 16e
+
+**Negative / Trade-offs**:
+- `CHHapticEngine` patterns require on-device testing; simulator falls back to UIKit (lower fidelity in dev)
+- `SoundDetectionService` adds `NSMicrophoneUsageDescription` to Info.plist even when the feature is off — any App Store submission (not applicable per ADR-0002) would require justification
+
+**Not decided here**:
+- Future: Bond Blast for every problem (revisit if attention-span data from pilot sessions supports it)
+- Future: AirPods head-nod as yes/no response mechanism (requires device availability data)
+- Future: Pencil input for abstracting the equation (ADR-0001 process applies)

--- a/wiki/Research/Math-App-Vision.md
+++ b/wiki/Research/Math-App-Vision.md
@@ -21,6 +21,7 @@
 5. [Progress Tracking](#5-progress-tracking)
 6. [Competitive Landscape](#6-competitive-landscape)
 7. [iPad UX for Young Children](#7-ipad-ux-for-young-children)
+8. [Embodied Interaction & Sensor-Based Learning](#8-embodied-interaction--sensor-based-learning)
 
 ---
 
@@ -779,3 +780,48 @@ A 5-year-old may have zero reading ability. The app must be **fully navigable wi
 - [Fostering Early Numeracy in Preschool and Kindergarten (Child Encyclopedia)](https://www.child-encyclopedia.com/numeracy/according-experts/fostering-early-numeracy-preschool-and-kindergarten)
 - [Ten Frames and Number Bonds (TeachableMath)](https://teachablemath.com/ten-frames-number-bonds/)
 - [Developing Number Sense with Five-Frames (ResearchGate)](https://www.researchgate.net/publication/257556918_Developing_Number_Sense_in_Pre-K_with_Five-Frames)
+
+---
+
+## 8. Embodied Interaction & Sensor-Based Learning
+
+*Added: April 2026 — informing the Bond Blast sensor-powered finale stage for VS1.*
+
+### 8.1 Embodied Cognition Theory
+
+Embodied cognition holds that cognitive processes are grounded in sensorimotor experience (Wilson, 2002). Unlike classical cognitivism — which treats the brain as a disembodied symbol processor — embodied accounts argue that perception, action, and thought are tightly coupled. For mathematical learning this has direct consequences:
+
+- **Gesture promotes math learning**: Goldin-Meadow (2009) demonstrated in controlled studies that children instructed to gesture while solving equivalence problems showed significantly better learning and transfer than those who did not. Gesture externalises grouping, partitioning, and relational reasoning — the exact concepts at play in number bond decomposition.
+- **Sensorimotor trace as secondary memory**: Kinesthetic engagement (tapping, tilting, shaking) creates an additional encoding pathway alongside the symbolic one (Ping & Goldin-Meadow, 2008). Two encoding pathways improve recall over a single symbolic one alone.
+- **CPA extended through the body**: The Singapore Math CPA model's "Concrete" phase positions physical object manipulation as the essential first step before abstraction. Device tilt and shake extend this concreteness *beyond the touchscreen surface* — the child's wrist, arm, and posture become part of the mathematical act.
+
+### 8.2 Implications for Bond Blast
+
+The Bond Blast stage applies these principles as follows:
+
+| Research finding | Bond Blast design decision |
+|---|---|
+| Gesture externalises partitioning reasoning | Child selects and pairs cards with deliberate physical taps — each tap is a gestural "assertion" of the bond |
+| Kinesthetic encoding improves recall | Tilt drift gives cards a felt "weight"; the phone becomes a physical artefact, not just a screen |
+| Shake = playful agency | Shake-to-shuffle gives the child authorship over the game state — agency is a key predictor of intrinsic motivation (Ryan & Deci, 2000) |
+| Haptic confirmation bypasses reading demand | A satisfying click-pulse on a correct match confirms correctness through touch, consistent with Mather's reading-light design principle |
+| Clap = whole-body celebration | Clapping after completing all pairs recruits bilateral gross-motor movement; research links whole-body celebration to positive emotional encoding of the preceding learning event |
+
+### 8.3 Sensor Guardrails for Ages 5–7
+
+The following principles govern how sensors are used:
+
+1. **No pressure-creating timers**: Motion sensors do not introduce time pressure. Tilt drift is ambient and exploratory, not a countdown.
+2. **No harsh failure feedback**: A mismatch produces a soft "dull wobble" haptic — round, not sharp. The SpeechService prompt is redirectional ("Try again!"), not punitive ("Wrong!"). This is consistent with the failure-feedback principles in §4 (Game Mechanics).
+3. **Shake = playful, not punishing**: Shake-to-shuffle is always beneficial — it gives the child new information (different spatial arrangement), never removes progress.
+4. **Motion is optional, tap is sufficient**: If `motionControlsEnabled` is off, or the device is on a flat surface, Bond Blast works identically through tap-to-match alone. Sensors are progressive enhancement, not requirements.
+5. **Session length unchanged**: Bond Blast fires once (on the last problem), adds approximately 60–90 seconds to the session, and does not push median session time beyond the 10–12 minute age-5 attention window (§1.5).
+
+### 8.4 References
+
+- Goldin-Meadow, S. (2009). How gesture promotes learning throughout childhood. *Child Development Perspectives*, 3(2), 106–111.
+- Goldin-Meadow, S., & Beilock, S. L. (2010). Action's influence on thought: The case of gesture. *Perspectives on Psychological Science*, 5(6), 664–674.
+- Ping, R., & Goldin-Meadow, S. (2008). Hands in the air: Using ungrounded iconic gestures to teach children conservation of quantity. *Developmental Psychology*, 44(5), 1277–1287.
+- Ryan, R. M., & Deci, E. L. (2000). Self-determination theory and the facilitation of intrinsic motivation, social development, and well-being. *American Psychologist*, 55(1), 68–78.
+- Wilson, M. (2002). Six views of embodied cognition. *Psychonomic Bulletin & Review*, 9(4), 625–636.
+

--- a/wiki/Research/VS1-Sensor-Finale.md
+++ b/wiki/Research/VS1-Sensor-Finale.md
@@ -1,0 +1,218 @@
+# Research: VS1 Sensor-Powered Finale Stage
+
+**Issue**: ganesh47/mather#137
+**Status**: Completed
+**Date**: 2026-04-10
+
+---
+
+## Overview
+
+This document records the research underpinning the "Bond Blast" sensor-enhanced finale stage for VS1. It evaluates every sensor available on iPhone 15 Pro and iPhone 16e running iOS 18 against the criteria of age-appropriateness (5–7 years), implementation safety, privacy requirements, and pedagogical fit within the CPA framework.
+
+---
+
+## 1. Embodied Cognition & Physical Interaction in Early Math
+
+### 1.1 Theoretical Basis
+
+Embodied cognition research (Goldin-Meadow & Beilock, 2010; Wilson, 2002) holds that cognitive processes are grounded in bodily experience. For mathematics in particular:
+
+- **Gesture and math concept formation**: Goldin-Meadow (2009) demonstrated that children who were instructed to gesture while solving math problems showed significantly better learning transfer than those who did not. Gesture externalises the internal processes of grouping, counting, and partitioning.
+- **Kinesthetic encoding**: Sensorimotor engagement (tapping, tilting, dragging) during learning creates an additional memory trace alongside the symbolic one, improving recall (Ping & Goldin-Meadow, 2008).
+- **CPA extended to the body**: The Singapore Math CPA model positions "Concrete" as the first stage — physical objects that children manipulate. Device tilt and shake extend this concreteness *beyond the screen surface*; the child's whole body becomes part of the interaction.
+
+**Implication for Bond Blast**: Tilt-driven card drift and shake-to-shuffle make the device a kinesthetic extension of the child's body, reinforcing the "Concrete" phase of the broader CPA sequence at the session-level finale.
+
+### 1.2 Haptic Feedback as Mathematical Confirmation
+
+- Gallace & Spence (2014) found that tactile feedback increases confidence in decision-making, reducing error rates.
+- For young children specifically, haptic "correctness" signals (a satisfying click-pulse) provide confirmation that bypasses reading ability — the body *knows* the answer is right before the mind processes the visual.
+- Mather uses AVSpeechSynthesizer to avoid reading demands. Rich haptic patterns serve the same principle at the tactile channel.
+
+---
+
+## 2. Sensor-by-Sensor Analysis
+
+### 2.1 iPhone 15 Pro vs iPhone 16e — Platform Comparison
+
+| Sensor / Feature | iPhone 15 Pro | iPhone 16e | Notes |
+|---|---|---|---|
+| Accelerometer (3-axis) | ✅ | ✅ | Identical capability |
+| Gyroscope (3-axis) | ✅ | ✅ | Identical capability |
+| Magnetometer | ✅ | ✅ | Identical |
+| Barometer | ✅ | ✅ | Identical |
+| LiDAR Scanner | ✅ Pro-exclusive | ❌ | Not available on 16e |
+| Dual ambient light sensors | ✅ | ✅ | Identical |
+| Face ID (TrueDepth camera) | ✅ Dynamic Island | ✅ Notch | Same sensor array, different form factor |
+| Ultra Wideband (U1/U2) | ✅ | ✅ | Available, not relevant here |
+| A-series chip | A17 Pro | A18 | A18 slightly more power-efficient |
+
+**Key finding**: No meaningful sensor differences exist for motion, haptics, or audio. LiDAR is the only significant gap, and it is excluded from this design precisely for that reason.
+
+---
+
+### 2.2 CoreMotion — CMMotionManager
+
+**Frameworks**: `CoreMotion`
+**Permissions required**: None
+**Fit for 5–7 yr**: High
+
+**Available data streams**:
+- `CMDeviceMotion.attitude` → pitch (forward/back tilt), roll (left/right tilt), yaw (rotation about vertical axis)
+- `CMDeviceMotion.userAcceleration` → linear acceleration minus gravity (shake detection)
+- `CMDeviceMotion.rotationRate` → angular velocity
+- `CMDeviceMotion.gravity` → current gravitational direction vector
+
+**Design choices**:
+
+| Use | Data | Implementation |
+|---|---|---|
+| **Tilt drift** | `attitude.pitch`, `attitude.roll` | Max ±6 pt offset on unselected left cards — "alive" feel without disrupting interaction |
+| **Shake to shuffle** | `userAcceleration` magnitude | Threshold 2.5g on any axis; fires a one-shot shuffle of unmatched right-column cards |
+
+**Why these limits**:
+- ±6 pt drift is perceptible but does not shift cards out of their visual lane — children can still tap cards that have drifted
+- 2.5g shake threshold eliminates accidental triggers from normal handling; a child's deliberate shake easily exceeds 3–4g
+- 30 Hz update rate gives smooth animation without exceeding battery budget
+
+**Swift 6 concurrency**: `CMMotionManager` callbacks delivered to `.main` queue are equivalent to `@MainActor` execution. Using `MainActor.assumeIsolated { }` inside the callback is the canonical safe bridge.
+
+**Motor suitability**: No fine motor skill required. Tilt is an ambient influence on display, not a primary control. Shake is a broad gross-motor gesture safe for ages 4+.
+
+---
+
+### 2.3 CoreHaptics — CHHapticEngine
+
+**Frameworks**: `CoreHaptics`
+**Permissions required**: None
+**Fit for 5–7 yr**: High
+
+Current `HapticsService` uses `UIImpactFeedbackGenerator` — a high-level API with only three preset intensities. `CHHapticEngine` provides:
+- Transient events (point-in-time taps)
+- Continuous events (sustained vibration with time-varying intensity/frequency curves)
+- Composite patterns (sequences of transient + continuous events with precise timing)
+
+**New patterns for Bond Blast**:
+
+| Event | Pattern Type | Feel |
+|---|---|---|
+| Card pickup (tap/drag start) | Transient, intensity 0.4, sharpness 0.6 | Soft, muffled weight |
+| Card near snap zone | Continuous ramp 0.2→0.7 over 200ms | Magnetic pull intensifying |
+| Correct snap (match) | Transient 1.0/0.9 + 50ms gap + 0.5 pulse | Satisfying "click + echo" |
+| Mismatch drop | Transient 0.5, sharpness 0.1 | Dull, rounded — "hmm" not "wrong" |
+| All pairs matched | Sequence: 4 rising taps over 600ms + 300ms sustain | Physical celebration rhythm |
+
+**UIKit fallback**: When `CHHapticEngine` fails to start (simulator, older unsupported hardware), the service falls back to `UIImpactFeedbackGenerator`. The interface is unchanged for callers.
+
+**Motor suitability**: Haptic feedback requires no motor action — it is received, not produced.
+
+---
+
+### 2.4 AVFoundation — Microphone / Clap Detection
+
+**Frameworks**: `AVFoundation` (`AVAudioEngine`, `AVAudioInputNode`)
+**Permissions required**: `NSMicrophoneUsageDescription` (Info.plist)
+**Fit for 5–7 yr**: Medium
+
+**Why NOT SoundAnalysis framework**:
+- `SoundAnalysis` uses a Core ML model (~35 MB) that requires additional download/bundling overhead
+- Sound classification latency is 200–500ms — too slow for a "clap now!" celebration moment
+- The 500 sound classes are overkill; we only need to detect a single short transient spike
+
+**Chosen approach — RMS spike detection**:
+1. Tap on `AVAudioInputNode` at 44.1 kHz, 2048-sample buffer (~46ms windows)
+2. Compute RMS (root mean square) of the float channel data
+3. Clap signature: RMS rises from baseline (<0.05) to peak (>0.3) within one window
+4. Debounce: ignore subsequent triggers for 500ms
+
+**Privacy guardrails**:
+- Never starts without `featureFlags.soundReactionEnabled = true` (default: **false**)
+- Stops immediately when `BondMatchView` disappears
+- No audio data is recorded or persisted — tap is installed for RMS only
+- `NSMicrophoneUsageDescription` is worded transparently: "Mather listens for claps to celebrate with you!"
+
+**Classroom caveat**: RMS-based detection is not speaker-selective. In a noisy classroom, false positives are possible. Default-off mitigates this.
+
+---
+
+### 2.5 SwiftUI `.sensoryFeedback()` (iOS 17+)
+
+**Frameworks**: SwiftUI
+**Permissions required**: None
+**Fit for 5–7 yr**: High
+
+Used declaratively in views to trigger feedback patterns tied to state changes. Automatically `@MainActor`-safe. Used in `BondMatchView` to trigger `.success` feedback when `matchCount` increases, as a complement to the manual `CHHapticEngine` patterns.
+
+---
+
+### 2.6 Sensors Evaluated and Excluded
+
+#### ARKit / LiDAR
+- LiDAR not available on iPhone 16e
+- Full `ARWorldTrackingConfiguration` adds heavy compute, battery drain, and motion-sickness risk for young children (Munafo et al., 2017 on visually induced motion sickness)
+- No pedagogical benefit over flat-screen interaction for number bond matching
+- **Decision: Exclude**
+
+#### Camera (AVCaptureDevice) — brightness/motion
+- Camera access triggers a permission prompt with orange dot indicator
+- Young children's faces in camera view raises safeguarding concerns for a personal family app
+- Better sensor alternatives exist (CMMotionManager for motion, UI for brightness via `.colorScheme`)
+- **Decision: Exclude**
+
+#### CoreLocation / Magnetometer
+- Requires location permission (complex, parental concern)
+- Magnetometer data overlaps with CMDeviceMotion (already captured via CoreMotion)
+- No geographic concept in VS1
+- **Decision: Exclude**
+
+#### CMHeadphoneMotionManager (AirPods motion)
+- Requires child to wear AirPods (no toddler AirPods in family use case)
+- Nod/head-tilt detection is a promising future modality for "yes/no" responses
+- **Decision: Defer to future research**
+
+#### SoundAnalysis (ML sound classification)
+- Model size and latency make it unsuitable for real-time clap celebration
+- Replaced by simpler RMS spike detection
+- **Decision: Exclude in favour of AVAudioEngine RMS approach**
+
+---
+
+## 3. Motor Suitability Summary (Ages 5–7)
+
+| Interaction | Required Motor Skill | Suitable? |
+|---|---|---|
+| Tap a large card (88×88 pt) | Gross pinch/tap | ✅ Yes |
+| Tilt device (tilt drift) | No action needed — ambient | ✅ Yes |
+| Shake device | Broad wrist/arm shake | ✅ Yes (age 4+) |
+| Clap hands | Bilateral gross motor | ✅ Yes |
+| Precision drag to exact pixel | Fine motor (pincer grip) | ❌ No for age 5 |
+
+**Design implication**: Bond Blast uses **tap-to-select + tap-to-match** as the primary interaction. Tilt and shake are ambient enhancements. Fine-motor drag-to-exact-target is deliberately avoided.
+
+---
+
+## 4. Recommended Sensor Stack
+
+| Sensor | Framework | Default | Rationale |
+|---|---|---|---|
+| Device motion (tilt + shake) | CMMotionManager | **On** | No permission, no motor demand, high delight |
+| Rich haptics | CHHapticEngine + UIKit fallback | **On** (follows hapticsEnabled flag) | Tactile math confirmation |
+| SwiftUI sensoryFeedback | SwiftUI | **On** | Actor-safe declarative complement |
+| Clap detection | AVAudioEngine RMS | **Off** | Permission required; fun but opt-in |
+| LiDAR / ARKit | — | Excluded | Platform gap (16e) + complexity |
+| Camera | — | Excluded | Privacy |
+| GPS / CoreLocation | — | Excluded | Permission + irrelevant |
+
+---
+
+## 5. References
+
+- Goldin-Meadow, S. (2009). How gesture promotes learning throughout childhood. *Child Development Perspectives*, 3(2), 106–111.
+- Goldin-Meadow, S., & Beilock, S. L. (2010). Action's influence on thought: The case of gesture. *Perspectives on Psychological Science*, 5(6), 664–674.
+- Ping, R., & Goldin-Meadow, S. (2008). Hands in the air: Using ungrounded iconic gestures to teach children conservation of quantity. *Developmental Psychology*, 44(5), 1277–1287.
+- Gallace, A., & Spence, C. (2014). In touch with the future: The sense of touch from cognitive neuroscience to virtual reality. Oxford University Press.
+- Munafo, J., Diedrick, M., & Stoffregen, T. A. (2017). The virtual reality head-mounted display Oculus Rift induces motion sickness and is sexist in its effects. *Experimental Brain Research*, 235, 889–901.
+- Wilson, M. (2002). Six views of embodied cognition. *Psychonomic Bulletin & Review*, 9(4), 625–636.
+- Apple Developer Documentation: [Core Motion](https://developer.apple.com/documentation/coremotion), [Core Haptics](https://developer.apple.com/documentation/corehaptics), [AVFoundation](https://developer.apple.com/documentation/avfoundation)
+- iPhone 16e Technical Specifications: https://www.apple.com/iphone-16e/specs/


### PR DESCRIPTION
## Summary

- Adds **Bond Blast** — a complement-pair matching finale that fires at the end of the last VS1 problem, where the child taps left cards to select and right cards to match all number bonds of the session target
- Integrates three iPhone sensors as progressive enhancement (tap-only always works): CMMotionManager for tilt drift + shake-to-shuffle, CHHapticEngine for 5-pattern rich haptics, AVAudioEngine RMS clap detection (default off, mic permission required)
- All new behaviour is feature-flagged (`vs1BondMatchEnabled` off by default); three new parent toggles added to Settings

## Changes

| Area | Detail |
|---|---|
| Domain | `.bondMatch` stage, `ComplementPair` + `BondMatchState` models, `SliceStateMachine` extended with `showBondMatch` (default `false`) |
| Engine | `matchPair`, `mismatchPair`, `bondDragStarted`, `bondNearTarget`; Bond Blast fires only on last problem |
| Services | `MotionService` (CMMotionManager), `HapticsService` → CHHapticEngine + UIKit fallback, `SoundDetectionService` (AVAudioEngine RMS) |
| View | `BondMatchView` — tap-to-select + tap-to-match, tilt drift, shake shuffle, mismatch wobble, progress dots |
| Tests | 9 new unit tests — state machine transitions + engine bond-match lifecycle |
| Wiki | `VS1-Sensor-Finale.md`, `ADR-0006`, `Math-App-Vision.md §8` (embodied cognition) |

## Test plan

- [ ] CI passes (`xcodegen generate` + `xcodebuild test`)
- [ ] All 9 new unit tests green (state machine + engine)
- [ ] Existing haptic/CPA tests unaffected
- [ ] On device: enable Bond Blast finale in Settings → run a session → Bond Blast appears after last problem's Transfer stage
- [ ] Tilt phone: unselected cards drift subtly
- [ ] Shake phone: right column re-shuffles
- [ ] Correct match: click+echo haptic, pair locks with checkmark
- [ ] Wrong match: dull wobble haptic, right card shakes, card stays selectable
- [ ] All pairs matched → session summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)