### PR TITLE
ux: delight upgrades for Angle Cannon, Symmetry Fold, Rectangle Factory

### DIFF
--- a/Features/AngleCannon/AngleCannonView.swift
+++ b/Features/AngleCannon/AngleCannonView.swift
@@ -4,10 +4,16 @@ import SwiftUI
 /// learn that the angle determines where a projectile lands, and see
 /// the degree label only AFTER a successful hit.
 ///
+/// UX improvements (v2):
+/// - Auto-calibrate on appear (no tap-to-aim dead zone)
+/// - neutralRoll NOT reset between shots — keeps aim between retries
+/// - Preview arc is bright coral so the aim is unmissable
+/// - "Too high / too low" directional speech on miss
+/// - Three star icons replace the abstract "Hit X of 3" text
+/// - Target rendered as a bouncing star emoji label for delight
+/// - Miss shows a brief directional arrow hinting which way to adjust
+///
 /// Age range: 7–9. CPA level: Concrete/Pictorial → Abstract.
-/// Sensor: neutral-relative roll tilt (backward tilt = higher launch angle).
-/// Three targets in a round (15°, 30°/45°/60°, 75°), randomly ordered.
-/// Hit tolerance is 15° for level 1, 10° for level 2.
 struct AngleCannonView: View {
 
     @Bindable var appModel: AppModel
@@ -15,6 +21,7 @@ struct AngleCannonView: View {
     // MARK: - Local state
 
     @State private var neutralRoll: Double? = nil
+    @State private var calibrating = false          // shows "Hold steady…" banner
     /// Current aim angle in degrees [10, 80]. Snaps to multiples of 15°.
     @State private var currentAngleDeg: Double = 45
     /// Non-nil once FIRE is tapped; freezes the arc on screen.
@@ -23,14 +30,18 @@ struct AngleCannonView: View {
     @State private var targetAngleDeg: Double = 45
     @State private var roundsWon = 0
     @State private var level: Int = 1   // 1 or 2
+    /// Briefly true on FIRE to animate the cannon barrel kick
+    @State private var firePulse = false
 
     // MARK: - Constants
 
     private let snapDeg: Double = 15
     private let maxTiltRadians: Double = .pi / 4
     private let angleRange: ClosedRange<Double> = 10...80
-    /// Available target angles — the arc must make a meaningful shape at each.
     private let targetPool: [Double] = [15, 30, 45, 60, 75]
+    /// Target symbols — rendered at the landing position for delight
+    private let targetSymbols = ["🎈", "⭐️", "🎯", "🍎", "🪁"]
+    @State private var targetSymbol = "🎯"
 
     private var hitTolerance: Double { level == 1 ? 15 : 10 }
 
@@ -45,7 +56,6 @@ struct AngleCannonView: View {
                         .padding(.horizontal, 20)
                         .padding(.top, 14)
 
-                    // Playing field
                     canvasView(size: geo.size)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -53,23 +63,55 @@ struct AngleCannonView: View {
                         .padding(.horizontal, 20)
                         .padding(.bottom, 20)
                 }
+
+                // "Hold steady…" calibration banner
+                if calibrating {
+                    VStack(spacing: 6) {
+                        Text("Hold steady…")
+                            .font(.headline.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text("Setting your aim baseline")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 14)
+                    .background(.ultraThinMaterial,
+                                in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    .transition(.scale.combined(with: .opacity))
+                }
             }
         }
         .onChange(of: appModel.motionService.tiltRoll) { _, roll in
-            guard neutralRoll != nil, firedAngleDeg == nil else { return }
-            let delta = roll - neutralRoll!
-            // Tilt right (positive delta) → higher angle.
+            guard let neutral = neutralRoll, firedAngleDeg == nil else { return }
+            let delta = roll - neutral
             let raw = 45.0 + delta / maxTiltRadians * 35.0
             let clamped = max(angleRange.lowerBound, min(raw, angleRange.upperBound))
-            // Snap to nearest 15°
             currentAngleDeg = (clamped / snapDeg).rounded() * snapDeg
         }
         .onAppear {
             appModel.motionService.startUpdates()
             pickTarget()
+            autoCalibrateNeutral()
         }
         .onDisappear {
             appModel.motionService.stopUpdates()
+        }
+    }
+
+    // MARK: - Auto-calibration
+
+    /// Records neutralRoll after a short delay so the child has time to settle.
+    /// Shows a "Hold steady…" banner during the wait.
+    private func autoCalibrateNeutral() {
+        guard neutralRoll == nil else { return }
+        calibrating = true
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(600))
+            neutralRoll = appModel.motionService.tiltRoll
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
+                calibrating = false
+            }
         }
     }
 
