### PR TITLE
Polish Room Quest setup readiness copy

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -177,13 +177,13 @@ final class RoomQuestEngine {
 
     var missingSetupRequirementsMessage: String {
         let pendingRoles = stations.filter { !$0.isReadyForRoomQuest }.map { $0.role.title }
-        guard !pendingRoles.isEmpty else { return "" }
+        guard !pendingRoles.isEmpty else { return "Both stations are ready for Room Quest." }
 
         if pendingRoles.count == 1 {
-            return "Save a hiding-place reference for \(pendingRoles[0]) before you start."
+            return "Finish setup for \(pendingRoles[0]) before you start."
         }
 
-        return "Save a hiding-place reference for both stations before you start."
+        return "Finish setup for both stations before you start."
     }
 
     var currentStation: RoomQuestStation? {

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -283,8 +283,8 @@ enum RoomQuestStationVerificationMethod: String, Codable, Equatable {
 
     var badgeTitle: String {
         switch self {
-        case .cameraVerified: "Camera verified"
-        case .manualConfirmed: "Confirmed manually"
+        case .cameraVerified: "Marker scanned"
+        case .manualConfirmed: "Fallback used"
         }
     }
 }
@@ -296,9 +296,9 @@ enum RoomQuestReferenceCaptureState: String, Equatable, Codable {
 
     var badgeTitle: String {
         switch self {
-        case .notCaptured: "Reference not saved"
-        case .captured: "Reference saved"
-        case .manualFallback: "Reference skipped"
+        case .notCaptured: "Place check not saved"
+        case .captured: "Place photo saved"
+        case .manualFallback: "Same-place fallback saved"
         }
     }
 }

--- a/Features/RoomQuest/RoomSetupView.swift
+++ b/Features/RoomQuest/RoomSetupView.swift
@@ -12,7 +12,7 @@ struct RoomSetupView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("Set up the room")
                         .font(.largeTitle.weight(.black))
-                    Text("Place the two station markers in one room, then camera-verify each one or use the manual fallback.")
+                    Text("Place both station markers in one room, then finish setup for each station below.")
                         .font(.subheadline)
                         .foregroundStyle(MatherTheme.cardSubtitle)
                 }
@@ -37,21 +37,22 @@ struct RoomSetupView: View {
 
                 CardSurface {
                     VStack(alignment: .leading, spacing: 10) {
-                        Label("Scan-friendly setup", systemImage: "camera.viewfinder")
+                        Label(engine.allStationsRegistered ? "Ready to start" : "Setup progress", systemImage: engine.allStationsRegistered ? "checkmark.seal.fill" : "list.bullet.clipboard")
                             .font(.headline.weight(.semibold))
-                            .foregroundStyle(MatherTheme.softBlue)
-                        Text("Tap Camera verify first. If scanning is awkward, use the manual same-place fallback.")
+                            .foregroundStyle(engine.allStationsRegistered ? MatherTheme.accent : MatherTheme.softBlue)
+                        Text("\(engine.stations.filter(\.isReadyForRoomQuest).count) of \(engine.stations.count) stations ready")
+                            .font(.title3.weight(.bold))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text("Scan each station marker first. If needed, a grown-up can save the same-place fallback instead.")
                             .font(.subheadline)
                             .foregroundStyle(MatherTheme.cardSubtitle)
                         Text("Both stations must stay in the same room as this iPad.")
                             .font(.subheadline)
                             .foregroundStyle(MatherTheme.cardSubtitle)
 
-                        if !engine.missingSetupRequirementsMessage.isEmpty {
-                            Text(engine.missingSetupRequirementsMessage)
-                                .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(MatherTheme.coral)
-                        }
+                        Text(engine.missingSetupRequirementsMessage)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(engine.allStationsRegistered ? MatherTheme.accent : MatherTheme.coral)
 
                         switch engine.scanState {
                         case .idle:
@@ -94,7 +95,7 @@ struct RoomSetupView: View {
                     }
                 }
 
-                Button("Ready — stations are set!") {
+                Button("Ready, start Room Quest!") {
                     engine.markSetupComplete()
                 }
                 .buttonStyle(PrimaryActionButtonStyle())
@@ -109,6 +110,13 @@ struct RoomSetupView: View {
         let colour = station.role == .redRocket ? MatherTheme.warm : MatherTheme.accent
 
         return VStack(spacing: 12) {
+            Text(station.isReadyForRoomQuest ? "Ready to play" : "Needs setup")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(station.isReadyForRoomQuest ? MatherTheme.accent : MatherTheme.coral)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background((station.isReadyForRoomQuest ? MatherTheme.accent : MatherTheme.coral).opacity(0.14))
+                .clipShape(Capsule())
             RoundedRectangle(cornerRadius: 16)
                 .fill(colour)
                 .frame(height: 80)
@@ -151,7 +159,7 @@ struct RoomSetupView: View {
             referencePreview(for: station)
 
             VStack(spacing: 8) {
-                Button(station.verificationMethod == .cameraVerified ? "Camera verified" : "Camera verify") {
+                Button(station.verificationMethod == .cameraVerified ? "Marker scanned" : "Scan station marker") {
                     engine.verifyStationWithCamera(station.role)
                 }
                 .buttonStyle(SecondaryTileButtonStyle(fill: colour.opacity(0.18)))
@@ -159,7 +167,7 @@ struct RoomSetupView: View {
                 .disabled({ if case .scanning = engine.scanState { return true } else { return false } }())
                 .accessibilityIdentifier("room-station-camera-\(station.role.rawValue)")
 
-                Button(station.verificationMethod == .manualConfirmed ? "Manual fallback saved" : "Same-place fallback") {
+                Button(station.verificationMethod == .manualConfirmed ? "Same-place fallback saved" : "Save same-place fallback") {
                     engine.confirmStationManually(station.role)
                 }
                 .buttonStyle(.plain)
@@ -185,7 +193,7 @@ struct RoomSetupView: View {
                 .frame(maxWidth: .infinity)
                 .clipShape(RoundedRectangle(cornerRadius: 14))
                 .overlay(alignment: .bottomLeading) {
-                    Text("Saved preview")
+                    Text("Saved place photo")
                         .font(.caption2.weight(.bold))
                         .foregroundStyle(.white)
                         .padding(.horizontal, 8)
@@ -201,7 +209,7 @@ struct RoomSetupView: View {
                     VStack(spacing: 6) {
                         Image(systemName: station.referenceCaptureState == .captured ? "photo.badge.checkmark" : "checklist")
                             .font(.title3.weight(.semibold))
-                        Text(station.referenceCaptureState == .captured ? "Saved reference" : "Fallback saved")
+                        Text(station.referenceCaptureState == .captured ? "Place photo saved" : "Same-place fallback saved")
                             .font(.caption.weight(.semibold))
                     }
                     .foregroundStyle(MatherTheme.ink)

--- a/Tests/MatherUITests/RoomQuestUITests.swift
+++ b/Tests/MatherUITests/RoomQuestUITests.swift
@@ -50,7 +50,7 @@ final class RoomQuestUITests: XCTestCase {
         // Accept — transitions to Setup
         app.buttons["I understand — let's go"].tap()
         XCTAssertTrue(app.staticTexts["Set up the room"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.buttons["Camera verify"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Scan station marker"].waitForExistence(timeout: 5))
         snapshot(app, "RoomQuest-SetupAfterAck")
     }
 
@@ -111,12 +111,12 @@ final class RoomQuestUITests: XCTestCase {
         app.buttons["Start Room Quest"].tap()
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
 
-        XCTAssertTrue(app.staticTexts["Save a hiding-place reference for both stations before you start."].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Finish setup for both stations before you start."].waitForExistence(timeout: 5))
 
         configureSetupViaManualFallback(app)
 
-        XCTAssertTrue(app.staticTexts["Fallback saved"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.buttons["Ready — stations are set!"].exists)
+        XCTAssertTrue(app.staticTexts["Same-place fallback saved"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Ready, start Room Quest!"].exists)
     }
 
     // MARK: - Pause / Resume
@@ -198,13 +198,13 @@ final class RoomQuestUITests: XCTestCase {
         XCTAssertTrue(redCard.waitForExistence(timeout: 5))
         XCTAssertTrue(blueCard.waitForExistence(timeout: 5))
 
-        redCard.buttons["Camera verify"].tap()
+        redCard.buttons["Scan station marker"].tap()
         XCTAssertTrue(app.staticTexts["room-scan-status"].waitForExistence(timeout: 5))
-        tapWhenHittable(redCard.buttons["Same-place fallback"], in: app, reveal: .up)
+        tapWhenHittable(redCard.buttons["Save same-place fallback"], in: app, reveal: .up)
 
-        blueCard.buttons["Camera verify"].tap()
+        blueCard.buttons["Scan station marker"].tap()
         XCTAssertTrue(app.staticTexts["room-scan-status"].waitForExistence(timeout: 5))
-        tapWhenHittable(blueCard.buttons["Same-place fallback"], in: app, reveal: .up)
+        tapWhenHittable(blueCard.buttons["Save same-place fallback"], in: app, reveal: .up)
     }
 
     private enum RevealDirection {

--- a/Tests/MatherUITests/RoomQuestUITests.swift
+++ b/Tests/MatherUITests/RoomQuestUITests.swift
@@ -66,7 +66,7 @@ final class RoomQuestUITests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["Red Rocket"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.staticTexts["Blue Bubble"].waitForExistence(timeout: 3))
-        XCTAssertTrue(app.staticTexts["Scan-friendly setup"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["Setup progress"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.staticTexts["Safety reminder"].waitForExistence(timeout: 3))
         snapshot(app, "RoomQuest-SetupView")
     }
@@ -188,7 +188,7 @@ final class RoomQuestUITests: XCTestCase {
 
     private func completeSetupViaManualFallback(_ app: XCUIApplication) {
         configureSetupViaManualFallback(app)
-        app.buttons["Ready — stations are set!"].tap()
+        app.buttons["Ready, start Room Quest!"].tap()
     }
 
     private func configureSetupViaManualFallback(_ app: XCUIApplication) {


### PR DESCRIPTION
## Summary\n- add a clearer top-level setup progress/readiness card for Room Quest\n- add explicit per-station readiness badges and align badge copy with the current QR-first flow\n- tighten setup CTA and UI test copy around marker scans vs same-place fallback\n\n## Testing\n- git diff --check\n- UI tests not run in this Linux subagent environment\n