### PR TITLE
docs(product): add product brief and Room Quest direction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 DerivedData/
 xcuserdata/
 *.xcuserstate
+product-os.md

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Mather
+
+Mather is an Apple-platform math learning product for young children, currently centered on ages 5 to 7.
+
+It is designed around a CPA-first, play-based, concept-first approach rather than worksheet-style drill. The current active product slice is VS1, including Make & Break to 10, transfer, parent summaries, and Bond Blast follow-on work.
+
+## Current product focus
+
+- stabilize and evidence the current VS1 learning loop
+- fix Bond Blast handoff reliability issues
+- turn Room Quest research into implementation-ready execution slices
+- preserve a path from family-first distribution toward broader alpha users later
+
+## Product truth locations
+
+Use this order when orienting:
+
+1. repo reality: code, wiki specs, ADRs, tests
+2. workspace product memory: `memory/mather-product-durable.md`, `memory/mather-product-working-notes.md`, `memory/mather-knowledge-index.md`
+3. live GitHub issue / PR / CI state
+4. current conversation instructions
+
+## Working model
+
+- GitHub is the main progress surface for repo-backed work
+- incomplete work should move quickly toward branch, PR, and CI
+- product memory remains workspace-global, with private operating guidance in `product-os.md`
+- milestone status should stay honest and evidence-backed
+
+## Current gaps worth pushing
+
+- stronger product evidence for VS1 pilot quality and usage
+- closure on Bond Blast handoff reliability
+- implementation-ready breakdown for Room Quest
+- continued tightening of repo-root product onboarding artifacts

