### PR TITLE
feat(room-quest): add QR scanner and AR celebration

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -13,6 +13,7 @@ final class AppModel {
     let hapticsService: HapticsService
     let motionService: MotionService
     let soundDetectionService: SoundDetectionService
+    let roomQuestScanner: RoomQuestLiveScanner
     let roomQuestEngine: RoomQuestEngine
 
     init(modelContext: ModelContext) {
@@ -23,6 +24,7 @@ final class AppModel {
         let hapticsService = HapticsService()
         let motionService = MotionService()
         let soundDetectionService = SoundDetectionService()
+        let roomQuestScanner = RoomQuestLiveScanner()
 
         self.featureFlags = featureFlags
         self.speechService = speechService
@@ -31,6 +33,7 @@ final class AppModel {
         self.hapticsService = hapticsService
         self.motionService = motionService
         self.soundDetectionService = soundDetectionService
+        self.roomQuestScanner = roomQuestScanner
 
         let vsEngine = VerticalSliceEngine(
             featureFlags: featureFlags,
@@ -45,7 +48,8 @@ final class AppModel {
             featureFlags: featureFlags,
             telemetryWriter: telemetryWriter,
             speechService: speechService,
-            hapticsService: hapticsService
+            hapticsService: hapticsService,
+            scanner: roomQuestScanner
         )
         self.roomQuestEngine = roomQuestEngine
         roomQuestEngine.onExitToHome = { [weak vsEngine] in vsEngine?.showHome() }

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Mather listens for claps to celebrate with you! Enable in Settings → Clap reaction.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Room Quest uses the camera to scan station markers and unlock playful AR moments for kids.</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -24,6 +24,12 @@ struct RootView: View {
                     SettingsView(appModel: appModel, summaries: sessionSummaries)
                 case .roomQuest:
                     RoomSessionView(engine: appModel.roomQuestEngine, vsEngine: appModel.engine)
+                        .sheet(item: Binding(
+                            get: { appModel.roomQuestScanner.activeSession },
+                            set: { _ in }
+                        )) { _ in
+                            RoomQuestScannerSheet(scanner: appModel.roomQuestScanner)
+                        }
                 }
             }
             .navigationBarTitleDisplayMode(.inline)

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -44,7 +44,10 @@ final class RoomQuestEngine {
     private let telemetryWriter: TelemetryWriter
     private let speechService: SpeechService
     private let hapticsService: HapticsService
+    private let scanner: RoomQuestScanner
     var onExitToHome: (() -> Void)?
+
+    private(set) var scanState: RoomQuestScanState = .idle
 
     static let roomPhaseLimitSeconds: TimeInterval = 4 * 60
 
@@ -54,12 +57,14 @@ final class RoomQuestEngine {
         featureFlags: FeatureFlagService,
         telemetryWriter: TelemetryWriter,
         speechService: SpeechService,
-        hapticsService: HapticsService = HapticsService()
+        hapticsService: HapticsService = HapticsService(),
+        scanner: RoomQuestScanner = NoopRoomQuestScanner()
     ) {
         self.featureFlags = featureFlags
         self.telemetryWriter = telemetryWriter
         self.speechService = speechService
         self.hapticsService = hapticsService
+        self.scanner = scanner
     }
 
     // MARK: - Session lifecycle
@@ -91,10 +96,46 @@ final class RoomQuestEngine {
     }
 
     func verifyStationWithCamera(_ role: RoomQuestStationRole) {
-        setStationRegistered(role, method: .cameraVerified)
+        guard featureFlags.roomQuestMarkerSetupEnabled else {
+            feedbackMessage = "Camera setup is off right now. Use the same-place fallback."
+            scanState = .failed(role: role, message: feedbackMessage)
+            return
+        }
+
+        scanState = .scanning(role: role)
+        feedbackMessage = "Scan the \(role.title) marker with the camera."
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let result = try await scanner.scanMarker(for: role)
+                self.setStationRegistered(result.role, method: .cameraVerified)
+                self.scanState = .celebrating(role: result.role, usedARCelebration: result.usedARCelebration)
+                self.hapticsService.success(enabled: self.featureFlags.hapticsEnabled)
+                self.speechService.speak("You found \(result.role.title)!", enabled: self.featureFlags.audioEnabled)
+                try? await Task.sleep(for: .seconds(1.2))
+                if case .celebrating(let currentRole, _) = self.scanState, currentRole == result.role {
+                    self.scanState = .idle
+                }
+            } catch let error as RoomQuestScannerError {
+                switch error {
+                case .cancelled:
+                    self.feedbackMessage = "Camera check cancelled. Use the same-place fallback or try again."
+                case .unavailable:
+                    self.feedbackMessage = "Camera scan is unavailable on this device right now. Use the same-place fallback."
+                case .wrongMarker(let expected, let detected):
+                    self.feedbackMessage = "That looked like \(detected.title). Scan the \(expected.title) marker instead."
+                }
+                self.scanState = .failed(role: role, message: self.feedbackMessage)
+            } catch {
+                self.feedbackMessage = "Camera check did not finish. Try again or use the same-place fallback."
+                self.scanState = .failed(role: role, message: self.feedbackMessage)
+            }
+        }
     }
 
     func confirmStationManually(_ role: RoomQuestStationRole) {
+        scanState = .idle
         setStationRegistered(role, method: .manualConfirmed)
     }
 

--- a/Domain/RoomQuestScanner.swift
+++ b/Domain/RoomQuestScanner.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct RoomQuestMarkerScanResult: Equatable {
+    let role: RoomQuestStationRole
+    let usedARCelebration: Bool
+}
+
+enum RoomQuestScannerError: Error, Equatable {
+    case cancelled
+    case unavailable
+    case wrongMarker(expected: RoomQuestStationRole, detected: RoomQuestStationRole)
+}
+
+@MainActor
+protocol RoomQuestScanner {
+    func scanMarker(for role: RoomQuestStationRole) async throws -> RoomQuestMarkerScanResult
+}
+
+struct NoopRoomQuestScanner: RoomQuestScanner {
+    func scanMarker(for role: RoomQuestStationRole) async throws -> RoomQuestMarkerScanResult {
+        throw RoomQuestScannerError.unavailable
+    }
+}

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -240,6 +240,13 @@ enum RoomQuestStationVerificationMethod: String, Codable, Equatable {
     }
 }
 
+enum RoomQuestScanState: Equatable {
+    case idle
+    case scanning(role: RoomQuestStationRole)
+    case celebrating(role: RoomQuestStationRole, usedARCelebration: Bool)
+    case failed(role: RoomQuestStationRole, message: String)
+}
+
 @Model
 final class StoredSessionSummary {
     @Attribute(.unique) var sessionId: String

--- a/Features/RoomQuest/RoomSessionView.swift
+++ b/Features/RoomQuest/RoomSessionView.swift
@@ -227,6 +227,7 @@ private struct ReturningView: View {
                 Button("We're back!") {
                     engine.markReturned()
                 }
+                .accessibilityIdentifier("room-return-confirm-button")
                 .buttonStyle(PrimaryActionButtonStyle())
                 .padding(.horizontal, 40)
                 .padding(.bottom, 40)
@@ -234,23 +235,13 @@ private struct ReturningView: View {
 
             // Pause always accessible
             HStack(spacing: 12) {
-                Button {
+                roomReturningChromeButton(title: "Pause", systemImage: "pause.circle.fill", accessibilityID: "room-pause-button-returning") {
                     engine.pauseSession()
-                } label: {
-                    Label("Pause", systemImage: "pause.circle.fill")
-                        .font(.title2.weight(.semibold))
-                        .foregroundStyle(MatherTheme.ink)
                 }
-                .accessibilityIdentifier("room-pause-button-returning")
 
-                Button {
+                roomReturningChromeButton(title: "Home", systemImage: "house.circle.fill", accessibilityID: "room-home-button-returning") {
                     engine.onExitToHome?()
-                } label: {
-                    Label("Home", systemImage: "house.circle.fill")
-                        .font(.title2.weight(.semibold))
-                        .foregroundStyle(MatherTheme.ink)
                 }
-                .accessibilityIdentifier("room-home-button-returning")
             }
             .padding(24)
         }
@@ -258,6 +249,20 @@ private struct ReturningView: View {
 }
 
 /// Hard pause screen — resume or abandon.
+private func roomReturningChromeButton(title: String, systemImage: String, accessibilityID: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+        Label(title, systemImage: systemImage)
+            .font(.title2.weight(.semibold))
+            .foregroundStyle(MatherTheme.ink)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(.white.opacity(0.9), in: Capsule())
+    }
+    .accessibilityIdentifier(accessibilityID)
+    .accessibilityLabel(accessibilityID)
+    .accessibilityAddTraits(.isButton)
+}
+
 private struct RoomPausedView: View {
     @Bindable var engine: RoomQuestEngine
     let resumingTo: RoomPhase

--- a/Features/RoomQuest/RoomSetupView.swift
+++ b/Features/RoomQuest/RoomSetupView.swift
@@ -45,6 +45,26 @@ struct RoomSetupView: View {
                         Text("Both stations must stay in the same room as this iPad.")
                             .font(.subheadline)
                             .foregroundStyle(MatherTheme.cardSubtitle)
+
+                        switch engine.scanState {
+                        case .idle:
+                            EmptyView()
+                        case .scanning(let role):
+                            Label("Scanning \(role.title)… point the camera at its marker.", systemImage: "camera.metering.center.weighted")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(MatherTheme.ink)
+                                .accessibilityIdentifier("room-scan-status")
+                        case .celebrating(let role, let usedARCelebration):
+                            Label(usedARCelebration ? "\(role.title) unlocked with AR sparkle!" : "\(role.title) found!", systemImage: usedARCelebration ? "sparkles.rectangle.stack.fill" : "checkmark.seal.fill")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(MatherTheme.accent)
+                                .accessibilityIdentifier("room-scan-status")
+                        case .failed(_, let message):
+                            Label(message, systemImage: "exclamationmark.triangle.fill")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(MatherTheme.coral)
+                                .accessibilityIdentifier("room-scan-status")
+                        }
                     }
                 }
 
@@ -105,6 +125,7 @@ struct RoomSetupView: View {
                 }
                 .buttonStyle(SecondaryTileButtonStyle(fill: colour.opacity(0.18)))
                 .foregroundStyle(colour)
+                .disabled({ if case .scanning = engine.scanState { return true } else { return false } }())
                 .accessibilityIdentifier("room-station-camera-\(station.role.rawValue)")
 
                 Button(station.verificationMethod == .manualConfirmed ? "Manual fallback saved" : "Same-place fallback") {
@@ -118,6 +139,7 @@ struct RoomSetupView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("room-station-card-\(station.role.rawValue)")
     }
 }

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// Per-spot screen shown on the iPad during the room phase.
 /// Large colour fill and spoken prompt — child needs no reading ability.
@@ -63,6 +64,7 @@ struct SpotPromptView: View {
                 Button(station?.role.fallbackButtonTitle ?? "I found it") {
                     engine.markSpotVisited(index: spotIndex)
                 }
+                .accessibilityIdentifier("room-spot-confirm-button")
                 .buttonStyle(RoomQuestPrimaryButtonStyle())
                 .padding(.horizontal, 40)
 
@@ -78,30 +80,34 @@ struct SpotPromptView: View {
             }
 
             HStack(spacing: 12) {
-                Button {
+                roomChromeButton(title: "Pause", systemImage: "pause.circle.fill", accessibilityID: "room-pause-button") {
                     engine.pauseSession()
-                } label: {
-                    Label("Pause", systemImage: "pause.circle.fill")
-                        .font(.title2.weight(.semibold))
-                        .foregroundStyle(.white)
                 }
-                .accessibilityIdentifier("room-pause-button")
 
-                Button {
+                roomChromeButton(title: "Home", systemImage: "house.circle.fill", accessibilityID: "room-home-button") {
                     engine.onExitToHome?()
-                } label: {
-                    Label("Home", systemImage: "house.circle.fill")
-                        .font(.title2.weight(.semibold))
-                        .foregroundStyle(.white)
                 }
-                .accessibilityIdentifier("room-home-button")
             }
             .padding(24)
         }
     }
 }
 
-/// Primary button style for room phase — large, white fill on coloured background.
+private func roomChromeButton(title: String, systemImage: String, accessibilityID: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+        Label(title, systemImage: systemImage)
+            .font(.title2.weight(.semibold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(.black.opacity(0.18), in: Capsule())
+    }
+    .accessibilityIdentifier(accessibilityID)
+    .accessibilityLabel(accessibilityID)
+    .accessibilityAddTraits(.isButton)
+}
+
+/// Primary button style for room phase, large, white fill on coloured background.
 private struct RoomQuestPrimaryButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label

--- a/Services/RoomQuestLiveScanner.swift
+++ b/Services/RoomQuestLiveScanner.swift
@@ -1,0 +1,299 @@
+import ARKit
+import AVFoundation
+import Foundation
+import Observation
+import RealityKit
+import SwiftUI
+
+@MainActor
+@Observable
+final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
+    struct Session: Identifiable {
+        let id = UUID()
+        let expectedRole: RoomQuestStationRole
+        let continuation: CheckedContinuation<RoomQuestMarkerScanResult, Error>
+    }
+
+    private(set) var activeSession: Session?
+
+    func scanMarker(for role: RoomQuestStationRole) async throws -> RoomQuestMarkerScanResult {
+        try await withCheckedThrowingContinuation { continuation in
+            activeSession = Session(expectedRole: role, continuation: continuation)
+        }
+    }
+
+    func resolveScan(payload: String) {
+        guard let session = activeSession else { return }
+        guard let detectedRole = Self.role(from: payload) else {
+            session.continuation.resume(throwing: RoomQuestScannerError.unavailable)
+            activeSession = nil
+            return
+        }
+        guard detectedRole == session.expectedRole else {
+            session.continuation.resume(throwing: RoomQuestScannerError.wrongMarker(expected: session.expectedRole, detected: detectedRole))
+            activeSession = nil
+            return
+        }
+        session.continuation.resume(returning: RoomQuestMarkerScanResult(role: detectedRole, usedARCelebration: true))
+        activeSession = nil
+    }
+
+    func cancelScan() {
+        guard let session = activeSession else { return }
+        session.continuation.resume(throwing: RoomQuestScannerError.cancelled)
+        activeSession = nil
+    }
+
+    private static func role(from payload: String) -> RoomQuestStationRole? {
+        switch payload.trimmingCharacters(in: .whitespacesAndNewlines) {
+        case "mather:roomquest:redRocket:v1":
+            return .redRocket
+        case "mather:roomquest:blueBubble:v1":
+            return .blueBubble
+        default:
+            return nil
+        }
+    }
+}
+
+struct RoomQuestScannerSheet: View {
+    @Bindable var scanner: RoomQuestLiveScanner
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let session = scanner.activeSession {
+                    RoomQuestCameraScannerView(expectedRole: session.expectedRole) { payload in
+                        scanner.resolveScan(payload: payload)
+                    } onCancel: {
+                        scanner.cancelScan()
+                    }
+                } else {
+                    ContentUnavailableView("Camera verify", systemImage: "camera.viewfinder", description: Text("Preparing scanner…"))
+                }
+            }
+            .navigationTitle("Camera verify")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+private struct RoomQuestCameraScannerView: UIViewControllerRepresentable {
+    let expectedRole: RoomQuestStationRole
+    let onPayload: (String) -> Void
+    let onCancel: () -> Void
+
+    func makeUIViewController(context: Context) -> ScannerViewController {
+        let controller = ScannerViewController()
+        controller.expectedRole = expectedRole
+        controller.onPayload = onPayload
+        controller.onCancel = onCancel
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: ScannerViewController, context: Context) {}
+}
+
+final class ScannerViewController: UIViewController, @preconcurrency AVCaptureMetadataOutputObjectsDelegate {
+    var expectedRole: RoomQuestStationRole = .redRocket
+    var onPayload: ((String) -> Void)?
+    var onCancel: (() -> Void)?
+
+    private let session = AVCaptureSession()
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var hasResolved = false
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        configureCamera()
+        addOverlay()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if !session.isRunning { session.startRunning() }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if session.isRunning { session.stopRunning() }
+    }
+
+    private func configureCamera() {
+        guard let device = AVCaptureDevice.default(for: .video),
+              let input = try? AVCaptureDeviceInput(device: device),
+              session.canAddInput(input)
+        else {
+            onCancel?()
+            return
+        }
+        session.addInput(input)
+
+        let output = AVCaptureMetadataOutput()
+        guard session.canAddOutput(output) else {
+            onCancel?()
+            return
+        }
+        session.addOutput(output)
+        output.setMetadataObjectsDelegate(self, queue: .main)
+        output.metadataObjectTypes = [.qr]
+
+        let previewLayer = AVCaptureVideoPreviewLayer(session: session)
+        previewLayer.videoGravity = .resizeAspectFill
+        previewLayer.frame = view.bounds
+        view.layer.addSublayer(previewLayer)
+        self.previewLayer = previewLayer
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.bounds
+    }
+
+    private func addOverlay() {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.textColor = .white
+        label.font = .preferredFont(forTextStyle: .title2)
+        label.text = "Scan the \(expectedRole.title) marker"
+
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("Use fallback instead", for: .normal)
+        button.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+        button.tintColor = .white
+        button.addAction(UIAction { [weak self] _ in self?.onCancel?() }, for: .touchUpInside)
+
+        let stack = UIStackView(arrangedSubviews: [label, button])
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            stack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -32)
+        ])
+    }
+
+    @MainActor
+    private func presentARCelebration(for payload: String) {
+        let celebration = RoomQuestARCelebrationViewController(role: expectedRole) { [weak self] in
+            self?.onPayload?(payload)
+        }
+        celebration.modalPresentationStyle = .fullScreen
+        present(celebration, animated: false)
+    }
+
+    nonisolated func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
+        guard let object = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+              let payload = object.stringValue
+        else { return }
+
+        Task { @MainActor [weak self] in
+            guard let self, !self.hasResolved else { return }
+            self.hasResolved = true
+            self.session.stopRunning()
+            self.presentARCelebration(for: payload)
+        }
+    }
+}
+
+@MainActor
+private final class RoomQuestARCelebrationViewController: UIViewController {
+    private let role: RoomQuestStationRole
+    private let onComplete: () -> Void
+    private var arView: ARView?
+    private var completed = false
+
+    init(role: RoomQuestStationRole, onComplete: @escaping () -> Void) {
+        self.role = role
+        self.onComplete = onComplete
+        super.init(nibName: nil, bundle: nil)
+        modalTransitionStyle = .crossDissolve
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+
+        let arView = ARView(frame: view.bounds)
+        arView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(arView)
+        NSLayoutConstraint.activate([
+            arView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            arView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            arView.topAnchor.constraint(equalTo: view.topAnchor),
+            arView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        self.arView = arView
+
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.textColor = .white
+        label.font = .preferredFont(forTextStyle: .title1)
+        label.text = "\(role.title) found!"
+        view.addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 32)
+        ])
+
+        runCelebration(on: arView)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(1.1))
+            self?.finishIfNeeded()
+        }
+    }
+
+    private func runCelebration(on arView: ARView) {
+        let configuration = ARWorldTrackingConfiguration()
+        configuration.planeDetection = []
+        arView.session.run(configuration)
+
+        let anchor = AnchorEntity(world: [0, 0, -0.8])
+        let mesh = MeshResource.generateSphere(radius: 0.12)
+        let color: UIColor = role == .redRocket ? .systemRed : .systemBlue
+        let material = SimpleMaterial(color: color, roughness: 0.2, isMetallic: false)
+        let orb = ModelEntity(mesh: mesh, materials: [material])
+        orb.position = [0, 0, 0]
+
+        let ringMesh = MeshResource.generateBox(size: 0.04)
+        let ringMaterial = SimpleMaterial(color: color.withAlphaComponent(0.75), roughness: 0.1, isMetallic: true)
+        for offset in [-0.22 as Float, 0.22] {
+            let spark = ModelEntity(mesh: ringMesh, materials: [ringMaterial])
+            spark.position = [offset, 0.08, 0]
+            anchor.addChild(spark)
+        }
+
+        anchor.addChild(orb)
+        arView.scene.addAnchor(anchor)
+
+        orb.move(to: Transform(scale: SIMD3<Float>(repeating: 1.35), rotation: simd_quatf(angle: .pi, axis: [0, 1, 0]), translation: [0, 0.05, 0]), relativeTo: orb, duration: 0.9, timingFunction: .easeInOut)
+    }
+
+    private func finishIfNeeded() {
+        guard !completed else { return }
+        completed = true
+        arView?.session.pause()
+        dismiss(animated: false) { [onComplete] in
+            onComplete()
+        }
+    }
+}

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -14,6 +14,7 @@ final class FeatureFlagService {
         static let soundReactionEnabled = "feature.soundReactionEnabled"
         static let roomQuestEnabled = "feature.roomQuestEnabled"
         static let roomQuestSafetyAcknowledged = "feature.roomQuestSafetyAcknowledged"
+        static let roomQuestMarkerSetupEnabled = "feature.roomQuestMarkerSetupEnabled"
     }
 
     var verticalSlice1Enabled: Bool {
@@ -67,6 +68,11 @@ final class FeatureFlagService {
         didSet { defaults.set(roomQuestSafetyAcknowledged, forKey: Keys.roomQuestSafetyAcknowledged) }
     }
 
+    /// Enables real camera-backed marker scanning during Room Quest setup.
+    var roomQuestMarkerSetupEnabled: Bool {
+        didSet { defaults.set(roomQuestMarkerSetupEnabled, forKey: Keys.roomQuestMarkerSetupEnabled) }
+    }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -86,6 +92,7 @@ final class FeatureFlagService {
             Keys.soundReactionEnabled: false,
             Keys.roomQuestEnabled: false,
             Keys.roomQuestSafetyAcknowledged: false,
+            Keys.roomQuestMarkerSetupEnabled: true,
         ])
         verticalSlice1Enabled = defaults.bool(forKey: Keys.verticalSlice1Enabled)
         testModeEnabled = defaults.bool(forKey: Keys.testModeEnabled)