@@ -81,9 +123,23 @@ struct AngleCannonView: View {
                 Text("Angle Cannon")
                     .font(.title2.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
-                Text("Level \(level) · Hit \(roundsWon) of 3")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(MatherTheme.cardSubtitle)
+                HStack(spacing: 6) {
+                    Text("Level \(level)")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                    Text("·")
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                    // Stars progress — fills as rounds are won
+                    HStack(spacing: 3) {
+                        ForEach(0..<3, id: \.self) { i in
+                            Image(systemName: i < roundsWon ? "star.fill" : "star")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(i < roundsWon ? MatherTheme.warm : MatherTheme.ink.opacity(0.25))
+                                .scaleEffect(i < roundsWon ? 1.15 : 1.0)
+                                .animation(.spring(response: 0.3, dampingFraction: 0.6), value: roundsWon)
+                        }
+                    }
+                }
             }
             Spacer()
             Button("Done") {
@@ -118,7 +174,7 @@ struct AngleCannonView: View {
             ground.addLine(to: CGPoint(x: canvasSize.width, y: canvasSize.height * 0.92))
             ctx.stroke(ground, with: .color(MatherTheme.ink.opacity(0.15)), lineWidth: 2)
 
-            // Fired arc (solid amber)
+            // Fired arc — green on hit, warm amber on miss
             if let fired = firedAngleDeg {
                 let firedPts = Self.arcPoints(angleDeg: fired, cannon: cannon, size: canvasSize)
                 if firedPts.count >= 2 {
@@ -127,11 +183,11 @@ struct AngleCannonView: View {
                     for pt in firedPts.dropFirst() { arcPath.addLine(to: pt) }
                     ctx.stroke(arcPath,
                                with: .color(hitTarget ? MatherTheme.accent : MatherTheme.warm),
-                               style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
+                               style: StrokeStyle(lineWidth: 3.5, lineCap: .round, lineJoin: .round))
                 }
             }
 
-            // Preview arc (dotted, current aim)
+            // Live preview arc — bright coral, dashed, prominent
             if firedAngleDeg == nil, neutralRoll != nil {
                 let pts = Self.arcPoints(angleDeg: currentAngleDeg, cannon: cannon, size: canvasSize)
                 if pts.count >= 2 {
@@ -139,105 +195,114 @@ struct AngleCannonView: View {
                     previewPath.move(to: pts[0])
                     for pt in pts.dropFirst() { previewPath.addLine(to: pt) }
                     ctx.stroke(previewPath,
-                               with: .color(MatherTheme.ink.opacity(0.3)),
-                               style: StrokeStyle(lineWidth: 2.5, lineCap: .round,
-                                                  dash: [8, 10]))
+                               with: .color(MatherTheme.coral.opacity(0.75)),
+                               style: StrokeStyle(lineWidth: 3, lineCap: .round,
+                                                  dash: [10, 8]))
                 }
             }
 
-            // Target: outer ring + inner dot
+            // Target ring (drawn in canvas; symbol rendered in overlay)
             ctx.stroke(Circle().path(in: CGRect(
-                x: target.x - 24, y: target.y - 24, width: 48, height: 48
-            )), with: .color(MatherTheme.coral), lineWidth: 3)
-            ctx.fill(Circle().path(in: CGRect(
-                x: target.x - 10, y: target.y - 10, width: 20, height: 20
-            )), with: .color(hitTarget ? MatherTheme.accent : MatherTheme.coral))
+                x: target.x - 28, y: target.y - 28, width: 56, height: 56
+            )), with: .color(hitTarget ? MatherTheme.accent : MatherTheme.coral), lineWidth: 3)
 
-            // Cannon body
+            // Cannon body — scales on firePulse via overlay scaleEffect
             drawCannon(ctx: ctx, at: cannon, angleDeg: firedAngleDeg ?? currentAngleDeg)
-
-            // "Tap to aim" callout when no neutral set
-            if neutralRoll == nil {
-                let calloutRect = CGRect(x: cannon.x + 20, y: cannon.y - 60, width: 160, height: 40)
-                ctx.fill(
-                    RoundedRectangle(cornerRadius: 8).path(in: calloutRect),
-                    with: .color(MatherTheme.warm.opacity(0.15))
-                )
-            }
         }
         .contentShape(Rectangle())
-        .onTapGesture {
-            if neutralRoll == nil {
-                neutralRoll = appModel.motionService.tiltRoll
-            }
-        }
-        .overlay(degreeLabel, alignment: .center)
-        .overlay(tapToAimLabel, alignment: .bottomLeading)
+        .overlay(canvasOverlays)
         .accessibilityIdentifier("angle-cannon-canvas")
     }
 
     @ViewBuilder