--- a/wiki/Research/Room-Quest-Sensor-Capabilities-and-Design-Direction.md
+++ b/wiki/Research/Room-Quest-Sensor-Capabilities-and-Design-Direction.md
@@ -1,0 +1,167 @@
+# Research: Room Quest Sensor Capabilities and Hardware-Tier Design
+
+**Status**: Draft
+**Date**: 2026-04-11
+**Context**: follow-on research to `Room-Scale-Embodied-Math-Gameplay.md` after product direction changed from parent-seeded manual spots to a more device-driven, sensor-aware scavenger experience.
+
+---
+
+## Overview
+
+This note revises the earlier Room Quest framing. The new product goal is **not** a purely manual room activity with parent-seeded physical cards. The goal is a **sensor-aware scavenger setup with the device**, using the best available hardware on each supported Apple device while degrading gracefully when higher-precision sensors are unavailable.
+
+Key constraint: the app must stay **honest** about what it can actually sense. It should not pretend to know exact in-room coordinates when the device cannot reliably provide them.
+
+The right design is therefore **tiered**:
+
+1. **Marker + camera baseline** for broadest compatibility
+2. **Motion/audio guidance enhancement** on all supported devices
+3. **LiDAR-enhanced spatial anchoring** on hardware that actually has it
+4. **No GPS/altitude-only room positioning**, because those primitives are too coarse or too noisy for child-trustworthy in-room play
+
+---
+
+## Hardware capability summary
+
+### iPhone 15 Pro
+
+Official / grounded capabilities relevant to Room Quest:
+- **LiDAR scanner**: yes
+- **ARKit plane / image detection**: yes
+- **Barometer / relative altitude**: yes
+- **Precision dual-frequency GNSS**: yes
+- **Ultra Wideband (UWB)**: yes, second-generation
+- **Accelerometer / gyroscope / magnetometer**: yes
+- **Camera**: yes
+
+Implication:
+- iPhone 15 Pro is the only device in this target set that can support a strong **spatial-anchor enhanced mode** without pretending.
+- It is still **not** a reason to use GPS for in-room position.
+
+### iPhone 16e
+
+Grounded capability read:
+- **LiDAR scanner**: no
+- **UWB**: no
+- **Barometer**: yes
+- **GNSS**: yes
+- **Accelerometer / gyroscope / magnetometer**: yes
+- **Camera**: yes
+
+Implication:
+- iPhone 16e can support a good **marker + motion + audio** Room Quest.
+- It cannot support the same LiDAR anchor mode as iPhone 15 Pro.
+- It should not be marketed as giving high-precision indoor positioning.
+
+### iPad Air
+
+Grounded capability read for current iPad Air family:
+- **LiDAR scanner**: no
+- **UWB**: not officially listed / not a dependable product assumption
+- **Barometer**: yes
+- **GNSS**: only on cellular variants; Wi‑Fi models use Wi‑Fi/iBeacon location, not true GPS
+- **Accelerometer / gyroscope / compass**: yes
+- **Camera**: yes
+- **ARKit plane / image detection**: yes
+
+Implication:
+- iPad Air is suitable for **marker-based scavenger setup** and on-screen guided play.
+- It should not be treated as a high-precision spatial anchor device.
+- Large-screen UX may actually make marker scanning and child guidance easier than on phone.
+
+---
+
+## Why GPS and altitude are the wrong primary mechanic
+
+### GPS / GNSS
+
+Even strong phone GNSS is the wrong primitive for in-room play:
+- indoor accuracy is too coarse
+- signal quality is environment-dependent
+- room-level differentiation is unreliable
+- it creates a fake promise of precision the app cannot consistently keep
+
+Conclusion:
+- **Do not base Room Quest on GPS coordinates inside a room**.
+- GPS may be useful only for coarse outdoors or neighborhood-scale gameplay, which is a different product.
+
+### Barometer / relative altitude
+
+Barometer data is useful for **coarse vertical change**, but not as a standalone room-position mechanic:
+- Apple exposes relative altitude, not a guaranteed indoor “which spot are you at” signal
+- readings are noisy enough that child-facing exactness would be dishonest
+- useful for “did the user go upstairs/downstairs” style hints, not for “you found the blue station”
+
+Conclusion:
+- **Do not base Room Quest location on altitude changes alone**.
+- Relative altitude can be a soft secondary signal at most.
+
+---
+
+## Why UWB is not the baseline answer
+
+Nearby Interaction / UWB is powerful, but not the simple answer here.
+
+Important constraint:
+- Apple’s UWB peer ranging requires **another compatible peer or accessory** and token exchange
+- that means another device or dedicated accessory at each station
+- this is too much setup for a family math game baseline
+
+Implication:
+- even on iPhone 15 Pro, UWB is not a practical default Room Quest mechanic unless the product later introduces dedicated accessories
+- iPhone 16e does not have UWB anyway
+
+Conclusion:
+- **Do not anchor the Room Quest spec around UWB** for now.
+
+---
+
+## Best-fit sensing stack by reliability
+
+### Tier 1: camera markers + image detection (recommended baseline)
+
+Use printed visual markers / spot cards that the device can detect with camera-based image recognition.
+
+Why this is the best baseline:
+- works on iPhone 15 Pro, iPhone 16e, and iPad Air
+- honest and legible: “scan this marker” is understandable to parent and child
+- avoids fake location precision
+- enables magical moments without expensive hardware assumptions
+- supports explicit station identity: red station, blue station, number station, shape station
+
+### Tier 2: motion + heading + step-like guidance (recommended enhancement)
+
+Use device motion and orientation to create a treasure-hunt feel without claiming exact coordinates.
+
+Good uses:
+- warmer/colder cues
+- compass-like turn prompts
+- walk-a-little-farther hints
+- celebratory motion interactions when station is reached
+
+### Tier 3: LiDAR-enhanced anchor mode (recommended only for 15 Pro-class hardware)
+
+On LiDAR devices, the app can offer a better setup and stronger AR anchoring.
+
+Recommendation:
+- use LiDAR to improve setup quality and anchor stability, not as the only station identity mechanism
+
+---
+
+## Recommended product direction
+
+Room Quest should become a **device-guided scavenger experience** with hardware tiers:
+
+- **Baseline on all supported devices**: printed markers + camera recognition + spoken guidance + motion/audio feedback
+- **Enhanced on higher-end hardware**: more stable AR anchoring and richer spatial setup on LiDAR devices
+
+The product should say things like:
+- scan the red station to start
+- find the blue marker
+- the device will guide you
+- listen for hotter/colder clues
+
+It should **not** say things like:
+- the device knows your exact room location
+- walk to these coordinates
+- use GPS to find the station indoors