@@ -97,5 +104,6 @@ final class FeatureFlagService {
         soundReactionEnabled = defaults.bool(forKey: Keys.soundReactionEnabled)
         roomQuestEnabled = defaults.bool(forKey: Keys.roomQuestEnabled)
         roomQuestSafetyAcknowledged = defaults.bool(forKey: Keys.roomQuestSafetyAcknowledged)
+        roomQuestMarkerSetupEnabled = defaults.bool(forKey: Keys.roomQuestMarkerSetupEnabled)
     }
 }

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -7,13 +7,17 @@ struct RoomQuestEngineTests {
 
     // MARK: - Helpers
 
-    private func makeEngine(safetyAcknowledged: Bool = true) -> RoomQuestEngine {
+    private func makeEngine(
+        safetyAcknowledged: Bool = true,
+        scanner: RoomQuestScanner = NoopRoomQuestScanner()
+    ) -> RoomQuestEngine {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.roomQuestSafetyAcknowledged = safetyAcknowledged
         return RoomQuestEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),
-            speechService: SpeechService()
+            speechService: SpeechService(),
+            scanner: scanner
         )
     }
 
@@ -53,24 +57,70 @@ struct RoomQuestEngineTests {
     }
 
     @Test
-    func markSetupCompleteTransitionsToFirstSpotAfterRegistration() {
-        let engine = makeEngine()
+    func markSetupCompleteTransitionsToFirstSpotAfterRegistration() async throws {
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+            RoomQuestMarkerScanResult(role: role, usedARCelebration: true)
+        })
         engine.startSession()
         engine.verifyStationWithCamera(.redRocket)
