### PR TITLE
test(engine): fix post-merge transfer stage expectation

### DIFF
--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -30,6 +30,12 @@ struct VerticalSliceEngineTests {
         engine.submitCurrentStage()
         try await Task.sleep(for: .milliseconds(200))
         #expect(engine.currentStage == .abstract)
+
+        engine.equationLeftInput = String(engine.currentProblem?.decompositionA ?? 0)
+        engine.equationRightInput = String(engine.currentProblem?.decompositionB ?? 0)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(engine.currentStage == .transfer)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- fix stale VerticalSliceEngine test expectations after #151
- complete stage progression before asserting later CPA transitions

## Testing
- xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:MatherTests/VerticalSliceEngineTests CODE_SIGNING_ALLOWED=NO

Fixes the post-merge main CI failure after #151.