### PR TITLE
fix(vs1): guard Bond Blast state on match

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -280,20 +280,22 @@ final class VerticalSliceEngine {
     /// Advances to `.done` when all pairs are matched.
     func matchPair(id: UUID) {
         guard currentStage == .bondMatch,
-              let idx = bondMatchState?.pairs.firstIndex(where: { $0.id == id }),
-              let problem = currentProblem else { return }
+              let problem = currentProblem,
+              var state = bondMatchState,
+              let idx = state.pairs.firstIndex(where: { $0.id == id }) else { return }
 
-        bondMatchState?.pairs[idx].isMatched = true
-        let pair = bondMatchState!.pairs[idx]
+        state.pairs[idx].isMatched = true
+        let pair = state.pairs[idx]
+        bondMatchState = state
 
         logBondMatchTelemetry("pair_matched", extra: [
             "left": String(pair.left),
             "right": String(pair.right),
-            "match_count": String(bondMatchState?.matchCount ?? 0)
+            "match_count": String(state.matchCount)
         ])
         hapticsService.cardSnapCorrect(enabled: featureFlags.hapticsEnabled)
 
-        if bondMatchState?.isComplete == true {
+        if state.isComplete {
             let msg = "Amazing! You matched all the bonds for \(problem.target)!"
             completeStage(successMessage: msg)
         }

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -377,6 +377,44 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
+    func matchPairGracefullyIgnoresUnknownPairId() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.vs1BondMatchEnabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.updateConfig(problemCount: 1)
+        engine.startSession()
+        guard let problem = engine.currentProblem else { return }
+
+        engine.adjustConcrete(by: problem.target)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.equationLeftInput = String(problem.decompositionA)
+        engine.equationRightInput = String(problem.decompositionB)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        engine.adjustTransfer(by: problem.decompositionA, side: .left)
+        engine.adjustTransfer(by: problem.decompositionB, side: .right)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+
+        let before = engine.bondMatchState
+        engine.matchPair(id: UUID())
+
+        #expect(engine.currentStage == .bondMatch)
+        #expect(engine.bondMatchState?.pairs.map(\.isMatched) == before?.pairs.map(\.isMatched))
+    }
+
+    @Test
     func bondMatchNotFiredOnIntermediateProblems() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true


### PR DESCRIPTION
## Summary
- remove the Bond Blast force unwrap in matchPair(id:)
- update matching to work from a guarded local state copy
- add regression coverage for unknown/late Bond Blast pair IDs

## Validation
- xcodegen generate
- xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:MatherTests/VerticalSliceEngineTests CODE_SIGNING_ALLOWED=NO