-    private var degreeLabel: some View {
-        if hitTarget, let fired = firedAngleDeg {
-            VStack(spacing: 2) {
-                Text("\(Int(fired))°")
-                    .font(.system(size: 52, weight: .black, design: .rounded))
-                    .foregroundStyle(MatherTheme.accent)
-                Text("degrees!")
-                    .font(.title3.weight(.bold))
-                    .foregroundStyle(MatherTheme.accent)
-            }
-            .padding(16)
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-            .transition(.scale(scale: 0.6).combined(with: .opacity))
-        }
-    }
+    private var canvasOverlays: some View {
+        GeometryReader { geo in
+            let canvasSize = geo.size
+            let cannon = cannonOrigin(in: canvasSize)
+            let target = Self.targetPosition(
+                angleDeg: targetAngleDeg,
+                cannon: cannon,
+                canvasSize: canvasSize
+            )
 
-    @ViewBuilder
-    private var tapToAimLabel: some View {
-        if neutralRoll == nil {
-            HStack(spacing: 6) {
-                Image(systemName: "hand.tap.fill")
-                    .foregroundStyle(MatherTheme.coral)
-                Text("Tap to aim")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(MatherTheme.cardSubtitle)
+            // Target symbol (bounces before firing)
+            Text(targetSymbol)
+                .font(.system(size: 30))
+                .position(target)
+                .opacity(hitTarget ? 0 : 1)
+                .scaleEffect(hitTarget ? 2.0 : 1.0)
+                .animation(.spring(response: 0.4, dampingFraction: 0.5), value: hitTarget)
+
+            // Hit celebration burst
+            if hitTarget {
+                Text("💥")
+                    .font(.system(size: 48))
+                    .position(target)
+                    .transition(.scale(scale: 0.3).combined(with: .opacity))
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
-            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-            .padding(.horizontal, 20)
-            .padding(.bottom, 8)
+
+            // Degree label — revealed only on hit (CPA abstract reveal)
+            if hitTarget, let fired = firedAngleDeg {
+                VStack(spacing: 2) {
+                    Text("\(Int(fired))°")
+                        .font(.system(size: 52, weight: .black, design: .rounded))
+                        .foregroundStyle(MatherTheme.accent)
+                    Text("degrees!")
+                        .font(.title3.weight(.bold))
+                        .foregroundStyle(MatherTheme.accent)
+                }
+                .padding(16)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .position(x: canvasSize.width / 2, y: canvasSize.height * 0.35)
+                .transition(.scale(scale: 0.6).combined(with: .opacity))
+            }
+
+            // "Too high / Too low" miss hint
+            if let fired = firedAngleDeg, !hitTarget {
+                let tooHigh = fired > targetAngleDeg
+                HStack(spacing: 6) {
+                    Image(systemName: tooHigh ? "arrow.down.circle.fill" : "arrow.up.circle.fill")
+                        .foregroundStyle(MatherTheme.warm)
+                    Text(tooHigh ? "Too high — tilt less" : "Too low — tilt more")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(MatherTheme.ink)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .position(x: canvasSize.width / 2, y: canvasSize.height * 0.55)
+                .transition(.scale.combined(with: .opacity))
+            }
+
+            // Aim angle readout while aiming (shows during aim, not before)
+            if neutralRoll != nil, firedAngleDeg == nil {
+                Text("\(Int(currentAngleDeg))°")
+                    .font(.system(size: 28, weight: .black, design: .rounded))
+                    .foregroundStyle(MatherTheme.coral)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 10))
+                    .position(x: cannon.x + 80, y: cannon.y - 50)
+                    .animation(.none, value: currentAngleDeg)
+            }
         }
+        .animation(.spring(response: 0.35, dampingFraction: 0.6), value: hitTarget)
+        .animation(.easeOut(duration: 0.25), value: firedAngleDeg != nil)
     }
 
     // MARK: - Controls
 
     private var controlRow: some View {
         HStack {
-            // Current angle indicator (visible while aiming)
-            if neutralRoll != nil && firedAngleDeg == nil {
-                VStack(spacing: 2) {
-                    Text("\(Int(currentAngleDeg))°")
-                        .font(.system(size: 32, weight: .black, design: .rounded))
-                        .foregroundStyle(MatherTheme.ink)
-                    Text("aim angle")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                }
-                .frame(minWidth: 80)
-                .accessibilityIdentifier("angle-cannon-angle-label")
-            }
-
             Spacer()
 
             if hitTarget {
-                Button("Next") {
+                Button("Next →") {
                     advanceRound()
                 }
                 .font(.headline.weight(.black))
                 .foregroundStyle(.white)
-                .frame(minWidth: 120, minHeight: 60)
+                .frame(minWidth: 140, minHeight: 60)
                 .background(MatherTheme.accent, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
                 .accessibilityIdentifier("angle-cannon-next-button")
             } else if firedAngleDeg == nil {
@@ -246,12 +311,14 @@ struct AngleCannonView: View {
                 }
                 .font(.system(size: 22, weight: .black, design: .rounded))
                 .foregroundStyle(.white)
-                .frame(minWidth: 120, minHeight: 60)
+                .frame(minWidth: 140, minHeight: 60)
                 .background(
-                    neutralRoll != nil ? MatherTheme.coral : MatherTheme.coral.opacity(0.4),
+                    neutralRoll != nil ? MatherTheme.coral : MatherTheme.coral.opacity(0.35),
                     in: RoundedRectangle(cornerRadius: 16, style: .continuous)
                 )
                 .disabled(neutralRoll == nil)
+                .scaleEffect(firePulse ? 0.92 : 1.0)
+                .animation(.spring(response: 0.2, dampingFraction: 0.5), value: firePulse)
                 .accessibilityIdentifier("angle-cannon-fire-button")
             } else if !hitTarget {
                 Button("Try Again") {
@@ -259,8 +326,9 @@ struct AngleCannonView: View {
                 }
                 .font(.headline.weight(.semibold))
                 .foregroundStyle(.white)
-                .frame(minWidth: 120, minHeight: 60)
-                .background(MatherTheme.ink.opacity(0.7), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .frame(minWidth: 140, minHeight: 60)
+                .background(MatherTheme.ink.opacity(0.7),
+                            in: RoundedRectangle(cornerRadius: 16, style: .continuous))
                 .accessibilityIdentifier("angle-cannon-retry-button")
             }
         }
@@ -268,8 +336,6 @@ struct AngleCannonView: View {
 
     // MARK: - Physics helpers (static so tests can call them)
 
-    /// Parabolic arc through screen coordinates.
-    /// Cannon at `cannon`; angle above horizontal in degrees.
     nonisolated static func arcPoints(
         angleDeg: Double,
         cannon: CGPoint,
@@ -284,8 +350,6 @@ struct AngleCannonView: View {
         var t = 0.0
         while t <= 2.5 {
             let x = cannon.x + vx * t
-            // Screen y: cannon.y is near bottom, moving up = y decreasing.
-            // vy*t moves up (decreasing screen-y), gravity moves it down (increasing screen-y).
             let y = cannon.y - vy * t + 0.5 * gravity * t * t
             guard x < size.width + 60, y < size.height + 40 else { break }
             pts.append(CGPoint(x: x, y: y))
@@ -294,7 +358,6 @@ struct AngleCannonView: View {
         return pts
     }
 
-    /// Position of the target: on the arc at t=0.8s.
     nonisolated static func targetPosition(
         angleDeg: Double,
         cannon: CGPoint,
@@ -306,13 +369,11 @@ struct AngleCannonView: View {
         let a = angleDeg * .pi / 180
         let x = cannon.x + velocity * cos(a) * t
         let y = cannon.y - (velocity * sin(a) * t - 0.5 * gravity * t * t)
-        // Clamp to visible area
         let cx = max(80, min(x, canvasSize.width - 80))
         let cy = max(60, min(y, canvasSize.height * 0.85))
         return CGPoint(x: cx, y: cy)
     }
 
-    /// True if fired angle is within tolerance of target angle.
     nonisolated static func isHit(firedDeg: Double, targetDeg: Double, toleranceDeg: Double) -> Bool {
         abs(firedDeg - targetDeg) <= toleranceDeg
     }
@@ -325,38 +386,48 @@ struct AngleCannonView: View {
 
     private func drawCannon(ctx: GraphicsContext, at origin: CGPoint, angleDeg: Double) {
         let a = angleDeg * .pi / 180
-        let barrelLen: CGFloat = 56
+        let barrelLen: CGFloat = 64
         let tipX = origin.x + barrelLen * cos(a)
         let tipY = origin.y - barrelLen * sin(a)
 
-        // Barrel
         var barrel = Path()
         barrel.move(to: origin)
         barrel.addLine(to: CGPoint(x: tipX, y: tipY))
         ctx.stroke(barrel,
-                   with: .color(MatherTheme.ink.opacity(0.85)),
-                   style: StrokeStyle(lineWidth: 10, lineCap: .round))
+                   with: .color(MatherTheme.ink.opacity(0.9)),
+                   style: StrokeStyle(lineWidth: 12, lineCap: .round))
 
-        // Wheels (two circles)
-        let wheelR: CGFloat = 14
-        ctx.fill(
-            Circle().path(in: CGRect(x: origin.x - wheelR * 1.4 - wheelR,
-                                     y: origin.y - wheelR / 2,
-                                     width: wheelR * 2, height: wheelR * 2)),
-            with: .color(MatherTheme.ink.opacity(0.7))
-        )
-        ctx.fill(
-            Circle().path(in: CGRect(x: origin.x - wheelR / 2,
-                                     y: origin.y - wheelR / 2,
-                                     width: wheelR * 2, height: wheelR * 2)),
-            with: .color(MatherTheme.ink.opacity(0.7))
-        )
+        // Carriage
+        let wheelR: CGFloat = 16
+        ctx.fill(Circle().path(in: CGRect(x: origin.x - wheelR * 2.2,
+                                          y: origin.y - wheelR * 0.6,
+                                          width: wheelR * 2, height: wheelR * 2)),
+                 with: .color(MatherTheme.ink.opacity(0.7)))
+        ctx.fill(Circle().path(in: CGRect(x: origin.x - wheelR * 0.4,
+                                          y: origin.y - wheelR * 0.6,
+                                          width: wheelR * 2, height: wheelR * 2)),
+                 with: .color(MatherTheme.ink.opacity(0.7)))
+
+        // Muzzle flash ring when firing
+        if firePulse {
+            ctx.stroke(Circle().path(in: CGRect(x: tipX - 14, y: tipY - 14,
+                                                 width: 28, height: 28)),
+                       with: .color(MatherTheme.warm.opacity(0.8)), lineWidth: 3)
+        }
     }
 
     // MARK: - Actions
 
     private func fire() {
         guard neutralRoll != nil else { return }
+
+        // Kick animation
+        firePulse = true
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(150))
+            firePulse = false
+        }
+
         firedAngleDeg = currentAngleDeg
         let hit = Self.isHit(firedDeg: currentAngleDeg, targetDeg: targetAngleDeg,
                              toleranceDeg: hitTolerance)
@@ -364,19 +435,26 @@ struct AngleCannonView: View {
         if hit {
             appModel.hapticsService.balanceLock(enabled: appModel.featureFlags.hapticsEnabled)
             appModel.speechService.speak(
-                "\(Int(currentAngleDeg)) degrees — you hit it!",
+                "\(Int(currentAngleDeg)) degrees — bullseye!",
                 enabled: appModel.featureFlags.audioEnabled
             )
             roundsWon += 1
         } else {
             appModel.hapticsService.failure(enabled: appModel.featureFlags.hapticsEnabled)
+            let tooHigh = currentAngleDeg > targetAngleDeg
+            appModel.speechService.speak(
+                tooHigh ? "Too high — tilt a little less next time!"
+                        : "Too low — tilt a bit more!",
+                enabled: appModel.featureFlags.audioEnabled
+            )
         }
     }
 
+    /// Reset shot state but KEEP neutralRoll so the child doesn't lose calibration.
     private func resetShot() {
         firedAngleDeg = nil
         hitTarget = false
-        neutralRoll = nil   // re-calibrate neutral on next tap
+        // Deliberately NOT resetting neutralRoll — keeps aim baseline between retries.
     }
 
     private func advanceRound() {
@@ -391,13 +469,16 @@ struct AngleCannonView: View {
         }
         resetShot()
         pickTarget()
+        // Re-calibrate neutral for each new target (fresh tilt reference)
+        neutralRoll = nil
+        autoCalibrateNeutral()
     }
 
     private func pickTarget() {
-        // Pick a random target, different from current
         var candidates = targetPool.filter { abs($0 - targetAngleDeg) > 5 }
         if candidates.isEmpty { candidates = targetPool }
         targetAngleDeg = candidates.randomElement() ?? 45
+        targetSymbol = targetSymbols.randomElement() ?? "🎯"
         currentAngleDeg = 45
     }
 }

--- a/Features/RectangleFactory/RectangleFactoryView.swift
+++ b/Features/RectangleFactory/RectangleFactoryView.swift
@@ -5,11 +5,16 @@ import SwiftUI
 // When frameWidth × frameHeight == targetN the rectangle is valid (a factor pair).
 // Collecting all factor pairs for a given N advances to the next N in the sequence.
 // Shake resets the current frame.
+//
+// UX improvements over v1:
+//  • Smart start: frame opens near √N so child makes small adjustments, not big drags.
+//  • Dot-grid thumbnails: found-factors gallery shows mini dot grids, not plain text chips.
+//  • Star progress row in header: one ★ per factor pair, filled in as discovered.
+//  • Wider grid (8 cols for N > 12) so larger factor pairs like 3×8 are reachable.
 
 struct RectangleFactoryView: View {
     @Bindable var appModel: AppModel
 
-    // N progression: mix of composites and primes so child encounters "only one rectangle" moments
     private static let nSequence: [Int] = [4, 6, 9, 12, 7, 11, 16, 18, 13, 24]
 
     @State private var sequenceIndex: Int = 0
@@ -21,10 +26,15 @@ struct RectangleFactoryView: View {
     @State private var lastEquation: String = ""
     @State private var allFoundForN: Bool = false
 
-    // Grid layout constants
+    // MARK: - Grid constants
+
     private let dotSize: CGFloat = 22
     private let dotSpacing: CGFloat = 10
-    private let gridColumns: Int = 6   // dots per row
+
+    /// Wider grid for large N so more factor pairs fit on screen.
+    private var gridColumns: Int { targetN > 12 ? 8 : 6 }
+    /// Maximum frame dimension the drag handle can reach.
+    private var maxFrameDim: Int  { targetN > 12 ? 8 : 6 }
 
     var body: some View {
         ZStack {
@@ -50,16 +60,31 @@ struct RectangleFactoryView: View {
     // MARK: - Header
 
     private var headerBar: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 2) {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 4) {
                 Text("Rectangle Factory")
                     .font(.title2.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
-                Text("Make \(targetN) dots fit perfectly")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    Text("Make \(targetN) dots fit perfectly")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    // Star progress: one star per factor pair
+                    let total = Self.factorsOf(targetN).count
+                    HStack(spacing: 3) {
+                        ForEach(0..<total, id: \.self) { i in
+                            Image(systemName: i < foundFactors.count ? "star.fill" : "star")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(
+                                    i < foundFactors.count ? MatherTheme.warm : MatherTheme.warm.opacity(0.3)
+                                )
+                                .animation(.spring(response: 0.3, dampingFraction: 0.6), value: foundFactors.count)
+                        }
+                    }
+                }
             }
-            Spacer()
+            Spacer(minLength: 12)
             Button {
                 appModel.engine.showHome()
             } label: {
@@ -94,7 +119,7 @@ struct RectangleFactoryView: View {
             // Selection frame overlay
             selectionFrame(w: frameW, h: frameH, valid: valid, cellSize: cellSize)
 
-            // Equation label (floats above top-right of frame)
+            // Equation label (floats above top-right of frame on valid snap)
             if showEquation {
                 Text(lastEquation)
                     .font(.system(size: 22, weight: .black, design: .rounded))
@@ -138,7 +163,6 @@ struct RectangleFactoryView: View {
         let borderWidth: CGFloat = valid ? 3 : 2
 
         return ZStack(alignment: .bottomTrailing) {
-            // Frame border
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .strokeBorder(borderColor, lineWidth: borderWidth)
                 .frame(width: w, height: h)
@@ -170,22 +194,24 @@ struct RectangleFactoryView: View {
 
     private var bottomBar: some View {
         VStack(spacing: 10) {
-            // Found factor chips
+            // Found-factors gallery: mini dot-grid thumbnails
             if !foundFactors.isEmpty {
                 ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
+                    HStack(spacing: 10) {
                         ForEach(foundFactors.sorted(), id: \.self) { key in
-                            factorChip(key)
+                            thumbnailChip(key)
                         }
                     }
                     .padding(.horizontal, 20)
                 }
-                .frame(height: 40)
+                .frame(height: 56)
             }
 
             if allFoundForN {
                 Button(action: advanceToNextN) {
-                    Text(sequenceIndex + 1 < RectangleFactoryView.nSequence.count ? "Next Number →" : "All done! 🎉")
+                    Text(sequenceIndex + 1 < RectangleFactoryView.nSequence.count
+                         ? "Next Number →"
+                         : "All done! 🎉")
                         .font(.headline.weight(.bold))
                         .foregroundStyle(.white)
                         .frame(maxWidth: .infinity)
@@ -203,16 +229,50 @@ struct RectangleFactoryView: View {
         }
     }
 
-    private func factorChip(_ key: String) -> some View {
+    /// Mini dot-grid thumbnail chip with dimensions label.
+    /// Shows up to 4 rows × 6 cols of dots to stay compact.
+    private func thumbnailChip(_ key: String) -> some View {
         let parts = key.split(separator: "x").compactMap { Int($0) }
-        let label = parts.count == 2 ? "\(parts[0]) × \(parts[1]) = \(targetN)" : key
-        return Text(label)
-            .font(.subheadline.weight(.semibold))
-            .foregroundStyle(MatherTheme.ink)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
+        guard parts.count == 2 else { return AnyView(EmptyView()) }
+        let rows = parts[0]    // smaller dimension → rows
+        let cols = parts[1]    // larger dimension → cols
+        let displayRows = min(rows, 4)
+        let displayCols = min(cols, 6)
+
+        return AnyView(
+            HStack(spacing: 7) {
+                // Mini dot grid
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(0..<displayRows, id: \.self) { _ in
+                        HStack(spacing: 2) {
+                            ForEach(0..<displayCols, id: \.self) { _ in
+                                Circle()
+                                    .fill(MatherTheme.accent)
+                                    .frame(width: 5, height: 5)
+                            }
+                            if cols > 6 {
+                                Text("⋯")
+                                    .font(.system(size: 5))
+                                    .foregroundStyle(MatherTheme.accent.opacity(0.6))
+                            }
+                        }
+                    }
+                    if rows > 4 {
+                        Text("⋮")
+                            .font(.system(size: 5))
+                            .foregroundStyle(MatherTheme.accent.opacity(0.6))
+                    }
+                }
+                // Dimension label
+                Text("\(rows)×\(cols)")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(MatherTheme.ink)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 9)
             .background(MatherTheme.accent.opacity(0.15))
-            .clipShape(Capsule())
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        )
     }
 
     // MARK: - Drag handling
@@ -227,10 +287,10 @@ struct RectangleFactoryView: View {
             dragStartW = frameWidth
             dragStartH = frameHeight
         }
-        let newW = max(1, min(dragStartW + Int((translation.width / cellSize).rounded()), gridColumns))
-        let newH = max(1, min(dragStartH + Int((translation.height / cellSize).rounded()), gridColumns))
+        let newW = max(1, min(dragStartW + Int((translation.width  / cellSize).rounded()), maxFrameDim))
+        let newH = max(1, min(dragStartH + Int((translation.height / cellSize).rounded()), maxFrameDim))
         if newW != frameWidth || newH != frameHeight {
-            frameWidth = newW
+            frameWidth  = newW
             frameHeight = newH
             showEquation = false
         }
@@ -246,7 +306,10 @@ struct RectangleFactoryView: View {
         lastEquation = "\(min(frameWidth, frameHeight)) × \(max(frameWidth, frameHeight)) = \(targetN)"
         showEquation = true
         appModel.hapticsService.cardSnapCorrect(enabled: appModel.featureFlags.hapticsEnabled)
-        appModel.speechService.speak("\(min(frameWidth, frameHeight)) times \(max(frameWidth, frameHeight)) equals \(targetN)!", enabled: appModel.featureFlags.audioEnabled)
+        appModel.speechService.speak(
+            "\(min(frameWidth, frameHeight)) times \(max(frameWidth, frameHeight)) equals \(targetN)!",
+            enabled: appModel.featureFlags.audioEnabled
+        )
         Task { @MainActor in
             try? await Task.sleep(for: .seconds(1.5))
             showEquation = false
@@ -256,18 +319,17 @@ struct RectangleFactoryView: View {
 
     private func checkAllFound() {
         let allFactors = Self.factorsOf(targetN)
-        if foundFactors.count >= allFactors.count {
-            allFoundForN = true
-            appModel.hapticsService.bondMatchComplete(enabled: appModel.featureFlags.hapticsEnabled)
-            let count = allFactors.count
-            let noun = count == 1 ? "rectangle" : "rectangles"
-            appModel.speechService.speak(
-                count == 1
-                    ? "\(targetN) is prime — only one \(noun)!"
-                    : "You found all \(count) \(noun) for \(targetN)!",
-                enabled: appModel.featureFlags.audioEnabled
-            )
-        }
+        guard foundFactors.count >= allFactors.count else { return }
+        allFoundForN = true
+        appModel.hapticsService.bondMatchComplete(enabled: appModel.featureFlags.hapticsEnabled)
+        let count = allFactors.count
+        let noun  = count == 1 ? "rectangle" : "rectangles"
+        appModel.speechService.speak(
+            count == 1
+                ? "\(targetN) is prime — only one \(noun)!"
+                : "You found all \(count) \(noun) for \(targetN)!",
+            enabled: appModel.featureFlags.audioEnabled
+        )
     }
 
     private func advanceToNextN() {
@@ -280,37 +342,56 @@ struct RectangleFactoryView: View {
         loadN(RectangleFactoryView.nSequence[next])
     }
 
+    /// Load a new target N, starting the frame near √N so the child
+    /// makes small adjustments rather than dragging from 1×1.
     private func loadN(_ n: Int) {
         targetN = n
         foundFactors = []
         allFoundForN = false
         showEquation = false
-        frameWidth = 1
-        frameHeight = 1
+        let start = Self.smartStartDimensions(for: n)
+        frameWidth  = start.width
+        frameHeight = start.height
     }
 
     private func resetFrame() {
-        frameWidth = 1
-        frameHeight = 1
+        let start = Self.smartStartDimensions(for: targetN)
+        frameWidth  = start.width
+        frameHeight = start.height
         showEquation = false
     }
 
-    // MARK: - Helpers
+    // MARK: - Static helpers
 
     /// Canonical factor key: smaller dimension first so 3×4 and 4×3 hash identically.
     nonisolated static func factorKey(_ a: Int, _ b: Int) -> String {
         "\(min(a, b))x\(max(a, b))"
     }
 
-    /// All distinct canonical factor pairs for n (excluding 1×n when n is prime — included).
+    /// All distinct canonical factor pairs for n.
     nonisolated static func factorsOf(_ n: Int) -> Set<String> {
         var result = Set<String>()
-        for i in 1...n {
-            if n % i == 0 {
-                result.insert(factorKey(i, n / i))
-            }
+        for i in 1...n where n % i == 0 {
+            result.insert(factorKey(i, n / i))
         }
         return result
     }
-}
 
+    /// Starting frame dimensions: one cell wider than the square-root floor,
+    /// one cell shorter — visually near the centre of the dot grid but not
+    /// on a valid factor pair.  Edge-case checked so it never accidentally
+    /// land on the answer.
+    nonisolated static func smartStartDimensions(for n: Int) -> (width: Int, height: Int) {
+        let s = max(1, Int(sqrt(Double(n)).rounded(.down)))
+        var w = s + 1
+        var h = max(1, s - 1)
+        // Clamp to on-screen grid (8 max)
+        w = min(w, 8)
+        h = min(h, 8)
+        // If this accidentally lands on a valid answer, shift width by 1
+        if w * h == n {
+            w = min(w + 1, 8)
+        }
+        return (width: w, height: h)
+    }
+}

--- a/Features/SymmetryFold/SymmetryFoldView.swift
+++ b/Features/SymmetryFold/SymmetryFoldView.swift
@@ -3,62 +3,77 @@ import SwiftUI
 /// Symmetry Fold — children tilt the iPad to fold the right half of a shape
 /// onto the left half along a vertical axis of symmetry.
 ///
-/// When both halves overlap perfectly the shape "snaps" closed and the child
-/// discovers that the two halves are mirror images — the definition of
-/// reflective symmetry.
+/// UX improvements over v1:
+///  • 5 shapes (heart → star → hexagon → diamond → triangle) with
+///    progressively reduced guide opacity (0.28 → 0 on final level).
+///  • Hold-to-lock mechanic: child must hold ≥ 0.85 fold for 0.8 s — shown
+///    as a circular progress ring.  Prevents accidental solves and creates
+///    a satisfying "snap" moment.
+///  • Bilateral success: full shape glows on lock, not just the right half.
+///  • Level progress dots size-animate to show the active level clearly.
 ///
 /// Age range: 5–7. CPA level: Pictorial → Abstract.
 /// Sensor: neutral-relative roll tilt (left tilt folds right half onto left).
-/// Three levels of increasing abstraction:
-///   1. Heart with fold guide (dashed left-half ghost)
-///   2. Star with lighter fold guide
-///   3. Hexagon shape, no guide
 struct SymmetryFoldView: View {
 
     @Bindable var appModel: AppModel
 
     // MARK: - Local state
 
-    /// Roll value at the moment the child taps "ready". All subsequent tilt
-    /// is computed as a delta from this neutral, matching the Gravity Split
-    /// neutral-relative pattern to prevent accidental solves.
     @State private var neutralRoll: Double? = nil
-    /// 0 = shape is fully open; 1 = right half is folded flat onto left half.
+    /// 0 = shape open; 1 = right half fully folded onto left.
     @State private var foldAngle: Double = 0
     @State private var success = false
-    @State private var currentLevel: Int = 1   // 1, 2, 3
+    @State private var currentLevel: Int = 1   // 1–5
+    /// 0–1 progress filled by holding the shape in the folded zone.
+    @State private var holdProgress: Double = 0
+    @State private var holdTask: Task<Void, Never>? = nil
 
     // MARK: - Level config
 
     private struct LevelConfig {
         let symbolName: String
         let color: Color
-        let showGuide: Bool
+        let guideOpacity: Double
         let title: String
-        let accessibilityLabel: String
+        let speechPrompt: String
     }
 
     private let levels: [LevelConfig] = [
         LevelConfig(
             symbolName: "heart.fill",
             color: MatherTheme.coral,
-            showGuide: true,
+            guideOpacity: 0.28,
             title: "Fold the heart",
-            accessibilityLabel: "Heart shape. Tilt left to fold."
+            speechPrompt: "Tilt left to fold the heart in half!"
         ),
         LevelConfig(
             symbolName: "star.fill",
             color: MatherTheme.warm,
-            showGuide: true,
+            guideOpacity: 0.28,
             title: "Fold the star",
-            accessibilityLabel: "Star shape. Tilt left to fold."
+            speechPrompt: "Tilt left to fold the star!"
         ),
         LevelConfig(
             symbolName: "hexagon.fill",
             color: MatherTheme.accent,
-            showGuide: false,
-            title: "Fold it!",
-            accessibilityLabel: "Hexagon shape. Tilt left to fold."
+            guideOpacity: 0.18,
+            title: "Fold the hexagon",
+            speechPrompt: "Tilt left to fold the hexagon. Lighter guide this time!"
+        ),
+        LevelConfig(
+            symbolName: "diamond.fill",
+            color: MatherTheme.softBlue,
+            guideOpacity: 0.10,
+            title: "Fold the diamond",
+            speechPrompt: "Tiny guide now — use what you remember!"
+        ),
+        LevelConfig(
+            symbolName: "triangle.fill",
+            color: MatherTheme.warm,
+            guideOpacity: 0.0,
+            title: "No guide — you've got this!",
+            speechPrompt: "No guide! You know where the fold goes. Tilt left!"
         ),
     ]
 
@@ -68,8 +83,8 @@ struct SymmetryFoldView: View {
 
     // MARK: - Constants
 
-    /// Full 45° tilt maps to fully folded.
     private let maxTiltRadians: Double = .pi / 4
+    private static let holdDuration: Double = 0.8
 
     // MARK: - Body
 
@@ -95,21 +110,20 @@ struct SymmetryFoldView: View {
         }
         .onChange(of: appModel.motionService.tiltRoll) { _, roll in
             guard let neutral = neutralRoll, !success else { return }
-            // Left tilt → roll decreases from neutral → negative delta → foldAngle increases.
             let delta = roll - neutral
-            foldAngle = max(0.0, min(-delta / maxTiltRadians, 1.0))
-            if foldAngle >= 0.95 {
-                handleSuccess()
-            }
+            let newFold = max(0.0, min(-delta / maxTiltRadians, 1.0))
+            foldAngle = newFold
+            updateHoldProgress(for: newFold)
         }
         .onAppear {
             appModel.motionService.startUpdates()
         }
         .onDisappear {
+            holdTask?.cancel()
             appModel.motionService.stopUpdates()
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(config.accessibilityLabel)
+        .accessibilityLabel(config.title)
     }
 
     // MARK: - Header
@@ -126,8 +140,9 @@ struct SymmetryFoldView: View {
             }
             Spacer()
             Button("Done") {
-                appModel.engine.showHome()
+                holdTask?.cancel()
                 appModel.motionService.stopUpdates()
+                appModel.engine.showHome()
             }
             .font(.headline.weight(.semibold))
             .foregroundStyle(.white)
@@ -146,15 +161,15 @@ struct SymmetryFoldView: View {
         GeometryReader { geo in
             let size = min(geo.size.width * 0.8, geo.size.height * 0.8, 280.0)
             ZStack {
-                // Ghost left-half (visible guide only on levels 1 and 2)
-                if config.showGuide {
+                // Ghost left-half guide (fades with each level)
+                if config.guideOpacity > 0 {
                     ghostHalf(size: size)
                 }
 
-                // Dashed vertical fold line
+                // Dashed fold line
                 foldLine(size: size)
 
-                // Foldable right half
+                // Foldable right half — 3D-rotates as child tilts
                 foldableRightHalf(size: size)
                     .rotation3DEffect(
                         .degrees(foldAngle * -180),
@@ -167,13 +182,37 @@ struct SymmetryFoldView: View {
                         value: foldAngle
                     )
 
-                // Success overlay
+                // Hold-to-lock circular progress ring
+                if holdProgress > 0 && !success {
+                    Circle()
+                        .trim(from: 0, to: holdProgress)
+                        .stroke(
+                            config.color,
+                            style: StrokeStyle(lineWidth: 7, lineCap: .round)
+                        )
+                        .frame(width: size + 28, height: size + 28)
+                        .rotationEffect(.degrees(-90))
+                        .animation(.linear(duration: 0.05), value: holdProgress)
+                }
+
+                // Success: bilateral flash — full shape glows
                 if success {
-                    successOverlay(size: size)
+                    Image(systemName: config.symbolName)
+                        .resizable()
+                        .scaledToFit()
+                        .foregroundStyle(config.color)
+                        .frame(width: size, height: size)
                         .transition(.scale(scale: 0.7).combined(with: .opacity))
                 }
 
-                // "Tap to start" prompt
+                // Success overlay card
+                if success {
+                    successOverlay
+                        .transition(.scale(scale: 0.85).combined(with: .opacity))
+                        .zIndex(10)
+                }
+
+                // Tap-to-start prompt
                 if neutralRoll == nil && !success {
                     tapPrompt(size: size)
                         .transition(.opacity)
@@ -188,6 +227,10 @@ struct SymmetryFoldView: View {
                     withAnimation(.easeOut(duration: 0.15)) {
                         neutralRoll = appModel.motionService.tiltRoll
                     }
+                    appModel.speechService.speak(
+                        config.speechPrompt,
+                        enabled: appModel.featureFlags.audioEnabled
+                    )
                 } else if success {
                     advanceLevel()
                 }
@@ -195,16 +238,17 @@ struct SymmetryFoldView: View {
             .accessibilityIdentifier("symmetry-fold-scene")
         }
         .frame(maxWidth: .infinity)
-        .frame(height: 300)
+        .frame(height: 320)
     }
+
+    // MARK: - Scene sub-views
 
     private func ghostHalf(size: CGFloat) -> some View {
         Image(systemName: config.symbolName)
             .resizable()
             .scaledToFit()
-            .foregroundStyle(config.color.opacity(0.18))
+            .foregroundStyle(config.color.opacity(config.guideOpacity))
             .frame(width: size, height: size)
-            // Mask: show only the left half
             .mask(
                 HStack(spacing: 0) {
                     Color.black.frame(width: size / 2)
@@ -214,7 +258,6 @@ struct SymmetryFoldView: View {
     }
 
     private func foldLine(size: CGFloat) -> some View {
-        // Dashed vertical line
         Canvas { ctx, canvasSize in
             var path = Path()
             var y: CGFloat = 0
@@ -224,8 +267,11 @@ struct SymmetryFoldView: View {
                 path.addLine(to: CGPoint(x: x, y: min(y + 10, canvasSize.height)))
                 y += 18
             }
-            ctx.stroke(path, with: .color(MatherTheme.ink.opacity(0.3)),
-                       style: StrokeStyle(lineWidth: 2, lineCap: .round))
+            ctx.stroke(
+                path,
+                with: .color(MatherTheme.ink.opacity(0.3)),
+                style: StrokeStyle(lineWidth: 2, lineCap: .round)
+            )
         }
         .frame(width: size, height: size)
     }
@@ -234,9 +280,8 @@ struct SymmetryFoldView: View {
         Image(systemName: config.symbolName)
             .resizable()
             .scaledToFit()
-            .foregroundStyle(success ? MatherTheme.accent : config.color)
+            .foregroundStyle(config.color)
             .frame(width: size, height: size)
-            // Mask: show only the right half
             .mask(
                 HStack(spacing: 0) {
                     Color.clear.frame(width: size / 2)
@@ -249,7 +294,7 @@ struct SymmetryFoldView: View {
         ZStack {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(.ultraThinMaterial)
-                .frame(width: size * 0.7, height: 110)
+                .frame(width: size * 0.72, height: 110)
             VStack(spacing: 8) {
                 Image(systemName: "hand.tap.fill")
                     .font(.system(size: 28))
@@ -264,25 +309,18 @@ struct SymmetryFoldView: View {
         }
     }
 
-    private func successOverlay(size: CGFloat) -> some View {
-        VStack(spacing: 6) {
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 56))
-                .foregroundStyle(MatherTheme.accent)
+    private var successOverlay: some View {
+        VStack(spacing: 8) {
+            Text("✨")
+                .font(.system(size: 44))
             Text("Symmetric!")
                 .font(.title2.weight(.black))
                 .foregroundStyle(MatherTheme.accent)
-            if currentLevel < 3 {
-                Text("Tap for the next shape")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(MatherTheme.cardSubtitle)
-            } else {
-                Text("All done! Tap to finish.")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(MatherTheme.cardSubtitle)
-            }
+            Text(currentLevel < levels.count ? "Tap for the next shape" : "All done! Tap to finish.")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
         }
-        .padding(20)
+        .padding(24)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
     }
 
@@ -290,28 +328,73 @@ struct SymmetryFoldView: View {
 
     private var bottomBar: some View {
         VStack(spacing: 12) {
+            // Contextual tilt hint
             if !success && neutralRoll != nil {
                 HStack(spacing: 8) {
                     Image(systemName: "gyroscope")
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(config.color.opacity(0.8))
-                    Text("Tilt left to fold")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
+                    if holdProgress > 0 {
+                        Text("Hold steady…")
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(config.color)
+                    } else {
+                        Text("Tilt left to fold")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                    }
                 }
+                .animation(.easeInOut(duration: 0.2), value: holdProgress > 0)
             }
 
-            // Level progress dots
+            // Level progress dots (5) — active dot is slightly larger
             HStack(spacing: 8) {
-                ForEach(1...3, id: \.self) { lvl in
+                ForEach(1...levels.count, id: \.self) { lvl in
+                    let isActive = lvl == currentLevel
+                    let isPast   = lvl < currentLevel
                     Circle()
-                        .fill(lvl <= currentLevel
-                              ? config.color
-                              : config.color.opacity(0.2))
-                        .frame(width: 10, height: 10)
-                        .animation(.easeInOut(duration: 0.25), value: currentLevel)
+                        .fill(
+                            isPast   ? MatherTheme.accent :
+                            isActive ? config.color :
+                            config.color.opacity(0.2)
+                        )
+                        .frame(
+                            width:  isActive ? 13 : 10,
+                            height: isActive ? 13 : 10
+                        )
+                        .animation(
+                            .spring(response: 0.3, dampingFraction: 0.6),
+                            value: currentLevel
+                        )
                 }
             }
+        }
+    }
+
+    // MARK: - Hold-to-lock
+
+    private func updateHoldProgress(for fold: Double) {
+        if fold >= 0.85 && !success {
+            // Start hold timer if not already running
+            if holdTask == nil {
+                let startDate = Date()
+                holdTask = Task { @MainActor in
+                    while !Task.isCancelled && !success {
+                        let elapsed = Date().timeIntervalSince(startDate)
+                        holdProgress = min(elapsed / Self.holdDuration, 1.0)
+                        if holdProgress >= 1.0 {
+                            handleSuccess()
+                            break
+                        }
+                        try? await Task.sleep(nanoseconds: 16_000_000)   // ~60 fps
+                    }
+                }
+            }
+        } else {
+            // Fold dropped — cancel and reset ring
+            holdTask?.cancel()
+            holdTask = nil
+            holdProgress = 0
         }
     }
 
@@ -319,6 +402,9 @@ struct SymmetryFoldView: View {
 
     private func handleSuccess() {
         success = true
+        holdTask?.cancel()
+        holdTask = nil
+        holdProgress = 0
         appModel.hapticsService.balanceLock(enabled: appModel.featureFlags.hapticsEnabled)
         appModel.speechService.speak(
             "Perfectly folded! Both sides match — it's symmetric!",
@@ -327,11 +413,14 @@ struct SymmetryFoldView: View {
     }
 
     private func advanceLevel() {
-        if currentLevel < 3 {
+        if currentLevel < levels.count {
             currentLevel += 1
             foldAngle = 0
             success = false
             neutralRoll = nil
+            holdProgress = 0
+            holdTask?.cancel()
+            holdTask = nil
         } else {
             appModel.engine.showHome()
         }


### PR DESCRIPTION
## Summary

UX improvements across three activities following live playtesting feedback — kids liked the ideas but engagement could be deeper and challenge better tuned.

### Angle Cannon
- **Auto-calibrate on appear** — no more tap-to-aim dead zone; "Hold steady…" banner → neutral recorded after 600ms
- **Aim persists between retries** — `neutralRoll` no longer cleared between shots so child keeps their bearing
- **Bright coral preview arc** — thick dashed arc is unmissable vs old thin line
- **Emoji targets** at landing zone (`🎈 ⭐️ 🎯 🍎 🪁`) — tactile delight, target changes each round
- **Directional miss hints** — speech says "Too high — tilt a little less" / "Too low — tilt a bit more" + arrow overlay
- **Stars progress header** — 3 `star.fill` icons replace abstract "Hit X of 3" text
- **Fire-pulse animation** — FIRE button scales to 0.92 on tap for kinetic feedback
- **CPA preserved** — degree label only appears on hit

### Symmetry Fold
- **5 shapes** (heart → star → hexagon → diamond → triangle) up from 3
- **Fading guide** — opacity steps from 0.28 → 0.28 → 0.18 → 0.10 → 0.0 across levels
- **Hold-to-lock** — child must hold ≥ 85% fold for 0.8 s; shown as circular progress ring → prevents accidental solves; creates a satisfying "snap" moment
- **Bilateral success flash** — full shape glows when locked (not just rotating half)
- **Contextual hint** — "Hold steady…" replaces generic tilt copy when in the lock zone

### Rectangle Factory
- **Smart start** — frame opens near `√N` (not 1×1 corner) so first drag is a small adjustment
- **Dot-grid thumbnails** — found-factors gallery shows mini visual grids + dimension label instead of plain text chips
- **Star progress row** in header — one ★ per factor pair, fills on discovery
- **Wider grid** — 8 cols for N > 12, exposes factor pairs like 3×8, 4×6 for N=24
- **Reset to smart-start** — shake restores `√N` position, not the 1×1 corner

## Test plan
- [ ] Angle Cannon: open activity, verify "Hold steady…" banner appears then disappears; tilt to aim and fire — confirm arc visible, degree hidden on miss, degree revealed on hit; check speech says "Too high" vs "Too low"
- [ ] Symmetry Fold: tap to start each level; tilt left near-fold; verify ring appears when ≥ 85%; hold 0.8s — confirm full bilateral shape glow + success card; level 5 has no ghost guide
- [ ] Rectangle Factory: open each N — verify frame starts near centre not corner; drag to valid pair — confirm mini dot thumbnail appears in gallery; collect all pairs — stars fill to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)