+        try await Task.sleep(for: .milliseconds(100))
         engine.confirmStationManually(.blueBubble)
         engine.markSetupComplete()
         #expect(engine.phase == .spot(index: 0))
     }
 
     @Test
-    func stationVerificationTracksCameraVsManualFallback() {
-        let engine = makeEngine()
+    func stationVerificationTracksCameraVsManualFallback() async throws {
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+            RoomQuestMarkerScanResult(role: role, usedARCelebration: false)
+        })
         engine.startSession()
         engine.verifyStationWithCamera(.redRocket)
+        try await Task.sleep(for: .milliseconds(100))
         engine.confirmStationManually(.blueBubble)
 
         #expect(engine.stations.first(where: { $0.role == .redRocket })?.verificationMethod == .cameraVerified)
         #expect(engine.stations.first(where: { $0.role == .blueBubble })?.verificationMethod == .manualConfirmed)
+    }
+
+    @Test
+    func cameraScanSuccessMarksStationAndCelebrates() async throws {
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+            RoomQuestMarkerScanResult(role: role, usedARCelebration: true)
+        })
+
+        engine.startSession()
+        engine.acknowledgedSafety()
+        engine.verifyStationWithCamera(.redRocket)
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(engine.stations.first(where: { $0.role == .redRocket })?.verificationMethod == .cameraVerified)
+        if case .celebrating(let role, let usedARCelebration) = engine.scanState {
+            #expect(role == .redRocket)
+            #expect(usedARCelebration)
+        } else {
+            Issue.record("Expected celebrating scan state after successful camera scan")
+        }
+    }
+
+    @Test
+    func wrongMarkerLeavesStationUnregisteredAndShowsError() async throws {
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+            throw RoomQuestScannerError.wrongMarker(expected: role, detected: .blueBubble)
+        })
+
+        engine.startSession()
+        engine.acknowledgedSafety()
+        engine.verifyStationWithCamera(.redRocket)
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(engine.stations.first(where: { $0.role == .redRocket })?.verificationMethod == nil)
+        if case .failed(let role, let message) = engine.scanState {
+            #expect(role == .redRocket)
+            #expect(message.contains("Blue Bubble"))
+        } else {
+            Issue.record("Expected failed scan state after wrong-marker scan")
+        }
     }
 
     @Test
