### PR TITLE
chore(release): track testflight releases as deployments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,21 @@ on:
     tags:
       - 'v*.*.*'
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    environment: testflight-release
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
## Summary
- attach the release workflow to a GitHub environment so tagged releases show up as Deployments
- align mather with the Greats release workflow pattern
- use a dedicated `testflight-release` environment for release/TestFlight tracking

## Why
GitHub only shows Deployments when a workflow job targets an environment. Mather's release workflow was creating releases but not recording deployment entries, so the Deployments UI stayed empty.

## Test plan
- [ ] push a release tag after merge
- [ ] confirm the Release workflow run is associated with the `testflight-release` environment
- [ ] confirm GitHub shows the deployment in the repo Deployments UI
