### PR TITLE
feat(room-quest): save setup references for stations

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -9,6 +9,7 @@ final class AppModel {
     let speechService: SpeechService
     let telemetryWriter: TelemetryWriter
     let historyStore: SessionHistoryStore
+    let roomQuestStationStore: RoomQuestStationStore
     let engine: VerticalSliceEngine
     let hapticsService: HapticsService
     let motionService: MotionService
@@ -21,6 +22,7 @@ final class AppModel {
         let speechService = SpeechService()
         let telemetryWriter = TelemetryWriter()
         let historyStore = SessionHistoryStore(modelContext: modelContext)
+        let roomQuestStationStore = RoomQuestStationStore(modelContext: modelContext)
         let hapticsService = HapticsService()
         let motionService = MotionService()
         let soundDetectionService = SoundDetectionService()
@@ -30,6 +32,7 @@ final class AppModel {
         self.speechService = speechService
         self.telemetryWriter = telemetryWriter
         self.historyStore = historyStore
+        self.roomQuestStationStore = roomQuestStationStore
         self.hapticsService = hapticsService
         self.motionService = motionService
         self.soundDetectionService = soundDetectionService
@@ -49,7 +52,8 @@ final class AppModel {
             telemetryWriter: telemetryWriter,
             speechService: speechService,
             hapticsService: hapticsService,
-            scanner: roomQuestScanner
+            scanner: roomQuestScanner,
+            stationStore: roomQuestStationStore
         )
         self.roomQuestEngine = roomQuestEngine
         roomQuestEngine.onExitToHome = { [weak vsEngine] in vsEngine?.showHome() }

--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -8,7 +8,7 @@ struct MatherApp: App {
 
     init() {
         do {
-            container = try ModelContainer(for: StoredSessionSummary.self)
+            container = try ModelContainer(for: StoredSessionSummary.self, StoredRoomQuestStationReference.self)
             let appModel = AppModel(modelContext: container.mainContext)
             Self.seedSessionHistoryIfRequested(using: appModel)
             _appModel = State(initialValue: appModel)

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -142,7 +142,7 @@ final class RoomQuestEngine {
 
     func confirmStationManually(_ role: RoomQuestStationRole) {
         scanState = .idle
-        setReferenceState(.manualFallback, for: role, note: "Manual fallback saved")
+        persistReferenceState(.manualFallback, for: role, markerPayload: nil, note: "Manual fallback saved")
         setStationRegistered(role, method: .manualConfirmed)
     }
 
@@ -313,33 +313,38 @@ final class RoomQuestEngine {
     private func captureReference(for result: RoomQuestMarkerScanResult) {
         guard featureFlags.roomQuestReferenceCaptureEnabled else { return }
 
-        let note = "Reference saved for \(result.role.title)"
+        persistReferenceState(.captured, for: result.role, markerPayload: result.markerPayload, note: "Reference saved for \(result.role.title)")
+    }
+
+    private func persistReferenceState(_ state: RoomQuestReferenceCaptureState, for role: RoomQuestStationRole, markerPayload: String?, note: String) {
         let draft = RoomQuestStationReferenceDraft(
-            role: result.role,
-            markerPayload: result.markerPayload,
+            role: role,
+            markerPayload: markerPayload,
             capturedAt: .now,
             note: note,
-            imageJPEGData: result.referenceImageJPEGData
+            captureState: state
         )
 
         do {
             try stationStore.save(draft)
-            setReferenceState(.captured, for: result.role, note: note)
+            setReferenceState(state, for: role, note: note)
             try? telemetryWriter.append(SliceEvent(
                 type: .roomQuestReferenceCaptureCompleted,
                 payload: [
-                    "station_role": result.role.rawValue,
-                    "saved": "true",
-                    "marker_payload_present": String(result.markerPayload != nil)
+                    "station_role": role.rawValue,
+                    "saved": String(state == .captured),
+                    "capture_state": state.rawValue,
+                    "marker_payload_present": String(markerPayload != nil)
                 ]
             ))
         } catch {
-            setReferenceState(.notCaptured, for: result.role, note: "Reference save failed")
+            setReferenceState(.notCaptured, for: role, note: "Reference save failed")
             try? telemetryWriter.append(SliceEvent(
                 type: .roomQuestReferenceCaptureCompleted,
                 payload: [
-                    "station_role": result.role.rawValue,
-                    "saved": "false"
+                    "station_role": role.rawValue,
+                    "saved": "false",
+                    "capture_state": RoomQuestReferenceCaptureState.notCaptured.rawValue
                 ]
             ))
         }

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -45,6 +45,7 @@ final class RoomQuestEngine {
     private let speechService: SpeechService
     private let hapticsService: HapticsService
     private let scanner: RoomQuestScanner
+    private let stationStore: RoomQuestStationStore
     var onExitToHome: (() -> Void)?
 
     private(set) var scanState: RoomQuestScanState = .idle
@@ -58,13 +59,15 @@ final class RoomQuestEngine {
         telemetryWriter: TelemetryWriter,
         speechService: SpeechService,
         hapticsService: HapticsService = HapticsService(),
-        scanner: RoomQuestScanner = NoopRoomQuestScanner()
+        scanner: RoomQuestScanner = NoopRoomQuestScanner(),
+        stationStore: RoomQuestStationStore
     ) {
         self.featureFlags = featureFlags
         self.telemetryWriter = telemetryWriter
         self.speechService = speechService
         self.hapticsService = hapticsService
         self.scanner = scanner
+        self.stationStore = stationStore
     }
 
     // MARK: - Session lifecycle
@@ -77,6 +80,7 @@ final class RoomQuestEngine {
             RoomQuestStation(id: .redRocket, role: .redRocket, quantity: p.decompositionA),
             RoomQuestStation(id: .blueBubble, role: .blueBubble, quantity: p.decompositionB)
         ]
+        try? stationStore.clearAll()
         setupStartedAt = .now
         phase = featureFlags.roomQuestSafetyAcknowledged ? .setup : .safetyAck
         feedbackMessage = "Set up the stations, then scan each one or mark it ready."
@@ -104,12 +108,14 @@ final class RoomQuestEngine {
 
         scanState = .scanning(role: role)
         feedbackMessage = "Scan the \(role.title) marker with the camera."
+        try? telemetryWriter.append(SliceEvent(type: .roomQuestReferenceCaptureStarted, payload: ["station_role": role.rawValue]))
 
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
                 let result = try await scanner.scanMarker(for: role)
                 self.setStationRegistered(result.role, method: .cameraVerified)
+                self.captureReference(for: result)
                 self.scanState = .celebrating(role: result.role, usedARCelebration: result.usedARCelebration)
                 self.hapticsService.success(enabled: self.featureFlags.hapticsEnabled)
                 self.speechService.speak("You found \(result.role.title)!", enabled: self.featureFlags.audioEnabled)
@@ -136,6 +142,7 @@ final class RoomQuestEngine {
 
     func confirmStationManually(_ role: RoomQuestStationRole) {
         scanState = .idle
+        setReferenceState(.manualFallback, for: role, note: "Manual fallback saved")
         setStationRegistered(role, method: .manualConfirmed)
     }
 
@@ -301,6 +308,47 @@ final class RoomQuestEngine {
             hapticsService.success(enabled: featureFlags.hapticsEnabled)
             flashCelebration()
         }
+    }
+
+    private func captureReference(for result: RoomQuestMarkerScanResult) {
+        guard featureFlags.roomQuestReferenceCaptureEnabled else { return }
+
+        let note = "Reference saved for \(result.role.title)"
+        let draft = RoomQuestStationReferenceDraft(
+            role: result.role,
+            markerPayload: result.markerPayload,
+            capturedAt: .now,
+            note: note,
+            imageJPEGData: result.referenceImageJPEGData
+        )
+
+        do {
+            try stationStore.save(draft)
+            setReferenceState(.captured, for: result.role, note: note)
+            try? telemetryWriter.append(SliceEvent(
+                type: .roomQuestReferenceCaptureCompleted,
+                payload: [
+                    "station_role": result.role.rawValue,
+                    "saved": "true",
+                    "marker_payload_present": String(result.markerPayload != nil)
+                ]
+            ))
+        } catch {
+            setReferenceState(.notCaptured, for: result.role, note: "Reference save failed")
+            try? telemetryWriter.append(SliceEvent(
+                type: .roomQuestReferenceCaptureCompleted,
+                payload: [
+                    "station_role": result.role.rawValue,
+                    "saved": "false"
+                ]
+            ))
+        }
+    }
+
+    private func setReferenceState(_ state: RoomQuestReferenceCaptureState, for role: RoomQuestStationRole, note: String) {
+        guard let idx = stations.firstIndex(where: { $0.role == role }) else { return }
+        stations[idx].referenceCaptureState = state
+        stations[idx].referenceNote = note
     }
 }
 

--- a/Domain/RoomQuestScanner.swift
+++ b/Domain/RoomQuestScanner.swift
@@ -2,6 +2,8 @@ import Foundation
 
 struct RoomQuestMarkerScanResult: Equatable {
     let role: RoomQuestStationRole
+    let markerPayload: String?
+    let referenceImageJPEGData: Data?
     let usedARCelebration: Bool
 }
 

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -244,7 +244,7 @@ enum RoomQuestStationVerificationMethod: String, Codable, Equatable {
     }
 }
 
-enum RoomQuestReferenceCaptureState: Equatable, Codable {
+enum RoomQuestReferenceCaptureState: String, Equatable, Codable {
     case notCaptured
     case captured
     case manualFallback
@@ -270,7 +270,7 @@ struct RoomQuestStationReferenceDraft: Equatable, Codable {
     let markerPayload: String?
     let capturedAt: Date
     let note: String
-    let imageJPEGData: Data?
+    let captureState: RoomQuestReferenceCaptureState
 }
 
 @Model
@@ -279,18 +279,22 @@ final class StoredRoomQuestStationReference {
     var markerPayload: String?
     var capturedAt: Date
     var note: String
-    @Attribute(.externalStorage) var imageJPEGData: Data?
+    var captureStateRawValue: String
 
-    init(role: RoomQuestStationRole, markerPayload: String?, capturedAt: Date, note: String, imageJPEGData: Data?) {
+    init(role: RoomQuestStationRole, markerPayload: String?, capturedAt: Date, note: String, captureState: RoomQuestReferenceCaptureState) {
         self.roleRawValue = role.rawValue
         self.markerPayload = markerPayload
         self.capturedAt = capturedAt
         self.note = note
-        self.imageJPEGData = imageJPEGData
+        self.captureStateRawValue = captureState.rawValue
     }
 
     var role: RoomQuestStationRole? {
         RoomQuestStationRole(rawValue: roleRawValue)
+    }
+
+    var captureState: RoomQuestReferenceCaptureState? {
+        RoomQuestReferenceCaptureState(rawValue: captureStateRawValue)
     }
 }
 

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -37,6 +37,8 @@ enum SliceEventType: String, Codable {
     case roomQuestPhaseComplete = "room_quest_phase_complete"
     case roomQuestAbandoned = "room_quest_abandoned"
     case roomQuestCompleted = "room_quest_completed"
+    case roomQuestReferenceCaptureStarted = "room_quest_reference_capture_started"
+    case roomQuestReferenceCaptureCompleted = "room_quest_reference_capture_completed"
 }
 
 struct SliceConfig: Codable, Equatable {
@@ -226,6 +228,8 @@ struct RoomQuestStation: Equatable, Codable, Identifiable {
     let quantity: Int
     var isRegistered: Bool = false
     var verificationMethod: RoomQuestStationVerificationMethod? = nil
+    var referenceCaptureState: RoomQuestReferenceCaptureState = .notCaptured
+    var referenceNote: String? = nil
 }
 
 enum RoomQuestStationVerificationMethod: String, Codable, Equatable {
@@ -240,11 +244,54 @@ enum RoomQuestStationVerificationMethod: String, Codable, Equatable {
     }
 }
 
+enum RoomQuestReferenceCaptureState: Equatable, Codable {
+    case notCaptured
+    case captured
+    case manualFallback
+
+    var badgeTitle: String {
+        switch self {
+        case .notCaptured: "Reference not saved"
+        case .captured: "Reference saved"
+        case .manualFallback: "Reference skipped"
+        }
+    }
+}
+
 enum RoomQuestScanState: Equatable {
     case idle
     case scanning(role: RoomQuestStationRole)
     case celebrating(role: RoomQuestStationRole, usedARCelebration: Bool)
     case failed(role: RoomQuestStationRole, message: String)
+}
+
+struct RoomQuestStationReferenceDraft: Equatable, Codable {
+    let role: RoomQuestStationRole
+    let markerPayload: String?
+    let capturedAt: Date
+    let note: String
+    let imageJPEGData: Data?
+}
+
+@Model
+final class StoredRoomQuestStationReference {
+    var roleRawValue: String
+    var markerPayload: String?
+    var capturedAt: Date
+    var note: String
+    @Attribute(.externalStorage) var imageJPEGData: Data?
+
+    init(role: RoomQuestStationRole, markerPayload: String?, capturedAt: Date, note: String, imageJPEGData: Data?) {
+        self.roleRawValue = role.rawValue
+        self.markerPayload = markerPayload
+        self.capturedAt = capturedAt
+        self.note = note
+        self.imageJPEGData = imageJPEGData
+    }
+
+    var role: RoomQuestStationRole? {
+        RoomQuestStationRole(rawValue: roleRawValue)
+    }
 }
 
 @Model

--- a/Features/RoomQuest/RoomSetupView.swift
+++ b/Features/RoomQuest/RoomSetupView.swift
@@ -119,6 +119,23 @@ struct RoomSetupView: View {
                     .clipShape(Capsule())
             }
 
+            if station.referenceCaptureState != .notCaptured {
+                Text(station.referenceCaptureState.badgeTitle)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(MatherTheme.ink)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(MatherTheme.ink.opacity(0.08))
+                    .clipShape(Capsule())
+            }
+
+            if let referenceNote = station.referenceNote {
+                Text(referenceNote)
+                    .font(.caption)
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .multilineTextAlignment(.center)
+            }
+
             VStack(spacing: 8) {
                 Button(station.verificationMethod == .cameraVerified ? "Camera verified" : "Camera verify") {
                     engine.verifyStationWithCamera(station.role)

--- a/Persistence/RoomQuestStationStore.swift
+++ b/Persistence/RoomQuestStationStore.swift
@@ -21,7 +21,7 @@ final class RoomQuestStationStore {
             existing.markerPayload = draft.markerPayload
             existing.capturedAt = draft.capturedAt
             existing.note = draft.note
-            existing.imageJPEGData = draft.imageJPEGData
+            existing.captureStateRawValue = draft.captureState.rawValue
         } else {
             modelContext.insert(
                 StoredRoomQuestStationReference(
@@ -29,7 +29,7 @@ final class RoomQuestStationStore {
                     markerPayload: draft.markerPayload,
                     capturedAt: draft.capturedAt,
                     note: draft.note,
-                    imageJPEGData: draft.imageJPEGData
+                    captureState: draft.captureState
                 )
             )
         }

--- a/Persistence/RoomQuestStationStore.swift
+++ b/Persistence/RoomQuestStationStore.swift
@@ -1,0 +1,53 @@
+import Foundation
+import SwiftData
+
+@MainActor
+final class RoomQuestStationStore {
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    func save(_ draft: RoomQuestStationReferenceDraft) throws {
+        let roleRaw = draft.role.rawValue
+        let descriptor = FetchDescriptor<StoredRoomQuestStationReference>(
+            predicate: #Predicate { $0.roleRawValue == roleRaw }
+        )
+
+        if let existing = try modelContext.fetch(descriptor).first {
+            existing.markerPayload = draft.markerPayload
+            existing.capturedAt = draft.capturedAt
+            existing.note = draft.note
+            existing.imageJPEGData = draft.imageJPEGData
+        } else {
+            modelContext.insert(
+                StoredRoomQuestStationReference(
+                    role: draft.role,
+                    markerPayload: draft.markerPayload,
+                    capturedAt: draft.capturedAt,
+                    note: draft.note,
+                    imageJPEGData: draft.imageJPEGData
+                )
+            )
+        }
+
+        try modelContext.save()
+    }
+
+    func reference(for role: RoomQuestStationRole) throws -> StoredRoomQuestStationReference? {
+        let roleRaw = role.rawValue
+        let descriptor = FetchDescriptor<StoredRoomQuestStationReference>(
+            predicate: #Predicate { $0.roleRawValue == roleRaw }
+        )
+        return try modelContext.fetch(descriptor).first
+    }
+
+    func clearAll() throws {
+        let descriptor = FetchDescriptor<StoredRoomQuestStationReference>()
+        for item in try modelContext.fetch(descriptor) {
+            modelContext.delete(item)
+        }
+        try modelContext.save()
+    }
+}

--- a/Persistence/RoomQuestStationStore.swift
+++ b/Persistence/RoomQuestStationStore.swift
@@ -3,9 +3,11 @@ import SwiftData
 
 @MainActor
 final class RoomQuestStationStore {
+    private let modelContainer: ModelContainer?
     private let modelContext: ModelContext
 
-    init(modelContext: ModelContext) {
+    init(modelContext: ModelContext, modelContainer: ModelContainer? = nil) {
+        self.modelContainer = modelContainer
         self.modelContext = modelContext
     }
 

--- a/Services/RoomQuestLiveScanner.swift
+++ b/Services/RoomQuestLiveScanner.swift
@@ -34,7 +34,7 @@ final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
             activeSession = nil
             return
         }
-        session.continuation.resume(returning: RoomQuestMarkerScanResult(role: detectedRole, usedARCelebration: true))
+        session.continuation.resume(returning: RoomQuestMarkerScanResult(role: detectedRole, markerPayload: payload, referenceImageJPEGData: nil, usedARCelebration: true))
         activeSession = nil
     }
 

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -15,6 +15,7 @@ final class FeatureFlagService {
         static let roomQuestEnabled = "feature.roomQuestEnabled"
         static let roomQuestSafetyAcknowledged = "feature.roomQuestSafetyAcknowledged"
         static let roomQuestMarkerSetupEnabled = "feature.roomQuestMarkerSetupEnabled"
+        static let roomQuestReferenceCaptureEnabled = "feature.roomQuestReferenceCaptureEnabled"
     }
 
     var verticalSlice1Enabled: Bool {
@@ -73,6 +74,11 @@ final class FeatureFlagService {
         didSet { defaults.set(roomQuestMarkerSetupEnabled, forKey: Keys.roomQuestMarkerSetupEnabled) }
     }
 
+    /// Enables saving a lightweight station reference during camera verification.
+    var roomQuestReferenceCaptureEnabled: Bool {
+        didSet { defaults.set(roomQuestReferenceCaptureEnabled, forKey: Keys.roomQuestReferenceCaptureEnabled) }
+    }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -93,6 +99,7 @@ final class FeatureFlagService {
             Keys.roomQuestEnabled: false,
             Keys.roomQuestSafetyAcknowledged: false,
             Keys.roomQuestMarkerSetupEnabled: true,
+            Keys.roomQuestReferenceCaptureEnabled: true,
         ])
         verticalSlice1Enabled = defaults.bool(forKey: Keys.verticalSlice1Enabled)
         testModeEnabled = defaults.bool(forKey: Keys.testModeEnabled)
@@ -105,5 +112,6 @@ final class FeatureFlagService {
         roomQuestEnabled = defaults.bool(forKey: Keys.roomQuestEnabled)
         roomQuestSafetyAcknowledged = defaults.bool(forKey: Keys.roomQuestSafetyAcknowledged)
         roomQuestMarkerSetupEnabled = defaults.bool(forKey: Keys.roomQuestMarkerSetupEnabled)
+        roomQuestReferenceCaptureEnabled = defaults.bool(forKey: Keys.roomQuestReferenceCaptureEnabled)
     }
 }

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -20,7 +20,7 @@ struct RoomQuestEngineTests {
             telemetryWriter: TelemetryWriter(),
             speechService: SpeechService(),
             scanner: scanner,
-            stationStore: RoomQuestStationStore(modelContext: container.mainContext)
+            stationStore: RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
         )
     }
 

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftData
 import Testing
 @testable import Mather
 
@@ -13,11 +14,13 @@ struct RoomQuestEngineTests {
     ) -> RoomQuestEngine {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.roomQuestSafetyAcknowledged = safetyAcknowledged
+        let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
         return RoomQuestEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),
             speechService: SpeechService(),
-            scanner: scanner
+            scanner: scanner,
+            stationStore: RoomQuestStationStore(modelContext: container.mainContext)
         )
     }
 
@@ -59,7 +62,7 @@ struct RoomQuestEngineTests {
     @Test
     func markSetupCompleteTransitionsToFirstSpotAfterRegistration() async throws {
         let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
-            RoomQuestMarkerScanResult(role: role, usedARCelebration: true)
+            RoomQuestMarkerScanResult(role: role, markerPayload: "mather:roomquest:redRocket:v1", referenceImageJPEGData: nil, usedARCelebration: true)
         })
         engine.startSession()
         engine.verifyStationWithCamera(.redRocket)
@@ -72,7 +75,7 @@ struct RoomQuestEngineTests {
     @Test
     func stationVerificationTracksCameraVsManualFallback() async throws {
         let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
-            RoomQuestMarkerScanResult(role: role, usedARCelebration: false)
+            RoomQuestMarkerScanResult(role: role, markerPayload: "mather:roomquest:redRocket:v1", referenceImageJPEGData: nil, usedARCelebration: false)
         })
         engine.startSession()
         engine.verifyStationWithCamera(.redRocket)
@@ -81,12 +84,14 @@ struct RoomQuestEngineTests {
 
         #expect(engine.stations.first(where: { $0.role == .redRocket })?.verificationMethod == .cameraVerified)
         #expect(engine.stations.first(where: { $0.role == .blueBubble })?.verificationMethod == .manualConfirmed)
+        #expect(engine.stations.first(where: { $0.role == .redRocket })?.referenceCaptureState == .captured)
+        #expect(engine.stations.first(where: { $0.role == .blueBubble })?.referenceCaptureState == .manualFallback)
     }
 
     @Test
     func cameraScanSuccessMarksStationAndCelebrates() async throws {
         let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
-            RoomQuestMarkerScanResult(role: role, usedARCelebration: true)
+            RoomQuestMarkerScanResult(role: role, markerPayload: "mather:roomquest:redRocket:v1", referenceImageJPEGData: nil, usedARCelebration: true)
         })
 
         engine.startSession()
@@ -95,6 +100,7 @@ struct RoomQuestEngineTests {
         try await Task.sleep(for: .milliseconds(100))
 
         #expect(engine.stations.first(where: { $0.role == .redRocket })?.verificationMethod == .cameraVerified)
+        #expect(engine.stations.first(where: { $0.role == .redRocket })?.referenceCaptureState == .captured)
         if case .celebrating(let role, let usedARCelebration) = engine.scanState {
             #expect(role == .redRocket)
             #expect(usedARCelebration)


### PR DESCRIPTION
## Summary
- persist a lightweight Room Quest station reference record during setup verification
- track reference-captured vs manual-fallback state on each station
- surface saved/skipped reference status in Room Quest setup UI

## Notes
- this is the first execution slice for issue #171
- it improves setup truth and persistence, while keeping QR/manual fallback intact
- it does not yet add live Vision-based re-find comparison

## Validation
- targeted test validation still needs to run on ganesh@mba