### PR TITLE
fix: clarify Room Quest saved-place hunt guidance

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -181,11 +181,28 @@ final class RoomQuestEngine {
 
         switch station.referenceCaptureState {
         case .captured:
-            return "Saved camera reference ready for \(station.role.title)."
+            return "Saved camera place for \(station.role.title)"
         case .manualFallback:
-            return "No camera reference was saved for \(station.role.title)."
+            return "No saved camera place for \(station.role.title)"
         case .notCaptured:
-            return "Reference still needs to be saved for \(station.role.title)."
+            return "Camera place not saved for \(station.role.title)"
+        }
+    }
+
+    var currentSpotStatusTitle: String {
+        guard let station = currentStation else { return "" }
+
+        switch scanState {
+        case .almost:
+            return "Almost there"
+        case .failed:
+            return "Not this place yet"
+        case .celebrating:
+            return "You found it"
+        case .scanning:
+            return "Checking the camera"
+        case .idle:
+            return station.referenceCaptureState == .captured ? "Find the saved place" : "Find \(station.role.title)"
         }
     }
 
@@ -194,12 +211,14 @@ final class RoomQuestEngine {
 
         switch scanState {
         case .almost(let role, _):
-            return "Almost. Hold still, move a little closer, and point back at the saved \(role.title) place."
+            return "Hold still, move a little closer, and point back at the saved \(role.title) place."
         case .failed(let role, _):
-            return "Try again. Look for the saved \(role.title) place, then ask a grown-up to use fallback if the camera keeps missing it."
+            return "Try again at the saved \(role.title) place. Ask a grown-up to use fallback if the camera keeps missing it."
         case .celebrating(let role, _):
-            return "You found the saved \(role.title) place."
-        case .idle, .scanning:
+            return "Now collect from the saved \(role.title) place."
+        case .scanning(let role):
+            return "Keep the camera pointed at \(role.title) until it finishes checking."
+        case .idle:
             if station.referenceCaptureState == .captured {
                 return "Look for the saved \(station.role.title) place, then hold the camera still for a recheck."
             } else {

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -50,24 +50,33 @@ struct SpotPromptView: View {
                 scanStatusCard
 
                 CardSurface {
-                    VStack(alignment: .leading, spacing: 10) {
+                    VStack(alignment: .leading, spacing: 12) {
                         Label(engine.currentSpotReferenceLabel, systemImage: station?.referenceCaptureState == .captured ? "photo.badge.checkmark" : "photo")
                             .font(.headline.weight(.semibold))
                             .foregroundStyle(MatherTheme.ink)
-                        Text(engine.currentSpotSearchGuidance)
-                            .font(.subheadline)
-                            .foregroundStyle(MatherTheme.cardSubtitle)
-                            .fixedSize(horizontal: false, vertical: true)
+                        Divider()
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(engine.currentSpotStatusTitle)
+                                .font(.title3.weight(.black))
+                                .foregroundStyle(MatherTheme.ink)
+                            Text(engine.currentSpotSearchGuidance)
+                                .font(.subheadline)
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
                     }
                 }
                 .padding(.horizontal, 24)
 
                 CardSurface {
                     VStack(alignment: .leading, spacing: 10) {
-                        Label("Need a fallback?", systemImage: "hand.tap.fill")
+                        Label("Grown-up helper", systemImage: "figure.and.child.holdinghands")
                             .font(.headline.weight(.semibold))
                             .foregroundStyle(MatherTheme.ink)
-                        Text("Scanning is the main way to unlock progress. If the place is hard to confirm, use the fallback button below.")
+                        Text("Kid steps: look, point, hold still, then collect.")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text("If the camera keeps missing the place, a grown-up can tap the fallback button below.")
                             .font(.subheadline)
                             .foregroundStyle(MatherTheme.cardSubtitle)
                             .fixedSize(horizontal: false, vertical: true)

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -265,7 +265,8 @@ struct RoomQuestEngineTests {
         if case .almost(let role, let message) = recheckingEngine.scanState {
             #expect(role == .redRocket)
             #expect(message.localizedCaseInsensitiveContains("almost"))
-            #expect(recheckingEngine.currentSpotReferenceLabel.localizedCaseInsensitiveContains("saved camera reference"))
+            #expect(recheckingEngine.currentSpotReferenceLabel.localizedCaseInsensitiveContains("saved camera place"))
+            #expect(recheckingEngine.currentSpotStatusTitle.localizedCaseInsensitiveContains("almost there"))
             #expect(recheckingEngine.currentSpotSearchGuidance.localizedCaseInsensitiveContains("move a little closer"))
         } else {
             Issue.record("Expected almost scan state after saved-reference payload mismatch")
@@ -289,7 +290,8 @@ struct RoomQuestEngineTests {
         engine.confirmStationManually(.blueBubble)
         engine.markSetupComplete()
 
-        #expect(engine.currentSpotReferenceLabel.localizedCaseInsensitiveContains("saved camera reference"))
+        #expect(engine.currentSpotReferenceLabel.localizedCaseInsensitiveContains("saved camera place"))
+        #expect(engine.currentSpotStatusTitle.localizedCaseInsensitiveContains("find the saved place"))
         #expect(engine.currentSpotSearchGuidance.localizedCaseInsensitiveContains("hold the camera still"))
     }
 


### PR DESCRIPTION
## Summary
Tightens the smallest shippable Room Quest hunt UX slice so the saved camera place is more visible, the hunt state reads more clearly, and the child-facing guidance is easier to follow.

## Linked Issues
Refs UX review in `wiki/Research/Room-Quest-Camera-Flow-UX-Review.md`

## Type of Change
- [ ] Research / docs only
- [ ] New feature (behind feature flag)
- [x] New feature (ready to ship)
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] CI / tooling

## Trunk-Based Dev Checklist
- [x] Branch is short-lived (< 2 days from `main`)
- [x] Incomplete features are behind a feature flag
- [x] No merge commits — rebased onto latest `main`
- [ ] CI passes (build + tests)
- [x] New code has tests (or explain why not)
- [x] No new secrets, unsafe workflow permissions, or unpinned automation were introduced

## Testing
- Updated `RoomQuestEngineTests` coverage for the new saved-place/status copy.
- Could not run Xcode tests in this environment because the Apple toolchain (`xcodebuild` / `swift`) is not installed.

## Screenshots / Screen Recording
Not captured in this CLI environment.
