### PR TITLE
feat(vs1): Gravity Split — tilt-powered balance stage

### DIFF
--- a/Domain/ClassicTheme.swift
+++ b/Domain/ClassicTheme.swift
@@ -29,6 +29,7 @@ struct ClassicTheme: SliceTheme {
         case .pictorial:  return "That break still makes \(target)."
         case .abstract:   return "Your equation matches the split."
         case .transfer:   return "You matched the same equation with counters."
+        case .gravitySplit: return "Perfect balance!"
         case .bondMatch:  return "Bond Blast complete!"
         case .done:       return "Problem complete."
         }

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -6,6 +6,7 @@ enum SliceStage: String, Codable, CaseIterable, Identifiable {
     case pictorial
     case abstract
     case transfer
+    case gravitySplit
     case bondMatch
     case done
 
@@ -13,12 +14,13 @@ enum SliceStage: String, Codable, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .concrete:  "Make it"
-        case .pictorial: "Bond Blast!"
-        case .abstract:  "Write it"
-        case .transfer:  "Show it"
-        case .bondMatch: "Bond Blast!"
-        case .done:      "Done"
+        case .concrete:     "Make it"
+        case .pictorial:    "Bond Blast!"
+        case .abstract:     "Write it"
+        case .transfer:     "Show it"
+        case .gravitySplit: "Balance it!"
+        case .bondMatch:    "Bond Blast!"
+        case .done:         "Done"
         }
     }
 }
@@ -141,6 +143,38 @@ struct SessionSummaryDraft: Equatable {
     var medianLatencyMs: Int
     var nextTargetHint: String
     var exportFileName: String
+}
+
+// MARK: - Gravity Split models
+
+/// State for the Gravity Split balance stage — held by `VerticalSliceEngine`.
+///
+/// The child tilts the device; counters slide under simulated gravity between two pans.
+/// `isLocked` becomes true when the split matches the problem's decomposition exactly.
+struct GravitySplitState: Equatable {
+    let target: Int
+    let decompositionA: Int   // expected left-pan count
+    let decompositionB: Int   // expected right-pan count
+    var leftCount: Int        // current left-pan count (starts at 0)
+    var rightCount: Int       // always target − leftCount
+
+    var isLocked: Bool {
+        leftCount == decompositionA && rightCount == decompositionB
+    }
+
+    init(problem: SliceProblem) {
+        target         = problem.target
+        decompositionA = problem.decompositionA
+        decompositionB = problem.decompositionB
+        leftCount      = 0
+        rightCount     = problem.target   // all counters start on right pan
+    }
+
+    /// Sets `leftCount` to `count` (clamped 0…target) and derives `rightCount`.
+    mutating func setLeft(_ count: Int) {
+        leftCount  = min(max(count, 0), target)
+        rightCount = target - leftCount
+    }
 }
 
 // MARK: - Bond Blast models

