### PR TITLE
feat(room-quest): gate station progress on camera scan

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -206,6 +206,51 @@ final class RoomQuestEngine {
         }
     }
 
+    func verifyCurrentSpotWithCamera() {
+        guard case .spot(let index) = phase,
+              let station = stations[safe: index]
+        else { return }
+
+        scanState = .scanning(role: station.role)
+        feedbackMessage = "Scan \(station.role.title) to unlock the collect step."
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let result = try await scanner.scanMarker(for: station.role)
+
+                if let savedReference = try? stationStore.reference(for: station.role),
+                   let expectedRole = savedReference.role,
+                   expectedRole != result.role {
+                    self.feedbackMessage = "That doesn’t match the saved \(station.role.title) station yet."
+                    self.scanState = .failed(role: station.role, message: self.feedbackMessage)
+                    return
+                }
+
+                self.scanState = .celebrating(role: result.role, usedARCelebration: result.usedARCelebration)
+                self.hapticsService.success(enabled: self.featureFlags.hapticsEnabled)
+                self.speechService.speak("\(result.role.title) found. Collect \(station.quantity).", enabled: self.featureFlags.audioEnabled)
+                self.feedbackMessage = "\(result.role.title) unlocked. Collect \(station.quantity) \(station.quantity == 1 ? "token" : "tokens")."
+                try? await Task.sleep(for: .seconds(1.0))
+                self.scanState = .idle
+                self.markSpotVisited(index: index)
+            } catch let error as RoomQuestScannerError {
+                switch error {
+                case .cancelled:
+                    self.feedbackMessage = "Camera check cancelled. Use fallback if you already found \(station.role.title)."
+                case .unavailable:
+                    self.feedbackMessage = "Camera scan is unavailable right now. Use fallback if needed."
+                case .wrongMarker(let expected, let detected):
+                    self.feedbackMessage = "That looked like \(detected.title). Scan \(expected.title) to unlock this step."
+                }
+                self.scanState = .failed(role: station.role, message: self.feedbackMessage)
+            } catch {
+                self.feedbackMessage = "Camera check did not finish. Try again or use fallback."
+                self.scanState = .failed(role: station.role, message: self.feedbackMessage)
+            }
+        }
+    }
+
     func markReturned() {
         guard let p = problem else { return }
         roomPhaseTimer?.cancel()

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -36,23 +36,25 @@ struct SpotPromptView: View {
                     .font(.system(size: 72))
 
                 if let station {
-                    Text(station.role.scanPrompt)
+                    Text("Scan to find \(station.role.title).")
                         .font(.title3.weight(.bold))
                         .foregroundStyle(.white.opacity(0.92))
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 28)
 
-                    Text("Then collect \(station.quantity) \(station.quantity == 1 ? "token" : "tokens").")
+                    Text("When the marker is recognized, the app unlocks: collect \(station.quantity) \(station.quantity == 1 ? "token" : "tokens").")
                         .font(.title.weight(.semibold))
                         .foregroundStyle(.white.opacity(0.84))
                 }
+
+                scanStatusCard
 
                 CardSurface {
                     VStack(alignment: .leading, spacing: 10) {
                         Label("Need a fallback?", systemImage: "hand.tap.fill")
                             .font(.headline.weight(.semibold))
                             .foregroundStyle(MatherTheme.ink)
-                        Text("If the marker is hard to scan, the child can keep going with one big confirmation button.")
+                        Text("Scanning is the main way to unlock progress. If the marker is hard to scan, use the fallback button below.")
                             .font(.subheadline)
                             .foregroundStyle(MatherTheme.cardSubtitle)
                     }
@@ -61,21 +63,23 @@ struct SpotPromptView: View {
 
                 Spacer()
 
+                Button {
+                    engine.verifyCurrentSpotWithCamera()
+                } label: {
+                    Label("Scan to unlock", systemImage: "camera.viewfinder")
+                }
+                .accessibilityIdentifier("room-spot-scan-button")
+                .buttonStyle(RoomQuestPrimaryButtonStyle())
+                .padding(.horizontal, 40)
+
                 Button(station?.role.fallbackButtonTitle ?? "I found it") {
                     engine.markSpotVisited(index: spotIndex)
                 }
                 .accessibilityIdentifier("room-spot-confirm-button")
-                .buttonStyle(RoomQuestPrimaryButtonStyle())
-                .padding(.horizontal, 40)
-
-                Button {
-                    engine.markSpotVisited(index: spotIndex)
-                } label: {
-                    Label("Scan marker later, keep going now", systemImage: "camera.viewfinder")
-                }
                 .buttonStyle(.plain)
                 .font(.headline.weight(.bold))
-                .foregroundStyle(.white.opacity(0.9))
+                .foregroundStyle(.white.opacity(0.92))
+                .padding(.horizontal, 40)
                 .padding(.bottom, 40)
             }
 
@@ -89,6 +93,35 @@ struct SpotPromptView: View {
                 }
             }
             .padding(24)
+        }
+    }
+
+    @ViewBuilder
+    private var scanStatusCard: some View {
+        switch engine.scanState {
+        case .idle:
+            EmptyView()
+        case .scanning(let role):
+            CardSurface {
+                Label("Scanning for \(role.title)…", systemImage: "camera.metering.center.weighted")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.ink)
+            }
+            .padding(.horizontal, 24)
+        case .celebrating(let role, _):
+            CardSurface {
+                Label("\(role.title) unlocked!", systemImage: "sparkles")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.accent)
+            }
+            .padding(.horizontal, 24)
+        case .failed(_, let message):
+            CardSurface {
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.coral)
+            }
+            .padding(.horizontal, 24)
         }
     }
 }

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -141,6 +141,49 @@ struct RoomQuestEngineTests {
     }
 
     @Test