--- a/wiki/Specs/Room-Quest-Sensor-Driven.md
+++ b/wiki/Specs/Room-Quest-Sensor-Driven.md
@@ -1,0 +1,120 @@
+# Spec: Room Quest — Sensor-Driven Scavenger Mode
+
+**Status**: Draft
+**Date**: 2026-04-11
+**Supersedes direction in**: `Room-Quest-Future-Vertical-Slice.md`
+**Research base**:
+- `wiki/Research/Room-Scale-Embodied-Math-Gameplay.md`
+- `wiki/Research/Room-Quest-Sensor-Capabilities-and-Design-Direction.md`
+
+---
+
+## Overview
+
+Room Quest should be redesigned as a **sensor-driven scavenger mode** that uses the best available device capabilities without pretending to have exact indoor positioning when it does not.
+
+This means:
+- **not GPS-first indoor gameplay**
+- **not altitude-only room localization**
+- **not a purely manual card-only baseline**
+- **yes to marker-guided stations with camera recognition and motion/audio assistance**
+- **yes to LiDAR-enhanced setup/anchoring on devices that actually support it**
+
+---
+
+## Product framing
+
+Room Quest is a **device-guided embodied scavenger math mode**.
+
+The child should feel:
+- the device is guiding me to the next station
+- I found the station and unlocked the next clue
+- my movement matters
+
+The parent should feel:
+- setup is simple and trustworthy
+- the device is using visible, understandable signals
+- the game still works even if advanced sensors are unavailable
+
+---
+
+## Design principles
+
+1. **Station identity must be explicit**.
+2. **High-precision hardware enhances, but does not redefine, the loop**.
+3. **No fake exactness**.
+4. **The app guides; the child still plays physically**.
+5. **Graceful degradation is a core requirement**.
+6. **Fallbacks are part of the primary design**.
+
+---
+
+## Hardware tiers
+
+### Tier A: LiDAR-enhanced
+**Devices**: iPhone 15 Pro-class hardware
+
+Capabilities used:
+- camera marker detection
+- ARKit plane/image anchoring
+- LiDAR-enhanced scene understanding
+- motion / heading
+- audio / haptics
+
+### Tier B: camera + motion baseline
+**Devices**: iPhone 16e, iPad Air, and any non-LiDAR supported device
+
+Capabilities used:
+- camera marker detection
+- motion / heading
+- audio / haptics
+- optional ARKit image detection without LiDAR-specific assumptions
+
+### Explicit non-goals
+- GPS-first room positioning
+- UWB-dependent station finding
+- altitude-defined station identity
+
+---
+
+## Core interaction model
+
+### Setup
+1. Parent chooses Room Quest.
+2. App asks parent to place physical station markers in safe locations.
+3. Parent scans each station once with the device.
+4. App confirms station registration and associates each with a role.
+5. App shows a compact ready-to-hunt summary.
+
+### Play loop
+1. App gives the child a clue or mission.
+2. Child moves through the room with the device-guided flow.
+3. On arrival, child scans or confirms the station.
+4. App unlocks a count, collection, or grouping challenge.
+5. Child completes embodied math action.
+6. App guides to the next station.
+7. Session returns to on-screen CPA representation and abstraction.
+
+---
+
+## MVP gameplay loops
+
+### Loop A: Find and Count
+- simplest embodied baseline
+- validates the station-guided hunt feel
+
+### Loop B: Find and Gather
+- stronger CPA continuity
+- maps physical grouping to part-part-whole thinking
+
+### Loop C: Find and Unlock
+- stronger scavenger fantasy
+- unlocks the next clue or mini-challenge through station discovery
+
+---
+
+## Product rule
+
+Sensors must act as **enhancement layers**, not gates to understanding.
+
+The child must be able to complete the core experience without LiDAR, GPS, UWB, or fragile vision-only assumptions.


### PR DESCRIPTION
## Summary

- add a repo-root Mather product brief
- ignore private product-os.md so workspace-only operating docs stop showing up as repo noise
- add Room Quest research and a sensor-driven spec so the current product direction is captured durably in the repo

## Why

These docs and repo-hygiene changes were developed after PR #178 but did not actually land on main. This follow-up gets the product surface and Room Quest direction back onto a durable GitHub path.