--- a/Domain/SliceStateMachine.swift
+++ b/Domain/SliceStateMachine.swift
@@ -6,15 +6,18 @@ enum SliceStateMachine {
     /// - Parameters:
     ///   - stage: The stage that just completed successfully.
     ///   - success: Must be `true`; failure returns `stage` unchanged.
-    ///   - showTransfer: Whether the Transfer stage is enabled for this session.
+    ///   - showTransfer: Whether the Transfer (Show it) stepper stage is enabled.
+    ///   - showGravitySplit: Whether the Gravity Split balance stage replaces Transfer.
+    ///     When `true`, Abstract advances to `.gravitySplit` instead of `.transfer`.
+    ///     Mutually exclusive with `showTransfer` — Gravity Split takes priority.
     ///   - showBondMatch: Whether the Bond Blast finale should follow the last
-    ///     transfer (or abstract, when transfer is disabled). The engine passes
-    ///     `true` only on the last problem of the session when
-    ///     `featureFlags.vs1BondMatchEnabled` is set.
+    ///     transfer/gravity-split (or abstract when both are disabled). The engine
+    ///     passes `true` only on the last problem when `featureFlags.vs1BondMatchEnabled` is set.
     static func nextStage(
         after stage: SliceStage,
         success: Bool,
         showTransfer: Bool,
+        showGravitySplit: Bool = false,
         showBondMatch: Bool = false
     ) -> SliceStage {
         guard success else { return stage }
@@ -25,7 +28,10 @@ enum SliceStateMachine {
         case .pictorial:
             return .abstract
         case .abstract:
-            if showTransfer { return .transfer }
+            if showGravitySplit { return .gravitySplit }
+            if showTransfer     { return .transfer }
+            return showBondMatch ? .bondMatch : .done
+        case .gravitySplit:
             return showBondMatch ? .bondMatch : .done
         case .transfer:
             return showBondMatch ? .bondMatch : .done
@@ -40,8 +46,15 @@ enum SliceStateMachine {
         from current: SliceStage,
         to next: SliceStage,
         showTransfer: Bool,
+        showGravitySplit: Bool = false,
         showBondMatch: Bool = false
     ) -> Bool {
-        nextStage(after: current, success: true, showTransfer: showTransfer, showBondMatch: showBondMatch) == next
+        nextStage(
+            after: current,
+            success: true,
+            showTransfer: showTransfer,
+            showGravitySplit: showGravitySplit,
+            showBondMatch: showBondMatch
+        ) == next
     }
 }

--- a/Domain/VehicleSpec.swift
+++ b/Domain/VehicleSpec.swift
@@ -40,6 +40,7 @@ extension VehicleSpec {
             case .pictorial:  return "Both zones together make the same number."
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "You parked them perfectly."
+            case .gravitySplit: return "Perfect balance!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -63,6 +64,7 @@ extension VehicleSpec {
             case .pictorial:  return "Both groups add up to the same number."
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Trucks delivered perfectly."
+            case .gravitySplit: return "Perfect balance!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -86,6 +88,7 @@ extension VehicleSpec {
             case .pictorial:  return "Both routes carry the same total."
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Vans delivered!"
+            case .gravitySplit: return "Perfect balance!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -109,6 +112,7 @@ extension VehicleSpec {
             case .pictorial:  return "Both stops total the same."
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Buses on route!"
+            case .gravitySplit: return "Perfect balance!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -132,6 +136,7 @@ extension VehicleSpec {
             case .pictorial:  return "Both zones cover the same total."
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Bulldozers in position!"
+            case .gravitySplit: return "Perfect balance!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -155,6 +160,7 @@ extension VehicleSpec {
             case .pictorial:  return "Both pads together hold the same total."
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Helicopters landed perfectly."
+            case .gravitySplit: return "Perfect balance!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -178,6 +184,7 @@ extension VehicleSpec {
             case .pictorial:  return "Both terminals hold the same total."
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Planes ready for take-off!"
+            case .gravitySplit: return "Perfect balance!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -33,6 +33,8 @@ final class VerticalSliceEngine {
     var transferLeftCount = 0
     var transferRightCount = 0
     private(set) var bondMatchState: BondMatchState? = nil
+    private(set) var gravitySplitState: GravitySplitState? = nil
+    private var lastGravitySplitCount = -1
     var feedbackMessage = "Tap Play to start."
     var showCelebration = false
     var completedSummary: SessionSummaryDraft?
@@ -138,6 +140,8 @@ final class VerticalSliceEngine {
         transferLeftCount = 0
         transferRightCount = 0
         bondMatchState = nil
+        gravitySplitState = nil
+        lastGravitySplitCount = -1
         feedbackMessage = activeTheme.sessionStartFeedback()
         showCelebration = false
         completedSummary = nil
@@ -239,6 +243,8 @@ final class VerticalSliceEngine {
         case .transfer:
             isCorrect = transferLeftCount == currentProblem.decompositionA
                 && transferRightCount == currentProblem.decompositionB
+        case .gravitySplit:
+            isCorrect = gravitySplitState?.isLocked == true
         case .bondMatch:
             // Bond Blast is not submitted via submitCurrentStage — pairs are matched
             // individually via matchPair(id:). This case is unreachable in practice.
@@ -311,6 +317,55 @@ final class VerticalSliceEngine {
         speechService.speak(msg, enabled: featureFlags.audioEnabled)
     }
 
+    // MARK: - Gravity Split actions
+
+    /// Called each time tiltRoll updates (≈30 Hz from MotionService).
+    /// Maps device roll angle (radians) to a left-pan counter count.
+    func adjustGravitySplitByTilt(_ tiltRoll: Double) {
+        guard currentStage == .gravitySplit, let state = gravitySplitState,
+              !state.isLocked else { return }
+        let clamped = max(-Double.pi / 4, min(tiltRoll, Double.pi / 4))
+        let fraction = 0.5 - clamped / (Double.pi / 4) * 0.5
+        let newLeft = Int((Double(state.target) * fraction).rounded())
+        setGravitySplit(leftCount: newLeft)
+    }
+
+    /// Called by the ±1 tap fallback buttons in GravitySplitView.
+    func adjustGravitySplitByTap(delta: Int) {
+        guard currentStage == .gravitySplit, let state = gravitySplitState,
+              !state.isLocked else { return }
+        setGravitySplit(leftCount: state.leftCount + delta)
+    }
+
+    /// Resets all counters back to the right pan (shake gesture).
+    func resetGravitySplit() {
+        guard currentStage == .gravitySplit else { return }
+        gravitySplitState?.setLeft(0)
+        lastGravitySplitCount = -1
+    }
+
+    private func setGravitySplit(leftCount: Int) {
+        guard var state = gravitySplitState else { return }
+        let previousCount = state.leftCount
+        state.setLeft(leftCount)
+        gravitySplitState = state
+
+        if state.leftCount != previousCount {
+            hapticsService.counterSettle(enabled: featureFlags.hapticsEnabled)
+            hapticsService.counterSlide(enabled: featureFlags.hapticsEnabled)
+        }
+
+        // Whisper tick when passing through the balanced midpoint.
+        if previousCount != state.target / 2 && state.leftCount == state.target / 2 {
+            hapticsService.tiltNeutral(enabled: featureFlags.hapticsEnabled)
+        }
+
+        if state.isLocked, let problem = currentProblem {
+            hapticsService.balanceLock(enabled: featureFlags.hapticsEnabled)
+            completeStage(successMessage: successMessage(for: .gravitySplit, problem: problem))
+        }
+    }
+
     private func validateEquation(for problem: SliceProblem) -> Bool {
         guard let left = Int(equationLeftInput), let right = Int(equationRightInput) else { return false }
         return left + right == problem.target
@@ -323,11 +378,13 @@ final class VerticalSliceEngine {
         // Bond Blast fires only on the last problem of the session.
         let isLastProblem = currentProblemIndex + 1 >= problems.count
         let showBondMatch = featureFlags.vs1BondMatchEnabled && isLastProblem
+        let showGravitySplit = featureFlags.vs1GravitySplitEnabled
 
         let next = SliceStateMachine.nextStage(
             after: currentStage,
             success: true,
             showTransfer: config.showTransfer,
+            showGravitySplit: showGravitySplit,
             showBondMatch: showBondMatch
         )
         recordStageTransition(from: currentStage, to: next)
@@ -385,6 +442,11 @@ final class VerticalSliceEngine {
         case .transfer:
             transferLeftCount = 0
             transferRightCount = 0
+        case .gravitySplit:
+            if let problem = currentProblem {
+                gravitySplitState = GravitySplitState(problem: problem)
+                lastGravitySplitCount = -1
+            }
         case .bondMatch:
             if let problem = currentProblem {
                 bondMatchState = BondMatchState(
@@ -421,6 +483,8 @@ final class VerticalSliceEngine {
             equationRightInput = ""
             transferLeftCount = 0
             transferRightCount = 0
+            gravitySplitState = nil
+            lastGravitySplitCount = -1
             problemStartedAt = .now
             feedbackMessage = promptForCurrentStage()
             logProblemPresented()
@@ -582,6 +646,10 @@ final class VerticalSliceEngine {
             return activeTheme.abstractPrompt()
         case .transfer:
             return "Show the same two parts with counters."
+        case .gravitySplit:
+            let a = currentProblem.decompositionA
+            let b = currentProblem.decompositionB
+            return "Tilt to put \(a) on one side and \(b) on the other!"
         case .done:
             return "Nice work."
         }
@@ -620,6 +688,8 @@ final class VerticalSliceEngine {
             } else {
                 return "Build the same equation again with counters, one group on each side."
             }
+        case .gravitySplit:
+            return "Keep tilting! Get \(problem.decompositionA) on one side and \(problem.decompositionB) on the other."
         case .done:
             return "Try again."
         }

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -43,6 +43,13 @@ struct SettingsView: View {
         )
     }
 
+    private var gravitySplitBinding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.vs1GravitySplitEnabled },
+            set: { appModel.featureFlags.vs1GravitySplitEnabled = $0 }
+        )
+    }
+
     private var motionBinding: Binding<Bool> {
         Binding(
             get: { appModel.featureFlags.motionControlsEnabled },
@@ -99,6 +106,11 @@ struct SettingsView: View {
                                 title: "Bond Blast finale",
                                 subtitle: "Adds a free-match bonus round after all bonds for a number are found.",
                                 isOn: bondMatchBinding
+                            )
+                            VS1ToggleRow(
+                                title: "Gravity Split (beta)",
+                                subtitle: "Replace the Show-it step with a tilt-powered balance scale activity.",
+                                isOn: gravitySplitBinding
                             )
                             Toggle("Room Quest (beta)", isOn: roomQuestBinding)
                             if appModel.featureFlags.roomQuestEnabled {

--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -1,0 +1,283 @@
+import SwiftUI
+
+/// Balance-scale stage where the child tilts the iPad to slide counters
+/// between two pans until the split matches the problem's decomposition.
+///
+/// Tilt input arrives via `tiltRoll` (radians) and is forwarded to the engine
+/// through `onAdjustTilt`. Tap buttons provide a fallback for cases where
+/// motion is unavailable. When `state.isLocked` becomes true the beam snaps
+/// level and the view auto-advances after 0.6 s via `onSubmit`.
+struct GravitySplitView: View {
+
+    // MARK: - Inputs
+
+    let state: GravitySplitState
+    let tiltRoll: Double
+    let shakeDetected: Bool
+    let onAdjustTilt: (Double) -> Void
+    let onTap: (Int) -> Void            // delta ±1 for the left pan; right = target − left
+    let onShakeHandled: () -> Void
+    let onSubmit: () -> Void
+
+    // MARK: - Local animation state
+
+    @State private var lockScale: CGFloat = 1.0
+
+    // MARK: - Constants
+
+    private let maxBeamAngle: Double = 0.22   // radians ≈ 12.6°
+
+    // MARK: - Derived
+
+    /// Beam rotation in radians. Left-heavy → clockwise (left pan descends).
+    private var beamAngle: Double {
+        guard state.target > 0 else { return 0 }
+        if state.isLocked { return 0 }
+        let fraction = Double(state.leftCount - state.rightCount) / Double(state.target)
+        return fraction * maxBeamAngle
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 16) {
+                headerRow
+                balanceSceneView
+                tapControlRow
+                if !state.isLocked {
+                    instructionText
+                }
+            }
+        }
+        .onChange(of: tiltRoll) { _, roll in
+            onAdjustTilt(roll)
+        }
+        .onChange(of: shakeDetected) { _, shook in
+            guard shook else { return }
+            onShakeHandled()
+        }
+        .onChange(of: state.isLocked) { _, locked in
+            guard locked else { return }
+            withAnimation(.spring(response: 0.38, dampingFraction: 0.48)) {
+                lockScale = 1.12
+            }
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(600))
+                onSubmit()
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(
+            "Balance scale. Make \(state.target). Left: \(state.leftCount). Right: \(state.rightCount)."
+        )
+    }
+
+    // MARK: - Header
+
+    private var headerRow: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Balance it!")
+                    .font(.title2.weight(.black))
+                    .foregroundStyle(MatherTheme.coral)
+
+                HStack(spacing: 8) {
+                    counterPill(value: state.leftCount, fill: MatherTheme.warm)
+                    Text("+").font(.title3.weight(.black)).foregroundStyle(.secondary)
+                    counterPill(value: state.rightCount, fill: MatherTheme.accent)
+                    Text("=").font(.title3.weight(.black)).foregroundStyle(.secondary)
+                    Text("\(state.target)")
+                        .font(.system(size: 28, weight: .black, design: .rounded))
+                        .foregroundStyle(MatherTheme.ink)
+                }
+            }
+
+            Spacer()
+
+            if state.isLocked {
+                Text("⭐️")
+                    .font(.system(size: 44))
+                    .scaleEffect(lockScale)
+                    .transition(.scale.combined(with: .opacity))
+            }
+        }
+    }
+
+    private func counterPill(value: Int, fill: Color) -> some View {
+        Text("\(value)")
+            .font(.system(size: 26, weight: .black, design: .rounded))
+            .foregroundStyle(fill)
+            .frame(minWidth: 52, minHeight: 52)
+            .background(fill.opacity(0.13))
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(fill.opacity(0.28), lineWidth: 1.5)
+            )
+    }
+
+    // MARK: - Balance scene
+
+    private var balanceSceneView: some View {
+        ZStack(alignment: .bottom) {
+            // Pivot triangle
+            pivotTriangle
+                .frame(width: 32, height: 22)
+                .offset(y: 0)
+
+            // Beam + pans, rotated as a unit
+            HStack(spacing: 0) {
+                panView(count: state.leftCount, fill: MatherTheme.warm, side: "left")
+                    .frame(maxWidth: .infinity)
+
+                // Beam bar
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(MatherTheme.ink.opacity(0.72))
+                    .frame(width: 44, height: 10)
+
+                panView(count: state.rightCount, fill: MatherTheme.accent, side: "right")
+                    .frame(maxWidth: .infinity)
+            }
+            .rotationEffect(.radians(beamAngle), anchor: .bottom)
+            .animation(.interpolatingSpring(stiffness: 100, damping: 16), value: beamAngle)
+            .offset(y: -22)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 160)
+        .padding(.vertical, 4)
+    }
+
+    private var pivotTriangle: some View {
+        Canvas { context, size in
+            var path = Path()
+            path.move(to: CGPoint(x: size.width / 2, y: 0))
+            path.addLine(to: CGPoint(x: 0, y: size.height))
+            path.addLine(to: CGPoint(x: size.width, y: size.height))
+            path.closeSubpath()
+            context.fill(path, with: .color(MatherTheme.ink.opacity(0.55)))
+        }
+    }
+
+    private func panView(count: Int, fill: Color, side: String) -> some View {
+        VStack(spacing: 6) {
+            // Counter dots in the pan (up to target, max display 10)
+            let display = min(state.target, 10)
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 5),
+                spacing: 4
+            ) {
+                ForEach(0..<display, id: \.self) { idx in
+                    Circle()
+                        .fill(idx < count ? fill : fill.opacity(0.15))
+                        .overlay(
+                            Circle()
+                                .strokeBorder(fill.opacity(idx < count ? 0.3 : 0.4), lineWidth: 1.5)
+                        )
+                        .shadow(color: idx < count ? fill.opacity(0.3) : .clear, radius: 3, y: 1)
+                        .aspectRatio(1, contentMode: .fit)
+                        .accessibilityIdentifier("gravity-\(side)-dot-\(idx)")
+                }
+            }
+            .padding(8)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(fill.opacity(0.10))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .strokeBorder(fill.opacity(0.22), lineWidth: 1.5)
+                    )
+            )
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Tap fallback
+
+    private var tapControlRow: some View {
+        HStack(spacing: 12) {
+            panControlButtons(
+                label: "Left",
+                fill: MatherTheme.warm,
+                side: "left",
+                canDecrement: state.leftCount > 0 && !state.isLocked,
+                canIncrement: state.leftCount < state.target && !state.isLocked
+            ) { delta in
+                onTap(delta)
+            }
+
+            panControlButtons(
+                label: "Right",
+                fill: MatherTheme.accent,
+                side: "right",
+                canDecrement: state.rightCount > 0 && !state.isLocked,
+                canIncrement: state.rightCount < state.target && !state.isLocked
+            ) { delta in
+                onTap(-delta)   // right + → left −
+            }
+        }
+    }
+
+    private func panControlButtons(
+        label: String,
+        fill: Color,
+        side: String,
+        canDecrement: Bool,
+        canIncrement: Bool,
+        action: @escaping (Int) -> Void
+    ) -> some View {
+        HStack(spacing: 8) {
+            Button {
+                action(-1)
+            } label: {
+                Image(systemName: "minus.circle.fill")
+                    .font(.title.weight(.bold))
+                    .frame(minWidth: 48, minHeight: 48)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(canDecrement ? fill : fill.opacity(0.3))
+            .disabled(!canDecrement)
+            .accessibilityLabel("Remove from \(label.lowercased()) pan")
+            .accessibilityIdentifier("gravity-\(side)-minus")
+
+            Text(label)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(fill)
+                .frame(minWidth: 38)
+
+            Button {
+                action(1)
+            } label: {
+                Image(systemName: "plus.circle.fill")
+                    .font(.title.weight(.bold))
+                    .frame(minWidth: 48, minHeight: 48)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(canIncrement ? fill : fill.opacity(0.3))
+            .disabled(!canIncrement)
+            .accessibilityLabel("Add to \(label.lowercased()) pan")
+            .accessibilityIdentifier("gravity-\(side)-plus")
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(fill.opacity(0.08))
+        )
+    }
+
+    // MARK: - Instruction
+
+    private var instructionText: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "gyroscope")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.coral.opacity(0.8))
+            Text("Tilt the iPad to slide the counters")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+}

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -131,6 +131,22 @@ struct SliceSessionView: View {
                 onSubmit: appModel.engine.submitCurrentStage,
                 theme: appModel.engine.activeTheme
             )
+        case .gravitySplit:
+            if let splitState = appModel.engine.gravitySplitState {
+                GravitySplitView(
+                    state: splitState,
+                    tiltRoll: appModel.motionService.tiltRoll,
+                    shakeDetected: appModel.motionService.shakeDetected,
+                    onAdjustTilt: appModel.engine.adjustGravitySplitByTilt,
+                    onTap: appModel.engine.adjustGravitySplitByTap,
+                    onShakeHandled: { appModel.motionService.resetShake(); appModel.engine.resetGravitySplit() },
+                    onSubmit: appModel.engine.submitCurrentStage
+                )
+                .onAppear { appModel.motionService.startUpdates() }
+                .onDisappear { appModel.motionService.stopUpdates() }
+            } else {
+                CardSurface { Text("Loading Balance...") }
+            }
         case .bondMatch:
             if let bondState = appModel.engine.bondMatchState {
                 BondMatchView(
@@ -232,9 +248,10 @@ struct SliceSessionView: View {
         case .concrete:  MatherTheme.warm
         case .pictorial: MatherTheme.softBlue
         case .abstract:  MatherTheme.accent
-        case .transfer:  MatherTheme.coral
-        case .bondMatch: MatherTheme.accent
-        case .done:      .secondary
+        case .transfer:      MatherTheme.coral
+        case .gravitySplit:  MatherTheme.coral
+        case .bondMatch:     MatherTheme.accent
+        case .done:          .secondary
         }
     }
 

--- a/Services/HapticsService.swift
+++ b/Services/HapticsService.swift
@@ -18,6 +18,7 @@ final class HapticsService {
     private(set) var successFiredCount = 0
     private(set) var failureFiredCount = 0
     private(set) var stageSuccessFiredCount = 0
+    private(set) var balanceLockFiredCount = 0
 
     // MARK: - Engine
 

--- a/Services/HapticsService.swift
+++ b/Services/HapticsService.swift
@@ -193,12 +193,118 @@ final class HapticsService {
         }
     }
 
+    // MARK: - Gravity Split haptics
+
+    /// Bright transient tick fired once per integer boundary crossed while tilting.
+    /// Gives the child discrete tactile feedback for each counter that moves.
+    func counterSettle(enabled: Bool) {
+        guard enabled else { return }
+        playTransient(intensity: 0.45, sharpness: 0.85) {
+            UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+        }
+    }
+
+    /// Very brief continuous rumble while a tilt-driven count change is in progress.
+    /// Keeps the sensation "alive" between settle ticks — no UIKit fallback (too subtle).
+    func counterSlide(enabled: Bool) {
+        guard enabled else { return }
+        guard let engine else { return }
+        do {
+            let event = CHHapticEvent(
+                eventType: .hapticContinuous,
+                parameters: [
+                    CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.18),
+                    CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.72)
+                ],
+                relativeTime: 0,
+                duration: 0.08
+            )
+            let pattern = try CHHapticPattern(events: [event], parameterCurves: [])
+            let player = try engine.makePlayer(with: pattern)
+            try player.start(atTime: CHHapticTimeImmediate)
+        } catch { /* silent — too subtle for UIKit fallback */ }
+    }
+
+    /// Bilateral celebration pattern fired when the balance snaps to the correct split.
+    /// Two simultaneous pulses + echo + a short settling hum — distinct from Bond Blast.
+    func balanceLock(enabled: Bool) {
+        guard enabled else { return }
+        balanceLockFiredCount += 1
+        guard let engine else {
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            return
+        }
+        do {
+            let events: [CHHapticEvent] = [
+                CHHapticEvent(
+                    eventType: .hapticTransient,
+                    parameters: [
+                        CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.70),
+                        CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.75)
+                    ],
+                    relativeTime: 0.00
+                ),
+                CHHapticEvent(
+                    eventType: .hapticTransient,
+                    parameters: [
+                        CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.70),
+                        CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.55)
+                    ],
+                    relativeTime: 0.00
+                ),
+                CHHapticEvent(
+                    eventType: .hapticTransient,
+                    parameters: [
+                        CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.40),
+                        CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.60)
+                    ],
+                    relativeTime: 0.14
+                ),
+                CHHapticEvent(
+                    eventType: .hapticContinuous,
+                    parameters: [
+                        CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.45),
+                        CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.40)
+                    ],
+                    relativeTime: 0.28,
+                    duration: 0.25
+                )
+            ]
+            let pattern = try CHHapticPattern(events: events, parameterCurves: [])
+            let player = try engine.makePlayer(with: pattern)
+            try player.start(atTime: CHHapticTimeImmediate)
+        } catch {
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        }
+    }
+
+    /// Whisper tick fired when the device passes through the neutral (level) position.
+    /// Very subtle — no UIKit fallback.
+    func tiltNeutral(enabled: Bool) {
+        guard enabled else { return }
+        guard let engine else { return }
+        do {
+            let event = CHHapticEvent(
+                eventType: .hapticTransient,
+                parameters: [
+                    CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.15),
+                    CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.50)
+                ],
+                relativeTime: 0
+            )
+            let pattern = try CHHapticPattern(events: [event], parameterCurves: [])
+            let player = try engine.makePlayer(with: pattern)
+            try player.start(atTime: CHHapticTimeImmediate)
+        } catch { /* silent */ }
+    }
+
     // MARK: - Test support
 
     func resetCounts() {
         successFiredCount = 0
         failureFiredCount = 0
         stageSuccessFiredCount = 0
+        balanceLockFiredCount = 0
     }
 
     // MARK: - Private helpers

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -10,6 +10,7 @@ final class FeatureFlagService {
         static let hapticsEnabled = "feature.hapticsEnabled"
         static let selectedThemeId = "feature.selectedThemeId"
         static let vs1BondMatchEnabled = "feature.vs1BondMatchEnabled"
+        static let vs1GravitySplitEnabled = "feature.vs1GravitySplitEnabled"
         static let motionControlsEnabled = "feature.motionControlsEnabled"
         static let soundReactionEnabled = "feature.soundReactionEnabled"
         static let roomQuestEnabled = "feature.roomQuestEnabled"
@@ -44,6 +45,12 @@ final class FeatureFlagService {
     /// Gates the Bond Blast complement-match finale stage at the end of each VS1 session.
     var vs1BondMatchEnabled: Bool {
         didSet { defaults.set(vs1BondMatchEnabled, forKey: Keys.vs1BondMatchEnabled) }
+    }
+
+    /// Replaces the Transfer (Show it) stepper stage with the tilt-powered balance activity.
+    /// Default false — parent opts in via Settings.
+    var vs1GravitySplitEnabled: Bool {
+        didSet { defaults.set(vs1GravitySplitEnabled, forKey: Keys.vs1GravitySplitEnabled) }
     }
 
     /// Enables CMMotionManager tilt drift and shake-to-shuffle in Bond Blast.
@@ -94,6 +101,7 @@ final class FeatureFlagService {
             Keys.hapticsEnabled: true,
             Keys.selectedThemeId: "classic",
             Keys.vs1BondMatchEnabled: false,
+            Keys.vs1GravitySplitEnabled: false,
             Keys.motionControlsEnabled: true,
             Keys.soundReactionEnabled: false,
             Keys.roomQuestEnabled: false,
@@ -107,6 +115,7 @@ final class FeatureFlagService {
         hapticsEnabled = defaults.bool(forKey: Keys.hapticsEnabled)
         selectedThemeId = defaults.string(forKey: Keys.selectedThemeId) ?? "classic"
         vs1BondMatchEnabled = defaults.bool(forKey: Keys.vs1BondMatchEnabled)
+        vs1GravitySplitEnabled = defaults.bool(forKey: Keys.vs1GravitySplitEnabled)
         motionControlsEnabled = defaults.bool(forKey: Keys.motionControlsEnabled)
         soundReactionEnabled = defaults.bool(forKey: Keys.soundReactionEnabled)
         roomQuestEnabled = defaults.bool(forKey: Keys.roomQuestEnabled)

--- a/Tests/MatherTests/SliceStateMachineTests.swift
+++ b/Tests/MatherTests/SliceStateMachineTests.swift
@@ -47,4 +47,28 @@ struct SliceStateMachineTests {
         // Without showBondMatch, transfer → bondMatch is invalid
         #expect(SliceStateMachine.canTransition(from: .transfer, to: .bondMatch, showTransfer: true, showBondMatch: false) == false)
     }
+
+    // MARK: - Gravity Split transitions
+
+    @Test
+    func gravitySplitInsertedAfterAbstractWhenFlagOn() {
+        // Gravity Split takes priority over Transfer when showGravitySplit is true
+        #expect(SliceStateMachine.nextStage(after: .abstract, success: true, showTransfer: true, showGravitySplit: true) == .gravitySplit)
+    }
+
+    @Test
+    func gravitySplitLeadsToBondMatchOnLastProblem() {
+        #expect(SliceStateMachine.nextStage(after: .gravitySplit, success: true, showTransfer: true, showGravitySplit: true, showBondMatch: true) == .bondMatch)
+    }
+
+    @Test
+    func gravitySplitLeadsToDoneWhenBondMatchOff() {
+        #expect(SliceStateMachine.nextStage(after: .gravitySplit, success: true, showTransfer: true, showGravitySplit: true, showBondMatch: false) == .done)
+    }
+
+    @Test
+    func gravitySplitSkippedWhenFlagOff() {
+        // Default: showGravitySplit omitted → falls back to Transfer
+        #expect(SliceStateMachine.nextStage(after: .abstract, success: true, showTransfer: true) == .transfer)
+    }
 }

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -478,6 +478,93 @@ struct VerticalSliceEngineTests {
         #expect(engine.currentProblemIndex == 1)
     }
 
+    // MARK: - Gravity Split engine tests
+
+    private func advanceToGravitySplit(_ engine: VerticalSliceEngine) async throws {
+        guard let problem = engine.currentProblem else { return }
+        engine.adjustConcrete(by: problem.target)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        let pairIds = engine.bondMatchState?.pairs.map(\.id) ?? []
+        for id in pairIds { engine.matchPair(id: id) }
+        try await Task.sleep(for: .milliseconds(200))
+        engine.equationLeftInput = String(problem.decompositionA)
+        engine.equationRightInput = String(problem.decompositionB)
+        engine.submitCurrentStage()
+        try await Task.sleep(for: .milliseconds(200))
+        #expect(engine.currentStage == .gravitySplit)
+    }
+
+    @Test
+    func gravitySplitStateInitialisedOnStageEntry() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.vs1GravitySplitEnabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        try await advanceToGravitySplit(engine)
+
+        #expect(engine.gravitySplitState != nil)
+        #expect(engine.gravitySplitState?.leftCount == 0)
+        #expect(engine.gravitySplitState?.rightCount == engine.currentProblem?.target)
+    }
+
+    @Test
+    func gravitySplitAdjustByTapChangesCount() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.vs1GravitySplitEnabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        try await advanceToGravitySplit(engine)
+
+        engine.adjustGravitySplitByTap(delta: 1)
+        #expect(engine.gravitySplitState?.leftCount == 1)
+        engine.adjustGravitySplitByTap(delta: 1)
+        #expect(engine.gravitySplitState?.leftCount == 2)
+    }
+
+    @Test
+    func gravitySplitAutoAdvancesWhenLocked() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.vs1GravitySplitEnabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        try await advanceToGravitySplit(engine)
+
+        guard let problem = engine.currentProblem else { return }
+        // Tap to exact decomposition — should auto-advance
+        engine.adjustGravitySplitByTap(delta: problem.decompositionA)
+        // Drain the MainActor queue so the completeStage Task fires
+        for _ in 0..<100 {
+            if engine.currentStage != .gravitySplit { break }
+            await Task.yield()
+        }
+        #expect(engine.currentStage != .gravitySplit)
+    }
+
     @Test
     func concreteStageAcceptsCombinedWarmAndAccentTotal() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)


