### PR TITLE
feat: add Room Quest same-place recheck feedback

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -106,6 +106,8 @@ final class RoomQuestEngine {
             return
         }
 
+        guard !isScanActive else { return }
+
         scanState = .scanning(role: role)
         feedbackMessage = "Scan the \(role.title) marker with the camera."
         try? telemetryWriter.append(SliceEvent(type: .roomQuestReferenceCaptureStarted, payload: ["station_role": role.rawValue]))
@@ -210,6 +212,8 @@ final class RoomQuestEngine {
         guard case .spot(let index) = phase,
               let station = stations[safe: index]
         else { return }
+
+        guard !isScanActive else { return }
 
         scanState = .scanning(role: station.role)
         feedbackMessage = "Scan \(station.role.title) to unlock the collect step."
@@ -409,6 +413,15 @@ final class RoomQuestEngine {
         guard let idx = stations.firstIndex(where: { $0.role == role }) else { return }
         stations[idx].referenceCaptureState = state
         stations[idx].referenceNote = note
+    }
+
+    private var isScanActive: Bool {
+        switch scanState {
+        case .scanning, .celebrating:
+            return true
+        case .idle, .failed:
+            return false
+        }
     }
 }
 

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -149,7 +149,12 @@ final class RoomQuestEngine {
     }
 
     func registerStation(_ role: RoomQuestStationRole) {
-        confirmStationManually(role)
+        scanState = .idle
+        if let station = stations.first(where: { $0.role == role }), station.referenceCaptureState == .captured {
+            setStationRegistered(role, method: .cameraVerified)
+        } else {
+            confirmStationManually(role)
+        }
     }
 
     private func setStationRegistered(_ role: RoomQuestStationRole, method: RoomQuestStationVerificationMethod) {

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -80,7 +80,7 @@ final class RoomQuestEngine {
             RoomQuestStation(id: .redRocket, role: .redRocket, quantity: p.decompositionA),
             RoomQuestStation(id: .blueBubble, role: .blueBubble, quantity: p.decompositionB)
         ]
-        try? stationStore.clearAll()
+        loadSavedReferenceState()
         setupStartedAt = .now
         phase = featureFlags.roomQuestSafetyAcknowledged ? .setup : .safetyAck
         feedbackMessage = "Set up the stations, then scan each one or mark it ready."
@@ -171,6 +171,38 @@ final class RoomQuestEngine {
         return stations[index]
     }
 
+    var currentSpotReferenceLabel: String {
+        guard let station = currentStation else { return "" }
+
+        switch station.referenceCaptureState {
+        case .captured:
+            return "Saved camera reference ready for \(station.role.title)."
+        case .manualFallback:
+            return "No camera reference was saved for \(station.role.title)."
+        case .notCaptured:
+            return "Reference still needs to be saved for \(station.role.title)."
+        }
+    }
+
+    var currentSpotSearchGuidance: String {
+        guard let station = currentStation else { return "" }
+
+        switch scanState {
+        case .almost(let role, _):
+            return "Almost. Hold still, move a little closer, and point back at the saved \(role.title) place."
+        case .failed(let role, _):
+            return "Try again. Look for the saved \(role.title) place, then ask a grown-up to use fallback if the camera keeps missing it."
+        case .celebrating(let role, _):
+            return "You found the saved \(role.title) place."
+        case .idle, .scanning:
+            if station.referenceCaptureState == .captured {
+                return "Look for the saved \(station.role.title) place, then hold the camera still for a recheck."
+            } else {
+                return "Look for \(station.role.title), then ask a grown-up to use fallback if the camera cannot help yet."
+            }
+        }
+    }
+
     func markSetupComplete() {
         guard let p = problem else { return }
         guard allStationsRegistered else {
@@ -216,7 +248,9 @@ final class RoomQuestEngine {
         guard !isScanActive else { return }
 
         scanState = .scanning(role: station.role)
-        feedbackMessage = "Scan \(station.role.title) to unlock the collect step."
+        feedbackMessage = station.referenceCaptureState == .captured
+            ? "Rechecking the saved \(station.role.title) place."
+            : "Scan \(station.role.title) to unlock the collect step."
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -226,25 +260,26 @@ final class RoomQuestEngine {
                 if let savedReference = try? stationStore.reference(for: station.role),
                    let expectedRole = savedReference.role,
                    expectedRole != result.role {
-                    self.feedbackMessage = "That doesn’t match the saved \(station.role.title) station yet."
+                    self.feedbackMessage = "That is not the saved \(station.role.title) place yet. Try again."
                     self.scanState = .failed(role: station.role, message: self.feedbackMessage)
                     return
                 }
 
                 if let savedReference = try? stationStore.reference(for: station.role),
-                   savedReference.referenceCaptureState == .captured,
+                   savedReference.captureState == .captured,
                    let savedMarkerPayload = savedReference.markerPayload,
                    let scannedMarkerPayload = result.markerPayload,
                    savedMarkerPayload != scannedMarkerPayload {
-                    self.feedbackMessage = "That doesn’t match the saved \(station.role.title) station yet."
-                    self.scanState = .failed(role: station.role, message: self.feedbackMessage)
+                    self.feedbackMessage = "Almost. This looks close, but it is not the saved \(station.role.title) place yet."
+                    self.scanState = .almost(role: station.role, message: self.feedbackMessage)
                     return
                 }
 
+                self.setReferenceState(.captured, for: station.role, note: "Saved camera reference ready for recheck")
                 self.scanState = .celebrating(role: result.role, usedARCelebration: result.usedARCelebration)
                 self.hapticsService.success(enabled: self.featureFlags.hapticsEnabled)
-                self.speechService.speak("\(result.role.title) found. Collect \(station.quantity).", enabled: self.featureFlags.audioEnabled)
-                self.feedbackMessage = "\(result.role.title) unlocked. Collect \(station.quantity) \(station.quantity == 1 ? "token" : "tokens")."
+                self.speechService.speak("You found the saved \(result.role.title) place. Collect \(station.quantity).", enabled: self.featureFlags.audioEnabled)
+                self.feedbackMessage = "Found it. Collect \(station.quantity) \(station.quantity == 1 ? "token" : "tokens")."
                 try? await Task.sleep(for: .seconds(1.0))
                 self.scanState = .idle
                 self.markSpotVisited(index: index)
@@ -255,7 +290,7 @@ final class RoomQuestEngine {
                 case .unavailable:
                     self.feedbackMessage = "Camera scan is unavailable right now. Use fallback if needed."
                 case .wrongMarker(let expected, let detected):
-                    self.feedbackMessage = "That looked like \(detected.title). Scan \(expected.title) to unlock this step."
+                    self.feedbackMessage = "That looked like \(detected.title). Try again at the saved \(expected.title) place."
                 }
                 self.scanState = .failed(role: station.role, message: self.feedbackMessage)
             } catch {
@@ -415,11 +450,19 @@ final class RoomQuestEngine {
         stations[idx].referenceNote = note
     }
 
+    private func loadSavedReferenceState() {
+        for role in RoomQuestStationRole.allCases {
+            guard let savedReference = try? stationStore.reference(for: role),
+                  let captureState = savedReference.captureState else { continue }
+            setReferenceState(captureState, for: role, note: savedReference.note)
+        }
+    }
+
     private var isScanActive: Bool {
         switch scanState {
         case .scanning, .celebrating:
             return true
-        case .idle, .failed:
+        case .idle, .almost, .failed:
             return false
         }
     }

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -220,7 +220,7 @@ struct BondMatchState: Equatable {
 
 // MARK: - Room Quest models
 
-enum RoomQuestStationRole: String, Codable, Equatable {
+enum RoomQuestStationRole: String, Codable, Equatable, CaseIterable {
     case redRocket
     case blueBubble
 
@@ -300,6 +300,7 @@ enum RoomQuestScanState: Equatable {
     case idle
     case scanning(role: RoomQuestStationRole)
     case celebrating(role: RoomQuestStationRole, usedARCelebration: Bool)
+    case almost(role: RoomQuestStationRole, message: String)
     case failed(role: RoomQuestStationRole, message: String)
 }
 

--- a/Features/RoomQuest/RoomSetupView.swift
+++ b/Features/RoomQuest/RoomSetupView.swift
@@ -59,6 +59,11 @@ struct RoomSetupView: View {
                                 .font(.subheadline.weight(.semibold))
                                 .foregroundStyle(MatherTheme.accent)
                                 .accessibilityIdentifier("room-scan-status")
+                        case .almost(_, let message):
+                            Label(message, systemImage: "scope")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(MatherTheme.warm)
+                                .accessibilityIdentifier("room-scan-status")
                         case .failed(_, let message):
                             Label(message, systemImage: "exclamationmark.triangle.fill")
                                 .font(.subheadline.weight(.semibold))
@@ -119,7 +124,7 @@ struct RoomSetupView: View {
                     .clipShape(Capsule())
             }
 
-            if station.verificationMethod == nil && station.referenceCaptureState != .notCaptured {
+            if station.referenceCaptureState != .notCaptured {
                 Text(station.referenceCaptureState.badgeTitle)
                     .font(.caption.weight(.bold))
                     .foregroundStyle(MatherTheme.ink)
@@ -129,7 +134,7 @@ struct RoomSetupView: View {
                     .clipShape(Capsule())
             }
 
-            if let referenceNote = station.referenceNote, station.verificationMethod == nil {
+            if let referenceNote = station.referenceNote {
                 Text(referenceNote)
                     .font(.caption)
                     .foregroundStyle(MatherTheme.cardSubtitle)

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -36,13 +36,13 @@ struct SpotPromptView: View {
                     .font(.system(size: 72))
 
                 if let station {
-                    Text("Scan to find \(station.role.title).")
+                    Text(station.referenceCaptureState == .captured ? "Recheck the saved \(station.role.title) place." : "Scan to find \(station.role.title).")
                         .font(.title3.weight(.bold))
                         .foregroundStyle(.white.opacity(0.92))
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 28)
 
-                    Text("When the marker is recognized, the app unlocks: collect \(station.quantity) \(station.quantity == 1 ? "token" : "tokens").")
+                    Text("When the place matches, collect \(station.quantity) \(station.quantity == 1 ? "token" : "tokens").")
                         .font(.title.weight(.semibold))
                         .foregroundStyle(.white.opacity(0.84))
                 }
@@ -51,10 +51,23 @@ struct SpotPromptView: View {
 
                 CardSurface {
                     VStack(alignment: .leading, spacing: 10) {
+                        Label(engine.currentSpotReferenceLabel, systemImage: station?.referenceCaptureState == .captured ? "photo.badge.checkmark" : "photo")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text(engine.currentSpotSearchGuidance)
+                            .font(.subheadline)
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .padding(.horizontal, 24)
+
+                CardSurface {
+                    VStack(alignment: .leading, spacing: 10) {
                         Label("Need a fallback?", systemImage: "hand.tap.fill")
                             .font(.headline.weight(.semibold))
                             .foregroundStyle(MatherTheme.ink)
-                        Text("Scanning is the main way to unlock progress. If the marker is hard to scan, use the fallback button below.")
+                        Text("Scanning is the main way to unlock progress. If the place is hard to confirm, use the fallback button below.")
                             .font(.subheadline)
                             .foregroundStyle(MatherTheme.cardSubtitle)
                             .fixedSize(horizontal: false, vertical: true)
@@ -67,7 +80,7 @@ struct SpotPromptView: View {
                 Button {
                     engine.verifyCurrentSpotWithCamera()
                 } label: {
-                    Label("Scan to unlock", systemImage: "camera.viewfinder")
+                    Label(station?.referenceCaptureState == .captured ? "Recheck this place" : "Scan to unlock", systemImage: "camera.viewfinder")
                 }
                 .accessibilityIdentifier("room-spot-scan-button")
                 .buttonStyle(RoomQuestPrimaryButtonStyle())
@@ -75,7 +88,7 @@ struct SpotPromptView: View {
                     switch engine.scanState {
                     case .scanning, .celebrating:
                         return true
-                    case .idle, .failed:
+                    case .idle, .almost, .failed:
                         return false
                     }
                 }())
@@ -83,7 +96,7 @@ struct SpotPromptView: View {
                     switch engine.scanState {
                     case .scanning, .celebrating:
                         return 0.7
-                    case .idle, .failed:
+                    case .idle, .almost, .failed:
                         return 1
                     }
                 }())
@@ -130,6 +143,13 @@ struct SpotPromptView: View {
                 Label("\(role.title) unlocked!", systemImage: "sparkles")
                     .font(.headline.weight(.semibold))
                     .foregroundStyle(MatherTheme.accent)
+            }
+            .padding(.horizontal, 24)
+        case .almost(_, let message):
+            CardSurface {
+                Label(message, systemImage: "scope")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.warm)
             }
             .padding(.horizontal, 24)
         case .failed(_, let message):

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -71,6 +71,22 @@ struct SpotPromptView: View {
                 }
                 .accessibilityIdentifier("room-spot-scan-button")
                 .buttonStyle(RoomQuestPrimaryButtonStyle())
+                .disabled({
+                    switch engine.scanState {
+                    case .scanning, .celebrating:
+                        return true
+                    case .idle, .failed:
+                        return false
+                    }
+                }())
+                .opacity({
+                    switch engine.scanState {
+                    case .scanning, .celebrating:
+                        return 0.7
+                    case .idle, .failed:
+                        return 1
+                    }
+                }())
                 .padding(.horizontal, 40)
 
                 Button(station?.role.fallbackButtonTitle ?? "I found it") {

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -215,7 +215,7 @@ struct RoomQuestEngineTests {
         let engine = makeEngine(scanner: setupScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".setup")
         engine.startSession()
         engine.verifyStationWithCamera(.redRocket)
-        try await Task.sleep(for: .milliseconds(100))
+        try await Task.sleep(for: .milliseconds(1300))
         engine.confirmStationManually(.blueBubble)
         engine.markSetupComplete()
 

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -192,7 +192,7 @@ struct RoomQuestEngineTests {
     }
 
     @Test
-    func verifyCurrentSpotRejectsMarkerPayloadThatDoesNotMatchSavedReference() async throws {
+    func verifyCurrentSpotReportsAlmostWhenMarkerPayloadDoesNotMatchSavedReference() async throws {
         let setupScanner = FakeRoomQuestScanner { role in
             RoomQuestMarkerScanResult(
                 role: role,
@@ -229,12 +229,35 @@ struct RoomQuestEngineTests {
         try await Task.sleep(for: .milliseconds(100))
 
         #expect(recheckingEngine.phase == .spot(index: 0))
-        if case .failed(let role, let message) = recheckingEngine.scanState {
+        if case .almost(let role, let message) = recheckingEngine.scanState {
             #expect(role == .redRocket)
-            #expect(message.localizedCaseInsensitiveContains("saved red rocket station"))
+            #expect(message.localizedCaseInsensitiveContains("almost"))
+            #expect(recheckingEngine.currentSpotReferenceLabel.localizedCaseInsensitiveContains("saved camera reference"))
+            #expect(recheckingEngine.currentSpotSearchGuidance.localizedCaseInsensitiveContains("move a little closer"))
         } else {
-            Issue.record("Expected failed scan state after saved-reference payload mismatch")
+            Issue.record("Expected almost scan state after saved-reference payload mismatch")
         }
+    }
+
+    @Test
+    func verifyCurrentSpotUsesSavedReferenceCopyAfterSuccessfulSetupScan() async throws {
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+            RoomQuestMarkerScanResult(
+                role: role,
+                markerPayload: role == .redRocket ? "mather:roomquest:redRocket:v1" : "mather:roomquest:blueBubble:v1",
+                referenceImageJPEGData: nil,
+                usedARCelebration: false
+            )
+        })
+
+        engine.startSession()
+        engine.verifyStationWithCamera(.redRocket)
+        try await Task.sleep(for: .milliseconds(100))
+        engine.confirmStationManually(.blueBubble)
+        engine.markSetupComplete()
+
+        #expect(engine.currentSpotReferenceLabel.localizedCaseInsensitiveContains("saved camera reference"))
+        #expect(engine.currentSpotSearchGuidance.localizedCaseInsensitiveContains("hold the camera still"))
     }
 
     @Test

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -238,6 +238,41 @@ struct RoomQuestEngineTests {
     }
 
     @Test
+    func verifyCurrentSpotIgnoresDuplicateScanRequestsWhileScanIsActive() async throws {
+        let tracker = ScanTracker()
+        let scanner = FakeRoomQuestScanner { role in
+            await tracker.markStarted()
+            while !(await tracker.canFinish) {
+                try await Task.sleep(for: .milliseconds(20))
+            }
+            return RoomQuestMarkerScanResult(
+                role: role,
+                markerPayload: role == .redRocket ? "mather:roomquest:redRocket:v1" : "mather:roomquest:blueBubble:v1",
+                referenceImageJPEGData: nil,
+                usedARCelebration: false
+            )
+        }
+
+        let engine = makeEngine(scanner: scanner)
+        engine.startSession()
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
+        engine.markSetupComplete()
+
+        engine.verifyCurrentSpotWithCamera()
+        engine.verifyCurrentSpotWithCamera()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(await tracker.startCount == 1)
+        #expect(engine.phase == .spot(index: 0))
+
+        await tracker.allowFinish()
+        try await Task.sleep(for: .milliseconds(1200))
+
+        #expect(engine.phase == .spot(index: 1))
+    }
+
+    @Test
     func markSpotVisitedOneTransitionsToReturning() {
         let engine = makeEngine()
         engine.startSession()
@@ -368,6 +403,19 @@ struct RoomQuestEngineTests {
         engine.abandonSession(reason: "parent_abort")
         #expect(engine.phase == .complete)
         #expect(exitCalled)
+    }
+}
+
+private actor ScanTracker {
+    private(set) var startCount = 0
+    private(set) var canFinish = false
+
+    func markStarted() {
+        startCount += 1
+    }
+
+    func allowFinish() {
+        canFinish = true
     }
 }
 

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -219,10 +219,6 @@ struct RoomQuestEngineTests {
         engine.confirmStationManually(.blueBubble)
         engine.markSetupComplete()
 
-        let recheckingEngine = makeEngine(scanner: huntScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".recheck")
-        recheckingEngine.startSession()
-        recheckingEngine.registerStation(.redRocket)
-        recheckingEngine.registerStation(.blueBubble)
         try sharedStationStore.save(
             RoomQuestStationReferenceDraft(
                 role: .redRocket,
@@ -241,6 +237,10 @@ struct RoomQuestEngineTests {
                 captureState: .manualFallback
             )
         )
+        let recheckingEngine = makeEngine(scanner: huntScanner, stationStore: sharedStationStore, defaultsSuiteName: #function + ".recheck")
+        recheckingEngine.startSession()
+        recheckingEngine.registerStation(.redRocket)
+        recheckingEngine.registerStation(.blueBubble)
         recheckingEngine.markSetupComplete()
 
         recheckingEngine.verifyCurrentSpotWithCamera()


### PR DESCRIPTION
## Summary
- surface saved Room Quest reference copy in setup and spot prompts
- add a ternary recheck path so saved-reference mismatches report almost instead of a hard failure
- give the child-facing hunt screen retry guidance based on found, almost, and try-again states

## Testing
- Not run locally in this environment (no Swift/Xcode toolchain available)