### PR TITLE
feat(sum-sprint): spaced-repetition fluency practice for sums 11–20

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -16,6 +16,8 @@ final class AppModel {
     let soundDetectionService: SoundDetectionService
     let roomQuestScanner: RoomQuestLiveScanner
     let roomQuestEngine: RoomQuestEngine
+    let factStore: FactRecordStore
+    let sumSprintEngine: SumSprintEngine
 
     init(modelContext: ModelContext) {
         let featureFlags = FeatureFlagService()
@@ -57,5 +59,17 @@ final class AppModel {
         )
         self.roomQuestEngine = roomQuestEngine
         roomQuestEngine.onExitToHome = { [weak vsEngine] in vsEngine?.showHome() }
+
+        let factStore = FactRecordStore(modelContext: modelContext)
+        let sumSprintEngine = SumSprintEngine(
+            featureFlags: featureFlags,
+            telemetryWriter: telemetryWriter,
+            speechService: speechService,
+            hapticsService: hapticsService,
+            factStore: factStore
+        )
+        self.factStore = factStore
+        self.sumSprintEngine = sumSprintEngine
+        sumSprintEngine.onExitToHome = { [weak vsEngine] in vsEngine?.showHome() }
     }
 }

--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -8,7 +8,7 @@ struct MatherApp: App {
 
     init() {
         do {
-            container = try ModelContainer(for: StoredSessionSummary.self, StoredRoomQuestStationReference.self)
+            container = try ModelContainer(for: StoredSessionSummary.self, StoredRoomQuestStationReference.self, StoredFactRecord.self)
             let appModel = AppModel(modelContext: container.mainContext)
             Self.seedSessionHistoryIfRequested(using: appModel)
             _appModel = State(initialValue: appModel)

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -30,6 +30,21 @@ struct RootView: View {
                         )) { _ in
                             RoomQuestScannerSheet(scanner: appModel.roomQuestScanner)
                         }
+                case .sumSprint:
+                    switch appModel.sumSprintEngine.phase {
+                    case .idle:
+                        HomeView(appModel: appModel)
+                    case .session:
+                        SumSprintSessionView(appModel: appModel)
+                    case .summary:
+                        if let summary = appModel.sumSprintEngine.completedSummary {
+                            SumSprintSummaryView(
+                                summary: summary,
+                                onPlayAgain: { appModel.sumSprintEngine.startSession() },
+                                onDone: { appModel.sumSprintEngine.exitToHome() }
+                            )
+                        }
+                    }
                 }
             }
             .navigationBarTitleDisplayMode(.inline)

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -41,6 +41,10 @@ enum SliceEventType: String, Codable {
     case roomQuestCompleted = "room_quest_completed"
     case roomQuestReferenceCaptureStarted = "room_quest_reference_capture_started"
     case roomQuestReferenceCaptureCompleted = "room_quest_reference_capture_completed"
+    case sumSprintStarted = "sum_sprint_started"
+    case sumSprintCardShown = "sum_sprint_card_shown"
+    case sumSprintCardAnswered = "sum_sprint_card_answered"
+    case sumSprintCompleted = "sum_sprint_completed"
 }
 
 struct SliceConfig: Codable, Equatable {
@@ -329,6 +333,27 @@ final class StoredRoomQuestStationReference {
 
     var captureState: RoomQuestReferenceCaptureState? {
         RoomQuestReferenceCaptureState(rawValue: captureStateRawValue)
+    }
+}
+
+@Model
+final class StoredFactRecord {
+    @Attribute(.unique) var factKey: String  // "\(addendA)+\(addendB)"
+    var addendA: Int
+    var addendB: Int
+    var boxRawValue: Int
+    var sessionsSinceLastSeen: Int
+    var correctStreak: Int
+    var lastSeenAt: Date?
+
+    init(factKey: String, addendA: Int, addendB: Int) {
+        self.factKey = factKey
+        self.addendA = addendA
+        self.addendB = addendB
+        self.boxRawValue = 0
+        self.sessionsSinceLastSeen = 0
+        self.correctStreak = 0
+        self.lastSeenAt = nil
     }
 }
 

--- a/Domain/SumSprintEngine.swift
+++ b/Domain/SumSprintEngine.swift
@@ -1,0 +1,261 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class SumSprintEngine {
+
+    // MARK: - Published state
+
+    private(set) var cards: [SumSprintCard] = []
+    private(set) var currentCardIndex: Int = 0
+    private(set) var currentStreak: Int = 0
+    private(set) var peakStreak: Int = 0
+    private(set) var showCorrectFeedback: Bool = false
+    private(set) var showIncorrectFeedback: Bool = false
+    private(set) var completedSummary: SumSprintSessionSummary? = nil
+    private(set) var phase: SumSprintPhase = .idle
+
+    // MARK: - Dependencies
+
+    private let featureFlags: FeatureFlagService
+    private let telemetryWriter: TelemetryWriter
+    private let speechService: SpeechService
+    private let hapticsService: HapticsService
+    // Internal so @testable import tests can verify Leitner state directly
+    let factStore: FactRecordStore
+    let feedbackDuration: TimeInterval
+
+    // MARK: - Session tracking
+
+    private var sessionId: UUID = UUID()
+    private var sessionStartedAt: Date = .now
+    private var seenFactKeys: Set<String> = []
+
+    // MARK: - Callback
+
+    var onExitToHome: (@MainActor () -> Void)?
+
+    // MARK: - Init
+
+    init(
+        featureFlags: FeatureFlagService,
+        telemetryWriter: TelemetryWriter,
+        speechService: SpeechService,
+        hapticsService: HapticsService = HapticsService(),
+        factStore: FactRecordStore,
+        feedbackDuration: TimeInterval = 0.6
+    ) {
+        self.featureFlags = featureFlags
+        self.telemetryWriter = telemetryWriter
+        self.speechService = speechService
+        self.hapticsService = hapticsService
+        self.factStore = factStore
+        self.feedbackDuration = feedbackDuration
+    }
+
+    // MARK: - Navigation
+
+    func startSession() {
+        sessionId = UUID()
+        sessionStartedAt = .now
+        seenFactKeys = []
+        currentCardIndex = 0
+        currentStreak = 0
+        peakStreak = 0
+        showCorrectFeedback = false
+        showIncorrectFeedback = false
+        completedSummary = nil
+
+        let records = factStore.fetchAll()
+        let facts = SumSprintGenerator.generateSession(allRecords: records)
+        cards = facts.map { SumSprintCard(id: UUID(), fact: $0) }
+
+        phase = .session
+
+        logEvent(.sumSprintStarted, payload: [
+            "session_id": sessionId.uuidString,
+            "card_count": String(cards.count)
+        ])
+
+        speechService.speak("Let's practice! What's the sum?", enabled: featureFlags.audioEnabled)
+        showCurrentCard()
+    }
+
+    func exitToHome() {
+        phase = .idle
+        onExitToHome?()
+    }
+
+    // MARK: - Card interaction
+
+    func appendDigit(_ digit: Int) {
+        guard phase == .session, currentCardIndex < cards.count else { return }
+        let current = cards[currentCardIndex].typedAnswer
+        // Max 2 digits: sums are at most 20
+        guard current.count < 2 else { return }
+        cards[currentCardIndex].typedAnswer = current + String(digit)
+    }
+
+    func deleteLastDigit() {
+        guard phase == .session, currentCardIndex < cards.count else { return }
+        let current = cards[currentCardIndex].typedAnswer
+        guard !current.isEmpty else { return }
+        cards[currentCardIndex].typedAnswer = String(current.dropLast())
+    }
+
+    func submitAnswer() {
+        guard phase == .session, currentCardIndex < cards.count else { return }
+        let card = cards[currentCardIndex]
+        guard let entered = Int(card.typedAnswer) else { return }
+
+        let isCorrect = entered == card.fact.sum
+        cards[currentCardIndex].attemptCount += 1
+        let isFirstTry = cards[currentCardIndex].attemptCount == 1
+
+        seenFactKeys.insert(card.fact.factKey)
+
+        if isCorrect {
+            handleCorrect(isFirstTry: isFirstTry)
+        } else {
+            handleIncorrect()
+        }
+    }
+
+    // MARK: - Private
+
+    private func showCurrentCard() {
+        guard currentCardIndex < cards.count else { return }
+        let card = cards[currentCardIndex]
+        logEvent(.sumSprintCardShown, payload: [
+            "card_index": String(currentCardIndex),
+            "fact_key": card.fact.factKey,
+            "sum": String(card.fact.sum)
+        ])
+    }
+
+    private func handleCorrect(isFirstTry: Bool) {
+        let card = cards[currentCardIndex]
+        cards[currentCardIndex].result = .correct(firstTry: isFirstTry)
+
+        currentStreak += 1
+        peakStreak = max(peakStreak, currentStreak)
+
+        logEvent(.sumSprintCardAnswered, payload: [
+            "fact_key": card.fact.factKey,
+            "correct": "true",
+            "first_try": String(isFirstTry),
+            "streak": String(currentStreak)
+        ])
+
+        hapticsService.cardSnapCorrect(enabled: featureFlags.hapticsEnabled)
+
+        // Streak milestone every 3
+        if currentStreak > 0 && currentStreak % 3 == 0 {
+            hapticsService.bondMatchComplete(enabled: featureFlags.hapticsEnabled)
+            speechService.speak("\(currentStreak) in a row!", enabled: featureFlags.audioEnabled)
+        }
+
+        applyLeitnerUpdate(factKey: card.fact.factKey, correct: true, firstTry: isFirstTry)
+
+        showCorrectFeedback = true
+        Task { @MainActor in
+            if feedbackDuration > 0 {
+                try? await Task.sleep(for: .seconds(feedbackDuration))
+            }
+            showCorrectFeedback = false
+            advanceCard()
+        }
+    }
+
+    private func handleIncorrect() {
+        let card = cards[currentCardIndex]
+        let attempts = cards[currentCardIndex].attemptCount
+        cards[currentCardIndex].result = .incorrect(attempts: attempts)
+        cards[currentCardIndex].typedAnswer = ""
+
+        currentStreak = 0
+
+        logEvent(.sumSprintCardAnswered, payload: [
+            "fact_key": card.fact.factKey,
+            "correct": "false",
+            "attempts": String(attempts),
+            "streak": "0"
+        ])
+
+        hapticsService.cardSnapMismatch(enabled: featureFlags.hapticsEnabled)
+        speechService.speak("Try again!", enabled: featureFlags.audioEnabled)
+
+        applyLeitnerUpdate(factKey: card.fact.factKey, correct: false, firstTry: false)
+
+        showIncorrectFeedback = true
+        Task { @MainActor in
+            if feedbackDuration > 0 {
+                try? await Task.sleep(for: .seconds(feedbackDuration * 0.5))
+            }
+            showIncorrectFeedback = false
+        }
+    }
+
+    private func advanceCard() {
+        let nextIndex = currentCardIndex + 1
+        if nextIndex >= cards.count {
+            finishSession()
+        } else {
+            currentCardIndex = nextIndex
+            showCurrentCard()
+        }
+    }
+
+    private func finishSession() {
+        factStore.incrementSessionCounts(excludingKeys: seenFactKeys)
+
+        let summary = SumSprintSessionSummary(
+            sessionId: sessionId,
+            startedAt: sessionStartedAt,
+            endedAt: .now,
+            cards: cards,
+            peakStreak: peakStreak
+        )
+        completedSummary = summary
+        phase = .summary
+
+        logEvent(.sumSprintCompleted, payload: [
+            "session_id": sessionId.uuidString,
+            "cards_completed": String(cards.count),
+            "peak_streak": String(peakStreak),
+            "first_try_accuracy": String(format: "%.2f", summary.firstTryAccuracy)
+        ])
+    }
+
+    // MARK: - Leitner updates
+
+    private func applyLeitnerUpdate(factKey: String, correct: Bool, firstTry: Bool) {
+        factStore.upsert(factKey: factKey) { record in
+            record.lastSeenAt = .now
+            record.sessionsSinceLastSeen = 0
+
+            let currentBox = LeitnerBox(rawValue: record.boxRawValue) ?? .box0
+
+            if correct && firstTry {
+                record.correctStreak += 1
+                switch currentBox {
+                case .box0: record.boxRawValue = LeitnerBox.box1.rawValue
+                case .box1: record.boxRawValue = LeitnerBox.box2.rawValue
+                case .box2: break
+                }
+            } else if !correct {
+                record.correctStreak = 0
+                record.boxRawValue = LeitnerBox.box0.rawValue
+            }
+        }
+    }
+
+    // MARK: - Telemetry
+
+    private func logEvent(_ type: SliceEventType, payload: [String: String]) {
+        try? telemetryWriter.append(
+            SliceEvent(type: type, payload: payload)
+        )
+    }
+}

--- a/Domain/SumSprintGenerator.swift
+++ b/Domain/SumSprintGenerator.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Pure enum — no state. Selects which ArithmeticFacts to practice this session
+/// based on the current Leitner box state stored in StoredFactRecord.
+enum SumSprintGenerator {
+
+    // MARK: - Fact pool
+
+    /// All unique unordered pairs {a, b} where a ≤ b, a ≥ 1, b ≥ 1, a+b in 11…20.
+    /// Generated once; 75 facts total (5+6+6+7+7+8+8+9+9+10 per sum 11→20).
+    static let allFacts: [ArithmeticFact] = {
+        var facts: [ArithmeticFact] = []
+        for sum in 11...20 {
+            let maxA = sum / 2
+            for a in 1...maxA {
+                let b = sum - a
+                guard b >= 1 else { continue }
+                facts.append(ArithmeticFact(id: stableID(a: a, b: b), addendA: a, addendB: b))
+            }
+        }
+        return facts
+    }()
+
+    // MARK: - Session selection
+
+    /// Returns up to 10 ArithmeticFacts ordered by Leitner priority.
+    /// - Parameter allRecords: Current state from FactRecordStore.fetchAll().
+    /// - Parameter sessionCount: Used only in tests to verify determinism; not used in selection logic.
+    static func generateSession(allRecords: [StoredFactRecord]) -> [ArithmeticFact] {
+        let recordByKey = Dictionary(uniqueKeysWithValues: allRecords.map { ($0.factKey, $0) })
+
+        // Partition facts into eligible and ineligible
+        var eligible: [ScoredFact] = []
+        var ineligible: [ScoredFact] = []
+
+        for fact in allFacts {
+            let record = recordByKey[fact.factKey]
+            let box = LeitnerBox(rawValue: record?.boxRawValue ?? 0) ?? .box0
+            let sinceLastSeen = record?.sessionsSinceLastSeen ?? Int.max
+            let attempts = record?.correctStreak ?? 0  // re-use correctStreak as proxy for difficulty
+
+            let scored = ScoredFact(fact: fact, box: box, sinceLastSeen: sinceLastSeen, attempts: attempts)
+
+            if isEligible(box: box, sinceLastSeen: sinceLastSeen) {
+                eligible.append(scored)
+            } else {
+                ineligible.append(scored)
+            }
+        }
+
+        // Sort: box0 first, then box1, then box2; within each box, most attempts first
+        let sorted = eligible.sorted { lhs, rhs in
+            if lhs.box.rawValue != rhs.box.rawValue { return lhs.box.rawValue < rhs.box.rawValue }
+            return lhs.attempts > rhs.attempts
+        }
+
+        var selected = sorted
+
+        // Backfill if fewer than 10 eligible facts
+        if selected.count < 10 {
+            // Prefer box0 ineligible facts for backfill, then others
+            let backfill = ineligible.sorted { lhs, rhs in
+                if lhs.box.rawValue != rhs.box.rawValue { return lhs.box.rawValue < rhs.box.rawValue }
+                return lhs.attempts > rhs.attempts
+            }
+            selected += backfill
+        }
+
+        return Array(selected.prefix(10).map(\.fact))
+    }
+
+    // MARK: - Helpers
+
+    private static func isEligible(box: LeitnerBox, sinceLastSeen: Int) -> Bool {
+        switch box {
+        case .box0: return true
+        case .box1: return sinceLastSeen >= 2
+        case .box2: return sinceLastSeen >= 5
+        }
+    }
+
+    /// Produces a stable deterministic UUID for a given (a, b) pair.
+    /// This is consistent across app launches because it is derived from the fact key string.
+    static func stableID(a: Int, b: Int) -> UUID {
+        let key = "\(a)+\(b)"
+        // Use a simple hash-derived UUID (version 5 style using name bytes)
+        var bytes = [UInt8](repeating: 0, count: 16)
+        let keyBytes = Array(key.utf8)
+        for (i, byte) in keyBytes.enumerated() {
+            bytes[i % 16] ^= byte &+ UInt8(i & 0xFF)
+        }
+        // Set version (4) and variant bits to make it a valid UUID format
+        bytes[6] = (bytes[6] & 0x0F) | 0x40
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+}
+
+// MARK: - Private helpers
+
+private struct ScoredFact {
+    let fact: ArithmeticFact
+    let box: LeitnerBox
+    let sinceLastSeen: Int
+    let attempts: Int
+}

--- a/Domain/SumSprintModels.swift
+++ b/Domain/SumSprintModels.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+// MARK: - ArithmeticFact
+
+/// A single addition fact: addendA + addendB = sum, where sum is in 11…20.
+struct ArithmeticFact: Identifiable, Codable, Hashable {
+    let id: UUID
+    let addendA: Int
+    let addendB: Int
+
+    var sum: Int { addendA + addendB }
+
+    /// Stable string key used as the primary key in StoredFactRecord.
+    var factKey: String { "\(addendA)+\(addendB)" }
+}
+
+// MARK: - LeitnerBox
+
+enum LeitnerBox: Int, Codable, CaseIterable {
+    case box0 = 0   // new / failed — shown every session
+    case box1 = 1   // first correct — shown every 2 sessions
+    case box2 = 2   // mastered — shown every 5 sessions
+}
+
+// MARK: - Card
+
+struct SumSprintCard: Identifiable, Equatable {
+    let id: UUID
+    let fact: ArithmeticFact
+    var typedAnswer: String = ""
+    var result: CardResult = .unanswered
+    var attemptCount: Int = 0
+}
+
+enum CardResult: Equatable {
+    case unanswered
+    case correct(firstTry: Bool)
+    case incorrect(attempts: Int)
+}
+
+// MARK: - Session summary
+
+struct SumSprintSessionSummary: Equatable {
+    let sessionId: UUID
+    let startedAt: Date
+    let endedAt: Date
+    let cards: [SumSprintCard]
+    let peakStreak: Int
+
+    var correctCount: Int {
+        cards.filter {
+            if case .correct = $0.result { return true }
+            return false
+        }.count
+    }
+
+    var firstTryAccuracy: Double {
+        guard !cards.isEmpty else { return 0 }
+        let firstTry = cards.filter {
+            if case .correct(let ft) = $0.result { return ft }
+            return false
+        }.count
+        return Double(firstTry) / Double(cards.count)
+    }
+}
+
+// MARK: - Engine phase
+
+enum SumSprintPhase: Equatable {
+    case idle
+    case session
+    case summary
+}

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -9,6 +9,7 @@ enum AppRoute {
     case parentSummary
     case settings
     case roomQuest
+    case sumSprint
 }
 
 @MainActor
@@ -97,6 +98,7 @@ final class VerticalSliceEngine {
     func showParentSummary() { route = .parentSummary }
     func showSessionConfig() { route = .sessionConfig }
     func showRoomQuest() { route = .roomQuest }
+    func showSumSprint() { route = .sumSprint }
 
     func startSession() {
         // Freeze the active theme from the user's current selection — unless a custom

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -71,6 +71,13 @@ struct SettingsView: View {
         )
     }
 
+    private var sumSprintBinding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.sumSprintEnabled },
+            set: { appModel.featureFlags.sumSprintEnabled = $0 }
+        )
+    }
+
     private func smokeStep(_ text: String) -> some View {
         Label(text, systemImage: "checkmark.circle")
             .font(.subheadline)
@@ -112,6 +119,7 @@ struct SettingsView: View {
                                 subtitle: "Replace the Show-it step with a tilt-powered balance scale activity.",
                                 isOn: gravitySplitBinding
                             )
+                            Toggle("Sum Sprint — sums 11–20", isOn: sumSprintBinding)
                             Toggle("Room Quest (beta)", isOn: roomQuestBinding)
                             if appModel.featureFlags.roomQuestEnabled {
                                 Button("Review Room Quest safety rules") {

--- a/Features/SumSprint/FlashCardView.swift
+++ b/Features/SumSprint/FlashCardView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+struct FlashCardView: View {
+    let card: SumSprintCard
+    let onAppend: (Int) -> Void
+    let onDelete: () -> Void
+    let onSubmit: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        CardSurface {
+            VStack(spacing: 24) {
+                dotClusterRow
+                equationFrame
+                numpad
+            }
+        }
+    }
+
+    // MARK: - Dot clusters (pictorial aid)
+
+    private var dotClusterRow: some View {
+        HStack(spacing: 16) {
+            DotCluster(count: card.fact.addendA, color: MatherTheme.warm)
+            Text("+")
+                .font(.title.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            DotCluster(count: card.fact.addendB, color: MatherTheme.accent)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Equation frame
+
+    private var equationFrame: some View {
+        HStack(spacing: 12) {
+            Text("\(card.fact.addendA)")
+                .font(.system(size: 48, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.warm)
+            Text("+")
+                .font(.system(size: 36, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+            Text("\(card.fact.addendB)")
+                .font(.system(size: 48, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.accent)
+            Text("=")
+                .font(.system(size: 36, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+            answerSlot
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var answerSlot: some View {
+        let isEmpty = card.typedAnswer.isEmpty
+        return Text(isEmpty ? "?" : card.typedAnswer)
+            .font(.system(size: 48, weight: .black, design: .rounded))
+            .foregroundStyle(isEmpty ? MatherTheme.ink.opacity(0.35) : MatherTheme.ink)
+            .frame(minWidth: 64, minHeight: 64)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(MatherTheme.softBlue.opacity(colorScheme == .dark ? 0.32 : 0.22))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(
+                        isEmpty
+                            ? MatherTheme.panelDeep.opacity(0.4)
+                            : MatherTheme.accent.opacity(0.7),
+                        lineWidth: 2
+                    )
+            )
+    }
+
+    // MARK: - Numpad
+
+    private var numpad: some View {
+        let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)
+        return VStack(spacing: 8) {
+            LazyVGrid(columns: columns, spacing: 8) {
+                ForEach(1...9, id: \.self) { digit in
+                    numpadButton(label: "\(digit)") { onAppend(digit) }
+                }
+            }
+            LazyVGrid(columns: columns, spacing: 8) {
+                numpadButton(label: "⌫", color: MatherTheme.danger.opacity(0.18)) { onDelete() }
+                numpadButton(label: "0") { onAppend(0) }
+                numpadButton(label: "✓", color: MatherTheme.accent.opacity(0.85), labelColor: .white) { onSubmit() }
+            }
+        }
+    }
+
+    private func numpadButton(
+        label: String,
+        color: Color = MatherTheme.softBlue.opacity(0.55),
+        labelColor: Color = MatherTheme.ink,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.title3.weight(.bold))
+                .foregroundStyle(labelColor)
+                .frame(maxWidth: .infinity, minHeight: 80)
+                .background(color)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .strokeBorder(
+                            colorScheme == .dark ? .white.opacity(0.08) : .clear,
+                            lineWidth: 1
+                        )
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        }
+        .accessibilityLabel(label)
+    }
+}
+
+// MARK: - DotCluster
+
+private struct DotCluster: View {
+    let count: Int
+    let color: Color
+
+    private let dotsPerRow = 5
+
+    var body: some View {
+        let rows = Int(ceil(Double(count) / Double(dotsPerRow)))
+        VStack(spacing: 4) {
+            ForEach(0..<rows, id: \.self) { row in
+                HStack(spacing: 4) {
+                    let start = row * dotsPerRow
+                    let end = min(start + dotsPerRow, count)
+                    ForEach(start..<end, id: \.self) { _ in
+                        Circle()
+                            .fill(color)
+                            .frame(width: 14, height: 14)
+                    }
+                    // Pad row to 5 dots wide so alignment is consistent
+                    if (end - start) < dotsPerRow && row < rows - 1 {
+                        ForEach(0..<(dotsPerRow - (end - start)), id: \.self) { _ in
+                            Circle()
+                                .fill(Color.clear)
+                                .frame(width: 14, height: 14)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(8)
+        .background(color.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+}

--- a/Features/SumSprint/SumSprintSessionView.swift
+++ b/Features/SumSprint/SumSprintSessionView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+struct SumSprintSessionView: View {
+    @Bindable var appModel: AppModel
+
+    private var engine: SumSprintEngine { appModel.sumSprintEngine }
+
+    var body: some View {
+        ZStack {
+            MatherTheme.background.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                header
+                    .padding(.horizontal, 20)
+                    .padding(.top, 12)
+
+                ScrollView {
+                    VStack(spacing: 20) {
+                        if let card = engine.cards.indices.contains(engine.currentCardIndex)
+                            ? engine.cards[engine.currentCardIndex] : nil {
+                            FlashCardView(
+                                card: card,
+                                onAppend: { engine.appendDigit($0) },
+                                onDelete: { engine.deleteLastDigit() },
+                                onSubmit: { engine.submitAnswer() }
+                            )
+                            .padding(.horizontal, 20)
+                            .transition(.asymmetric(
+                                insertion: .move(edge: .trailing).combined(with: .opacity),
+                                removal: .move(edge: .leading).combined(with: .opacity)
+                            ))
+                            .id(engine.currentCardIndex)
+                        }
+                    }
+                    .padding(.vertical, 16)
+                }
+            }
+
+            // Correct feedback overlay
+            if engine.showCorrectFeedback {
+                feedbackOverlay(correct: true)
+            }
+
+            // Incorrect feedback overlay
+            if engine.showIncorrectFeedback {
+                feedbackOverlay(correct: false)
+            }
+        }
+        .animation(.spring(response: 0.35, dampingFraction: 0.8), value: engine.currentCardIndex)
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(spacing: 8) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(engine.progressLabel)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.ink.opacity(0.6))
+
+                    if engine.currentStreak > 0 {
+                        Text("\(engine.currentStreak) in a row!")
+                            .font(.headline.weight(.black))
+                            .foregroundStyle(MatherTheme.accent)
+                            .transition(.scale.combined(with: .opacity))
+                    }
+                }
+                Spacer()
+                Button {
+                    engine.exitToHome()
+                } label: {
+                    Image(systemName: "house.fill")
+                        .font(.title3)
+                        .foregroundStyle(MatherTheme.ink.opacity(0.55))
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel("Go home")
+            }
+
+            ProgressView(value: Double(engine.currentCardIndex), total: Double(max(engine.cards.count, 1)))
+                .tint(MatherTheme.accent)
+                .frame(maxWidth: .infinity)
+        }
+        .animation(.spring(response: 0.3), value: engine.currentStreak)
+    }
+
+    // MARK: - Feedback overlay
+
+    private func feedbackOverlay(correct: Bool) -> some View {
+        ZStack {
+            Color.black.opacity(0.12).ignoresSafeArea()
+            Text(correct ? "✓" : "✗")
+                .font(.system(size: 80, weight: .black))
+                .foregroundStyle(correct ? MatherTheme.accent : MatherTheme.danger)
+                .transition(.scale.combined(with: .opacity))
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Progress label helper
+
+@MainActor
+private extension SumSprintEngine {
+    var progressLabel: String {
+        guard !cards.isEmpty else { return "" }
+        return "Card \(currentCardIndex + 1) of \(cards.count)"
+    }
+}

--- a/Features/SumSprint/SumSprintSummaryView.swift
+++ b/Features/SumSprint/SumSprintSummaryView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+struct SumSprintSummaryView: View {
+    let summary: SumSprintSessionSummary
+    let onPlayAgain: () -> Void
+    let onDone: () -> Void
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [MatherTheme.warm.opacity(0.25), MatherTheme.accent.opacity(0.18)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: 28) {
+                    Spacer(minLength: 20)
+
+                    celebrationBlock
+
+                    factsPracticedGrid
+
+                    buttonStack
+                }
+                .padding(24)
+            }
+        }
+    }
+
+    // MARK: - Celebration
+
+    private var celebrationBlock: some View {
+        VStack(spacing: 12) {
+            Text(summary.peakStreak >= 5 ? "⭐️" : "🎉")
+                .font(.system(size: 72))
+
+            Text(summary.peakStreak >= 5 ? "Amazing streak!" : "Great practice!")
+                .font(.system(size: 32, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+                .multilineTextAlignment(.center)
+
+            if summary.peakStreak > 0 {
+                Text("\(summary.peakStreak) in a row!")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(MatherTheme.accent)
+            }
+
+            Text("\(summary.correctCount) of \(summary.cards.count) correct")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(MatherTheme.ink.opacity(0.6))
+        }
+    }
+
+    // MARK: - Facts practiced grid
+
+    private var factsPracticedGrid: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Facts practiced")
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(MatherTheme.ink.opacity(0.7))
+
+                let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 2)
+                LazyVGrid(columns: columns, spacing: 8) {
+                    ForEach(summary.cards) { card in
+                        factPill(card: card)
+                    }
+                }
+            }
+        }
+    }
+
+    private func factPill(card: SumSprintCard) -> some View {
+        let wasCorrect: Bool = {
+            if case .correct = card.result { return true }
+            return false
+        }()
+
+        return HStack(spacing: 6) {
+            Text("\(card.fact.addendA) + \(card.fact.addendB) = \(card.fact.sum)")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.ink)
+            Spacer()
+            Image(systemName: wasCorrect ? "checkmark.circle.fill" : "xmark.circle.fill")
+                .foregroundStyle(wasCorrect ? MatherTheme.accent : MatherTheme.danger)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(wasCorrect
+                    ? MatherTheme.accent.opacity(0.1)
+                    : MatherTheme.danger.opacity(0.1))
+        )
+    }
+
+    // MARK: - Buttons
+
+    private var buttonStack: some View {
+        VStack(spacing: 12) {
+            Button("Play again") {
+                onPlayAgain()
+            }
+            .buttonStyle(PrimaryActionButtonStyle())
+
+            Button("Done") {
+                onDone()
+            }
+            .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.55)))
+        }
+    }
+}

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -20,6 +20,14 @@ struct HomeView: View {
                     lockedActivityCard
                 }
 
+                if appModel.featureFlags.sumSprintEnabled {
+                    Button("Sum Sprint") {
+                        appModel.engine.showSumSprint()
+                        appModel.sumSprintEngine.startSession()
+                    }
+                    .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.65)))
+                }
+
                 if appModel.featureFlags.roomQuestEnabled {
                     Button("Start Room Quest") {
                         appModel.engine.showRoomQuest()

--- a/Persistence/FactRecordStore.swift
+++ b/Persistence/FactRecordStore.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Observation
+import SwiftData
+
+@MainActor
+@Observable
+final class FactRecordStore {
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    // MARK: - Fetch
+
+    func fetchAll() -> [StoredFactRecord] {
+        let descriptor = FetchDescriptor<StoredFactRecord>()
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
+    func record(forKey key: String) -> StoredFactRecord? {
+        var descriptor = FetchDescriptor<StoredFactRecord>(
+            predicate: #Predicate { $0.factKey == key }
+        )
+        descriptor.fetchLimit = 1
+        return try? modelContext.fetch(descriptor).first
+    }
+
+    // MARK: - Upsert
+
+    /// Updates an existing record or creates one if it doesn't exist.
+    func upsert(factKey: String, update: (StoredFactRecord) -> Void) {
+        if let existing = record(forKey: factKey) {
+            update(existing)
+        } else {
+            let parts = factKey.split(separator: "+").compactMap { Int($0) }
+            guard parts.count == 2 else { return }
+            let new = StoredFactRecord(factKey: factKey, addendA: parts[0], addendB: parts[1])
+            update(new)
+            modelContext.insert(new)
+        }
+        try? modelContext.save()
+    }
+
+    // MARK: - Session bookkeeping
+
+    /// Called at the end of each session.
+    /// Increments sessionsSinceLastSeen for all records that were NOT seen this session.
+    func incrementSessionCounts(excludingKeys seenKeys: Set<String>) {
+        let all = fetchAll()
+        for record in all where !seenKeys.contains(record.factKey) {
+            record.sessionsSinceLastSeen += 1
+        }
+        try? modelContext.save()
+    }
+}

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -17,6 +17,7 @@ final class FeatureFlagService {
         static let roomQuestSafetyAcknowledged = "feature.roomQuestSafetyAcknowledged"
         static let roomQuestMarkerSetupEnabled = "feature.roomQuestMarkerSetupEnabled"
         static let roomQuestReferenceCaptureEnabled = "feature.roomQuestReferenceCaptureEnabled"
+        static let sumSprintEnabled = "feature.sumSprintEnabled"
     }
 
     var verticalSlice1Enabled: Bool {
@@ -86,6 +87,11 @@ final class FeatureFlagService {
         didSet { defaults.set(roomQuestReferenceCaptureEnabled, forKey: Keys.roomQuestReferenceCaptureEnabled) }
     }
 
+    /// Gates the Sum Sprint fluency activity (sums 11–20). Default false; parent enables in Settings.
+    var sumSprintEnabled: Bool {
+        didSet { defaults.set(sumSprintEnabled, forKey: Keys.sumSprintEnabled) }
+    }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -108,6 +114,7 @@ final class FeatureFlagService {
             Keys.roomQuestSafetyAcknowledged: false,
             Keys.roomQuestMarkerSetupEnabled: true,
             Keys.roomQuestReferenceCaptureEnabled: true,
+            Keys.sumSprintEnabled: false,
         ])
         verticalSlice1Enabled = defaults.bool(forKey: Keys.verticalSlice1Enabled)
         testModeEnabled = defaults.bool(forKey: Keys.testModeEnabled)
@@ -122,5 +129,6 @@ final class FeatureFlagService {
         roomQuestSafetyAcknowledged = defaults.bool(forKey: Keys.roomQuestSafetyAcknowledged)
         roomQuestMarkerSetupEnabled = defaults.bool(forKey: Keys.roomQuestMarkerSetupEnabled)
         roomQuestReferenceCaptureEnabled = defaults.bool(forKey: Keys.roomQuestReferenceCaptureEnabled)
+        sumSprintEnabled = defaults.bool(forKey: Keys.sumSprintEnabled)
     }
 }

--- a/Tests/MatherTests/SumSprintEngineTests.swift
+++ b/Tests/MatherTests/SumSprintEngineTests.swift
@@ -1,0 +1,306 @@
+import Foundation
+import Testing
+import SwiftData
+@testable import Mather
+
+@MainActor
+struct SumSprintEngineTests {
+
+    // MARK: - Helpers
+
+    private func makeEngine(feedbackDuration: TimeInterval = 0) throws -> (SumSprintEngine, FeatureFlagService) {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.sumSprintEnabled = true
+        flags.audioEnabled = false
+        flags.hapticsEnabled = false
+
+        let schema = Schema([StoredFactRecord.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: config)
+        let store = FactRecordStore(modelContext: ModelContext(container))
+
+        let engine = SumSprintEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            factStore: store,
+            feedbackDuration: feedbackDuration
+        )
+        return (engine, flags)
+    }
+
+    // MARK: - Session start
+
+    @Test
+    func startSessionPopulates10Cards() throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+        #expect(engine.cards.count == 10)
+    }
+
+    @Test
+    func startSessionSetsPhaseToSession() throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+        #expect(engine.phase == .session)
+    }
+
+    @Test
+    func startSessionResetsStreak() throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+        #expect(engine.currentStreak == 0)
+        #expect(engine.peakStreak == 0)
+    }
+
+    // MARK: - Digit input
+
+    @Test
+    func appendDigitUpdatesTypedAnswer() throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+        engine.appendDigit(7)
+        #expect(engine.cards[0].typedAnswer == "7")
+    }
+
+    @Test
+    func appendDigitCapsAtTwoDigits() throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+        engine.appendDigit(1)
+        engine.appendDigit(2)
+        engine.appendDigit(3) // should be ignored
+        #expect(engine.cards[0].typedAnswer == "12")
+    }
+
+    @Test
+    func deleteLastDigitRemovesCharacter() throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+        engine.appendDigit(1)
+        engine.appendDigit(5)
+        engine.deleteLastDigit()
+        #expect(engine.cards[0].typedAnswer == "1")
+    }
+
+    @Test
+    func deleteLastDigitOnEmptyAnswerIsNoop() throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+        engine.deleteLastDigit()
+        #expect(engine.cards[0].typedAnswer == "")
+    }
+
+    // MARK: - Submit answer
+
+    @Test
+    func correctAnswerFirstTryAdvancesCardIndex() async throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+        let fact = engine.cards[0].fact
+        let sumStr = String(fact.sum)
+        for ch in sumStr { engine.appendDigit(Int(String(ch))!) }
+        engine.submitAnswer()
+        // Wait for async feedback task to complete (feedbackDuration = 0)
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(engine.currentCardIndex == 1)
+    }
+
+    @Test
+    func incorrectAnswerResetsStreak() async throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+        // Answer first card correctly
+        let fact0 = engine.cards[0].fact
+        for ch in String(fact0.sum) { engine.appendDigit(Int(String(ch))!) }
+        engine.submitAnswer()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(engine.currentStreak == 1)
+
+        // Answer second card incorrectly (enter wrong number)
+        engine.appendDigit(1)
+        engine.submitAnswer()
+        #expect(engine.currentStreak == 0)
+    }
+
+    @Test
+    func consecutiveCorrectFirstTryIncrementsStreak() async throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+
+        for i in 0..<3 {
+            let fact = engine.cards[i].fact
+            for ch in String(fact.sum) { engine.appendDigit(Int(String(ch))!) }
+            engine.submitAnswer()
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        #expect(engine.currentStreak == 3)
+        #expect(engine.peakStreak == 3)
+    }
+
+    @Test
+    func peakStreakRetainsMaxAfterReset() async throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+
+        // Build streak of 3
+        for i in 0..<3 {
+            let fact = engine.cards[i].fact
+            for ch in String(fact.sum) { engine.appendDigit(Int(String(ch))!) }
+            engine.submitAnswer()
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        // Wrong answer on card 4
+        engine.appendDigit(1)
+        engine.submitAnswer()
+
+        #expect(engine.currentStreak == 0)
+        #expect(engine.peakStreak == 3)
+    }
+
+    // MARK: - Leitner box transitions
+
+    @Test
+    func correctFirstTryPromotesBox0ToBox1() async throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+
+        let fact = engine.cards[0].fact
+        for ch in String(fact.sum) { engine.appendDigit(Int(String(ch))!) }
+        engine.submitAnswer()
+        try await Task.sleep(for: .milliseconds(50))
+
+        let record = engine.factStore.record(forKey: fact.factKey)
+        #expect(record != nil)
+        #expect(record?.boxRawValue == LeitnerBox.box1.rawValue)
+    }
+
+    @Test
+    func correctFirstTryPromotesBox1ToBox2() async throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+
+        // Pre-seed the first card's fact in box1
+        let fact = engine.cards[0].fact
+        engine.factStore.upsert(factKey: fact.factKey) { record in
+            record.boxRawValue = LeitnerBox.box1.rawValue
+        }
+
+        for ch in String(fact.sum) { engine.appendDigit(Int(String(ch))!) }
+        engine.submitAnswer()
+        try await Task.sleep(for: .milliseconds(50))
+
+        let record = engine.factStore.record(forKey: fact.factKey)
+        #expect(record?.boxRawValue == LeitnerBox.box2.rawValue)
+    }
+
+    @Test
+    func incorrectAnswerDemotesBox1ToBox0() throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+
+        let fact = engine.cards[0].fact
+        engine.factStore.upsert(factKey: fact.factKey) { record in
+            record.boxRawValue = LeitnerBox.box1.rawValue
+        }
+
+        // Enter wrong answer
+        engine.appendDigit(1)
+        engine.submitAnswer()
+
+        let record = engine.factStore.record(forKey: fact.factKey)
+        #expect(record?.boxRawValue == LeitnerBox.box0.rawValue)
+    }
+
+    @Test
+    func incorrectAnswerDemotesBox2ToBox0() throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+
+        let fact = engine.cards[0].fact
+        engine.factStore.upsert(factKey: fact.factKey) { record in
+            record.boxRawValue = LeitnerBox.box2.rawValue
+        }
+
+        engine.appendDigit(1)
+        engine.submitAnswer()
+
+        let record = engine.factStore.record(forKey: fact.factKey)
+        #expect(record?.boxRawValue == LeitnerBox.box0.rawValue)
+    }
+
+    @Test
+    func incorrectAnswerClearsTypedAnswer() throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+        engine.appendDigit(1)
+        engine.submitAnswer() // wrong (sum is 11–20, entered "1")
+        #expect(engine.cards[0].typedAnswer == "")
+    }
+
+    // MARK: - Session completion
+
+    @Test
+    func allCardsAnsweredTransitionsToSummaryPhase() async throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+
+        for i in 0..<engine.cards.count {
+            let fact = engine.cards[i].fact
+            for ch in String(fact.sum) { engine.appendDigit(Int(String(ch))!) }
+            engine.submitAnswer()
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        #expect(engine.phase == .summary)
+        #expect(engine.completedSummary != nil)
+    }
+
+    @Test
+    func completedSummaryHasCorrectCardCount() async throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+
+        for i in 0..<engine.cards.count {
+            let fact = engine.cards[i].fact
+            for ch in String(fact.sum) { engine.appendDigit(Int(String(ch))!) }
+            engine.submitAnswer()
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        #expect(engine.completedSummary?.cards.count == 10)
+    }
+
+    // MARK: - Navigation
+
+    @Test
+    func exitToHomeCallsCallback() throws {
+        let (engine, _) = try makeEngine()
+        var callbackFired = false
+        engine.onExitToHome = { callbackFired = true }
+        engine.exitToHome()
+        #expect(callbackFired == true)
+        #expect(engine.phase == .idle)
+    }
+
+    // MARK: - Feature flag
+
+    @Test
+    func sumSprintEnabledDefaultsFalse() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        #expect(flags.sumSprintEnabled == false)
+    }
+
+    // MARK: - Cards contain valid sums
+
+    @Test
+    func allCardsHaveSumsIn11To20() throws {
+        let (engine, _) = try makeEngine()
+        engine.startSession()
+        for card in engine.cards {
+            #expect(card.fact.sum >= 11)
+            #expect(card.fact.sum <= 20)
+        }
+    }
+}