### PR DESCRIPTION
## Summary

- Adds a new `gravitySplit` CPA stage gated behind `vs1GravitySplitEnabled` (default off). When enabled, the Transfer ("Show it") stepper is replaced by a tilt-powered balance scale where the child tilts the iPad to slide counters between two pans until the split matches the problem's decomposition.
- Four new haptic patterns (counterSettle, counterSlide, balanceLock, tiltNeutral) tuned for the tilt mechanic.
- ±1 tap buttons on each pan provide a fallback when motion is unavailable.
- When the balance locks, the beam snaps level with a spring animation + bilateral haptic and auto-advances after 0.6 s.
- Settings: new "Gravity Split (beta)" toggle in the Activities section.
- All existing behaviour is preserved when the flag is off (default).

## Test plan

- [ ] 7 new unit tests pass (4 `SliceStateMachineTests` + 3 `VerticalSliceEngineTests`)
- [ ] All existing tests green (flag off by default = zero regressions)
- [ ] Manual: enable flag in Settings → play a session → reach "Balance it!" screen
- [ ] Tilting moves counters; ±1 tap buttons work as fallback
- [ ] Matching the decomposition snaps beam + celebrates + auto-advances
- [ ] Shake gesture resets counters to right pan
- [ ] Bond Blast still fires correctly after Gravity Split on the last problem
- [ ] CI screenshot tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)