@@ -215,5 +265,13 @@ struct RoomQuestEngineTests {
         engine.abandonSession(reason: "parent_abort")
         #expect(engine.phase == .complete)
         #expect(exitCalled)
+    }
+}
+
+private struct FakeRoomQuestScanner: RoomQuestScanner {
+    let handler: @MainActor (RoomQuestStationRole) async throws -> RoomQuestMarkerScanResult
+
+    func scanMarker(for role: RoomQuestStationRole) async throws -> RoomQuestMarkerScanResult {
+        try await handler(role)
     }
 }

--- a/Tests/MatherUITests/RoomQuestUITests.swift
+++ b/Tests/MatherUITests/RoomQuestUITests.swift
@@ -81,22 +81,20 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons.matching(identifier: "room-station-card-redRocket").firstMatch.tap()
-        app.buttons.matching(identifier: "room-station-card-blueBubble").element(boundBy: 1).tap()
-        app.buttons["Ready — stations are set!"].tap()
+        completeSetupViaManualFallback(app)
 
         XCTAssertTrue(app.staticTexts["Red Rocket"].waitForExistence(timeout: 5))
         snapshot(app, "RoomQuest-Spot1-Red")
 
         XCTAssertTrue(app.buttons["room-pause-button"].waitForExistence(timeout: 3))
 
