### PR TITLE
fix(vs1): remove break-it prefill

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -363,7 +363,7 @@ final class VerticalSliceEngine {
     private func prepareForStage(_ stage: SliceStage) {
         switch stage {
         case .pictorial:
-            splitLeftCount = currentProblem?.decompositionA ?? 0
+            splitLeftCount = 0
         case .abstract:
             equationLeftInput = ""
             equationRightInput = ""

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -39,6 +39,36 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
+    func pictorialStageStartsBlankInsteadOfPrefilledAnswer() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.verticalSlice1Enabled = true
+        flags.testModeEnabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        guard let problem = engine.currentProblem else {
+            Issue.record("Expected deterministic problem")
+            return
+        }
+
+        engine.adjustConcrete(by: problem.target)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+
+        #expect(engine.currentStage == .pictorial)
+        #expect(engine.splitLeftCount == 0)
+        #expect(problem.decompositionA > 0)
+        #expect(problem.decompositionA != engine.splitLeftCount)
+    }
+
+    @Test
     func hapticsStageSuccessFiredOnConcreteStageClear() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -31,6 +31,8 @@ final class CompactLayoutTests: XCTestCase {
 
         let pictorialLabel = app.staticTexts.element(matching: NSPredicate(format: "label BEGINSWITH 'Break '"))
         _ = pictorialLabel.waitForExistence(timeout: 10)
+        let leftBucketCount = app.staticTexts["0"]
+        XCTAssertTrue(leftBucketCount.waitForExistence(timeout: 5), "Expected pictorial stage to start blank instead of prefilled")
         app.buttons["Use this break"].tap()
 
         let abstractLabel = app.staticTexts["Write it"]


### PR DESCRIPTION
## Summary
- stop seeding the pictorial break-it stage with the canonical decomposition answer
- start the break-it screen blank so the child must create the split
- add regression coverage for the engine stage handoff and compact layout flow

Closes #153
