### PR TITLE
fix(vs1): transfer stage no longer pre-reveals decomposition

### DIFF
--- a/Domain/ClassicTheme.swift
+++ b/Domain/ClassicTheme.swift
@@ -20,7 +20,7 @@ struct ClassicTheme: SliceTheme {
     }
 
     func transferPrompt(decompositionA: Int, decompositionB: Int) -> String {
-        "Show the same equation with counters again. Put \(decompositionA) on the left and \(decompositionB) on the right."
+        "Split the counters into two groups that make \(decompositionA + decompositionB)."
     }
 
     func stageSuccessPhrase(for stage: SliceStage, target: Int) -> String {

--- a/Domain/VehicleSpec.swift
+++ b/Domain/VehicleSpec.swift
@@ -33,7 +33,7 @@ extension VehicleSpec {
         concretePromptFn: { "Park \($0) cars in the garage." },
         pictorialPromptFn: { _ in "Split the cars into two parking zones." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) cars on the left and \($1) on the right." },
+        transferPromptFn: { "Split \($0 + $1) cars into two parking zones." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "You filled the garage!"
@@ -56,7 +56,7 @@ extension VehicleSpec {
         concretePromptFn: { "Load \($0) trucks at the depot." },
         pictorialPromptFn: { _ in "Split the trucks into two groups." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) trucks on the left and \($1) on the right." },
+        transferPromptFn: { "Split \($0 + $1) trucks into two groups." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "All trucks loaded!"
@@ -79,7 +79,7 @@ extension VehicleSpec {
         concretePromptFn: { "Send \($0) vans to the warehouse." },
         pictorialPromptFn: { _ in "Split the vans into two routes." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) vans on the left and \($1) on the right." },
+        transferPromptFn: { "Split \($0 + $1) vans into two routes." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "Warehouse full!"
@@ -102,7 +102,7 @@ extension VehicleSpec {
         concretePromptFn: { "Fill \($0) buses with passengers." },
         pictorialPromptFn: { _ in "Split the buses into two stops." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) buses at the left stop and \($1) at the right." },
+        transferPromptFn: { "Split \($0 + $1) buses into two stops." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "All aboard!"
@@ -125,7 +125,7 @@ extension VehicleSpec {
         concretePromptFn: { "Line up \($0) bulldozers on the site." },
         pictorialPromptFn: { _ in "Split the bulldozers into two zones." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) bulldozers on the left and \($1) on the right." },
+        transferPromptFn: { "Split \($0 + $1) bulldozers into two zones." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "Site ready!"
@@ -148,7 +148,7 @@ extension VehicleSpec {
         concretePromptFn: { "Land \($0) helicopters on the pad." },
         pictorialPromptFn: { _ in "Split the helicopters into two pads." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) helicopters on the left pad and \($1) on the right." },
+        transferPromptFn: { "Split \($0 + $1) helicopters between two pads." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "All landed!"
@@ -171,7 +171,7 @@ extension VehicleSpec {
         concretePromptFn: { "Park \($0) planes at the gate." },
         pictorialPromptFn: { _ in "Split the planes into two terminals." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) planes at the left terminal and \($1) at the right." },
+        transferPromptFn: { "Split \($0 + $1) planes between two terminals." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "All planes at the gate!"

--- a/Features/VerticalSlice1/TransferCheckView.swift
+++ b/Features/VerticalSlice1/TransferCheckView.swift
@@ -12,12 +12,13 @@ struct TransferCheckView: View {
     var body: some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 14) {
+                // Show only the target — decomposition values are not revealed up front.
                 HStack(spacing: 10) {
-                    equationPill(value: problem.decompositionA, fill: MatherTheme.warm)
+                    questionPill(fill: MatherTheme.warm)
                     Text("+")
                         .font(.title.weight(.black))
                         .foregroundStyle(.secondary)
-                    equationPill(value: problem.decompositionB, fill: MatherTheme.accent)
+                    questionPill(fill: MatherTheme.accent)
                     Text("=")
                         .font(.title.weight(.black))
                         .foregroundStyle(.secondary)
@@ -44,7 +45,7 @@ struct TransferCheckView: View {
                     )
                 }
 
-                Button("Check the same equation") {
+                Button("Check it!") {
                     onSubmit()
                 }
                 .buttonStyle(PrimaryActionButtonStyle())
@@ -52,12 +53,12 @@ struct TransferCheckView: View {
         }
     }
 
-    private func equationPill(value: Int, fill: Color) -> some View {
-        Text("\(value)")
+    private func questionPill(fill: Color) -> some View {
+        Text("?")
             .font(.system(size: 28, weight: .black, design: .rounded))
-            .foregroundStyle(fill)
+            .foregroundStyle(fill.opacity(0.6))
             .frame(minWidth: 58, minHeight: 58)
-            .background(fill.opacity(0.14))
+            .background(fill.opacity(0.10))
             .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
     }
 
@@ -66,15 +67,10 @@ struct TransferCheckView: View {
         let bucketBorder = colorScheme == .dark ? MatherTheme.panelDeep.opacity(0.78) : fill.opacity(0.18)
 
         return VStack(spacing: 8) {
-            HStack {
-                Text(title)
-                    .font(.caption.weight(.bold))
-                    .foregroundStyle(MatherTheme.ink)
-                Spacer()
-                Text("\(targetCount)")
-                    .font(.system(size: 22, weight: .black, design: .rounded))
-                    .foregroundStyle(fill)
-            }
+            Text(title)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(MatherTheme.ink)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             LazyVGrid(
                 columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 5),

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -47,8 +47,10 @@ struct ThemeTests {
 
     @Test func classicThemeTransferPrompt() {
         let prompt = ClassicTheme().transferPrompt(decompositionA: 3, decompositionB: 4)
-        #expect(prompt.contains("3"))
-        #expect(prompt.contains("4"))
+        // Prompt should reference the total (7), not the individual decomposition values.
+        #expect(prompt.contains("7"))
+        #expect(!prompt.contains("on the left"))
+        #expect(!prompt.contains("on the right"))
     }
 
     @Test func classicThemeStageSuccessPhrases() {
@@ -141,10 +143,12 @@ struct ThemeTests {
         #expect(VehicleTheme().sessionStartFeedback() != ClassicTheme().sessionStartFeedback())
     }
 
-    @Test func vehicleTransferPromptIncludesDecompositionNumbers() {
+    @Test func vehicleTransferPromptShowsTargetNotDecomposition() {
         let prompt = VehicleTheme().transferPrompt(decompositionA: 2, decompositionB: 5)
-        #expect(prompt.contains("2"))
-        #expect(prompt.contains("5"))
+        // Prompt should reference the total (7), not the individual split values.
+        #expect(prompt.contains("7"))
+        #expect(!prompt.contains("on the left"))
+        #expect(!prompt.contains("on the right"))
     }
 
     // MARK: - Celebration emoji (PR8)

--- a/Tests/MatherTests/TransferIntentTests.swift
+++ b/Tests/MatherTests/TransferIntentTests.swift
@@ -5,16 +5,19 @@ import Testing
 @MainActor
 struct TransferIntentTests {
     @Test
-    func transferPromptReferencesShowingTheSameEquationAgain() async throws {
+    func transferPromptShowsTargetWithoutRevealingDecomposition() async throws {
         let engine = makeEngine()
         engine.startSession()
 
         guard let problem = engine.currentProblem else { return }
         try await advanceToTransfer(engine, problem: problem)
 
-        #expect(engine.feedbackMessage.contains("same equation"))
-        #expect(engine.feedbackMessage.contains("\(problem.decompositionA)"))
-        #expect(engine.feedbackMessage.contains("\(problem.decompositionB)"))
+        // Prompt must mention the target so the child knows the goal.
+        #expect(engine.feedbackMessage.contains("\(problem.target)"))
+        // Prompt must not contain the phrase "on the left" or "on the right" —
+        // those phrases are the tell-tale sign of pre-revealing the split.
+        #expect(!engine.feedbackMessage.contains("on the left"))
+        #expect(!engine.feedbackMessage.contains("on the right"))
     }
 
     @Test

--- a/Tests/MatherTests/VehicleSpecTests.swift
+++ b/Tests/MatherTests/VehicleSpecTests.swift
@@ -34,11 +34,13 @@ struct VehicleSpecTests {
         }
     }
 
-    @Test func vehicleSpecTransferPromptIncludesDecompositionNumbers() {
+    @Test func vehicleSpecTransferPromptShowsTargetNotDecomposition() {
         for spec in VehicleSpec.pool {
             let prompt = spec.transferPromptFn(2, 5)
-            #expect(prompt.contains("2"))
-            #expect(prompt.contains("5"))
+            // Prompt should reference the total (7), not the pre-revealed split values.
+            #expect(prompt.contains("7"))
+            #expect(!prompt.contains("on the left"))
+            #expect(!prompt.contains("on the right"))
         }
     }
 


### PR DESCRIPTION
## Summary

- Transfer header now shows `? + ? = target` instead of `decompositionA + decompositionB = target` — only the goal is visible before the child interacts
- Per-bucket target-count labels removed (was another pre-reveal)
- `ClassicTheme.transferPrompt` and all 7 `VehicleSpec.transferPromptFn` closures updated to say "Split N vehicles into two groups" — no individual split values
- Submit button renamed from "Check the same equation" to "Check it!"
- Tests updated to assert the target appears and "on the left"/"on the right" phrases are absent

## Root cause

`TransferCheckView` rendered the exact `decompositionA` and `decompositionB` values in the header and in each bucket title, reducing the stage from retrieval to copying. Reported in TestFlight feedback #144.

## Test plan

- [x] `classicThemeTransferPrompt` — now checks for total, not split values
- [x] `vehicleTransferPromptShowsTargetNotDecomposition` — same
- [x] `vehicleSpecTransferPromptShowsTargetNotDecomposition` — same
- [x] `transferPromptShowsTargetWithoutRevealingDecomposition` — engine-level check
- [x] `transferSuccessMessageReferencesMatchingTheSameEquation` — still passes (success message is post-submit)
- [ ] On device: child sees `? + ? = 6`, fills counters freely, taps "Check it!"

Closes #146. Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)