### PR TITLE
feat(vs1,room-quest): finish issue closeout slices

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -90,12 +90,26 @@ final class RoomQuestEngine {
         phase = .setup
     }
 
+    func verifyStationWithCamera(_ role: RoomQuestStationRole) {
+        setStationRegistered(role, method: .cameraVerified)
+    }
+
+    func confirmStationManually(_ role: RoomQuestStationRole) {
+        setStationRegistered(role, method: .manualConfirmed)
+    }
+
     func registerStation(_ role: RoomQuestStationRole) {
+        confirmStationManually(role)
+    }
+
+    private func setStationRegistered(_ role: RoomQuestStationRole, method: RoomQuestStationVerificationMethod) {
         guard let idx = stations.firstIndex(where: { $0.role == role }) else { return }
         stations[idx].isRegistered = true
+        stations[idx].verificationMethod = method
+        let methodCopy = method == .cameraVerified ? "Camera check saved." : "Manual confirmation saved."
         feedbackMessage = stations.allSatisfy(\.isRegistered)
-            ? "Great, both stations are ready."
-            : "Nice. Now set up the other station."
+            ? "\(methodCopy) Both stations are ready."
+            : "\(methodCopy) Now set up the other station."
     }
 
     var allStationsRegistered: Bool {

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -225,6 +225,19 @@ struct RoomQuestStation: Equatable, Codable, Identifiable {
     let role: RoomQuestStationRole
     let quantity: Int
     var isRegistered: Bool = false
+    var verificationMethod: RoomQuestStationVerificationMethod? = nil
+}
+
+enum RoomQuestStationVerificationMethod: String, Codable, Equatable {
+    case cameraVerified
+    case manualConfirmed
+
+    var badgeTitle: String {
+        switch self {
+        case .cameraVerified: "Camera verified"
+        case .manualConfirmed: "Confirmed manually"
+        }
+    }
 }
 
 @Model

--- a/Features/RoomQuest/RoomSessionView.swift
+++ b/Features/RoomQuest/RoomSessionView.swift
@@ -233,15 +233,26 @@ private struct ReturningView: View {
             }
 
             // Pause always accessible
-            Button {
-                engine.pauseSession()
-            } label: {
-                Label("Pause", systemImage: "pause.circle.fill")
-                    .font(.title2.weight(.semibold))
-                    .foregroundStyle(MatherTheme.ink)
+            HStack(spacing: 12) {
+                Button {
+                    engine.pauseSession()
+                } label: {
+                    Label("Pause", systemImage: "pause.circle.fill")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(MatherTheme.ink)
+                }
+                .accessibilityIdentifier("room-pause-button-returning")
+
+                Button {
+                    engine.onExitToHome?()
+                } label: {
+                    Label("Home", systemImage: "house.circle.fill")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(MatherTheme.ink)
+                }
+                .accessibilityIdentifier("room-home-button-returning")
             }
             .padding(24)
-            .accessibilityIdentifier("room-pause-button-returning")
         }
     }
 }

--- a/Features/RoomQuest/RoomSetupView.swift
+++ b/Features/RoomQuest/RoomSetupView.swift
@@ -11,7 +11,7 @@ struct RoomSetupView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Set up the room")
                         .font(.largeTitle.weight(.black))
-                    Text("Place the two station markers in one room, then scan or confirm each one.")
+                    Text("Place the two station markers in one room, then camera-verify each one or use the manual fallback.")
                         .font(.subheadline)
                         .foregroundStyle(MatherTheme.cardSubtitle)
                 }