+    func verifyCurrentSpotWithCameraUnlocksAndAdvances() async throws {
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+            RoomQuestMarkerScanResult(role: role, markerPayload: role == .redRocket ? "mather:roomquest:redRocket:v1" : "mather:roomquest:blueBubble:v1", referenceImageJPEGData: nil, usedARCelebration: false)
+        })
+
+        engine.startSession()
+        engine.verifyStationWithCamera(.redRocket)
+        try await Task.sleep(for: .milliseconds(100))
+        engine.verifyStationWithCamera(.blueBubble)
+        try await Task.sleep(for: .milliseconds(100))
+        engine.markSetupComplete()
+
+        engine.verifyCurrentSpotWithCamera()
+        try await Task.sleep(for: .milliseconds(1200))
+
+        #expect(engine.phase == .spot(index: 1))
+        #expect(engine.feedbackMessage.localizedCaseInsensitiveContains("Blue Bubble"))
+    }
+
+    @Test
+    func verifyCurrentSpotWithWrongMarkerDoesNotAdvance() async throws {
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+            throw RoomQuestScannerError.wrongMarker(expected: role, detected: role == .redRocket ? .blueBubble : .redRocket)
+        })
+
+        engine.startSession()
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
+        engine.markSetupComplete()
+
+        engine.verifyCurrentSpotWithCamera()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(engine.phase == .spot(index: 0))
+        if case .failed(let role, let message) = engine.scanState {
+            #expect(role == .redRocket)
+            #expect(message.contains("Blue Bubble"))
+        } else {
+            Issue.record("Expected failed scan state after wrong-marker hunt scan")
+        }
+    }
+
+    @Test
     func markSpotVisitedOneTransitionsToReturning() {
         let engine = makeEngine()
         engine.startSession()

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -157,7 +157,7 @@ struct RoomQuestEngineTests {
         try await Task.sleep(for: .milliseconds(1200))
 
         #expect(engine.phase == .spot(index: 1))
-        #expect(engine.feedbackMessage.localizedCaseInsensitiveContains("Blue Bubble"))
+        #expect(engine.currentStation?.role == .blueBubble)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- make Room Quest spot progression camera-led instead of tap-led
- require hunt-time scan to unlock each station by default
- keep same-screen fallback available when scanning is awkward

## Why
Direct TestFlight feedback said the new mode still feels unconnected and primitive. This slice makes camera verification part of the actual child loop, not just setup.

## Validation
- targeted Mac/simulator validation pending on ganesh@mba