### PR TITLE
fix(room-quest): honor saved marker identity during recheck

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -228,7 +228,7 @@ final class RoomQuestEngine {
                 }
 
                 if let savedReference = try? stationStore.reference(for: station.role),
-                   savedReference.referenceCaptureState == .captured,
+                   savedReference.captureState == .captured,
                    let savedMarkerPayload = savedReference.markerPayload,
                    let scannedMarkerPayload = result.markerPayload,
                    savedMarkerPayload != scannedMarkerPayload {

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -227,6 +227,16 @@ final class RoomQuestEngine {
                     return
                 }
 
+                if let savedReference = try? stationStore.reference(for: station.role),
+                   savedReference.referenceCaptureState == .captured,
+                   let savedMarkerPayload = savedReference.markerPayload,
+                   let scannedMarkerPayload = result.markerPayload,
+                   savedMarkerPayload != scannedMarkerPayload {
+                    self.feedbackMessage = "That doesn’t match the saved \(station.role.title) station yet."
+                    self.scanState = .failed(role: station.role, message: self.feedbackMessage)
+                    return
+                }
+
                 self.scanState = .celebrating(role: result.role, usedARCelebration: result.usedARCelebration)
                 self.hapticsService.success(enabled: self.featureFlags.hapticsEnabled)
                 self.speechService.speak("\(result.role.title) found. Collect \(station.quantity).", enabled: self.featureFlags.audioEnabled)

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -219,22 +219,22 @@ final class RoomQuestEngine {
             do {
                 let result = try await scanner.scanMarker(for: station.role)
 
-                if let savedReference = try? stationStore.reference(for: station.role) {
-                    if let expectedRole = savedReference.role,
-                       expectedRole != result.role {
-                        self.feedbackMessage = "That doesn’t match the saved \(station.role.title) station yet."
-                        self.scanState = .failed(role: station.role, message: self.feedbackMessage)
-                        return
-                    }
+                if let savedReference = try? stationStore.reference(for: station.role),
+                   let expectedRole = savedReference.role,
+                   expectedRole != result.role {
+                    self.feedbackMessage = "That doesn’t match the saved \(station.role.title) station yet."
+                    self.scanState = .failed(role: station.role, message: self.feedbackMessage)
+                    return
+                }
 
-                    if savedReference.captureState == .captured,
-                       let expectedPayload = savedReference.markerPayload,
-                       let scannedPayload = result.markerPayload,
-                       expectedPayload != scannedPayload {
-                        self.feedbackMessage = "That marker doesn’t match the saved \(station.role.title) station yet."
-                        self.scanState = .failed(role: station.role, message: self.feedbackMessage)
-                        return
-                    }
+                if let savedReference = try? stationStore.reference(for: station.role),
+                   savedReference.referenceCaptureState == .captured,
+                   let savedMarkerPayload = savedReference.markerPayload,
+                   let scannedMarkerPayload = result.markerPayload,
+                   savedMarkerPayload != scannedMarkerPayload {
+                    self.feedbackMessage = "That doesn’t match the saved \(station.role.title) station yet."
+                    self.scanState = .failed(role: station.role, message: self.feedbackMessage)
+                    return
                 }
 
                 self.scanState = .celebrating(role: result.role, usedARCelebration: result.usedARCelebration)

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -219,22 +219,22 @@ final class RoomQuestEngine {
             do {
                 let result = try await scanner.scanMarker(for: station.role)
 
-                if let savedReference = try? stationStore.reference(for: station.role),
-                   let expectedRole = savedReference.role,
-                   expectedRole != result.role {
-                    self.feedbackMessage = "That doesn’t match the saved \(station.role.title) station yet."
-                    self.scanState = .failed(role: station.role, message: self.feedbackMessage)
-                    return
-                }
+                if let savedReference = try? stationStore.reference(for: station.role) {
+                    if let expectedRole = savedReference.role,
+                       expectedRole != result.role {
+                        self.feedbackMessage = "That doesn’t match the saved \(station.role.title) station yet."
+                        self.scanState = .failed(role: station.role, message: self.feedbackMessage)
+                        return
+                    }
 
-                if let savedReference = try? stationStore.reference(for: station.role),
-                   savedReference.referenceCaptureState == .captured,
-                   let savedMarkerPayload = savedReference.markerPayload,
-                   let scannedMarkerPayload = result.markerPayload,
-                   savedMarkerPayload != scannedMarkerPayload {
-                    self.feedbackMessage = "That doesn’t match the saved \(station.role.title) station yet."
-                    self.scanState = .failed(role: station.role, message: self.feedbackMessage)
-                    return
+                    if savedReference.captureState == .captured,
+                       let expectedPayload = savedReference.markerPayload,
+                       let scannedPayload = result.markerPayload,
+                       expectedPayload != scannedPayload {
+                        self.feedbackMessage = "That marker doesn’t match the saved \(station.role.title) station yet."
+                        self.scanState = .failed(role: station.role, message: self.feedbackMessage)
+                        return
+                    }
                 }
 
                 self.scanState = .celebrating(role: result.role, usedARCelebration: result.usedARCelebration)

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -10,25 +10,17 @@ struct RoomQuestEngineTests {
 
     private func makeEngine(
         safetyAcknowledged: Bool = true,
-        scanner: RoomQuestScanner = NoopRoomQuestScanner(),
-        stationStore: RoomQuestStationStore? = nil,
-        defaultsSuiteName: String = #function
+        scanner: RoomQuestScanner = NoopRoomQuestScanner()
     ) -> RoomQuestEngine {
-        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: defaultsSuiteName)!)
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.roomQuestSafetyAcknowledged = safetyAcknowledged
-        let resolvedStationStore: RoomQuestStationStore
-        if let stationStore {
-            resolvedStationStore = stationStore
-        } else {
-            let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
-            resolvedStationStore = RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
-        }
+        let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
         return RoomQuestEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),
             speechService: SpeechService(),
             scanner: scanner,
-            stationStore: resolvedStationStore
+            stationStore: RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
         )
     }
 
@@ -193,48 +185,27 @@ struct RoomQuestEngineTests {
 
     @Test
     func verifyCurrentSpotRejectsMarkerPayloadThatDoesNotMatchSavedReference() async throws {
-        let setupScanner = FakeRoomQuestScanner { role in
-            RoomQuestMarkerScanResult(
-                role: role,
-                markerPayload: role == .redRocket ? "mather:roomquest:redRocket:v1" : "mather:roomquest:blueBubble:v1",
-                referenceImageJPEGData: nil,
-                usedARCelebration: false
-            )
-        }
-        let huntScanner = FakeRoomQuestScanner { role in
-            RoomQuestMarkerScanResult(
-                role: role,
-                markerPayload: role == .redRocket ? "mather:roomquest:redRocket:DIFFERENT" : "mather:roomquest:blueBubble:v1",
-                referenceImageJPEGData: nil,
-                usedARCelebration: false
-            )
-        }
-        let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
-        let sharedStationStore = RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+            let payload = role == .redRocket ? "mather:roomquest:redRocket:v2" : "mather:roomquest:blueBubble:v1"
+            return RoomQuestMarkerScanResult(role: role, markerPayload: payload, referenceImageJPEGData: nil, usedARCelebration: false)
+        })
 
-        let engine = makeEngine(scanner: setupScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".setup")
         engine.startSession()
         engine.verifyStationWithCamera(.redRocket)
         try await Task.sleep(for: .milliseconds(100))
-        engine.confirmStationManually(.blueBubble)
+        engine.verifyStationWithCamera(.blueBubble)
+        try await Task.sleep(for: .milliseconds(100))
         engine.markSetupComplete()
 
-        let recheckingEngine = makeEngine(scanner: huntScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".recheck")
-        recheckingEngine.startSession()
-        recheckingEngine.verifyStationWithCamera(.redRocket)
-        try await Task.sleep(for: .milliseconds(100))
-        recheckingEngine.confirmStationManually(.blueBubble)
-        recheckingEngine.markSetupComplete()
-
-        recheckingEngine.verifyCurrentSpotWithCamera()
+        engine.verifyCurrentSpotWithCamera()
         try await Task.sleep(for: .milliseconds(100))
 
-        #expect(recheckingEngine.phase == .spot(index: 0))
-        if case .failed(let role, let message) = recheckingEngine.scanState {
+        #expect(engine.phase == .spot(index: 0))
+        if case .failed(let role, let message) = engine.scanState {
             #expect(role == .redRocket)
-            #expect(message.localizedCaseInsensitiveContains("saved red rocket station"))
+            #expect(message.localizedCaseInsensitiveContains("doesn’t match the saved"))
         } else {
-            Issue.record("Expected failed scan state after saved-reference payload mismatch")
+            Issue.record("Expected failed scan state after mismatched saved marker payload")
         }
     }
 

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -10,17 +10,25 @@ struct RoomQuestEngineTests {
 
     private func makeEngine(
         safetyAcknowledged: Bool = true,
-        scanner: RoomQuestScanner = NoopRoomQuestScanner()
+        scanner: RoomQuestScanner = NoopRoomQuestScanner(),
+        stationStore: RoomQuestStationStore? = nil,
+        defaultsSuiteName: String = #function
     ) -> RoomQuestEngine {
-        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: defaultsSuiteName)!)
         flags.roomQuestSafetyAcknowledged = safetyAcknowledged
-        let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        let resolvedStationStore: RoomQuestStationStore
+        if let stationStore {
+            resolvedStationStore = stationStore
+        } else {
+            let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+            resolvedStationStore = RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
+        }
         return RoomQuestEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),
             speechService: SpeechService(),
             scanner: scanner,
-            stationStore: RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
+            stationStore: resolvedStationStore
         )
     }
 
@@ -185,27 +193,48 @@ struct RoomQuestEngineTests {
 
     @Test
     func verifyCurrentSpotRejectsMarkerPayloadThatDoesNotMatchSavedReference() async throws {
-        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
-            let payload = role == .redRocket ? "mather:roomquest:redRocket:v2" : "mather:roomquest:blueBubble:v1"
-            return RoomQuestMarkerScanResult(role: role, markerPayload: payload, referenceImageJPEGData: nil, usedARCelebration: false)
-        })
+        let setupScanner = FakeRoomQuestScanner { role in
+            RoomQuestMarkerScanResult(
+                role: role,
+                markerPayload: role == .redRocket ? "mather:roomquest:redRocket:v1" : "mather:roomquest:blueBubble:v1",
+                referenceImageJPEGData: nil,
+                usedARCelebration: false
+            )
+        }
+        let huntScanner = FakeRoomQuestScanner { role in
+            RoomQuestMarkerScanResult(
+                role: role,
+                markerPayload: role == .redRocket ? "mather:roomquest:redRocket:DIFFERENT" : "mather:roomquest:blueBubble:v1",
+                referenceImageJPEGData: nil,
+                usedARCelebration: false
+            )
+        }
+        let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        let sharedStationStore = RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
 
+        let engine = makeEngine(scanner: setupScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".setup")
         engine.startSession()
         engine.verifyStationWithCamera(.redRocket)
         try await Task.sleep(for: .milliseconds(100))
-        engine.verifyStationWithCamera(.blueBubble)
-        try await Task.sleep(for: .milliseconds(100))
+        engine.confirmStationManually(.blueBubble)
         engine.markSetupComplete()
 
-        engine.verifyCurrentSpotWithCamera()
+        let recheckingEngine = makeEngine(scanner: huntScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".recheck")
+        recheckingEngine.startSession()
+        recheckingEngine.verifyStationWithCamera(.redRocket)
+        try await Task.sleep(for: .milliseconds(100))
+        recheckingEngine.confirmStationManually(.blueBubble)
+        recheckingEngine.markSetupComplete()
+
+        recheckingEngine.verifyCurrentSpotWithCamera()
         try await Task.sleep(for: .milliseconds(100))
 
-        #expect(engine.phase == .spot(index: 0))
-        if case .failed(let role, let message) = engine.scanState {
+        #expect(recheckingEngine.phase == .spot(index: 0))
+        if case .failed(let role, let message) = recheckingEngine.scanState {
             #expect(role == .redRocket)
-            #expect(message.localizedCaseInsensitiveContains("doesn’t match the saved"))
+            #expect(message.localizedCaseInsensitiveContains("saved red rocket station"))
         } else {
-            Issue.record("Expected failed scan state after mismatched saved marker payload")
+            Issue.record("Expected failed scan state after saved-reference payload mismatch")
         }
     }
 

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -10,17 +10,25 @@ struct RoomQuestEngineTests {
 
     private func makeEngine(
         safetyAcknowledged: Bool = true,
-        scanner: RoomQuestScanner = NoopRoomQuestScanner()
+        scanner: RoomQuestScanner = NoopRoomQuestScanner(),
+        stationStore: RoomQuestStationStore? = nil,
+        defaultsSuiteName: String = #function
     ) -> RoomQuestEngine {
-        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: defaultsSuiteName)!)
         flags.roomQuestSafetyAcknowledged = safetyAcknowledged
-        let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        let resolvedStationStore: RoomQuestStationStore
+        if let stationStore {
+            resolvedStationStore = stationStore
+        } else {
+            let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+            resolvedStationStore = RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
+        }
         return RoomQuestEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),
             speechService: SpeechService(),
             scanner: scanner,