-        let gotRed = app.buttons["I found Red Rocket"]
+        let gotRed = app.buttons["room-spot-confirm-button"]
         XCTAssertTrue(gotRed.waitForExistence(timeout: 5))
         gotRed.tap()
 
         XCTAssertTrue(app.staticTexts["Blue Bubble"].waitForExistence(timeout: 5))
         snapshot(app, "RoomQuest-Spot2-Blue")
-        app.buttons["I found Blue Bubble"].tap()
+        app.buttons["room-spot-confirm-button"].tap()
 
         XCTAssertTrue(app.staticTexts["Bring them back!"].waitForExistence(timeout: 5))
         snapshot(app, "RoomQuest-Returning")
@@ -110,20 +108,18 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons.matching(identifier: "room-station-card-redRocket").firstMatch.tap()
-        app.buttons.matching(identifier: "room-station-card-blueBubble").element(boundBy: 1).tap()
-        app.buttons["Ready — stations are set!"].tap()
+        completeSetupViaManualFallback(app)
 
         _ = app.staticTexts["Red Rocket"].waitForExistence(timeout: 5)
-        let gotRed = app.buttons["I found Red Rocket"]
+        let gotRed = app.buttons["room-spot-confirm-button"]
         _ = gotRed.waitForExistence(timeout: 5)
         gotRed.tap()
 
         _ = app.staticTexts["Blue Bubble"].waitForExistence(timeout: 5)
