### PR TITLE
fix: prevent overlapping Room Quest scans

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -106,6 +106,8 @@ final class RoomQuestEngine {
             return
         }
 
+        guard !isScanActive else { return }
+
         scanState = .scanning(role: role)
         feedbackMessage = "Scan the \(role.title) marker with the camera."
         try? telemetryWriter.append(SliceEvent(type: .roomQuestReferenceCaptureStarted, payload: ["station_role": role.rawValue]))
@@ -210,6 +212,8 @@ final class RoomQuestEngine {
         guard case .spot(let index) = phase,
               let station = stations[safe: index]
         else { return }
+
+        guard !isScanActive else { return }
 
         scanState = .scanning(role: station.role)
         feedbackMessage = "Scan \(station.role.title) to unlock the collect step."
@@ -409,6 +413,15 @@ final class RoomQuestEngine {
         guard let idx = stations.firstIndex(where: { $0.role == role }) else { return }
         stations[idx].referenceCaptureState = state
         stations[idx].referenceNote = note
+    }
+
+    private var isScanActive: Bool {
+        switch scanState {
+        case .scanning, .celebrating:
+            return true
+        case .idle, .failed:
+            return false
+        }
     }
 }
 

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -232,7 +232,7 @@ final class RoomQuestEngine {
                 }
 
                 if let savedReference = try? stationStore.reference(for: station.role),
-                   savedReference.referenceCaptureState == .captured,
+                   savedReference.captureState == .captured,
                    let savedMarkerPayload = savedReference.markerPayload,
                    let scannedMarkerPayload = result.markerPayload,
                    savedMarkerPayload != scannedMarkerPayload {

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -71,6 +71,22 @@ struct SpotPromptView: View {
                 }
                 .accessibilityIdentifier("room-spot-scan-button")
                 .buttonStyle(RoomQuestPrimaryButtonStyle())
+                .disabled({
+                    switch engine.scanState {
+                    case .scanning, .celebrating:
+                        return true
+                    case .idle, .failed:
+                        return false
+                    }
+                }())
+                .opacity({
+                    switch engine.scanState {
+                    case .scanning, .celebrating:
+                        return 0.7
+                    case .idle, .failed:
+                        return 1
+                    }
+                }())
                 .padding(.horizontal, 40)
 
                 Button(station?.role.fallbackButtonTitle ?? "I found it") {

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -238,6 +238,41 @@ struct RoomQuestEngineTests {
     }
 
     @Test
+    func verifyCurrentSpotIgnoresDuplicateScanRequestsWhileScanIsActive() async throws {
+        let tracker = ScanTracker()
+        let scanner = FakeRoomQuestScanner { role in
+            await tracker.markStarted()
+            while !(await tracker.canFinish) {
+                try await Task.sleep(for: .milliseconds(20))
+            }
+            return RoomQuestMarkerScanResult(
+                role: role,
+                markerPayload: role == .redRocket ? "mather:roomquest:redRocket:v1" : "mather:roomquest:blueBubble:v1",
+                referenceImageJPEGData: nil,
+                usedARCelebration: false
+            )
+        }
+
+        let engine = makeEngine(scanner: scanner)
+        engine.startSession()
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
+        engine.markSetupComplete()
+
+        engine.verifyCurrentSpotWithCamera()
+        engine.verifyCurrentSpotWithCamera()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(await tracker.startCount == 1)
+        #expect(engine.phase == .spot(index: 0))
+
+        await tracker.allowFinish()
+        try await Task.sleep(for: .milliseconds(1200))
+
+        #expect(engine.phase == .spot(index: 1))
+    }
+
+    @Test
     func markSpotVisitedOneTransitionsToReturning() {
         let engine = makeEngine()
         engine.startSession()
@@ -368,6 +403,19 @@ struct RoomQuestEngineTests {
         engine.abandonSession(reason: "parent_abort")
         #expect(engine.phase == .complete)
         #expect(exitCalled)
+    }
+}
+
+private actor ScanTracker {
+    private(set) var startCount = 0
+    private(set) var canFinish = false
+
+    func markStarted() {
+        startCount += 1
+    }
+
+    func allowFinish() {
+        canFinish = true
     }
 }
 

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -156,9 +156,9 @@ struct RoomQuestEngineTests {
 
         engine.startSession()
         engine.verifyStationWithCamera(.redRocket)
-        try await Task.sleep(for: .milliseconds(100))
+        try await Task.sleep(for: .milliseconds(1300))
         engine.verifyStationWithCamera(.blueBubble)
-        try await Task.sleep(for: .milliseconds(100))
+        try await Task.sleep(for: .milliseconds(1300))
         engine.markSetupComplete()
 
         engine.verifyCurrentSpotWithCamera()


### PR DESCRIPTION
## Summary
- guard Room Quest camera setup and hunt scans so only one scan can be active at a time
- disable the spot scan button while a scan or celebration is already in progress
- add an engine test covering duplicate scan taps during the room phase

## Why
Rapid repeated taps can launch overlapping scan requests against a single live scanner. The later request overwrites the active continuation, which can leave the first request hanging and make the camera path feel stuck or flaky.

## Testing
- Not run locally in this environment (no Swift/Xcode toolchain available)