### PR TITLE
test(vs1): align transfer-stage expectation with room quest route

### DIFF
--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -5,7 +5,7 @@ import Testing
 @MainActor
 struct VerticalSliceEngineTests {
     @Test
-    func sessionAlwaysIncludesTransferStage() async throws {
+    func sessionIncludesTransferStageWhenRoomQuestIsNotActive() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
@@ -36,6 +36,26 @@ struct VerticalSliceEngineTests {
         engine.submitCurrentStage()
         try await Task.sleep(for: .milliseconds(200))
         #expect(engine.currentStage == .transfer)
+    }
+
+    @Test
+    func roomQuestRouteDoesNotForceTransferStageInVs1Engine() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.verticalSlice1Enabled = true
+        flags.testModeEnabled = true
+        flags.roomQuestEnabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+
+        engine.showRoomQuest()
+        #expect(engine.route == .roomQuest)
+        #expect(engine.currentStage == .concrete)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- rename the stale transfer-stage test to match current VS1 scope
- add explicit coverage that Room Quest routing does not alter the VS1 engine stage state

## Validation
- targeted VerticalSliceEngineTests passed on ganesh@mba clean checkout
- timed Mac rerun: 85.66s real