-        app.buttons["I found Blue Bubble"].tap()
+        app.buttons["room-spot-confirm-button"].tap()
 
         _ = app.staticTexts["Bring them back!"].waitForExistence(timeout: 5)
-        app.buttons["We're back!"].tap()
+        app.buttons["room-return-confirm-button"].tap()
 
         // Pictorial (locked SplitView — "From your walk" badge is visible)
         let fromYourWalk = app.staticTexts["From your walk"]
@@ -171,9 +167,7 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons.matching(identifier: "room-station-card-redRocket").firstMatch.tap()
-        app.buttons.matching(identifier: "room-station-card-blueBubble").element(boundBy: 1).tap()
-        app.buttons["Ready — stations are set!"].tap()
+        completeSetupViaManualFallback(app)
 
         _ = app.staticTexts["Red Rocket"].waitForExistence(timeout: 5)
 
@@ -192,14 +186,12 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons.matching(identifier: "room-station-card-redRocket").firstMatch.tap()
-        app.buttons.matching(identifier: "room-station-card-blueBubble").element(boundBy: 1).tap()
-        app.buttons["Ready — stations are set!"].tap()
+        completeSetupViaManualFallback(app)
 
-        _ = app.buttons["I found Red Rocket"].waitForExistence(timeout: 5)
-        app.buttons["I found Red Rocket"].tap()
+        _ = app.buttons["room-spot-confirm-button"].waitForExistence(timeout: 5)
+        app.buttons["room-spot-confirm-button"].tap()
         _ = app.staticTexts["Blue Bubble"].waitForExistence(timeout: 5)
