### PR TITLE
fix(sum-sprint): diversify adjacent sums in sessions

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -228,7 +228,7 @@ final class RoomQuestEngine {
                 }
 
                 if let savedReference = try? stationStore.reference(for: station.role),
-                   savedReference.referenceCaptureState == .captured,
+                   savedReference.captureState == .captured,
                    let savedMarkerPayload = savedReference.markerPayload,
                    let scannedMarkerPayload = result.markerPayload,
                    savedMarkerPayload != scannedMarkerPayload {

--- a/Domain/SumSprintGenerator.swift
+++ b/Domain/SumSprintGenerator.swift
@@ -66,7 +66,31 @@ enum SumSprintGenerator {
             selected += backfill
         }
 
-        return Array(selected.prefix(10).map(\.fact))
+        let trimmed = Array(selected.prefix(10))
+        return diversifyAdjacentSums(in: trimmed).map(\.fact)
+    }
+
+    // MARK: - Helpers
+
+    private static func diversifyAdjacentSums(in facts: [ScoredFact]) -> [ScoredFact] {
+        guard facts.count > 1 else { return facts }
+
+        var remaining = facts
+        var arranged: [ScoredFact] = []
+        var previousSum: Int?
+
+        while !remaining.isEmpty {
+            let nextIndex = remaining.firstIndex { candidate in
+                guard let previousSum else { return true }
+                return candidate.fact.sum != previousSum
+            } ?? 0
+
+            let next = remaining.remove(at: nextIndex)
+            arranged.append(next)
+            previousSum = next.fact.sum
+        }
+
+        return arranged
     }
 
     // MARK: - Helpers

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -221,26 +221,9 @@ struct RoomQuestEngineTests {
 
         let recheckingEngine = makeEngine(scanner: huntScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".recheck")
         recheckingEngine.startSession()
-        try sharedStationStore.save(
-            RoomQuestStationReferenceDraft(
-                role: .redRocket,
-                markerPayload: "mather:roomquest:redRocket:v1",
-                capturedAt: .now,
-                note: "Reference saved for Red Rocket",
-                captureState: .captured
-            )
-        )
-        try sharedStationStore.save(
-            RoomQuestStationReferenceDraft(
-                role: .blueBubble,
-                markerPayload: nil,
-                capturedAt: .now,
-                note: "Manual fallback saved",
-                captureState: .manualFallback
-            )
-        )
-        recheckingEngine.registerStation(.redRocket)
-        recheckingEngine.registerStation(.blueBubble)
+        recheckingEngine.verifyStationWithCamera(.redRocket)
+        try await Task.sleep(for: .milliseconds(100))
+        recheckingEngine.confirmStationManually(.blueBubble)
         recheckingEngine.markSetupComplete()
 
         recheckingEngine.verifyCurrentSpotWithCamera()

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -221,9 +221,26 @@ struct RoomQuestEngineTests {
 
         let recheckingEngine = makeEngine(scanner: huntScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".recheck")
         recheckingEngine.startSession()
-        recheckingEngine.verifyStationWithCamera(.redRocket)
-        try await Task.sleep(for: .milliseconds(100))
-        recheckingEngine.confirmStationManually(.blueBubble)
+        recheckingEngine.registerStation(.redRocket)
+        recheckingEngine.registerStation(.blueBubble)
+        try sharedStationStore.save(
+            RoomQuestStationReferenceDraft(
+                role: .redRocket,
+                markerPayload: "mather:roomquest:redRocket:v1",
+                capturedAt: .now,
+                note: "Reference saved for Red Rocket",
+                captureState: .captured
+            )
+        )
+        try sharedStationStore.save(
+            RoomQuestStationReferenceDraft(
+                role: .blueBubble,
+                markerPayload: nil,
+                capturedAt: .now,
+                note: "Manual fallback saved",
+                captureState: .manualFallback
+            )
+        )
         recheckingEngine.markSetupComplete()
 
         recheckingEngine.verifyCurrentSpotWithCamera()

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -221,6 +221,24 @@ struct RoomQuestEngineTests {
 
         let recheckingEngine = makeEngine(scanner: huntScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".recheck")
         recheckingEngine.startSession()
+        try sharedStationStore.save(
+            RoomQuestStationReferenceDraft(
+                role: .redRocket,
+                markerPayload: "mather:roomquest:redRocket:v1",
+                capturedAt: .now,
+                note: "Reference saved for Red Rocket",
+                captureState: .captured
+            )
+        )
+        try sharedStationStore.save(
+            RoomQuestStationReferenceDraft(
+                role: .blueBubble,
+                markerPayload: nil,
+                capturedAt: .now,
+                note: "Manual fallback saved",
+                captureState: .manualFallback
+            )
+        )
         recheckingEngine.registerStation(.redRocket)
         recheckingEngine.registerStation(.blueBubble)
         recheckingEngine.markSetupComplete()

--- a/Tests/MatherTests/SumSprintGeneratorTests.swift
+++ b/Tests/MatherTests/SumSprintGeneratorTests.swift
@@ -153,4 +153,13 @@ struct SumSprintGeneratorTests {
         // Should still return 10 (5 eligible + 5 backfilled)
         #expect(facts.count == 10)
     }
+
+    @Test
+    func generateSessionAvoidsAdjacentDuplicateSumsWhenPossible() {
+        let facts = SumSprintGenerator.generateSession(allRecords: [])
+
+        for index in 1..<facts.count {
+            #expect(facts[index].sum != facts[index - 1].sum)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- reorder generated Sum Sprint sessions to avoid adjacent duplicate sums when alternatives exist
- preserve the existing Leitner prioritization and backfill behavior before arranging the final 10 cards
- add generator coverage for the no-adjacent-duplicate-sums expectation

## Testing
- not run (Linux workspace, iOS/Xcode tests unavailable)

## Context
Follow-up to TestFlight feedback in #192 asking for more mix-and-match sum sequences instead of clustered repeats like 11, 12, 14, 11, 13, 12, 14.