--- a/Tests/MatherTests/SumSprintGeneratorTests.swift
+++ b/Tests/MatherTests/SumSprintGeneratorTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+import SwiftData
+@testable import Mather
+
+@MainActor
+struct SumSprintGeneratorTests {
+
+    // MARK: - Helpers
+
+    private func makeStore() throws -> FactRecordStore {
+        let schema = Schema([StoredFactRecord.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: config)
+        return FactRecordStore(modelContext: ModelContext(container))
+    }
+
+    // MARK: - Fact pool
+
+    @Test
+    func factPoolContainsOnly11To20Sums() {
+        let facts = SumSprintGenerator.allFacts
+        for fact in facts {
+            #expect(fact.sum >= 11)
+            #expect(fact.sum <= 20)
+            #expect(fact.addendA >= 1)
+            #expect(fact.addendB >= 1)
+            #expect(fact.addendA <= fact.addendB)
+        }
+    }
+
+    @Test
+    func factPoolHasNoDuplicates() {
+        let keys = SumSprintGenerator.allFacts.map(\.factKey)
+        let unique = Set(keys)
+        #expect(keys.count == unique.count)
+    }
+
+    @Test
+    func stableIDIsConsistentAcrossCalls() {
+        let id1 = SumSprintGenerator.stableID(a: 3, b: 8)
+        let id2 = SumSprintGenerator.stableID(a: 3, b: 8)
+        #expect(id1 == id2)
+    }
+
+    @Test
+    func stableIDDiffersForDifferentFacts() {
+        let id1 = SumSprintGenerator.stableID(a: 3, b: 8)
+        let id2 = SumSprintGenerator.stableID(a: 4, b: 7)
+        #expect(id1 != id2)
+    }
+
+    // MARK: - Session selection
+
+    @Test
+    func generateSessionReturns10FactsWhenNoRecords() throws {
+        let store = try makeStore()
+        let facts = SumSprintGenerator.generateSession(allRecords: store.fetchAll())
+        #expect(facts.count == 10)
+    }
+
+    @Test
+    func generateSessionReturnsSumsIn11To20() throws {
+        let store = try makeStore()
+        let facts = SumSprintGenerator.generateSession(allRecords: store.fetchAll())
+        for fact in facts {
+            #expect(fact.sum >= 11)
+            #expect(fact.sum <= 20)
+        }
+    }
+
+    @Test
+    func generateSessionRespectsBox1IntervalOf2() throws {
+        let store = try makeStore()
+        // Seed all 45 facts in box1 with sessionsSinceLastSeen = 1 (not yet eligible)
+        for fact in SumSprintGenerator.allFacts {
+            store.upsert(factKey: fact.factKey) { record in
+                record.boxRawValue = LeitnerBox.box1.rawValue
+                record.sessionsSinceLastSeen = 1
+            }
+        }
+        let facts = SumSprintGenerator.generateSession(allRecords: store.fetchAll())
+        // All box1 with sinceLastSeen=1 are ineligible — generator backfills from them
+        // but they should come from the ineligible pool (no pure-eligible box1 facts)
+        #expect(facts.count == 10)
+        // Verify none have sinceLastSeen >= 2 (they're all == 1)
+        let records = store.fetchAll()
+        let recordByKey = Dictionary(uniqueKeysWithValues: records.map { ($0.factKey, $0) })
+        for fact in facts {
+            let record = recordByKey[fact.factKey]
+            // They are ineligible (sinceLastSeen == 1 for box1) but selected as backfill
+            let sinceLastSeen = record?.sessionsSinceLastSeen ?? 0
+            #expect(sinceLastSeen < 2)
+        }
+    }
+
+    @Test
+    func generateSessionIncludesBox1WhenIntervalMet() throws {
+        let store = try makeStore()
+        // Seed exactly 10 facts in box1 with sessionsSinceLastSeen = 2 (eligible)
+        let eligibleFacts = Array(SumSprintGenerator.allFacts.prefix(10))
+        for fact in eligibleFacts {
+            store.upsert(factKey: fact.factKey) { record in
+                record.boxRawValue = LeitnerBox.box1.rawValue
+                record.sessionsSinceLastSeen = 2
+            }
+        }
+        // Seed remaining facts in box2 with sinceLastSeen = 1 (ineligible)
+        for fact in SumSprintGenerator.allFacts.dropFirst(10) {
+            store.upsert(factKey: fact.factKey) { record in
+                record.boxRawValue = LeitnerBox.box2.rawValue
+                record.sessionsSinceLastSeen = 1
+            }
+        }
+        let selectedKeys = Set(SumSprintGenerator.generateSession(allRecords: store.fetchAll()).map(\.factKey))
+        let eligibleKeys = Set(eligibleFacts.map(\.factKey))
+        // All selected should be from the eligible box1 facts
+        #expect(selectedKeys == eligibleKeys)
+    }
+
+    @Test
+    func generateSessionRespectsBox2IntervalOf5() throws {
+        let store = try makeStore()
+        // All facts in box2, sinceLastSeen = 4 (not yet eligible)
+        for fact in SumSprintGenerator.allFacts {
+            store.upsert(factKey: fact.factKey) { record in
+                record.boxRawValue = LeitnerBox.box2.rawValue
+                record.sessionsSinceLastSeen = 4
+            }
+        }
+        let facts = SumSprintGenerator.generateSession(allRecords: store.fetchAll())
+        // All are ineligible — backfilled from ineligible pool
+        #expect(facts.count == 10)
+    }
+
+    @Test
+    func generateSessionBackfillsWhenEligiblePoolSmall() throws {
+        let store = try makeStore()
+        // Only 5 facts in box0 (always eligible), rest in box2 with sinceLastSeen = 1
+        let box0Facts = Array(SumSprintGenerator.allFacts.prefix(5))
+        for fact in box0Facts {
+            store.upsert(factKey: fact.factKey) { record in
+                record.boxRawValue = LeitnerBox.box0.rawValue
+            }
+        }
+        for fact in SumSprintGenerator.allFacts.dropFirst(5) {
+            store.upsert(factKey: fact.factKey) { record in
+                record.boxRawValue = LeitnerBox.box2.rawValue
+                record.sessionsSinceLastSeen = 1
+            }
+        }
+        let facts = SumSprintGenerator.generateSession(allRecords: store.fetchAll())
+        // Should still return 10 (5 eligible + 5 backfilled)
+        #expect(facts.count == 10)
+    }
+}

--- a/wiki/Research/Room-Quest-Sensor-Capabilities-and-Design-Direction.md
+++ b/wiki/Research/Room-Quest-Sensor-Capabilities-and-Design-Direction.md
@@ -129,19 +129,41 @@ Why this is the best baseline:
 - enables magical moments without expensive hardware assumptions
 - supports explicit station identity: red station, blue station, number station, shape station
 
+Possible uses:
+- station registration during setup
+- child confirms arrival by scanning a marker
+- marker unlocks next clue, sound, or count challenge
+- marker can encode station type without QR-code ugliness if custom art is used
+
 ### Tier 2: motion + heading + step-like guidance (recommended enhancement)
 
-Use device motion and orientation to create a treasure-hunt feel without claiming exact coordinates.
+Use device motion and orientation to create a “treasure hunt” feel without claiming exact coordinates.
 
 Good uses:
 - warmer/colder cues
 - compass-like turn prompts
-- walk-a-little-farther hints
+- “walk a little farther” hints
+- step-count flavored progress, if reliable enough in testing
 - celebratory motion interactions when station is reached
+
+Bad uses:
+- claiming exact distances in meters indoors
+- claiming exact room coordinates
 
 ### Tier 3: LiDAR-enhanced anchor mode (recommended only for 15 Pro-class hardware)
 
-On LiDAR devices, the app can offer a better setup and stronger AR anchoring.
+On LiDAR devices, the app can offer a better setup and stronger AR anchoring:
+- faster plane understanding
+- more stable anchor placement
+- better persistence of virtual station placement during a session
+- richer “place the portal here” setup flow
+
+But even here, the design should remain **marker-first or anchor-assisted**, not pure free-space coordinate magic.
+
+Why:
+- marker confirmation is still easier for children to understand
+- AR drift still exists
+- camera-up walking is a safety and comfort concern
 
 Recommendation:
 - use LiDAR to improve setup quality and anchor stability, not as the only station identity mechanism
@@ -150,18 +172,96 @@ Recommendation:
 
 ## Recommended product direction
 
+### Core principle
+
 Room Quest should become a **device-guided scavenger experience** with hardware tiers:
 
 - **Baseline on all supported devices**: printed markers + camera recognition + spoken guidance + motion/audio feedback
 - **Enhanced on higher-end hardware**: more stable AR anchoring and richer spatial setup on LiDAR devices
 
+### Honest capability framing
+
 The product should say things like:
-- scan the red station to start
-- find the blue marker
-- the device will guide you
-- listen for hotter/colder clues
+- “Scan the red station to start”
+- “Find the blue marker”
+- “The device will guide you”
+- “Listen for hotter/colder clues”
 
 It should **not** say things like:
-- the device knows your exact room location
-- walk to these coordinates
-- use GPS to find the station indoors
+- “The device knows your exact room location”
+- “Walk to these coordinates”
+- “Use GPS to find the station indoors”
+
+---
+
+## Spec implications
+
+The prior Room Quest draft should be revised in these ways:
+
+1. **Change baseline from fully parent-seeded manual spots to marker-assisted stations**
+   - parent still places stations physically
+   - but the device now participates in station discovery/confirmation
+
+2. **Replace line-of-sight / same-room wording with device-guided setup language**
+   - clearer and more magical
+   - less misleading
+
+3. **Add hardware-tier capability matrix**
+   - iPhone 15 Pro: marker + motion/audio + LiDAR-enhanced setup
+   - iPhone 16e: marker + motion/audio
+   - iPad Air: marker + motion/audio, large-screen scan UX
+
+4. **Explicitly reject GPS-first indoor design**
+   - document why in the spec so it does not re-enter via vague “high precision” language
+
+5. **Define fallback behavior clearly**
+   - if marker tracking fails, child can still tap a large “I found it” confirmation
+   - if motion cues are noisy, spoken prompts remain sufficient
+
+---
+
+## Proposed gameplay architecture
+
+### Baseline loop
+
+1. Parent places physical markers/stations in the room.
+2. Device guides setup by asking parent to scan each station once.
+3. Child gets first clue.
+4. Child finds the station and scans / confirms it.
+5. Device reveals the count or challenge for that station.
+6. Child completes embodied count task.
+7. Device guides to next station.
+8. CPA handoff back to on-screen math.
+
+### Enhanced LiDAR loop
+
+1. Parent places station markers.
+2. Device scans room and stabilizes virtual overlays near markers.
+3. Child follows richer visual/audio guidance.
+4. Marker scan still confirms arrival.
+5. AR effects add delight, not core correctness.
+
+This keeps the system robust: markers handle identity, LiDAR improves feel.
+
+---
+
+## Recommended next spec move
+
+Write a new Room Quest spec that treats the feature as:
+
+**“marker-guided embodied scavenger math with hardware-tier enhancements”**
+
+not:
+- manual parent-only room setup, and not
+- GPS/altitude indoor positioning.
+
+---
+
+## Sources
+
+- Apple iPhone 15 Pro technical specs: https://support.apple.com/en-us/111829
+- Apple iPhone 16e specs / support pages: https://support.apple.com/en-us/122208 and Apple iPhone 16e specs pages
+- Apple iPad Air specs: https://www.apple.com/ipad-air/specs/
+- Apple Nearby Interaction documentation: https://developer.apple.com/documentation/nearbyinteraction
+- Apple ARKit documentation: https://developer.apple.com/documentation/arkit
+- Apple Core Motion altitude docs: https://developer.apple.com/documentation/coremotion/cmaltitudedata

--- a/wiki/Specs/Room-Quest-Sensor-Driven.md
+++ b/wiki/Specs/Room-Quest-Sensor-Driven.md
@@ -2,7 +2,7 @@
 
 **Status**: Draft
 **Date**: 2026-04-11
-**Supersedes direction in**: `Room-Quest-Future-Vertical-Slice.md`
+**Supersedes direction in**: `Room-Quest-Future-Vertical-Slice.md` where the old baseline assumed a mostly manual parent-seeded physical-card flow
 **Research base**:
 - `wiki/Research/Room-Scale-Embodied-Math-Gameplay.md`
 - `wiki/Research/Room-Quest-Sensor-Capabilities-and-Design-Direction.md`
@@ -12,6 +12,12 @@
 ## Overview
 
 Room Quest should be redesigned as a **sensor-driven scavenger mode** that uses the best available device capabilities without pretending to have exact indoor positioning when it does not.
+
+The product goal is:
+- make setup and exploration feel magical and device-guided
+- use higher-precision hardware when available
+- still work well on lower-capability devices
+- stay honest about what is being sensed
 
 This means:
 - **not GPS-first indoor gameplay**
@@ -27,25 +33,38 @@ This means:
 Room Quest is a **device-guided embodied scavenger math mode**.
 
 The child should feel:
-- the device is guiding me to the next station
-- I found the station and unlocked the next clue
-- my movement matters
+- “the device is guiding me to the next station”
+- “I found the station and unlocked the next clue”
+- “my movement matters”
 
 The parent should feel:
-- setup is simple and trustworthy
-- the device is using visible, understandable signals
-- the game still works even if advanced sensors are unavailable
+- “setup is simple and trustworthy”
+- “the device is using visible, understandable signals”
+- “the game still works even if advanced sensors are unavailable”
 
 ---
 
 ## Design principles
 
-1. **Station identity must be explicit**.
-2. **High-precision hardware enhances, but does not redefine, the loop**.
-3. **No fake exactness**.
-4. **The app guides; the child still plays physically**.
-5. **Graceful degradation is a core requirement**.
-6. **Fallbacks are part of the primary design**.
+1. **Station identity must be explicit**
+   - The app should know a station because it scanned a marker or confirmed a target, not because it guessed a room coordinate from noisy sensors.
+
+2. **High-precision hardware enhances, but does not redefine, the loop**
+   - LiDAR improves anchoring and delight on supported devices.
+   - It should not be required for the core experience.
+
+3. **No fake exactness**
+   - Indoors, GPS and altitude are not reliable enough for child-trustworthy exact location claims.
+
+4. **The app guides; the child still plays physically**
+   - Movement should remain central.
+   - The device should support and enrich the movement, not replace it with a pure screen task.
+
+5. **Graceful degradation is a core requirement**
+   - Same activity concept must work across iPhone 15 Pro, iPhone 16e, and iPad Air with capability-aware differences.
+
+6. **Fallbacks are part of the primary design**
+   - Scan failure, motion noise, lighting problems, or parent assist should not collapse the session.
 
 ---
 
@@ -61,6 +80,12 @@ Capabilities used:
 - motion / heading
 - audio / haptics
 
+What this unlocks:
+- faster station registration during setup
+- more stable anchored visual effects
+- richer “portal” / “beacon” station presentation
+- better confidence in placing virtual guidance near a real station
+
 ### Tier B: camera + motion baseline
 **Devices**: iPhone 16e, iPad Air, and any non-LiDAR supported device
 
@@ -70,6 +95,12 @@ Capabilities used:
 - audio / haptics
 - optional ARKit image detection without LiDAR-specific assumptions
 
+What this supports:
+- full marker-guided scavenger mode
+- station scan confirmation
+- motion/audio guidance
+- simpler visual feedback than Tier A
+
 ### Explicit non-goals
 - GPS-first room positioning
 - UWB-dependent station finding
@@ -77,44 +108,362 @@ Capabilities used:
 
 ---
 
+## Capability matrix
+
+| Capability | iPhone 15 Pro | iPhone 16e | iPad Air | Required for baseline? |
+|---|---:|---:|---:|---:|
+| Camera marker detection | Yes | Yes | Yes | Yes |
+| Motion guidance | Yes | Yes | Yes | Yes |
+| Spoken/audio cues | Yes | Yes | Yes | Yes |
+| LiDAR-enhanced anchor stability | Yes | No | No | No |
+| UWB peer ranging | Yes | No | Do not assume | No |
+| GNSS/GPS | Yes | Yes | Cellular only | No |
+| Barometric altitude | Yes | Yes | Yes | No |
+
+---
+
 ## Core interaction model
 
 ### Setup
 1. Parent chooses Room Quest.
-2. App asks parent to place physical station markers in safe locations.
+2. App asks parent to place **physical station markers** in safe locations.
 3. Parent scans each station once with the device.
-4. App confirms station registration and associates each with a role.
-5. App shows a compact ready-to-hunt summary.
+4. App confirms station registration and associates each with a role:
+   - red station
+   - blue station
+   - optional bonus station in future modes
+5. App shows a compact “ready to hunt” summary.
 
 ### Play loop
 1. App gives the child a clue or mission.
 2. Child moves through the room with the device-guided flow.
 3. On arrival, child scans or confirms the station.
-4. App unlocks a count, collection, or grouping challenge.
+4. App unlocks a count / collection / grouping challenge.
 5. Child completes embodied math action.
 6. App guides to the next station.
 7. Session returns to on-screen CPA representation and abstraction.
 
 ---
 
-## MVP gameplay loops
+## Recommended station mechanics
 
-### Loop A: Find and Count
-- simplest embodied baseline
-- validates the station-guided hunt feel
+### Station format
+Each station has:
+- a printable visual marker with strong recognition contrast
+- a child-facing identity, such as color + icon + friendly name
+- enough visual uniqueness to prevent station confusion
 
-### Loop B: Find and Gather
-- stronger CPA continuity
-- maps physical grouping to part-part-whole thinking
+Recommended station identities for MVP:
+- **Red Rocket station**
+- **Blue Bubble station**
 
-### Loop C: Find and Unlock
-- stronger scavenger fantasy
-- unlocks the next clue or mini-challenge through station discovery
+This is better than “station 1 / station 2” because it is easier for 4–6 year olds to remember and easier to voice-prompt.
+
+### Station registration
+During setup:
+- parent places the marker
+- app asks parent to scan it once
+- app stores a station record with:
+  - role
+  - marker identity
+  - optional anchor transform
+  - fallback label
+
+### Station arrival confirmation
+Primary confirmation:
+- camera sees the station marker
+
+Fallback confirmation:
+- large “I found Red Rocket” button
+- optional parent-assist confirmation path
+
+The session must continue even when vision confirmation is flaky.
 
 ---
 
-## Product rule
+## MVP gameplay loops
 
-Sensors must act as **enhancement layers**, not gates to understanding.
+### Loop A: Find and Count
+**Goal**: simplest embodied baseline
 
-The child must be able to complete the core experience without LiDAR, GPS, UWB, or fragile vision-only assumptions.
+1. Child gets clue to find a station.
+2. Child scans/confirms station.
+3. App says how many objects to count or tap at the station.
+4. Child performs the count action.
+5. App transitions to the next clue or back to on-screen representation.
+
+Use when:
+- earliest implementation
+- lowest engineering risk
+- validating the station-guided hunt feel
+
+### Loop B: Find and Gather
+**Goal**: better CPA continuity
+
+1. Child finds Red Rocket station.
+2. Child collects the first group.
+3. Child finds Blue Bubble station.
+4. Child collects the second group.
+5. App returns to on-screen split/equation stage.
+
+Use when:
+- CPA connection to VS1 is the main priority
+- physical grouping should map directly to part-part-whole
+
+### Loop C: Find and Unlock
+**Goal**: stronger scavenger fantasy
+
+1. Child finds station.
+2. Marker scan “unlocks” a challenge card or creature clue.
+3. Child completes a tiny count/grouping interaction.
+4. App reveals the next station.
+
+Use when:
+- delight is more important than shortest loop
+- after Loop A proves robust
+
+### Recommendation
+Implementation order should be:
+1. **Loop A**
+2. **Loop B**
+3. **Loop C**
+
+This keeps first shipping risk low.
+
+---
+
+## Guidance systems
+
+### Required guidance
+- spoken prompts
+- clear station color/identity
+- large arrival confirmation state
+- on-screen fallback if scan is hard
+
+### Preferred guidance
+- warmer/colder audio cue design
+- heading / orientation hints where useful
+- motion-reactive delight feedback
+
+### Optional Tier A guidance
+- anchored AR beacon or creature near the station
+- visual trail or portal effect during setup and confirmation
+
+---
+
+## Sensor policy
+
+### Camera / image detection
+**Use** as the primary station confirmation mechanism.
+
+Use cases:
+- register station during setup
+- confirm arrival during play
+- unlock the next clue or count interaction
+
+### Motion sensors
+**Use** for approximate guidance and delight, not exact localization.
+
+Use cases:
+- turn/heading prompts
+- device-reactive cues
+- rough movement progress
+- celebratory feedback
+
+### LiDAR
+**Use** only as an enhancement on supported hardware.
+
+Use cases:
+- stabilize station anchoring
+- improve setup confidence
+- support richer AR overlays
+
+Do not require LiDAR for correctness.
+
+### GPS / GNSS
+**Do not use** for in-room station positioning.
+
+Allowed use:
+- none for baseline gameplay
+- potentially future outdoor modes only
+
+### Altitude / barometer
+**Do not use** as the primary station-finding mechanic.
+
+Allowed use:
+- optional secondary hinting in future multi-floor research
+- not part of the baseline Room Quest spec
+
+### UWB
+**Do not require** for this version.
+
+Reason:
+- needs peer/accessory ecosystem
+- unavailable on some target devices
+- too much setup complexity for family baseline use
+
+---
+
+## Functional requirements
+
+- [ ] Room Quest works on iPhone 15 Pro, iPhone 16e, and iPad Air with capability-aware behavior.
+- [ ] Parent can register stations by scanning markers during setup.
+- [ ] Child can confirm a station by scanning or using a large fallback confirmation control.
+- [ ] Core scavenger loop works without LiDAR.
+- [ ] LiDAR-capable devices provide enhanced anchoring but not exclusive mechanics.
+- [ ] Gameplay never claims exact indoor coordinates unless the system truly has a trustworthy basis.
+- [ ] The post-room CPA handoff remains clear and pedagogically coherent.
+- [ ] Station identity remains understandable even if camera confirmation temporarily fails.
+
+---
+
+## UX requirements
+
+- [ ] Child language must describe what the device is actually doing.
+- [ ] The app should say “scan the red marker” or “find the blue station”, not imply hidden GPS magic.
+- [ ] Parent setup should stay within a realistic home-use budget.
+- [ ] Failure modes must be soft: if scanning fails, the child can still continue without technical frustration.
+- [ ] Sensor differences across hardware should improve polish, not fracture the game concept.
+- [ ] Station names/icons must be memorable for pre-readers.
+
+---
+
+## Safety requirements
+
+- [ ] No gameplay requires staring through the device while walking fast.
+- [ ] No requirement for exact continuous camera-up navigation.
+- [ ] Parent setup includes safe placement guidance.
+- [ ] Fallback controls exist if camera or motion sensing is awkward in a real home.
+- [ ] The device can be lowered between scan moments; core navigation must not require constant camera framing.
+
+---
+
+## Architecture direction
+
+### New capability layer
+Introduce a Room Quest capability model, for example:
+
+```swift
+struct RoomQuestCapabilities {
+    let supportsMarkerDetection: Bool
+    let supportsMotionGuidance: Bool
+    let supportsLiDAREnhancement: Bool
+    let supportsPrecisePeerRanging: Bool
+}
+```
+
+This allows the engine/view layer to choose the best mode honestly.
+
+### Suggested subsystems
+- `RoomQuestEngine`
+- `RoomQuestStationRegistry`
+- `RoomQuestSensorCoordinator`
+- `RoomQuestSetupView`
+- `RoomQuestHuntView`
+- `RoomQuestMarkerScannerView`
+- `RoomQuestArrivalFallbackView`
+
+### Important separation
+Do not bake device-specific heuristics directly into gameplay copy.
+Gameplay copy should express a stable child experience; capability selection should happen below that layer.
+
+---
+
+## Fallback logic
+
+### If marker scan fails
+- show large “I found the red station” fallback
+- allow parent assist path
+- keep the station visually identifiable by icon/color
+- do not hard-fail the session
+
+### If motion guidance is noisy
+- keep spoken directional prompts simple
+- remove warmer/colder precision language
+- never present movement hints as exact measurements
+
+### If LiDAR is absent
+- use marker-confirmed stations with lighter visual effects
+- preserve the same core loop and success criteria
+
+### If lighting is poor
+- use explicit prompt: “Move closer to the red marker”
+- allow immediate fallback confirmation after a short retry window
+
+---
+
+## Rollout plan
+
+### Phase 1: capability-aware scavenger skeleton
+- marker registration
+- station confirmation
+- spoken prompts
+- fallback confirmation path
+- simplest loop: Find and Count
+
+### Phase 2: CPA-connected embodied math
+- Find and Gather loop
+- explicit handoff back into on-screen split/equation flow
+- telemetry for station success/fallback rate
+
+### Phase 3: delight layer
+- warmer/colder guidance
+- station personality
+- unlock animations
+- optional small AR embellishments on all hardware
+
+### Phase 4: LiDAR enhancement
+- improved station anchoring on iPhone 15 Pro class
+- richer beacon/portal visuals
+- stronger setup flow for spatial continuity
+
+---
+
+## Suggested telemetry
+
+```jsonl
+{"type":"room_quest_started","deviceTier":"A|B","loop":"find_and_count","ts":"..."}
+{"type":"room_station_registered","stationRole":"red","scanSucceeded":true,"ts":"..."}
+{"type":"room_station_found","stationRole":"red","method":"scan|fallback|parent_assist","ts":"..."}
+{"type":"room_guidance_hint_used","hintType":"audio_warmer|turn_prompt|none","ts":"..."}
+{"type":"room_scan_failed","stationRole":"blue","lighting":"unknown","ts":"..."}
+{"type":"room_quest_completed","loop":"find_and_count","usedFallback":true,"ts":"..."}
+```
+
+Important product-learning questions:
+- how often does scan confirmation fail?
+- how often do families need fallback confirmation?
+- does LiDAR meaningfully improve success or just polish?
+
+---
+
+## Open questions
+
+- [ ] Should the child carry the device during the hunt, or should the parent hold it for scan/checkpoint moments?
+- [ ] What marker format balances reliability and kid-friendly aesthetics best?
+- [ ] Is station arrival primarily scan-confirmed, or can some flows support touch-confirmed completion after audio clueing?
+- [ ] How much AR is delightful before it becomes distracting or unsafe?
+- [ ] Should iPad Air be a preferred family setup device because of its screen size, despite weaker high-end sensing than iPhone 15 Pro?
+
+---
+
+## Recommendation
+
+Proceed with the next design stage as:
+
+**Room Quest = marker-guided embodied scavenger math with hardware-tier enhancements**
+
+Specifically:
+- baseline around **camera markers + spoken guidance + motion/audio cues**
+- enhance with **LiDAR-supported anchoring** on iPhone 15 Pro-class hardware
+- explicitly reject **GPS/altitude indoor positioning** as the core mechanic
+- ship against a phased rollout that starts with the simplest stable loop first
+
+---
+
+## References
+- `wiki/Research/Room-Scale-Embodied-Math-Gameplay.md`
+- `wiki/Research/Room-Quest-Sensor-Capabilities-and-Design-Direction.md`
+- Apple Nearby Interaction docs
+- Apple ARKit docs
+- Apple device technical specs for iPhone 15 Pro, iPhone 16e, and iPad Air


### PR DESCRIPTION
## Summary

- Adds **Sum Sprint** — a standalone flashcard activity for addition facts with sums 11–20, targeting Indian 5-year-olds who already count to 100 and need a fluency layer above VS1's ceiling
- **3-box Leitner spaced repetition** surfaces struggling facts every session, promotes correct-first-try facts to longer intervals (box1: every 2 sessions, box2: every 5)
- **Streak mechanic** (not a countdown timer) — "X in a row!" with haptic + speech milestone every 3rd consecutive correct answer; research-safe (no pressure timer)
- **Pictorial aids** — dot clusters (ten-frame layout) alongside the equation frame; child sees `addendA dots + addendB dots = ?` before typing
- Feature-flagged off by default (`sumSprintEnabled = false`); parent enables in Settings

## Architecture

Mirrors the `RoomQuestEngine` pattern exactly — standalone route (`.sumSprint`), standalone engine (`SumSprintEngine`), own SwiftData model (`StoredFactRecord`), `onExitToHome` callback back to `VerticalSliceEngine`. Zero changes to VS1 CPA flow.

## New files

| File | Purpose |
|---|---|
| `Domain/SumSprintModels.swift` | `ArithmeticFact`, `LeitnerBox`, `SumSprintCard`, `SumSprintSessionSummary` |
| `Domain/SumSprintGenerator.swift` | Pure fact-selection: 75-fact pool, Leitner eligibility, backfill |
| `Domain/SumSprintEngine.swift` | `@MainActor @Observable` session engine + Leitner logic |
| `Persistence/FactRecordStore.swift` | SwiftData store for per-fact SR state |
| `Features/SumSprint/FlashCardView.swift` | Dot clusters + equation frame + numpad (80pt touch targets) |
| `Features/SumSprint/SumSprintSessionView.swift` | Streak badge, progress bar, card transitions |
| `Features/SumSprint/SumSprintSummaryView.swift` | Peak streak celebration, facts-practiced grid |
| `Tests/MatherTests/SumSprintEngineTests.swift` | 20 engine tests |
| `Tests/MatherTests/SumSprintGeneratorTests.swift` | 9 generator/Leitner tests |

## Test plan

- [ ] `xcodegen generate && xcodebuild test` — all 29 new tests pass, existing suite unchanged
- [ ] Enable **Sum Sprint** in Settings → tap **Sum Sprint** on HomeView
- [ ] Complete 10 cards — verify streak counter increments on consecutive correct answers, resets on wrong
- [ ] Answer a card wrong then correctly — verify `typedAnswer` clears after wrong, card advances after correct
- [ ] Complete session → verify summary screen shows peak streak and facts grid
- [ ] Tap **Play again** → new session starts; tap **Done** → returns to HomeView
- [ ] Restart app → confirm SR state persisted (same facts still in their boxes)
- [ ] Disable flag in Settings → Sum Sprint button disappears from HomeView

## Research basis

Closes ganesh47/mather#179

Design decisions validated against `wiki/Research/Math-App-Vision.md`:
- §1.4: Spaced repetition via new game context (not pure recall flashcards)
- §4.1: Streak/personal-best mechanic is valid; countdown timers explicitly avoided
- §2.2: Fluency layer appropriate after conceptual mastery (VS1 establishes the concept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)