-            stationStore: RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
+            stationStore: resolvedStationStore
         )
     }
 
@@ -180,6 +188,53 @@ struct RoomQuestEngineTests {
             #expect(message.contains("Blue Bubble"))
         } else {
             Issue.record("Expected failed scan state after wrong-marker hunt scan")
+        }
+    }
+
+    @Test
+    func verifyCurrentSpotRejectsMarkerPayloadThatDoesNotMatchSavedReference() async throws {
+        let setupScanner = FakeRoomQuestScanner { role in
+            RoomQuestMarkerScanResult(
+                role: role,
+                markerPayload: role == .redRocket ? "mather:roomquest:redRocket:v1" : "mather:roomquest:blueBubble:v1",
+                referenceImageJPEGData: nil,
+                usedARCelebration: false
+            )
+        }
+        let huntScanner = FakeRoomQuestScanner { role in
+            RoomQuestMarkerScanResult(
+                role: role,
+                markerPayload: role == .redRocket ? "mather:roomquest:redRocket:DIFFERENT" : "mather:roomquest:blueBubble:v1",
+                referenceImageJPEGData: nil,
+                usedARCelebration: false
+            )
+        }
+        let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+        let sharedStationStore = RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
+
+        let engine = makeEngine(scanner: setupScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".setup")
+        engine.startSession()
+        engine.verifyStationWithCamera(.redRocket)
+        try await Task.sleep(for: .milliseconds(100))
+        engine.confirmStationManually(.blueBubble)
+        engine.markSetupComplete()
+
+        let recheckingEngine = makeEngine(scanner: huntScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".recheck")
+        recheckingEngine.startSession()
+        recheckingEngine.verifyStationWithCamera(.redRocket)
+        try await Task.sleep(for: .milliseconds(100))
+        recheckingEngine.confirmStationManually(.blueBubble)
+        recheckingEngine.markSetupComplete()
+
+        recheckingEngine.verifyCurrentSpotWithCamera()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(recheckingEngine.phase == .spot(index: 0))
+        if case .failed(let role, let message) = recheckingEngine.scanState {
+            #expect(role == .redRocket)
+            #expect(message.localizedCaseInsensitiveContains("saved red rocket station"))
+        } else {
+            Issue.record("Expected failed scan state after saved-reference payload mismatch")
         }
     }
 

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -221,23 +221,8 @@ struct RoomQuestEngineTests {
 
         let recheckingEngine = makeEngine(scanner: huntScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".recheck")
         recheckingEngine.startSession()
-        try sharedStationStore.save(RoomQuestStationReferenceDraft(
-            role: .redRocket,
-            markerPayload: "mather:roomquest:redRocket:v1",
-            capturedAt: .now,
-            note: "Reference saved for Red Rocket",
-            captureState: .captured
-        ))
-        try sharedStationStore.save(RoomQuestStationReferenceDraft(
-            role: .blueBubble,
-            markerPayload: nil,
-            capturedAt: .now,
-            note: "Manual fallback saved",
-            captureState: .manualFallback
-        ))
-        recheckingEngine.verifyStationWithCamera(.redRocket)
-        try await Task.sleep(for: .milliseconds(100))
-        recheckingEngine.confirmStationManually(.blueBubble)
+        recheckingEngine.registerStation(.redRocket)
+        recheckingEngine.registerStation(.blueBubble)
         recheckingEngine.markSetupComplete()
 
         recheckingEngine.verifyCurrentSpotWithCamera()

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -221,6 +221,20 @@ struct RoomQuestEngineTests {
 
         let recheckingEngine = makeEngine(scanner: huntScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".recheck")
         recheckingEngine.startSession()
+        try sharedStationStore.save(RoomQuestStationReferenceDraft(
+            role: .redRocket,
+            markerPayload: "mather:roomquest:redRocket:v1",
+            capturedAt: .now,
+            note: "Reference saved for Red Rocket",
+            captureState: .captured
+        ))
+        try sharedStationStore.save(RoomQuestStationReferenceDraft(
+            role: .blueBubble,
+            markerPayload: nil,
+            capturedAt: .now,
+            note: "Manual fallback saved",
+            captureState: .manualFallback
+        ))
         recheckingEngine.verifyStationWithCamera(.redRocket)
         try await Task.sleep(for: .milliseconds(100))
         recheckingEngine.confirmStationManually(.blueBubble)

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -193,43 +193,39 @@ struct RoomQuestEngineTests {
 
     @Test
     func verifyCurrentSpotRejectsMarkerPayloadThatDoesNotMatchSavedReference() async throws {
-        let setupScanner = FakeRoomQuestScanner { role in
-            RoomQuestMarkerScanResult(
-                role: role,
-                markerPayload: role == .redRocket ? "mather:roomquest:redRocket:v1" : "mather:roomquest:blueBubble:v1",
-                referenceImageJPEGData: nil,
-                usedARCelebration: false
-            )
+        enum ScanPhase {
+            case setup
+            case recheck
         }
-        let huntScanner = FakeRoomQuestScanner { role in
-            RoomQuestMarkerScanResult(
-                role: role,
-                markerPayload: role == .redRocket ? "mather:roomquest:redRocket:DIFFERENT" : "mather:roomquest:blueBubble:v1",
-                referenceImageJPEGData: nil,
-                usedARCelebration: false
-            )
-        }
-        let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
-        let sharedStationStore = RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
 
-        let engine = makeEngine(scanner: setupScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".setup")
+        var scanPhase = ScanPhase.setup
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+            let payload: String
+            switch (scanPhase, role) {
+            case (.setup, .redRocket):
+                payload = "mather:roomquest:redRocket:v1"
+            case (.setup, .blueBubble):
+                payload = "mather:roomquest:blueBubble:v1"
+            case (.recheck, .redRocket):
+                payload = "mather:roomquest:redRocket:DIFFERENT"
+            case (.recheck, .blueBubble):
+                payload = "mather:roomquest:blueBubble:v1"
+            }
+            return RoomQuestMarkerScanResult(role: role, markerPayload: payload, referenceImageJPEGData: nil, usedARCelebration: false)
+        })
+
         engine.startSession()
         engine.verifyStationWithCamera(.redRocket)
         try await Task.sleep(for: .milliseconds(100))
         engine.confirmStationManually(.blueBubble)
         engine.markSetupComplete()
 
-        let recheckingEngine = makeEngine(scanner: huntScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".recheck")
-        recheckingEngine.startSession()
-        recheckingEngine.registerStation(.redRocket)
-        recheckingEngine.registerStation(.blueBubble)
-        recheckingEngine.markSetupComplete()
-
-        recheckingEngine.verifyCurrentSpotWithCamera()
+        scanPhase = .recheck
+        engine.verifyCurrentSpotWithCamera()
         try await Task.sleep(for: .milliseconds(100))
 
-        #expect(recheckingEngine.phase == .spot(index: 0))
-        if case .failed(let role, let message) = recheckingEngine.scanState {
+        #expect(engine.phase == .spot(index: 0))
+        if case .failed(let role, let message) = engine.scanState {
             #expect(role == .redRocket)
             #expect(message.localizedCaseInsensitiveContains("saved red rocket station"))
         } else {


### PR DESCRIPTION
## Summary
- make Room Quest recheck honor the saved setup marker identity instead of only rechecking station role
- fail later verification when the scanned marker payload does not match the saved setup payload
- add regression coverage for saved-reference payload mismatch during hunt verification

## Why
TestFlight feedback in #185 reported that the setup capture/comparison path still felt broken or pointless. The root issue was that later verification loaded the saved reference but only compared role, which the scanner was already constrained to. That meant the saved setup capture never meaningfully influenced the unlock decision.

## Test plan
- [ ] `RoomQuestEngineTests.verifyCurrentSpotRejectsMarkerPayloadThatDoesNotMatchSavedReference()`
- [ ] existing Room Quest tests remain green
- [ ] manual device follow-through after merge / release

Closes #185
