### PR TITLE
feat(vs1): hide transfer decomposition until recall

### DIFF
--- a/Domain/ClassicTheme.swift
+++ b/Domain/ClassicTheme.swift
@@ -20,7 +20,7 @@ struct ClassicTheme: SliceTheme {
     }
 
     func transferPrompt(decompositionA: Int, decompositionB: Int) -> String {
-        "Show the same equation with counters again. Put \(decompositionA) on the left and \(decompositionB) on the right."
+        "Show the same equation with counters again. Build the two parts from memory."
     }
 
     func stageSuccessPhrase(for stage: SliceStage, target: Int) -> String {

--- a/Domain/VehicleSpec.swift
+++ b/Domain/VehicleSpec.swift
@@ -33,7 +33,7 @@ extension VehicleSpec {
         concretePromptFn: { "Park \($0) cars in the garage." },
         pictorialPromptFn: { _ in "Split the cars into two parking zones." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) cars on the left and \($1) on the right." },
+        transferPromptFn: { _, _ in "Park the cars to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "You filled the garage!"
@@ -56,7 +56,7 @@ extension VehicleSpec {
         concretePromptFn: { "Load \($0) trucks at the depot." },
         pictorialPromptFn: { _ in "Split the trucks into two groups." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) trucks on the left and \($1) on the right." },
+        transferPromptFn: { _, _ in "Park the trucks to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "All trucks loaded!"
@@ -79,7 +79,7 @@ extension VehicleSpec {
         concretePromptFn: { "Send \($0) vans to the warehouse." },
         pictorialPromptFn: { _ in "Split the vans into two routes." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) vans on the left and \($1) on the right." },
+        transferPromptFn: { _, _ in "Park the vans to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "Warehouse full!"
@@ -102,7 +102,7 @@ extension VehicleSpec {
         concretePromptFn: { "Fill \($0) buses with passengers." },
         pictorialPromptFn: { _ in "Split the buses into two stops." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) buses at the left stop and \($1) at the right." },
+        transferPromptFn: { _, _ in "Park the buses to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "All aboard!"
@@ -125,7 +125,7 @@ extension VehicleSpec {
         concretePromptFn: { "Line up \($0) bulldozers on the site." },
         pictorialPromptFn: { _ in "Split the bulldozers into two zones." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) bulldozers on the left and \($1) on the right." },
+        transferPromptFn: { _, _ in "Place the bulldozers to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "Site ready!"
@@ -148,7 +148,7 @@ extension VehicleSpec {
         concretePromptFn: { "Land \($0) helicopters on the pad." },
         pictorialPromptFn: { _ in "Split the helicopters into two pads." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) helicopters on the left pad and \($1) on the right." },
+        transferPromptFn: { _, _ in "Land the helicopters to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "All landed!"
@@ -171,7 +171,7 @@ extension VehicleSpec {
         concretePromptFn: { "Park \($0) planes at the gate." },
         pictorialPromptFn: { _ in "Split the planes into two terminals." },
         abstractPromptFn: { "Write the split as an equation." },
-        transferPromptFn: { "\($0) planes at the left terminal and \($1) at the right." },
+        transferPromptFn: { _, _ in "Park the planes to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
             case .concrete:   return "All planes at the gate!"

--- a/Features/VerticalSlice1/TransferCheckView.swift
+++ b/Features/VerticalSlice1/TransferCheckView.swift
@@ -12,20 +12,30 @@ struct TransferCheckView: View {
     var body: some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 14) {
-                HStack(spacing: 10) {
-                    equationPill(value: problem.decompositionA, fill: MatherTheme.warm)
-                    Text("+")
-                        .font(.title.weight(.black))
-                        .foregroundStyle(.secondary)
-                    equationPill(value: problem.decompositionB, fill: MatherTheme.accent)
-                    Text("=")
-                        .font(.title.weight(.black))
-                        .foregroundStyle(.secondary)
-                    Text("\(problem.target)")
-                        .font(.system(size: 34, weight: .black, design: .rounded))
-                        .foregroundStyle(MatherTheme.ink)
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Show it again")
+                        .font(.title.weight(.bold))
+                        .foregroundStyle(MatherTheme.coral)
+
+                    HStack(spacing: 10) {
+                        hiddenEquationPill(fill: MatherTheme.warm)
+                        Text("+")
+                            .font(.title.weight(.black))
+                            .foregroundStyle(.secondary)
+                        hiddenEquationPill(fill: MatherTheme.accent)
+                        Text("=")
+                            .font(.title.weight(.black))
+                            .foregroundStyle(.secondary)
+                        Text("\(problem.target)")
+                            .font(.system(size: 34, weight: .black, design: .rounded))
+                            .foregroundStyle(MatherTheme.ink)
+                    }
+                    .accessibilityIdentifier("transfer-equation")
+
+                    Text("Build the two parts from memory.")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
                 }
-                .accessibilityIdentifier("transfer-equation")
 
                 HStack(spacing: 12) {
                     transferBucket(
@@ -44,7 +54,7 @@ struct TransferCheckView: View {
                     )
                 }
 
-                Button("Check the same equation") {
+                Button("Check my groups") {
                     onSubmit()
                 }
                 .buttonStyle(PrimaryActionButtonStyle())
@@ -52,13 +62,18 @@ struct TransferCheckView: View {
         }
     }
 
-    private func equationPill(value: Int, fill: Color) -> some View {
-        Text("\(value)")
+    private func hiddenEquationPill(fill: Color) -> some View {
+        Text("?")
             .font(.system(size: 28, weight: .black, design: .rounded))
             .foregroundStyle(fill)
             .frame(minWidth: 58, minHeight: 58)
             .background(fill.opacity(0.14))
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .strokeBorder(fill.opacity(colorScheme == .dark ? 0.35 : 0.2), style: StrokeStyle(lineWidth: 1.5, dash: [5, 4]))
+            )
             .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .accessibilityLabel("Hidden part")
     }
 
     private func transferBucket(title: String, targetCount: Int, count: Int, fill: Color, side: TransferSide) -> some View {

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -12,7 +12,7 @@ private struct RocketTheme: SliceTheme {
     func pictorialPrompt(target: Int) -> String { "Split the rockets into two pads." }
     func abstractPrompt() -> String { "Type the rocket equation." }
     func transferPrompt(decompositionA: Int, decompositionB: Int) -> String {
-        "Relaunch \(decompositionA) and \(decompositionB) rockets."
+        "Relaunch the same total from memory."
     }
     func stageSuccessPhrase(for stage: SliceStage, target: Int) -> String { "Blast off!" }
     func sessionIntroPhrase() -> String { "Let's count rockets." }
@@ -47,8 +47,9 @@ struct ThemeTests {
 
     @Test func classicThemeTransferPrompt() {
         let prompt = ClassicTheme().transferPrompt(decompositionA: 3, decompositionB: 4)
-        #expect(prompt.contains("3"))
-        #expect(prompt.contains("4"))
+        #expect(!prompt.contains("3"))
+        #expect(!prompt.contains("4"))
+        #expect(prompt.localizedCaseInsensitiveContains("memory"))
     }
 
     @Test func classicThemeStageSuccessPhrases() {
@@ -141,10 +142,11 @@ struct ThemeTests {
         #expect(VehicleTheme().sessionStartFeedback() != ClassicTheme().sessionStartFeedback())
     }
 
-    @Test func vehicleTransferPromptIncludesDecompositionNumbers() {
+    @Test func vehicleTransferPromptDoesNotRevealDecompositionNumbers() {
         let prompt = VehicleTheme().transferPrompt(decompositionA: 2, decompositionB: 5)
-        #expect(prompt.contains("2"))
-        #expect(prompt.contains("5"))
+        #expect(!prompt.contains("2"))
+        #expect(!prompt.contains("5"))
+        #expect(prompt.localizedCaseInsensitiveContains("memory"))
     }
 
     // MARK: - Celebration emoji (PR8)

--- a/Tests/MatherTests/TransferIntentTests.swift
+++ b/Tests/MatherTests/TransferIntentTests.swift
@@ -13,8 +13,9 @@ struct TransferIntentTests {
         try await advanceToTransfer(engine, problem: problem)
 
         #expect(engine.feedbackMessage.contains("same equation"))
-        #expect(engine.feedbackMessage.contains("\(problem.decompositionA)"))
-        #expect(engine.feedbackMessage.contains("\(problem.decompositionB)"))
+        #expect(!engine.feedbackMessage.contains("\(problem.decompositionA)"))
+        #expect(!engine.feedbackMessage.contains("\(problem.decompositionB)"))
+        #expect(engine.feedbackMessage.localizedCaseInsensitiveContains("memory"))
     }
 
     @Test

--- a/Tests/MatherTests/VehicleSpecTests.swift
+++ b/Tests/MatherTests/VehicleSpecTests.swift
@@ -34,11 +34,12 @@ struct VehicleSpecTests {
         }
     }
 
-    @Test func vehicleSpecTransferPromptIncludesDecompositionNumbers() {
+    @Test func vehicleSpecTransferPromptDoesNotRevealDecompositionNumbers() {
         for spec in VehicleSpec.pool {
             let prompt = spec.transferPromptFn(2, 5)
-            #expect(prompt.contains("2"))
-            #expect(prompt.contains("5"))
+            #expect(!prompt.contains("2"))
+            #expect(!prompt.contains("5"))
+            #expect(prompt.localizedCaseInsensitiveContains("memory"))
         }
     }
 


### PR DESCRIPTION
## Summary
- redesign the VS1 transfer stage so it no longer pre-reveals the decomposition
- swap the visible transfer equation to `? + ? = target` and cue the child to rebuild from memory
- update theme and intent tests to assert the new recall-based behavior

## Validation
- on `ganesh@mba`: `xcodegen generate`
- on `ganesh@mba`: `xcodebuild build-for-testing -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17 Pro" CODE_SIGNING_ALLOWED=NO`
- on `ganesh@mba`: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:MatherTests CODE_SIGNING_ALLOWED=NO`

## Related
- closes #146
