### PR TITLE
feat(vs1): move Bond Blast before Write it

### DIFF
--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -14,9 +14,9 @@ enum SliceStage: String, Codable, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .concrete:  "Make it"
-        case .pictorial: "Break it"
+        case .pictorial: "Bond Blast!"
         case .abstract:  "Write it"
-        case .transfer:  "Show it again"
+        case .transfer:  "Show it"
         case .bondMatch: "Bond Blast!"
         case .done:      "Done"
         }

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -265,21 +265,21 @@ final class VerticalSliceEngine {
 
     /// Called by BondMatchView when the child begins dragging or taps a left card.
     func bondDragStarted(pairId: UUID) {
-        guard currentStage == .bondMatch else { return }
+        guard currentStage == .pictorial || currentStage == .bondMatch else { return }
         hapticsService.cardPickup(enabled: featureFlags.hapticsEnabled)
         logBondMatchTelemetry("pair_drag_started", extra: ["pair_id": pairId.uuidString])
     }
 
     /// Called by BondMatchView when a dragged card is hovering near a snap target.
     func bondNearTarget() {
-        guard currentStage == .bondMatch else { return }
+        guard currentStage == .pictorial || currentStage == .bondMatch else { return }
         hapticsService.cardNearSnap(enabled: featureFlags.hapticsEnabled)
     }
 
     /// Called when the child successfully matches a complement pair.
     /// Advances to `.done` when all pairs are matched.
     func matchPair(id: UUID) {
-        guard currentStage == .bondMatch,
+        guard (currentStage == .pictorial || currentStage == .bondMatch),
               let problem = currentProblem,
               var state = bondMatchState,
               let idx = state.pairs.firstIndex(where: { $0.id == id }) else { return }
@@ -303,7 +303,7 @@ final class VerticalSliceEngine {
 
     /// Called when the child drops a card on the wrong target.
     func mismatchPair() {
-        guard currentStage == .bondMatch, let problem = currentProblem else { return }
+        guard (currentStage == .pictorial || currentStage == .bondMatch), let problem = currentProblem else { return }
         logBondMatchTelemetry("pair_mismatch", extra: [:])
         hapticsService.cardSnapMismatch(enabled: featureFlags.hapticsEnabled)
         let msg = "Try again! Find two numbers that make \(problem.target)."
@@ -367,8 +367,19 @@ final class VerticalSliceEngine {
     private func prepareForStage(_ stage: SliceStage) {
         switch stage {
         case .pictorial:
-            splitLeftCount = 0
+            if let problem = currentProblem {
+                bondMatchState = BondMatchState(
+                    target: problem.target,
+                    pairs: BondMatchState.makePairs(for: problem.target)
+                )
+                logBondMatchTelemetry("bond_match_started", extra: [
+                    "target": String(problem.target),
+                    "pair_count": String(bondMatchState?.pairs.count ?? 0),
+                    "entry_stage": SliceStage.pictorial.rawValue
+                ])
+            }
         case .abstract:
+            bondMatchState = nil
             equationLeftInput = ""
             equationRightInput = ""
         case .transfer:
@@ -382,7 +393,8 @@ final class VerticalSliceEngine {
                 )
                 logBondMatchTelemetry("bond_match_started", extra: [
                     "target": String(problem.target),
-                    "pair_count": String(bondMatchState?.pairs.count ?? 0)
+                    "pair_count": String(bondMatchState?.pairs.count ?? 0),
+                    "entry_stage": SliceStage.bondMatch.rawValue
                 ])
             }
         case .concrete, .done:
@@ -564,17 +576,12 @@ final class VerticalSliceEngine {
         switch currentStage {
         case .concrete:
             return activeTheme.concretePrompt(target: currentProblem.target)
-        case .pictorial:
-            return activeTheme.pictorialPrompt(target: currentProblem.target)
+        case .pictorial, .bondMatch:
+            return "Bond Blast! Match the pairs that make \(currentProblem.target)!"
         case .abstract:
             return activeTheme.abstractPrompt()
         case .transfer:
-            return activeTheme.transferPrompt(
-                decompositionA: currentProblem.decompositionA,
-                decompositionB: currentProblem.decompositionB
-            )
-        case .bondMatch:
-            return "Bond Blast! Match the pairs that make \(currentProblem.target)!"
+            return "Show the same two parts with counters."
         case .done:
             return "Nice work."
         }
@@ -595,14 +602,8 @@ final class VerticalSliceEngine {
             } else {
                 return "Try tapping the \(activeTheme.counterNoun) one by one until you reach \(problem.target)."
             }
-        case .pictorial:
-            if attempts == 1 {
-                return "Try another break. Both groups together should still make \(problem.target)."
-            } else if attempts == 2 {
-                return "You have \(splitLeftCount) on the left and \(problem.target - splitLeftCount) on the right. That makes \(splitLeftCount + (problem.target - splitLeftCount))."
-            } else {
-                return "Any split is fine — left and right just need to add up to \(problem.target)."
-            }
+        case .pictorial, .bondMatch:
+            return "Try another pair. Look for two numbers that add up to \(problem.target)."
         case .abstract:
             if attempts == 1 {
                 return "Use two numbers that add up to \(problem.target)."
@@ -613,14 +614,12 @@ final class VerticalSliceEngine {
             }
         case .transfer:
             if attempts == 1 {
-                return "Look at the same equation again. Put \(problem.decompositionA) counters on the left and \(problem.decompositionB) on the right."
+                return "Show the same two parts with counters."
             } else if attempts == 2 {
-                return "This is still the same equation: \(problem.decompositionA) on the left, \(problem.decompositionB) on the right."
+                return "Use the same two numbers you wrote and build them with counters."
             } else {
-                return "Keep showing the same equation with counters: \(problem.decompositionA) in the first group and \(problem.decompositionB) in the second group."
+                return "Build the same equation again with counters, one group on each side."
             }
-        case .bondMatch:
-            return "Try another pair. Look for two numbers that add up to \(problem.target)."
         case .done:
             return "Try again."
         }
@@ -631,7 +630,7 @@ final class VerticalSliceEngine {
         var payload = extra
         payload["problem_id"] = currentProblem.id.uuidString
         payload["action"] = action
-        payload["stage"] = SliceStage.bondMatch.rawValue
+        payload["stage"] = currentStage.rawValue
         try? telemetryWriter.append(
             SliceEvent(type: .interaction, payload: payload)
         )

--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -193,6 +193,7 @@ struct BondMatchView: View {
         .frame(width: cardSize, height: cardSize)
         .accessibilityLabel("\(pair.left)\(isMatched ? ", matched" : isSelected ? ", selected" : "")")
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+        .accessibilityIdentifier("bond-left-\(pair.left)")
     }
 
     @ViewBuilder
@@ -238,6 +239,7 @@ struct BondMatchView: View {
             value: isWobbling
         )
         .accessibilityLabel("\(value)\(isMatched ? ", matched" : "")")
+        .accessibilityIdentifier("bond-right-\(value)")
     }
 
     // MARK: - Shared card fill

--- a/Features/VerticalSlice1/EquationResolveView.swift
+++ b/Features/VerticalSlice1/EquationResolveView.swift
@@ -13,47 +13,46 @@ struct EquationResolveView: View {
 
     @State private var selectedSide: EquationSide = .left
 
-    private let columns = Array(repeating: GridItem(.flexible(), spacing: 12), count: 3)
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 4)
 
     var body: some View {
         CardSurface {
-            VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 12) {
                 Text("Write it")
-                    .font(.largeTitle.weight(.black))
+                    .font(.title.weight(.black))
                 Text(theme.abstractPrompt())
-                    .font(.headline)
+                    .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.85)
 
                 ViewThatFits {
-                    HStack(spacing: 12) {
+                    HStack(spacing: 10) {
                         entryCard(title: "Part 1", value: leftInput, side: .left)
-                        Text("+").font(.largeTitle.weight(.black))
+                        Text("+").font(.title.weight(.black))
                         entryCard(title: "Part 2", value: rightInput, side: .right)
-                        Text("=").font(.largeTitle.weight(.black))
+                        Text("=").font(.title.weight(.black))
                         Text("\(target)")
-                            .font(.system(size: 42, weight: .black, design: .rounded))
+                            .font(.system(size: 32, weight: .black, design: .rounded))
                     }
-                    VStack(spacing: 10) {
-                        HStack(spacing: 12) {
+                    VStack(spacing: 8) {
+                        HStack(spacing: 10) {
                             entryCard(title: "Part 1", value: leftInput, side: .left)
-                            Text("+").font(.title.weight(.black))
+                            Text("+").font(.title2.weight(.black))
                             entryCard(title: "Part 2", value: rightInput, side: .right)
                         }
-                        HStack(spacing: 12) {
-                            Text("=").font(.title.weight(.black))
+                        HStack(spacing: 10) {
+                            Text("=").font(.title2.weight(.black))
                             Text("\(target)")
-                                .font(.system(size: 36, weight: .black, design: .rounded))
+                                .font(.system(size: 34, weight: .black, design: .rounded))
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
 
-                LazyVGrid(columns: columns, spacing: 12) {
+                LazyVGrid(columns: columns, spacing: 8) {
                     ForEach(0...10, id: \.self) { digit in
-                        Button("\(digit)") {
-                            onAppend(digit, selectedSide)
-                        }
-                        .buttonStyle(SecondaryTileButtonStyle(fill: selectedSide == .left ? MatherTheme.softBlue.opacity(0.75) : MatherTheme.warm.opacity(0.75)))
+                        keypadButton(digit)
                     }
                 }
 
@@ -67,20 +66,39 @@ struct EquationResolveView: View {
         }
     }
 
+    private func keypadButton(_ digit: Int) -> some View {
+        Button("\(digit)") {
+            onAppend(digit, selectedSide)
+        }
+        .font(.title3.weight(.bold))
+        .foregroundStyle(MatherTheme.ink)
+        .frame(maxWidth: .infinity, minHeight: 56)
+        .background(selectedSide == .left ? MatherTheme.softBlue.opacity(0.75) : MatherTheme.warm.opacity(0.75))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(
+                    colorScheme == .dark ? .white.opacity(0.08) : .clear,
+                    lineWidth: 1
+                )
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .accessibilityIdentifier("equation-digit-\(digit)")
+    }
+
     private func entryCard(title: String, value: String, side: EquationSide) -> some View {
         Button {
             selectedSide = side
         } label: {
-            VStack(spacing: 8) {
+            VStack(spacing: 6) {
                 Text(title)
-                    .font(.headline)
+                    .font(.subheadline.weight(.bold))
                 ZStack(alignment: .topTrailing) {
                     Text(value.isEmpty ? "?" : value)
-                        .font(.system(size: 40, weight: .black, design: .rounded))
-                        .frame(maxWidth: .infinity, minHeight: 84)
+                        .font(.system(size: 30, weight: .black, design: .rounded))
+                        .frame(maxWidth: .infinity, minHeight: 60)
                         .background(selectedSide == side ? MatherTheme.accent.opacity(colorScheme == .dark ? 0.28 : 0.18) : MatherTheme.softBlue.opacity(colorScheme == .dark ? 0.32 : 0.25))
                         .overlay(
-                            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
                                 .strokeBorder(
                                     selectedSide == side
                                         ? .white.opacity(colorScheme == .dark ? 0.12 : 0)
@@ -88,15 +106,14 @@ struct EquationResolveView: View {
                                     lineWidth: 1
                                 )
                         )
-                        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-                    // Inline clear — always reachable, no scrolling needed
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
                     if !value.isEmpty {
                         Button {
                             onClear(side)
                         } label: {
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundStyle(.secondary)
-                                .font(.title3)
+                                .font(.footnote.weight(.bold))
                         }
                         .buttonStyle(.plain)
                         .padding(8)

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -82,13 +82,35 @@ struct SliceSessionView: View {
                 theme: appModel.engine.activeTheme
             )
         case .pictorial:
-            SplitView(
-                target: problem.target,
-                leftCount: appModel.engine.splitLeftCount,
-                onAdjust: appModel.engine.moveSplit,
-                onSubmit: appModel.engine.submitCurrentStage,
-                theme: appModel.engine.activeTheme
-            )
+            if let bondState = appModel.engine.bondMatchState {
+                BondMatchView(
+                    state: bondState,
+                    tiltPitch: appModel.motionService.tiltPitch,
+                    tiltRoll: appModel.motionService.tiltRoll,
+                    shakeDetected: appModel.motionService.shakeDetected,
+                    clapDetected: appModel.soundDetectionService.clapDetected,
+                    onMatch: appModel.engine.matchPair(id:),
+                    onMismatch: appModel.engine.mismatchPair,
+                    onDragStarted: appModel.engine.bondDragStarted(pairId:),
+                    onNearTarget: appModel.engine.bondNearTarget,
+                    onShakeHandled: appModel.motionService.resetShake,
+                    onClapHandled: appModel.soundDetectionService.resetClap
+                )
+                .onAppear {
+                    if appModel.featureFlags.motionControlsEnabled {
+                        appModel.motionService.startUpdates()
+                    }
+                    if appModel.featureFlags.soundReactionEnabled {
+                        appModel.soundDetectionService.startListening()
+                    }
+                }
+                .onDisappear {
+                    appModel.motionService.stopUpdates()
+                    appModel.soundDetectionService.stopListening()
+                }
+            } else {
+                CardSurface { Text("Loading Bond Blast...") }
+            }
         case .abstract:
             EquationResolveView(
                 target: problem.target,
@@ -136,6 +158,8 @@ struct SliceSessionView: View {
                     appModel.motionService.stopUpdates()
                     appModel.soundDetectionService.stopListening()
                 }
+            } else {
+                CardSurface { Text("Loading Bond Blast...") }
             }
         case .done:
             CardSurface { Text("Moving to the next problem...") }

--- a/Features/VerticalSlice1/TransferCheckView.swift
+++ b/Features/VerticalSlice1/TransferCheckView.swift
@@ -11,45 +11,82 @@ struct TransferCheckView: View {
 
     var body: some View {
         CardSurface {
-            VStack(alignment: .leading, spacing: 14) {
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Show it again")
+            VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Show it")
                         .font(.title.weight(.bold))
                         .foregroundStyle(MatherTheme.coral)
 
-                    HStack(spacing: 10) {
-                        hiddenEquationPill(fill: MatherTheme.warm)
-                        Text("+")
-                            .font(.title.weight(.black))
-                            .foregroundStyle(.secondary)
-                        hiddenEquationPill(fill: MatherTheme.accent)
-                        Text("=")
-                            .font(.title.weight(.black))
-                            .foregroundStyle(.secondary)
-                        Text("\(problem.target)")
-                            .font(.system(size: 34, weight: .black, design: .rounded))
-                            .foregroundStyle(MatherTheme.ink)
+                    ViewThatFits {
+                        HStack(spacing: 10) {
+                            hiddenEquationPill(fill: MatherTheme.warm)
+                            Text("+")
+                                .font(.title.weight(.black))
+                                .foregroundStyle(.secondary)
+                            hiddenEquationPill(fill: MatherTheme.accent)
+                            Text("=")
+                                .font(.title.weight(.black))
+                                .foregroundStyle(.secondary)
+                            Text("\(problem.target)")
+                                .font(.system(size: 34, weight: .black, design: .rounded))
+                                .foregroundStyle(MatherTheme.ink)
+                        }
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack(spacing: 10) {
+                                hiddenEquationPill(fill: MatherTheme.warm)
+                                Text("+")
+                                    .font(.title2.weight(.black))
+                                    .foregroundStyle(.secondary)
+                                hiddenEquationPill(fill: MatherTheme.accent)
+                            }
+                            HStack(spacing: 10) {
+                                Text("=")
+                                    .font(.title2.weight(.black))
+                                    .foregroundStyle(.secondary)
+                                Text("\(problem.target)")
+                                    .font(.system(size: 34, weight: .black, design: .rounded))
+                                    .foregroundStyle(MatherTheme.ink)
+                            }
+                        }
                     }
                     .accessibilityIdentifier("transfer-equation")
 
-                    Text("Build the two parts from memory.")
+                    Text("Build the same two parts.")
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(MatherTheme.cardSubtitle)
                 }
 
-                HStack(spacing: 12) {
-                    transferBucket(
-                        title: "Left side",
-                        count: leftCount,
-                        fill: MatherTheme.warm,
-                        side: .left
-                    )
-                    transferBucket(
-                        title: "Right side",
-                        count: rightCount,
-                        fill: MatherTheme.accent,
-                        side: .right
-                    )
+                ViewThatFits {
+                    HStack(spacing: 12) {
+                        transferBucket(
+                            title: "Left side",
+                            count: leftCount,
+                            fill: MatherTheme.warm,
+                            side: .left
+                        )
+                        transferBucket(
+                            title: "Right side",
+                            count: rightCount,
+                            fill: MatherTheme.accent,
+                            side: .right
+                        )
+                    }
+
+                    VStack(spacing: 12) {
+                        transferBucket(
+                            title: "Left side",
+                            count: leftCount,
+                            fill: MatherTheme.warm,
+                            side: .left
+                        )
+                        transferBucket(
+                            title: "Right side",
+                            count: rightCount,
+                            fill: MatherTheme.accent,
+                            side: .right
+                        )
+                    }
                 }
 
                 Button("Check my groups") {

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -262,11 +262,11 @@ struct ThemeTests {
             saveSummary: { _ in }
         )
         engine.startSession()
-        // After advancing to pictorial, feedbackMessage should use theme pictorialPrompt
+        // The pictorial slot now uses Bond Blast copy rather than the theme-specific split prompt.
         engine.adjustConcrete(by: engine.currentProblem?.target ?? 0)
         engine.submitCurrentStage()
         try await Task.sleep(for: .milliseconds(200))
-        #expect(engine.feedbackMessage == "Split the rockets into two pads.")
+        #expect(engine.feedbackMessage == "Bond Blast! Match the pairs that make 6!")
     }
 
     // MARK: - counterNoun (UX review fix)

--- a/Tests/MatherTests/TransferExactRebuildTests.swift
+++ b/Tests/MatherTests/TransferExactRebuildTests.swift
@@ -78,7 +78,9 @@ struct TransferExactRebuildTests {
         engine.submitCurrentStage()
         try await Task.sleep(for: .milliseconds(200))
 
-        engine.submitCurrentStage()
+        for pair in engine.bondMatchState?.pairs ?? [] {
+            engine.matchPair(id: pair.id)
+        }
         try await Task.sleep(for: .milliseconds(200))
 
         engine.equationLeftInput = String(problem.decompositionA)
@@ -102,7 +104,9 @@ struct TransferExactRebuildTests {
         engine.adjustConcrete(by: currentProblem.target)
         engine.submitCurrentStage()
         try await Task.sleep(for: .milliseconds(200))
-        engine.submitCurrentStage()
+        for pair in engine.bondMatchState?.pairs ?? [] {
+            engine.matchPair(id: pair.id)
+        }
         try await Task.sleep(for: .milliseconds(200))
         engine.equationLeftInput = String(currentProblem.decompositionA)
         engine.equationRightInput = String(currentProblem.decompositionB)

--- a/Tests/MatherTests/TransferIntentTests.swift
+++ b/Tests/MatherTests/TransferIntentTests.swift
@@ -12,10 +12,10 @@ struct TransferIntentTests {
         guard let problem = engine.currentProblem else { return }
         try await advanceToTransfer(engine, problem: problem)
 
-        #expect(engine.feedbackMessage.contains("same equation"))
+        #expect(engine.feedbackMessage.localizedCaseInsensitiveContains("same two"))
         #expect(!engine.feedbackMessage.contains("\(problem.decompositionA)"))
         #expect(!engine.feedbackMessage.contains("\(problem.decompositionB)"))
-        #expect(engine.feedbackMessage.localizedCaseInsensitiveContains("memory"))
+        #expect(engine.feedbackMessage.localizedCaseInsensitiveContains("counters"))
     }
 
     @Test
@@ -51,7 +51,9 @@ struct TransferIntentTests {
         engine.submitCurrentStage()
         try await Task.sleep(for: .milliseconds(200))
 
-        engine.submitCurrentStage()
+        for pair in engine.bondMatchState?.pairs ?? [] {
+            engine.matchPair(id: pair.id)
+        }
         try await Task.sleep(for: .milliseconds(200))
 
         engine.equationLeftInput = String(problem.decompositionA)

--- a/Tests/MatherTests/VehicleSpecTests.swift
+++ b/Tests/MatherTests/VehicleSpecTests.swift
@@ -120,8 +120,9 @@ struct VehicleSpecTests {
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()                             // concrete → pictorial
         try await Task.sleep(for: .milliseconds(200))
-        engine.moveSplit(delta: 0)
-        engine.submitCurrentStage()                             // pictorial → abstract
+        for pair in engine.bondMatchState?.pairs ?? [] {
+            engine.matchPair(id: pair.id)
+        }
         try await Task.sleep(for: .milliseconds(200))
         engine.equationLeftInput = String(problem.decompositionA)
         engine.equationRightInput = String(problem.decompositionB)

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -4,8 +4,16 @@ import Testing
 
 @MainActor
 struct VerticalSliceEngineTests {
+    private func completePictorialBondBlast(_ engine: VerticalSliceEngine) {
+        let pairIds = engine.bondMatchState?.pairs.map(\.id) ?? []
+        #expect(!pairIds.isEmpty)
+        for id in pairIds {
+            engine.matchPair(id: id)
+        }
+    }
+
     @Test
-    func sessionIncludesTransferStageWhenRoomQuestIsNotActive() async throws {
+    func sessionRoutesThroughBondBlastThenWriteItThenTransfer() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
@@ -26,8 +34,8 @@ struct VerticalSliceEngineTests {
         try await Task.sleep(for: .milliseconds(200))
         #expect(engine.currentStage == .pictorial)
 
-        engine.moveSplit(delta: 0)
-        engine.submitCurrentStage()
+        #expect(engine.bondMatchState != nil)
+        completePictorialBondBlast(engine)
         try await Task.sleep(for: .milliseconds(200))
         #expect(engine.currentStage == .abstract)
 
@@ -59,7 +67,7 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
-    func pictorialStageStartsBlankInsteadOfPrefilledAnswer() async throws {
+    func bondBlastStartsWhenConcreteStageClears() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
@@ -83,9 +91,8 @@ struct VerticalSliceEngineTests {
         try await Task.sleep(for: .milliseconds(200))
 
         #expect(engine.currentStage == .pictorial)
-        #expect(engine.splitLeftCount == 0)
+        #expect(engine.bondMatchState != nil)
         #expect(problem.decompositionA > 0)
-        #expect(problem.decompositionA != engine.splitLeftCount)
     }
 
     @Test
@@ -137,7 +144,7 @@ struct VerticalSliceEngineTests {
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()    // concrete → pictorial (stageSuccess)
         try await Task.sleep(for: .milliseconds(200))
-        engine.submitCurrentStage()    // pictorial → abstract (stageSuccess)
+        completePictorialBondBlast(engine)
         try await Task.sleep(for: .milliseconds(200))
         engine.equationLeftInput = String(problem.decompositionA)
         engine.equationRightInput = String(problem.decompositionB)
@@ -222,7 +229,7 @@ struct VerticalSliceEngineTests {
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage() // → pictorial
         try await Task.sleep(for: .milliseconds(200))
-        engine.submitCurrentStage() // → abstract
+        completePictorialBondBlast(engine)
         try await Task.sleep(for: .milliseconds(200))
 
         #expect(engine.currentStage == .abstract)
@@ -313,7 +320,7 @@ struct VerticalSliceEngineTests {
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()
         try await Task.sleep(for: .milliseconds(200))
-        engine.submitCurrentStage()
+        completePictorialBondBlast(engine)
         try await Task.sleep(for: .milliseconds(200))
         engine.equationLeftInput = String(problem.decompositionA)
         engine.equationRightInput = String(problem.decompositionB)
@@ -352,7 +359,7 @@ struct VerticalSliceEngineTests {
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()
         try await Task.sleep(for: .milliseconds(200))
-        engine.submitCurrentStage()
+        completePictorialBondBlast(engine)
         try await Task.sleep(for: .milliseconds(200))
         engine.equationLeftInput = String(problem.decompositionA)
         engine.equationRightInput = String(problem.decompositionB)

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @MainActor
 final class CompactLayoutTests: XCTestCase {
-    func testAbstractStageSubmitIsReachableWithoutSwipe() {
+    func testVS1CompactFlowShowsUpdatedCopyAndKeepsCoreActionsReachableWithoutSwipe() {
         let app = launchWithVS1()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
 
@@ -29,11 +29,14 @@ final class CompactLayoutTests: XCTestCase {
         _ = concreteSubmit.waitForExistence(timeout: 5)
         concreteSubmit.tap()
 
-        let pictorialLabel = app.staticTexts.element(matching: NSPredicate(format: "label BEGINSWITH 'Break '"))
-        _ = pictorialLabel.waitForExistence(timeout: 10)
-        let leftBucketCount = app.staticTexts["0"]
-        XCTAssertTrue(leftBucketCount.waitForExistence(timeout: 5), "Expected pictorial stage to start blank instead of prefilled")
-        app.buttons["Use this break"].tap()
+        let bondBlastLabel = app.staticTexts["Bond Blast!"]
+        _ = bondBlastLabel.waitForExistence(timeout: 10)
+        XCTAssertFalse(app.staticTexts["Break It"].exists, "Expected Bond Blast to replace the old Break It title")
+
+        for (left, right) in [(1, 5), (2, 4), (3, 3)] {
+            app.buttons["bond-left-\(left)"].tap()
+            app.buttons["bond-right-\(right)"].tap()
+        }
 
         let abstractLabel = app.staticTexts["Write it"]
         _ = abstractLabel.waitForExistence(timeout: 10)
@@ -41,6 +44,19 @@ final class CompactLayoutTests: XCTestCase {
         let submitButton = app.buttons["Check equation"]
         _ = submitButton.waitForExistence(timeout: 5)
         XCTAssertTrue(submitButton.isHittable, "Expected abstract-stage submit to be reachable without additional scrolling")
+
+        app.buttons["equation-digit-3"].firstMatch.tap()
+        app.buttons["Part 2, ?"].tap()
+        app.buttons["equation-digit-3"].firstMatch.tap()
+        submitButton.tap()
+
+        let transferLabel = app.staticTexts["Show it"]
+        _ = transferLabel.waitForExistence(timeout: 10)
+        XCTAssertFalse(app.staticTexts["Show it again"].exists, "Expected old transfer-stage copy to be removed")
+
+        let transferSubmit = app.buttons["Check my groups"]
+        _ = transferSubmit.waitForExistence(timeout: 5)
+        XCTAssertTrue(transferSubmit.isHittable, "Expected transfer-stage submit to remain reachable without additional scrolling")
     }
 
     private func launchWithVS1() -> XCUIApplication {

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -146,9 +146,8 @@ final class ScreenshotTests: XCTestCase {
         accentRowFirstCell.tap()
         submitButton.tap()
 
-        // After a correct answer the stage advances to pictorial — wait for it
-        let breakPredicate = NSPredicate(format: "label BEGINSWITH 'Break '")
-        _ = app.staticTexts.element(matching: breakPredicate).waitForExistence(timeout: 10)
+        // After a correct answer the stage advances to Bond Blast in the pictorial slot.
+        _ = app.staticTexts["Bond Blast!"].waitForExistence(timeout: 10)
         snapshot(app, "Pictorial-AfterConcreteSuccess")
     }
 
@@ -282,8 +281,7 @@ final class ScreenshotTests: XCTestCase {
         _ = submitButton.waitForExistence(timeout: 5)
         submitButton.tap()
 
-        let breakPredicate = NSPredicate(format: "label BEGINSWITH 'Break '")
-        _ = app.staticTexts.element(matching: breakPredicate).waitForExistence(timeout: 10)
+        _ = app.staticTexts["Bond Blast!"].waitForExistence(timeout: 10)
         snapshot(app, "iPhone-SplitView")
     }
 


### PR DESCRIPTION
## Summary
- replace the old Break It stage with Bond Blast in the pictorial slot
- remove child-facing 'Show it again' copy and tighten Write it for compact iPhone layouts
- update engine/test flow so Bond Blast works correctly in the earlier slot

## Validation
- xcodegen generate on ganesh@mba: 0.07s real
- targeted VerticalSliceEngineTests on ganesh@mba: passed
- targeted CompactLayoutTests on ganesh@mba: passed after test selector repair, rerun 150.22s real
- broader Mac pass on ganesh@mba passed:
  - ThemeTests
  - TransferExactRebuildTests
  - TransferIntentTests
  - VehicleSpecTests
  - ScreenshotTests
  - wall time: 331.82s real
