### PR TITLE
feat(settings): add Physics & Geometry toggles section

### DIFF
--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -78,6 +78,27 @@ struct SettingsView: View {
         )
     }
 
+    private var symmetryFoldBinding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.symmetryFoldEnabled },
+            set: { appModel.featureFlags.symmetryFoldEnabled = $0 }
+        )
+    }
+
+    private var rectangleFactoryBinding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.rectangleFactoryEnabled },
+            set: { appModel.featureFlags.rectangleFactoryEnabled = $0 }
+        )
+    }
+
+    private var angleCannonBinding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.angleCannonEnabled },
+            set: { appModel.featureFlags.angleCannonEnabled = $0 }
+        )
+    }
+
     private func smokeStep(_ text: String) -> some View {
         Label(text, systemImage: "checkmark.circle")
             .font(.subheadline)
@@ -130,6 +151,15 @@ struct SettingsView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.leading, 4)
                             }
+
+                            Divider()
+
+                            Text("Physics & Geometry")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(.secondary)
+                            Toggle("Symmetry Fold — ages 5–7", isOn: symmetryFoldBinding)
+                            Toggle("Rectangle Factory — ages 7–9", isOn: rectangleFactoryBinding)
+                            Toggle("Angle Cannon — ages 7–9", isOn: angleCannonBinding)
 
                             Divider()
 


### PR DESCRIPTION
## Summary
- Adds a "Physics & Geometry" subsection to the Activities card in Settings
- Three new toggles: Symmetry Fold (ages 5–7), Rectangle Factory (ages 7–9), Angle Cannon (ages 7–9)
- Follows the same `Binding` wrapper pattern as Sum Sprint and Room Quest toggles
- All flags default to `false` (already in `FeatureFlags.swift`) — no behaviour change until parent enables

## Test plan
- [ ] Open Settings on device — new "Physics & Geometry" section visible below Room Quest
- [ ] Toggle Symmetry Fold on → returns to Home → "Symmetry Fold" button appears
- [ ] Toggle Rectangle Factory on → returns to Home → "Rectangle Factory" button appears
- [ ] Toggle Angle Cannon on → returns to Home → "Angle Cannon" button appears
- [ ] All three off by default on fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)