-        app.buttons["I found Blue Bubble"].tap()
+        app.buttons["room-spot-confirm-button"].tap()
 
         _ = app.staticTexts["Bring them back!"].waitForExistence(timeout: 5)
         app.buttons["room-pause-button-returning"].tap()
@@ -217,9 +209,7 @@ final class RoomQuestUITests: XCTestCase {
 
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        app.buttons.matching(identifier: "room-station-card-redRocket").firstMatch.tap()
-        app.buttons.matching(identifier: "room-station-card-blueBubble").element(boundBy: 1).tap()
-        app.buttons["Ready — stations are set!"].tap()
+        completeSetupViaManualFallback(app)
 
         _ = app.staticTexts["Red Rocket"].waitForExistence(timeout: 5)
         app.buttons["room-pause-button"].tap()
@@ -253,6 +243,24 @@ final class RoomQuestUITests: XCTestCase {
 
     // MARK: - Helpers
 
+
+    private func completeSetupViaManualFallback(_ app: XCUIApplication) {
+        let redCard = app.otherElements["room-station-card-redRocket"]
+        let blueCard = app.otherElements["room-station-card-blueBubble"]
+
+        XCTAssertTrue(redCard.waitForExistence(timeout: 5))
+        XCTAssertTrue(blueCard.waitForExistence(timeout: 5))
+
+        redCard.buttons["Camera verify"].tap()
+        XCTAssertTrue(app.staticTexts["room-scan-status"].waitForExistence(timeout: 5))
+        redCard.buttons["Same-place fallback"].tap()
+
+        blueCard.buttons["Camera verify"].tap()
+        XCTAssertTrue(app.staticTexts["room-scan-status"].waitForExistence(timeout: 5))
+        blueCard.buttons["Same-place fallback"].tap()
+
+        app.buttons["Ready — stations are set!"].tap()
+    }
     private func launch() -> XCUIApplication {
         continueAfterFailure = false
         let app = XCUIApplication()


### PR DESCRIPTION
## Summary
- add a live QR-backed Room Quest scanner with exact marker validation
- show a short ARKit/RealityKit celebration after successful scans
- harden Room Quest setup/room-phase accessibility and update engine/UI tests

## Validation
- on ganesh@mba, targeted RoomQuestEngineTests + RoomQuestUITests green
- iPhone 17 Pro simulator targeted Room Quest pass green
- physical-device camera/AR validation still pending and will be done via TestFlight