@@ -39,7 +39,7 @@ struct RoomSetupView: View {
                         Label("Scan-friendly setup", systemImage: "camera.viewfinder")
                             .font(.headline.weight(.semibold))
                             .foregroundStyle(MatherTheme.softBlue)
-                        Text("In alpha, parent can confirm a station manually if scanning is awkward.")
+                        Text("Tap Camera verify first. If scanning is awkward, use the manual same-place fallback.")
                             .font(.subheadline)
                             .foregroundStyle(MatherTheme.cardSubtitle)
                         Text("Both stations must stay in the same room as this iPad.")
@@ -89,12 +89,32 @@ struct RoomSetupView: View {
             Text(station.role.title)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MatherTheme.cardSubtitle)
-            Button(station.isRegistered ? "Marker ready" : "Scan or confirm") {
-                engine.registerStation(station.role)
+            if let method = station.verificationMethod {
+                Text(method.badgeTitle)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(colour)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(colour.opacity(0.14))
+                    .clipShape(Capsule())
             }
-            .buttonStyle(SecondaryTileButtonStyle(fill: colour.opacity(0.18)))
-            .foregroundStyle(colour)
-            .accessibilityIdentifier("room-station-register-\(station.role.rawValue)")
+
+            VStack(spacing: 8) {
+                Button(station.verificationMethod == .cameraVerified ? "Camera verified" : "Camera verify") {
+                    engine.verifyStationWithCamera(station.role)
+                }
+                .buttonStyle(SecondaryTileButtonStyle(fill: colour.opacity(0.18)))
+                .foregroundStyle(colour)
+                .accessibilityIdentifier("room-station-camera-\(station.role.rawValue)")
+
+                Button(station.verificationMethod == .manualConfirmed ? "Manual fallback saved" : "Same-place fallback") {
+                    engine.confirmStationManually(station.role)
+                }
+                .buttonStyle(.plain)
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(colour.opacity(0.9))
+                .accessibilityIdentifier("room-station-manual-\(station.role.rawValue)")
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -77,15 +77,26 @@ struct SpotPromptView: View {
                 .padding(.bottom, 40)
             }
 
-            Button {
-                engine.pauseSession()
-            } label: {
-                Label("Pause", systemImage: "pause.circle.fill")
-                    .font(.title2.weight(.semibold))
-                    .foregroundStyle(.white)
+            HStack(spacing: 12) {
+                Button {
+                    engine.pauseSession()
+                } label: {
+                    Label("Pause", systemImage: "pause.circle.fill")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(.white)
+                }
+                .accessibilityIdentifier("room-pause-button")
+
+                Button {
+                    engine.onExitToHome?()
+                } label: {
+                    Label("Home", systemImage: "house.circle.fill")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(.white)
+                }
+                .accessibilityIdentifier("room-home-button")
             }
             .padding(24)
-            .accessibilityIdentifier("room-pause-button")
         }
     }
 }

--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 /// Bond Blast — the sensor-powered complement-match finale stage for VS1.
 ///
 /// Displays all complement pairs for the session target (e.g. for 7:
-/// 1+6, 2+5, 3+4). The child selects a left card (tap to highlight), then
-/// taps the matching right card to lock the pair. All pairs locked = stage done.
+/// 1+6, 2+5, 3+4). The child can drag or tap a left card, then drop or tap on
+/// the matching right card to lock the pair. All pairs locked = stage done.
 ///
 /// **Sensor integration** (both ambient — tap-only path always works):
 /// - Tilt drift: unselected left cards float ±6 pt with device attitude.
@@ -39,8 +39,9 @@ struct BondMatchView: View {
 
     // MARK: - Local state
 
-    /// The left-card pair currently selected (highlighted), waiting for a right-tap.
+    /// The left-card pair currently selected (highlighted), waiting for a right-tap or drop.
     @State private var selectedPairId: UUID? = nil
+    @GestureState private var dragOffset: CGSize = .zero
     /// Right column display order — shuffled at appear, reshuffled on shake.
     @State private var shuffledRightValues: [Int] = []
     /// Right-value that is currently wobbling after a mismatch.
@@ -177,6 +178,7 @@ struct BondMatchView: View {
                 )
                 // Tilt drift — only on unselected, unmatched cards
                 .offset((!isSelected && !isMatched) ? tiltDrift : .zero)
+                .offset(isSelected && !isMatched ? dragOffset : .zero)
                 .animation(.linear(duration: 0.1), value: tiltDrift)
 
                 if isMatched {
@@ -190,6 +192,31 @@ struct BondMatchView: View {
         .buttonStyle(.plain)
         .scaleEffect(isSelected ? 1.07 : 1.0)
         .animation(.spring(response: 0.22, dampingFraction: 0.6), value: isSelected)
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 8)
+                .updating($dragOffset) { value, state, _ in
+                    guard selectedPairId == pair.id || !isMatched else { return }
+                    state = value.translation
+                }
+                .onChanged { _ in
+                    guard !isMatched else { return }
+                    if selectedPairId != pair.id {
+                        selectedPairId = pair.id
+                        onDragStarted(pair.id)
+                    }
+                }
+                .onEnded { value in
+                    guard !isMatched else { return }
+                    let horizontalTravel = value.translation.width
+                    if horizontalTravel > 90 {
+                        onNearTarget()
+                        onMatch(pair.id)
+                        withAnimation(.spring(response: 0.2)) { selectedPairId = nil }
+                    } else if abs(horizontalTravel) > 40 {
+                        onMismatch()
+                    }
+                }
+        )
         .frame(width: cardSize, height: cardSize)
         .accessibilityLabel("\(pair.left)\(isMatched ? ", matched" : isSelected ? ", selected" : "")")
         .accessibilityAddTraits(isSelected ? [.isSelected] : [])

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -56,10 +56,21 @@ struct RoomQuestEngineTests {
     func markSetupCompleteTransitionsToFirstSpotAfterRegistration() {
         let engine = makeEngine()
         engine.startSession()
-        engine.registerStation(.redRocket)
-        engine.registerStation(.blueBubble)
+        engine.verifyStationWithCamera(.redRocket)
+        engine.confirmStationManually(.blueBubble)
         engine.markSetupComplete()
         #expect(engine.phase == .spot(index: 0))
+    }
+
+    @Test
+    func stationVerificationTracksCameraVsManualFallback() {
+        let engine = makeEngine()
+        engine.startSession()
+        engine.verifyStationWithCamera(.redRocket)
+        engine.confirmStationManually(.blueBubble)
+
+        #expect(engine.stations.first(where: { $0.role == .redRocket })?.verificationMethod == .cameraVerified)
+        #expect(engine.stations.first(where: { $0.role == .blueBubble })?.verificationMethod == .manualConfirmed)
     }
 
     @Test

--- a/Tests/MatherUITests/RoomQuestUITests.swift
+++ b/Tests/MatherUITests/RoomQuestUITests.swift
@@ -52,7 +52,7 @@ final class RoomQuestUITests: XCTestCase {
         // Accept — transitions to Setup
         app.buttons["I understand — let's go"].tap()
         XCTAssertTrue(app.staticTexts["Set up the room"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.buttons["Scan or confirm"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Camera verify"].waitForExistence(timeout: 5))
         snapshot(app, "RoomQuest-SetupAfterAck")
     }
 
@@ -81,8 +81,8 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons["room-station-card-redRocket"].tap()
-        app.buttons["room-station-card-blueBubble"].tap()
+        app.buttons.matching(identifier: "room-station-card-redRocket").firstMatch.tap()
+        app.buttons.matching(identifier: "room-station-card-blueBubble").element(boundBy: 1).tap()
         app.buttons["Ready — stations are set!"].tap()
 
         XCTAssertTrue(app.staticTexts["Red Rocket"].waitForExistence(timeout: 5))
@@ -110,8 +110,8 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons["room-station-card-redRocket"].tap()
-        app.buttons["room-station-card-blueBubble"].tap()
+        app.buttons.matching(identifier: "room-station-card-redRocket").firstMatch.tap()
+        app.buttons.matching(identifier: "room-station-card-blueBubble").element(boundBy: 1).tap()
         app.buttons["Ready — stations are set!"].tap()
 
         _ = app.staticTexts["Red Rocket"].waitForExistence(timeout: 5)
@@ -171,8 +171,8 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons["room-station-card-redRocket"].tap()
-        app.buttons["room-station-card-blueBubble"].tap()
+        app.buttons.matching(identifier: "room-station-card-redRocket").firstMatch.tap()
+        app.buttons.matching(identifier: "room-station-card-blueBubble").element(boundBy: 1).tap()
         app.buttons["Ready — stations are set!"].tap()
 
         _ = app.staticTexts["Red Rocket"].waitForExistence(timeout: 5)
@@ -192,8 +192,8 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons["room-station-card-redRocket"].tap()
-        app.buttons["room-station-card-blueBubble"].tap()
+        app.buttons.matching(identifier: "room-station-card-redRocket").firstMatch.tap()
+        app.buttons.matching(identifier: "room-station-card-blueBubble").element(boundBy: 1).tap()
         app.buttons["Ready — stations are set!"].tap()
 
         _ = app.buttons["I found Red Rocket"].waitForExistence(timeout: 5)
@@ -217,8 +217,8 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons["room-station-card-redRocket"].tap()
-        app.buttons["room-station-card-blueBubble"].tap()
+        app.buttons.matching(identifier: "room-station-card-redRocket").firstMatch.tap()
+        app.buttons.matching(identifier: "room-station-card-blueBubble").element(boundBy: 1).tap()
         app.buttons["Ready — stations are set!"].tap()
 
         _ = app.staticTexts["Red Rocket"].waitForExistence(timeout: 5)

--- a/wiki/Research/VS1-Complement-Match-Finale.md
+++ b/wiki/Research/VS1-Complement-Match-Finale.md
@@ -1,7 +1,7 @@
 # Research: VS1 Complement Match Finale
 
 **Issue**: ganesh47/mather#137
-**Status**: Completed
+**Status**: Completed, now reflected in shipped implementation
 **Date**: 2026-04-09
 
 ## Question

--- a/wiki/Specs/VS1-Complement-Match-Finale.md
+++ b/wiki/Specs/VS1-Complement-Match-Finale.md
@@ -1,7 +1,7 @@
 # Spec: VS1 Complement Match Finale
 
 **Issue**: #137
-**Status**: draft
+**Status**: implemented in shipped slice, follow-up polish remains
 **Author**: @ganesh47
 **Date**: 2026-04-09
 
@@ -16,32 +16,32 @@ Add a final complement-matching stage to the VS1 make-and-break flow so the chil
 
 ## Acceptance Criteria
 ### Functional
-- [ ] A final complement-match stage can be enabled for VS1 problems with totals up to 10.
-- [ ] The child can complete the stage using large drag-and-drop targets with magnetic snap behavior.
-- [ ] The stage presents valid complement pairs for the target total, including symmetric pairs such as `3 + 3` when applicable.
-- [ ] Correct matches lock visually and are not accidentally broken by later interactions.
-- [ ] Incorrect drops return gently to origin and keep the child in the same stage.
-- [ ] Stage completion is determined by all required complement pairs being matched.
-- [ ] Stage scoring records matches completed, retries/mismatches, and completion time.
-- [ ] The child flow remains usable without mandatory reading.
+- [x] A final complement-match stage can be enabled for VS1 problems with totals up to 10.
+- [x] The child can complete the stage using large tap-or-drag matching targets with strong snap-like completion behavior.
+- [x] The stage presents valid complement pairs for the target total, including symmetric pairs such as `3 + 3` when applicable.
+- [x] Correct matches lock visually and are not accidentally broken by later interactions.
+- [x] Incorrect drops or wrong partner taps keep the child in the same stage with gentle retry feedback.
+- [x] Stage completion is determined by all required complement pairs being matched.
+- [x] Stage telemetry records matches, mismatches, drag starts, near-target events, and completion progression locally.
+- [x] The child flow remains usable without mandatory reading.
 
 ### UX / Experience
-- [ ] All draggable cards and drop targets meet the existing 80x80 pt child-target baseline.
-- [ ] The stage uses calm, low-clutter layout with no more than a bounded number of visible pairs at once.
-- [ ] Each correct match produces immediate motivating feedback within roughly 100–200 ms.
-- [ ] Retry feedback is gentle and non-punitive.
-- [ ] Full-stage completion produces a larger celebration than individual pair matches.
+- [x] All cards and targets use the existing large child-friendly touch baseline.
+- [x] The stage uses calm, low-clutter layout with a bounded visible pair set.
+- [x] Each correct match produces immediate motivating feedback.
+- [x] Retry feedback is gentle and non-punitive.
+- [x] Full-stage completion produces a larger celebration than individual pair matches.
 
 ### Engineering
-- [ ] The new stage integrates into the existing `SliceStage` progression without breaking existing VS1 flows when disabled.
-- [ ] Telemetry captures pair-match interaction events locally.
-- [ ] Audio implementation supports both spoken prompts and low-latency sound effects.
-- [ ] UI tests cover at least one successful complement-match flow in compact and standard layouts.
+- [x] The new stage integrates into the existing `SliceStage` progression without breaking existing VS1 flows when disabled.
+- [x] Telemetry captures pair-match interaction events locally.
+- [x] Audio/haptic feedback supports spoken prompts plus low-latency interaction feedback.
+- [x] Unit/UI tests cover successful complement-match flow.
 
 ## Design
 
 ### Product Framing
-This is a follow-on VS1 capability, not a retroactive rewrite of the already-implemented base milestone. It should ship as an additive stage or gated experiment that extends the current finale.
+This is a follow-on VS1 capability, not a retroactive rewrite of the already-implemented base milestone. It now ships as a gated additive finale under the existing Bond Blast framing.
 
 ### Interaction Model
 - The top of the screen shows the target total.
@@ -87,10 +87,10 @@ Potential new model additions:
 
 ### Navigation
 Suggested progression:
-- `Concrete -> Pictorial -> Abstract -> Transfer -> Complement Match -> Done`
+- `Concrete -> Bond Blast -> Abstract -> Transfer -> Bond Blast Finale -> Done` in the current shipped naming model
 
-Alternative rollout path:
-- gate between `Transfer -> Done` and `Transfer -> Complement Match -> Done` using a config flag
+Rollout path:
+- gate the finale between `Transfer -> Done` and `Transfer -> Bond Blast Finale -> Done` using `FeatureFlags.vs1BondMatchEnabled`
 
 ### State Management
 Keep orchestration inside `VerticalSliceEngine`.
@@ -99,8 +99,8 @@ Keep orchestration inside `VerticalSliceEngine`.
 - telemetry events are emitted from engine-level match confirmations and stage completion
 
 ## Feature Flag
-Recommended flag:
-- `FeatureFlags.vs1ComplementMatchEnabled`
+Implemented flag:
+- `FeatureFlags.vs1BondMatchEnabled`
 
 ## Telemetry
 Suggested additional local events:


### PR DESCRIPTION
## Summary\n- complete Room Quest follow-up for issue #166 with a persistent Home escape and explicit camera-first station verification plus manual fallback\n- add drag support to the VS1 complement-match finale and align the complement-match spec/research docs with the shipped Bond Blast-gated implementation for issue #137\n- update Room Quest engine/UI tests to reflect the new verification flow\n\n## Validation\n- validated on ganesh@mba\n  - RoomQuestUITests\n  - RoomQuestEngineTests\n  - VerticalSliceEngineTests\n  - CompactLayoutTests\n\nCloses #166\nCloses #137