### PR TITLE
feat(room-quest): add station setup and fallback confirmations

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -3,8 +3,8 @@ import Observation
 
 enum RoomPhase: Equatable {
     case safetyAck                          // one-time parent safety acknowledgement
-    case setup                              // parent placing spot-cards, sees quantities
-    case spot(index: Int)                   // child walking to spot i
+    case setup                              // parent placing station markers, sees quantities
+    case spot(index: Int)                   // child walking to station i
     case returning                          // child walking back to iPad
     case onScreenPictorial                  // SplitView (pre-populated from room phase)
     case onScreenAbstract                   // EquationResolveView
@@ -21,11 +21,12 @@ final class RoomQuestEngine {
 
     private(set) var phase: RoomPhase = .safetyAck
     private(set) var problem: SliceProblem?
+    private(set) var stations: [RoomQuestStation] = []
     var feedbackMessage = ""
     var showCelebration = false
 
     // On-screen CPA state — mirrors VerticalSliceEngine's public fields
-    private(set) var splitLeftCount = 0     // pre-populated from room phase decompositionA
+    private(set) var splitLeftCount = 0
     var equationLeftInput = ""
     var equationRightInput = ""
     var transferLeftCount = 0
@@ -43,7 +44,6 @@ final class RoomQuestEngine {
     private let telemetryWriter: TelemetryWriter
     private let speechService: SpeechService
     private let hapticsService: HapticsService
-    /// Set by AppModel after init. Callback to navigate back to Home via VerticalSliceEngine.
     var onExitToHome: (() -> Void)?
 
     static let roomPhaseLimitSeconds: TimeInterval = 4 * 60
@@ -64,14 +64,17 @@ final class RoomQuestEngine {
 
     // MARK: - Session lifecycle
 
-    /// Called when `RoomSessionView` appears. Generates a problem and enters the first phase.
     func startSession() {
         let problems = ProblemGenerator.generateProblems(config: SliceConfig())
         guard let p = problems.first else { return }
         problem = p
+        stations = [
+            RoomQuestStation(id: .redRocket, role: .redRocket, quantity: p.decompositionA),
+            RoomQuestStation(id: .blueBubble, role: .blueBubble, quantity: p.decompositionB)
+        ]
         setupStartedAt = .now
         phase = featureFlags.roomQuestSafetyAcknowledged ? .setup : .safetyAck
-        feedbackMessage = "Set up the spots, then tap Ready."
+        feedbackMessage = "Set up the stations, then scan each one or mark it ready."
         try? telemetryWriter.append(SliceEvent(
             type: .roomQuestStarted,
             payload: [
@@ -82,15 +85,34 @@ final class RoomQuestEngine {
         ))
     }
 
-    /// Parent taps "I understand" on the one-time safety acknowledgement screen.
     func acknowledgedSafety() {
         featureFlags.roomQuestSafetyAcknowledged = true
         phase = .setup
     }
 
-    /// Parent taps "Ready — spots are set!" to begin the room phase.
+    func registerStation(_ role: RoomQuestStationRole) {
+        guard let idx = stations.firstIndex(where: { $0.role == role }) else { return }
+        stations[idx].isRegistered = true
+        feedbackMessage = stations.allSatisfy(\.isRegistered)
+            ? "Great, both stations are ready."
+            : "Nice. Now set up the other station."
+    }
+
+    var allStationsRegistered: Bool {
+        stations.count == 2 && stations.allSatisfy(\.isRegistered)
+    }
+
+    var currentStation: RoomQuestStation? {
+        guard case .spot(let index) = phase, stations.indices.contains(index) else { return nil }
+        return stations[index]
+    }
+
     func markSetupComplete() {
         guard let p = problem else { return }
+        guard allStationsRegistered else {
+            feedbackMessage = "Scan or confirm both stations before you start."
+            return
+        }
         let setupMs = setupStartedAt.map { Int(Date.now.timeIntervalSince($0) * 1000) } ?? 0
         try? telemetryWriter.append(SliceEvent(
             type: .roomQuestSetupComplete,
@@ -98,20 +120,23 @@ final class RoomQuestEngine {
         ))
         roomPhaseStartedAt = .now
         phase = .spot(index: 0)
-        speechService.speak("Let's make \(p.target)! Walk to the red dot and pick up everything there.", enabled: featureFlags.audioEnabled)
+        speechService.speak("Let's make \(p.target)! Find the Red Rocket station and pick up everything there.", enabled: featureFlags.audioEnabled)
         startRoomPhaseTimer()
     }
 
-    /// Child or parent confirms arrival at a spot.
     func markSpotVisited(index: Int) {
-        guard let p = problem else { return }
-        let quantity = index == 0 ? p.decompositionA : p.decompositionB
+        guard let station = stations[safe: index] else { return }
+        let quantity = station.quantity
         try? telemetryWriter.append(SliceEvent(
             type: .roomQuestSpotVisited,
-            payload: ["spot_index": String(index), "quantity": String(quantity)]
+            payload: [
+                "spot_index": String(index),
+                "quantity": String(quantity),
+                "station_role": station.role.rawValue
+            ]
         ))
         if index == 0 {
-            speechService.speak("Great — now walk to the blue dot.", enabled: featureFlags.audioEnabled)
+            speechService.speak("Great, now find the Blue Bubble station.", enabled: featureFlags.audioEnabled)
             phase = .spot(index: 1)
         } else {
             speechService.speak("Bring them all back to me!", enabled: featureFlags.audioEnabled)
@@ -119,7 +144,6 @@ final class RoomQuestEngine {
         }
     }
 
-    /// Parent or child taps "We're back!" — transitions to on-screen CPA.
     func markReturned() {
         guard let p = problem else { return }
         roomPhaseTimer?.cancel()
@@ -136,8 +160,6 @@ final class RoomQuestEngine {
         feedbackMessage = "You collected them! Now let's show the split."
         flashCelebration()
     }
-
-    // MARK: - On-screen CPA
 
     func submitPictorial() {
         phase = .onScreenAbstract
@@ -159,8 +181,6 @@ final class RoomQuestEngine {
         let correct = transferLeftCount == p.decompositionA && transferRightCount == p.decompositionB
         finishSession(abstractCorrect: correct)
     }
-
-    // MARK: - Pause / abort
 
     func pauseSession() {
         let current = phase
@@ -185,8 +205,6 @@ final class RoomQuestEngine {
         phase = .complete
         onExitToHome?()
     }
-
-    // MARK: - Private
 
     private func flashCelebration() {
         showCelebration = true
@@ -228,5 +246,11 @@ final class RoomQuestEngine {
             hapticsService.success(enabled: featureFlags.hapticsEnabled)
             flashCelebration()
         }
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -178,6 +178,55 @@ struct BondMatchState: Equatable {
     }
 }
 
+// MARK: - Room Quest models
+
+enum RoomQuestStationRole: String, Codable, Equatable {
+    case redRocket
+    case blueBubble
+
+    var title: String {
+        switch self {
+        case .redRocket: "Red Rocket"
+        case .blueBubble: "Blue Bubble"
+        }
+    }
+
+    var colorName: String {
+        switch self {
+        case .redRocket: "red"
+        case .blueBubble: "blue"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .redRocket: "🚀"
+        case .blueBubble: "🫧"
+        }
+    }
+
+    var scanPrompt: String {
+        switch self {
+        case .redRocket: "Find and scan the Red Rocket marker."
+        case .blueBubble: "Find and scan the Blue Bubble marker."
+        }
+    }
+
+    var fallbackButtonTitle: String {
+        switch self {
+        case .redRocket: "I found Red Rocket"
+        case .blueBubble: "I found Blue Bubble"
+        }
+    }
+}
+
+struct RoomQuestStation: Equatable, Codable, Identifiable {
+    let id: RoomQuestStationRole
+    let role: RoomQuestStationRole
+    let quantity: Int
+    var isRegistered: Bool = false
+}
+
 @Model
 final class StoredSessionSummary {
     @Attribute(.unique) var sessionId: String

--- a/Features/RoomQuest/RoomSetupView.swift
+++ b/Features/RoomQuest/RoomSetupView.swift
@@ -11,7 +11,7 @@ struct RoomSetupView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Set up the room")
                         .font(.largeTitle.weight(.black))
-                    Text("Place the two spot-cards in one room, within line of sight of the iPad.")
+                    Text("Place the two station markers in one room, then scan or confirm each one.")
                         .font(.subheadline)
                         .foregroundStyle(MatherTheme.cardSubtitle)
                 }
@@ -19,25 +19,32 @@ struct RoomSetupView: View {
 
                 if let p = engine.problem {
                     HStack(spacing: 16) {
-                        spotCard(
-                            colour: MatherTheme.warm,
-                            label: "Red spot",
-                            quantity: p.decompositionA
-                        )
-                        spotCard(
-                            colour: MatherTheme.accent,
-                            label: "Blue spot",
-                            quantity: p.decompositionB
-                        )
+                        ForEach(engine.stations) { station in
+                            stationCard(for: station)
+                        }
                     }
 
                     CardSurface {
                         VStack(alignment: .leading, spacing: 6) {
                             Text("Target: \(p.target)")
                                 .font(.title2.weight(.bold))
-                            Text("Place \(p.decompositionA) red tokens at the red card and \(p.decompositionB) blue tokens at the blue card.")
+                            Text("Place \(p.decompositionA) tokens at Red Rocket and \(p.decompositionB) tokens at Blue Bubble.")
                                 .font(.body)
                         }
+                    }
+                }
+
+                CardSurface {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Label("Scan-friendly setup", systemImage: "camera.viewfinder")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.softBlue)
+                        Text("In alpha, parent can confirm a station manually if scanning is awkward.")
+                            .font(.subheadline)
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                        Text("Both stations must stay in the same room as this iPad.")
+                            .font(.subheadline)
+                            .foregroundStyle(MatherTheme.cardSubtitle)
                     }
                 }
 
@@ -46,36 +53,51 @@ struct RoomSetupView: View {
                         Label("Safety reminder", systemImage: "exclamationmark.triangle")
                             .font(.headline.weight(.semibold))
                             .foregroundStyle(MatherTheme.coral)
-                        Text("Place cards away from stairs, windows, balconies, and the kitchen.")
+                        Text("Place stations away from stairs, windows, balconies, and the kitchen.")
                             .font(.subheadline)
                             .foregroundStyle(MatherTheme.cardSubtitle)
-                        Text("Both spots must be in the same room as this iPad.")
+                        Text("Keep markers easy to see, but do not make the child walk while staring at the screen.")
                             .font(.subheadline)
                             .foregroundStyle(MatherTheme.cardSubtitle)
                     }
                 }
 
-                Button("Ready — spots are set!") {
+                Button("Ready — stations are set!") {
                     engine.markSetupComplete()
                 }
                 .buttonStyle(PrimaryActionButtonStyle())
+                .disabled(!engine.allStationsRegistered)
+                .opacity(engine.allStationsRegistered ? 1 : 0.55)
             }
             .padding(24)
         }
     }
 
-    private func spotCard(colour: Color, label: String, quantity: Int) -> some View {
-        VStack(spacing: 12) {
+    private func stationCard(for station: RoomQuestStation) -> some View {
+        let colour = station.role == .redRocket ? MatherTheme.warm : MatherTheme.accent
+
+        return VStack(spacing: 12) {
             RoundedRectangle(cornerRadius: 16)
                 .fill(colour)
                 .frame(height: 80)
-            Text("\(quantity)")
+                .overlay {
+                    Text(station.role.icon)
+                        .font(.system(size: 40))
+                }
+            Text("\(station.quantity)")
                 .font(.system(size: 48, weight: .black, design: .rounded))
-            Text(label)
+            Text(station.role.title)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MatherTheme.cardSubtitle)
+            Button(station.isRegistered ? "Marker ready" : "Scan or confirm") {
+                engine.registerStation(station.role)
+            }
+            .buttonStyle(SecondaryTileButtonStyle(fill: colour.opacity(0.18)))
+            .foregroundStyle(colour)
+            .accessibilityIdentifier("room-station-register-\(station.role.rawValue)")
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
+        .accessibilityIdentifier("room-station-card-\(station.role.rawValue)")
     }
 }

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -7,12 +7,16 @@ struct SpotPromptView: View {
     @Bindable var engine: RoomQuestEngine
     let spotIndex: Int
 
+    private var station: RoomQuestStation? {
+        engine.currentStation
+    }
+
     private var spotColour: Color {
-        spotIndex == 0 ? MatherTheme.warm : MatherTheme.accent
+        station?.role == .redRocket ? MatherTheme.warm : MatherTheme.accent
     }
 
     private var spotLabel: String {
-        spotIndex == 0 ? "Red spot" : "Blue spot"
+        station?.role.title ?? (spotIndex == 0 ? "Red Rocket" : "Blue Bubble")
     }
 
     var body: some View {
@@ -27,29 +31,52 @@ struct SpotPromptView: View {
                     .font(.system(size: 48, weight: .black, design: .rounded))
                     .foregroundStyle(.white)
 
-                if let p = engine.problem {
-                    let quantity = spotIndex == 0 ? p.decompositionA : p.decompositionB
-                    Text("\(quantity)")
-                        .font(.system(size: 120, weight: .black, design: .rounded))
-                        .foregroundStyle(.white.opacity(0.9))
-                    Text(quantity == 1 ? "token" : "tokens")
+                Text(station?.role.icon ?? "✨")
+                    .font(.system(size: 72))
+
+                if let station {
+                    Text(station.role.scanPrompt)
+                        .font(.title3.weight(.bold))
+                        .foregroundStyle(.white.opacity(0.92))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 28)
+
+                    Text("Then collect \(station.quantity) \(station.quantity == 1 ? "token" : "tokens").")
                         .font(.title.weight(.semibold))
-                        .foregroundStyle(.white.opacity(0.8))
+                        .foregroundStyle(.white.opacity(0.84))
                 }
 
+                CardSurface {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Label("Need a fallback?", systemImage: "hand.tap.fill")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text("If the marker is hard to scan, the child can keep going with one big confirmation button.")
+                            .font(.subheadline)
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                    }
+                }
+                .padding(.horizontal, 24)
+
                 Spacer()
+
+                Button(station?.role.fallbackButtonTitle ?? "I found it") {
+                    engine.markSpotVisited(index: spotIndex)
+                }
+                .buttonStyle(RoomQuestPrimaryButtonStyle())
+                .padding(.horizontal, 40)
 
                 Button {
                     engine.markSpotVisited(index: spotIndex)
                 } label: {
-                    Label("Got them!", systemImage: "checkmark.circle.fill")
+                    Label("Scan marker later, keep going now", systemImage: "camera.viewfinder")
                 }
-                .buttonStyle(RoomQuestPrimaryButtonStyle())
-                .padding(.horizontal, 40)
+                .buttonStyle(.plain)
+                .font(.headline.weight(.bold))
+                .foregroundStyle(.white.opacity(0.9))
                 .padding(.bottom, 40)
             }
 
-            // Pause button — always accessible, no unlock required
             Button {
                 engine.pauseSession()
             } label: {

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -44,9 +44,20 @@ struct RoomQuestEngineTests {
     // MARK: - Room phase state machine
 
     @Test
-    func markSetupCompleteTransitionsToFirstSpot() {
+    func markSetupCompleteRequiresBothStationsRegistered() {
         let engine = makeEngine()
         engine.startSession()
+        engine.markSetupComplete()
+        #expect(engine.phase == .setup)
+        #expect(engine.feedbackMessage.localizedCaseInsensitiveContains("both stations"))
+    }
+
+    @Test
+    func markSetupCompleteTransitionsToFirstSpotAfterRegistration() {
+        let engine = makeEngine()
+        engine.startSession()
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
         engine.markSetupComplete()
         #expect(engine.phase == .spot(index: 0))
     }
@@ -55,6 +66,8 @@ struct RoomQuestEngineTests {
     func markSpotVisitedZeroTransitionsToSpotOne() {
         let engine = makeEngine()
         engine.startSession()
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
         engine.markSetupComplete()
         engine.markSpotVisited(index: 0)
         #expect(engine.phase == .spot(index: 1))
@@ -64,6 +77,8 @@ struct RoomQuestEngineTests {
     func markSpotVisitedOneTransitionsToReturning() {
         let engine = makeEngine()
         engine.startSession()
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
         engine.markSetupComplete()
         engine.markSpotVisited(index: 0)
         engine.markSpotVisited(index: 1)
@@ -75,6 +90,8 @@ struct RoomQuestEngineTests {
         let engine = makeEngine()
         engine.startSession()
         guard let p = engine.problem else { return }
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
         engine.markSetupComplete()
         engine.markSpotVisited(index: 0)
         engine.markSpotVisited(index: 1)
@@ -89,6 +106,8 @@ struct RoomQuestEngineTests {
     func submitPictorialTransitionsToAbstract() {
         let engine = makeEngine()
         engine.startSession()
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
         engine.markSetupComplete()
         engine.markSpotVisited(index: 0)
         engine.markSpotVisited(index: 1)
@@ -102,6 +121,8 @@ struct RoomQuestEngineTests {
         let engine = makeEngine()
         engine.startSession()
         guard let p = engine.problem else { return }
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
         engine.markSetupComplete()
         engine.markSpotVisited(index: 0)
         engine.markSpotVisited(index: 1)
@@ -117,6 +138,8 @@ struct RoomQuestEngineTests {
     func wrongAbstractInputStaysAbstractWithFeedback() {
         let engine = makeEngine()
         engine.startSession()
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
         engine.markSetupComplete()
         engine.markSpotVisited(index: 0)
         engine.markSpotVisited(index: 1)
@@ -134,6 +157,8 @@ struct RoomQuestEngineTests {
         let engine = makeEngine()
         engine.startSession()
         guard let p = engine.problem else { return }
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
         engine.markSetupComplete()
         engine.markSpotVisited(index: 0)
         engine.markSpotVisited(index: 1)
@@ -154,6 +179,8 @@ struct RoomQuestEngineTests {
     func pauseAndResumeRestoresSpotPhase() {
         let engine = makeEngine()
         engine.startSession()
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
         engine.markSetupComplete()
         engine.markSpotVisited(index: 0)
         // Phase is now .spot(index: 1)
@@ -167,6 +194,8 @@ struct RoomQuestEngineTests {
     func abandonSessionCallsExitCallback() {
         let engine = makeEngine()
         engine.startSession()
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
         engine.markSetupComplete()
 
         var exitCalled = false

--- a/Tests/MatherUITests/RoomQuestUITests.swift
+++ b/Tests/MatherUITests/RoomQuestUITests.swift
@@ -52,6 +52,7 @@ final class RoomQuestUITests: XCTestCase {
         // Accept — transitions to Setup
         app.buttons["I understand — let's go"].tap()
         XCTAssertTrue(app.staticTexts["Set up the room"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Scan or confirm"].waitForExistence(timeout: 5))
         snapshot(app, "RoomQuest-SetupAfterAck")
     }
 
@@ -65,11 +66,9 @@ final class RoomQuestUITests: XCTestCase {
         app.buttons["Start Room Quest"].tap()
         XCTAssertTrue(app.staticTexts["Set up the room"].waitForExistence(timeout: 5))
 
-        // Spot labels (fixed subheadline font, rendered as text)
-        XCTAssertTrue(app.staticTexts["Red spot"].waitForExistence(timeout: 3))
-        XCTAssertTrue(app.staticTexts["Blue spot"].waitForExistence(timeout: 3))
-
-        // Safety reminder is visible
+        XCTAssertTrue(app.staticTexts["Red Rocket"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["Blue Bubble"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["Scan-friendly setup"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.staticTexts["Safety reminder"].waitForExistence(timeout: 3))
         snapshot(app, "RoomQuest-SetupView")
     }
@@ -82,26 +81,23 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons["Ready — spots are set!"].tap()
+        app.buttons["room-station-card-redRocket"].tap()
+        app.buttons["room-station-card-blueBubble"].tap()
+        app.buttons["Ready — stations are set!"].tap()
 
-        // Spot 1 (red)
-        XCTAssertTrue(app.staticTexts["Red spot"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Red Rocket"].waitForExistence(timeout: 5))
         snapshot(app, "RoomQuest-Spot1-Red")
 
-        // Pause button is present
         XCTAssertTrue(app.buttons["room-pause-button"].waitForExistence(timeout: 3))
 
-        // Confirm spot 1 collected
-        let gotThem = app.buttons.element(matching: NSPredicate(format: "label CONTAINS 'Got them'"))
-        XCTAssertTrue(gotThem.waitForExistence(timeout: 5))
-        gotThem.tap()
+        let gotRed = app.buttons["I found Red Rocket"]
+        XCTAssertTrue(gotRed.waitForExistence(timeout: 5))
+        gotRed.tap()
 
-        // Spot 2 (blue)
-        XCTAssertTrue(app.staticTexts["Blue spot"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Blue Bubble"].waitForExistence(timeout: 5))
         snapshot(app, "RoomQuest-Spot2-Blue")
-        gotThem.tap()
+        app.buttons["I found Blue Bubble"].tap()
 
-        // Returning screen
         XCTAssertTrue(app.staticTexts["Bring them back!"].waitForExistence(timeout: 5))
         snapshot(app, "RoomQuest-Returning")
     }
@@ -114,19 +110,18 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons["Ready — spots are set!"].tap()
+        app.buttons["room-station-card-redRocket"].tap()
+        app.buttons["room-station-card-blueBubble"].tap()
+        app.buttons["Ready — stations are set!"].tap()
 
-        // Spot 1
-        _ = app.staticTexts["Red spot"].waitForExistence(timeout: 5)
-        let gotThem = app.buttons.element(matching: NSPredicate(format: "label CONTAINS 'Got them'"))
-        _ = gotThem.waitForExistence(timeout: 5)
-        gotThem.tap()
+        _ = app.staticTexts["Red Rocket"].waitForExistence(timeout: 5)
+        let gotRed = app.buttons["I found Red Rocket"]
+        _ = gotRed.waitForExistence(timeout: 5)
+        gotRed.tap()
 
-        // Spot 2
-        _ = app.staticTexts["Blue spot"].waitForExistence(timeout: 5)
-        gotThem.tap()
+        _ = app.staticTexts["Blue Bubble"].waitForExistence(timeout: 5)
+        app.buttons["I found Blue Bubble"].tap()
 
-        // Returning
         _ = app.staticTexts["Bring them back!"].waitForExistence(timeout: 5)
         app.buttons["We're back!"].tap()
 
@@ -176,18 +171,18 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons["Ready — spots are set!"].tap()
+        app.buttons["room-station-card-redRocket"].tap()
+        app.buttons["room-station-card-blueBubble"].tap()
+        app.buttons["Ready — stations are set!"].tap()
 
-        _ = app.staticTexts["Red spot"].waitForExistence(timeout: 5)
+        _ = app.staticTexts["Red Rocket"].waitForExistence(timeout: 5)
 
-        // Tap pause
         app.buttons["room-pause-button"].tap()
         XCTAssertTrue(app.staticTexts["Paused"].waitForExistence(timeout: 5))
         snapshot(app, "RoomQuest-Paused")
 
-        // Resume
         app.buttons["Resume"].tap()
-        XCTAssertTrue(app.staticTexts["Red spot"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Red Rocket"].waitForExistence(timeout: 5))
         snapshot(app, "RoomQuest-ResumedToSpot")
     }
 
@@ -197,13 +192,14 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons["Ready — spots are set!"].tap()
+        app.buttons["room-station-card-redRocket"].tap()
+        app.buttons["room-station-card-blueBubble"].tap()
+        app.buttons["Ready — stations are set!"].tap()
 
-        let gotThem = app.buttons.element(matching: NSPredicate(format: "label CONTAINS 'Got them'"))
-        _ = gotThem.waitForExistence(timeout: 5)
-        gotThem.tap()
-        _ = app.staticTexts["Blue spot"].waitForExistence(timeout: 5)
-        gotThem.tap()
+        _ = app.buttons["I found Red Rocket"].waitForExistence(timeout: 5)
+        app.buttons["I found Red Rocket"].tap()
+        _ = app.staticTexts["Blue Bubble"].waitForExistence(timeout: 5)
+        app.buttons["I found Blue Bubble"].tap()
 
         _ = app.staticTexts["Bring them back!"].waitForExistence(timeout: 5)
         app.buttons["room-pause-button-returning"].tap()
@@ -221,9 +217,11 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons["Ready — spots are set!"].tap()
+        app.buttons["room-station-card-redRocket"].tap()
+        app.buttons["room-station-card-blueBubble"].tap()
+        app.buttons["Ready — stations are set!"].tap()
 
-        _ = app.staticTexts["Red spot"].waitForExistence(timeout: 5)
+        _ = app.staticTexts["Red Rocket"].waitForExistence(timeout: 5)
         app.buttons["room-pause-button"].tap()
         _ = app.staticTexts["Paused"].waitForExistence(timeout: 5)
 
@@ -261,7 +259,9 @@ final class RoomQuestUITests: XCTestCase {
         app.launchArguments = [
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
-            "-feature.testModeEnabled", "YES"
+            "-feature.testModeEnabled", "YES",
+            "-feature.roomQuestEnabled", "NO",
+            "-feature.roomQuestSafetyAcknowledged", "NO"
         ]
         app.launch()
         return app
@@ -274,7 +274,8 @@ final class RoomQuestUITests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
-            "-feature.roomQuestEnabled", "YES"
+            "-feature.roomQuestEnabled", "YES",
+            "-feature.roomQuestSafetyAcknowledged", "NO"
         ]
         app.launch()
         return app


### PR DESCRIPTION
## Summary
- introduce explicit Room Quest station identities for Red Rocket and Blue Bubble
- require setup-time station registration with scan-or-confirm fallback behavior
- update Room Quest engine and UI tests to cover the new station flow

## Validation
- RoomQuestUITests passed on ganesh@mba clean checkout
- RoomQuestEngineTests passed on ganesh@mba clean checkout
