### PR TITLE
fix(room-quest): make camera capture and fallback actually work

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -115,7 +115,7 @@ final class RoomQuestEngine {
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let result = try await scanner.scanMarker(for: role)
+                let result = try await scanner.scanMarker(for: role, mode: .setup)
                 guard self.captureReference(for: result) else {
                     self.feedbackMessage = "We found \(result.role.title), but could not save its hiding-place reference yet. Try again."
                     self.scanState = .failed(role: role, message: self.feedbackMessage)
@@ -234,21 +234,27 @@ final class RoomQuestEngine {
         case .scanning(let role):
             return "Keep the camera pointed at \(role.title) until it finishes checking."
         case .idle:
-            if station.referenceCaptureState == .captured {
-                return "Look for the saved \(station.role.title) place, then hold the camera still for a recheck."
-            } else {
+            switch station.referenceCaptureState {
+            case .captured:
+                return "Walk to the saved \(station.role.title) place and tap 'Recheck' to confirm you're there."
+            case .manualFallback:
+                return "No camera reference saved for \(station.role.title). Tap 'I found it' when you get there."
+            case .notCaptured:
                 return "Look for \(station.role.title), then start with a camera check. A grown-up fallback appears if the scan misses."
             }
         }
     }
 
     var shouldShowSpotManualFallback: Bool {
-        guard currentStation != nil else { return false }
+        guard let station = currentStation else { return false }
 
         switch scanState {
         case .almost, .failed:
             return true
-        case .idle, .scanning, .celebrating:
+        case .idle:
+            // Show fallback immediately when no camera reference was saved
+            return station.referenceCaptureState == .manualFallback
+        case .scanning, .celebrating:
             return false
         }
     }
@@ -305,7 +311,7 @@ final class RoomQuestEngine {
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let result = try await scanner.scanMarker(for: station.role)
+                let result = try await scanner.scanMarker(for: station.role, mode: .verify)
 
                 if let savedReference = try? stationStore.reference(for: station.role),
                    let expectedRole = savedReference.role,

--- a/Domain/RoomQuestScanner.swift
+++ b/Domain/RoomQuestScanner.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+enum RoomQuestScanMode {
+    case setup    // parent capturing a reference photo during station setup
+    case verify   // child confirming they are standing at the right spot
+}
+
 struct RoomQuestMarkerScanResult: Equatable {
     let role: RoomQuestStationRole
     let markerPayload: String?
@@ -15,11 +20,11 @@ enum RoomQuestScannerError: Error, Equatable {
 
 @MainActor
 protocol RoomQuestScanner {
-    func scanMarker(for role: RoomQuestStationRole) async throws -> RoomQuestMarkerScanResult
+    func scanMarker(for role: RoomQuestStationRole, mode: RoomQuestScanMode) async throws -> RoomQuestMarkerScanResult
 }
 
 struct NoopRoomQuestScanner: RoomQuestScanner {
-    func scanMarker(for role: RoomQuestStationRole) async throws -> RoomQuestMarkerScanResult {
+    func scanMarker(for role: RoomQuestStationRole, mode: RoomQuestScanMode) async throws -> RoomQuestMarkerScanResult {
         throw RoomQuestScannerError.unavailable
     }
 }

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -88,30 +88,25 @@ struct SpotPromptView: View {
 
                 Spacer()
 
-                Button {
-                    engine.verifyCurrentSpotWithCamera()
-                } label: {
-                    Label(station?.referenceCaptureState == .captured ? "Recheck this place" : "Scan to unlock", systemImage: "camera.viewfinder")
+                // Camera scan button — only active for stations with a saved photo reference
+                if station?.referenceCaptureState == .captured {
+                    let isScanBusy: Bool = {
+                        switch engine.scanState {
+                        case .scanning, .celebrating: return true
+                        default: return false
+                        }
+                    }()
+                    Button {
+                        engine.verifyCurrentSpotWithCamera()
+                    } label: {
+                        Label("Recheck this place", systemImage: "camera.viewfinder")
+                    }
+                    .accessibilityIdentifier("room-spot-scan-button")
+                    .buttonStyle(RoomQuestPrimaryButtonStyle())
+                    .disabled(isScanBusy)
+                    .opacity(isScanBusy ? 0.7 : 1)
+                    .padding(.horizontal, 40)
                 }
-                .accessibilityIdentifier("room-spot-scan-button")
-                .buttonStyle(RoomQuestPrimaryButtonStyle())
-                .disabled({
-                    switch engine.scanState {
-                    case .scanning, .celebrating:
-                        return true
-                    case .idle, .almost, .failed:
-                        return station?.referenceCaptureState != .captured
-                    }
-                }())
-                .opacity({
-                    switch engine.scanState {
-                    case .scanning, .celebrating:
-                        return 0.7
-                    case .idle, .almost, .failed:
-                        return station?.referenceCaptureState == .captured ? 1 : 0.55
-                    }
-                }())
-                .padding(.horizontal, 40)
 
                 if engine.shouldShowSpotManualFallback {
                     Button(station?.role.fallbackButtonTitle ?? "I found it") {
@@ -123,12 +118,15 @@ struct SpotPromptView: View {
                     .foregroundStyle(.white.opacity(0.92))
                     .padding(.horizontal, 40)
                     .padding(.bottom, 40)
-                } else {
-                    Text("Fallback unlocks only after a missed scan.")
+                } else if station?.referenceCaptureState != .captured {
+                    // Station has no reference yet — scan button is hidden, fallback not yet triggered
+                    Text("Start a camera check to unlock collect.")
                         .font(.headline.weight(.bold))
                         .foregroundStyle(.white.opacity(0.92))
                         .padding(.horizontal, 40)
                         .padding(.bottom, 40)
+                } else {
+                    Spacer().frame(height: 40)
                 }
             }
 

--- a/Services/RoomQuestLiveScanner.swift
+++ b/Services/RoomQuestLiveScanner.swift
@@ -11,14 +11,15 @@ final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
     struct Session: Identifiable {
         let id = UUID()
         let expectedRole: RoomQuestStationRole
+        let mode: RoomQuestScanMode
         let continuation: CheckedContinuation<RoomQuestMarkerScanResult, Error>
     }
 
     private(set) var activeSession: Session?
 
-    func scanMarker(for role: RoomQuestStationRole) async throws -> RoomQuestMarkerScanResult {
+    func scanMarker(for role: RoomQuestStationRole, mode: RoomQuestScanMode) async throws -> RoomQuestMarkerScanResult {
         try await withCheckedThrowingContinuation { continuation in
-            activeSession = Session(expectedRole: role, continuation: continuation)
+            activeSession = Session(expectedRole: role, mode: mode, continuation: continuation)
         }
     }
 
@@ -35,6 +36,30 @@ final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
             return
         }
         session.continuation.resume(returning: RoomQuestMarkerScanResult(role: detectedRole, markerPayload: payload, referenceImageJPEGData: nil, usedARCelebration: true))
+        activeSession = nil
+    }
+
+    /// Called when parent takes a photo to save this place as the station reference.
+    func resolveWithPhoto(_ jpegData: Data) {
+        guard let session = activeSession else { return }
+        session.continuation.resume(returning: RoomQuestMarkerScanResult(
+            role: session.expectedRole,
+            markerPayload: nil,
+            referenceImageJPEGData: jpegData,
+            usedARCelebration: false
+        ))
+        activeSession = nil
+    }
+
+    /// Called when child confirms they are at the correct spot (no QR required).
+    func resolveWithConfirm() {
+        guard let session = activeSession else { return }
+        session.continuation.resume(returning: RoomQuestMarkerScanResult(
+            role: session.expectedRole,
+            markerPayload: nil,
+            referenceImageJPEGData: nil,
+            usedARCelebration: false
+        ))
         activeSession = nil
     }
 
@@ -63,11 +88,14 @@ struct RoomQuestScannerSheet: View {
         NavigationStack {
             Group {
                 if let session = scanner.activeSession {
-                    RoomQuestCameraScannerView(expectedRole: session.expectedRole) { payload in
-                        scanner.resolveScan(payload: payload)
-                    } onCancel: {
-                        scanner.cancelScan()
-                    }
+                    RoomQuestCameraScannerView(
+                        expectedRole: session.expectedRole,
+                        scanMode: session.mode,
+                        onPayload: { payload in scanner.resolveScan(payload: payload) },
+                        onPhoto: { jpegData in scanner.resolveWithPhoto(jpegData) },
+                        onConfirm: { scanner.resolveWithConfirm() },
+                        onCancel: { scanner.cancelScan() }
+                    )
                 } else {
                     ContentUnavailableView("Camera verify", systemImage: "camera.viewfinder", description: Text("Preparing scanner…"))
                 }
@@ -80,13 +108,19 @@ struct RoomQuestScannerSheet: View {
 
 private struct RoomQuestCameraScannerView: UIViewControllerRepresentable {
     let expectedRole: RoomQuestStationRole
+    let scanMode: RoomQuestScanMode
     let onPayload: (String) -> Void
+    let onPhoto: (Data) -> Void
+    let onConfirm: () -> Void
     let onCancel: () -> Void
 
     func makeUIViewController(context: Context) -> ScannerViewController {
         let controller = ScannerViewController()
         controller.expectedRole = expectedRole
+        controller.scanMode = scanMode
         controller.onPayload = onPayload
+        controller.onPhoto = onPhoto
+        controller.onConfirm = onConfirm
         controller.onCancel = onCancel
         return controller
     }
@@ -94,13 +128,20 @@ private struct RoomQuestCameraScannerView: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: ScannerViewController, context: Context) {}
 }
 
-final class ScannerViewController: UIViewController, @preconcurrency AVCaptureMetadataOutputObjectsDelegate {
+final class ScannerViewController: UIViewController,
+    @preconcurrency AVCaptureMetadataOutputObjectsDelegate,
+    AVCapturePhotoCaptureDelegate {
+
     var expectedRole: RoomQuestStationRole = .redRocket
+    var scanMode: RoomQuestScanMode = .setup
     var onPayload: ((String) -> Void)?
+    var onPhoto: ((Data) -> Void)?
+    var onConfirm: (() -> Void)?
     var onCancel: (() -> Void)?
 
-    private let session = AVCaptureSession()
+    private let captureSession = AVCaptureSession()
     private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var photoOutput: AVCapturePhotoOutput?
     private var hasResolved = false
 
     override func viewDidLoad() {
@@ -112,34 +153,40 @@ final class ScannerViewController: UIViewController, @preconcurrency AVCaptureMe
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        if !session.isRunning { session.startRunning() }
+        if !captureSession.isRunning { captureSession.startRunning() }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        if session.isRunning { session.stopRunning() }
+        if captureSession.isRunning { captureSession.stopRunning() }
     }
 
     private func configureCamera() {
         guard let device = AVCaptureDevice.default(for: .video),
               let input = try? AVCaptureDeviceInput(device: device),
-              session.canAddInput(input)
+              captureSession.canAddInput(input)
         else {
             onCancel?()
             return
         }
-        session.addInput(input)
+        captureSession.addInput(input)
 
-        let output = AVCaptureMetadataOutput()
-        guard session.canAddOutput(output) else {
+        let metadataOutput = AVCaptureMetadataOutput()
+        guard captureSession.canAddOutput(metadataOutput) else {
             onCancel?()
             return
         }
-        session.addOutput(output)
-        output.setMetadataObjectsDelegate(self, queue: .main)
-        output.metadataObjectTypes = [.qr]
+        captureSession.addOutput(metadataOutput)
+        metadataOutput.setMetadataObjectsDelegate(self, queue: .main)
+        metadataOutput.metadataObjectTypes = [.qr]
 
-        let previewLayer = AVCaptureVideoPreviewLayer(session: session)
+        let photoOut = AVCapturePhotoOutput()
+        if captureSession.canAddOutput(photoOut) {
+            captureSession.addOutput(photoOut)
+            self.photoOutput = photoOut
+        }
+
+        let previewLayer = AVCaptureVideoPreviewLayer(session: captureSession)
         previewLayer.videoGravity = .resizeAspectFill
         previewLayer.frame = view.bounds
         view.layer.addSublayer(previewLayer)
@@ -158,27 +205,84 @@ final class ScannerViewController: UIViewController, @preconcurrency AVCaptureMe
         label.numberOfLines = 0
         label.textColor = .white
         label.font = .preferredFont(forTextStyle: .title2)
-        label.text = "Scan the \(expectedRole.title) marker"
 
-        let button = UIButton(type: .system)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("Use fallback instead", for: .normal)
-        button.titleLabel?.font = .preferredFont(forTextStyle: .headline)
-        button.tintColor = .white
-        button.addAction(UIAction { [weak self] _ in self?.onCancel?() }, for: .touchUpInside)
+        var primaryConfig = UIButton.Configuration.filled()
+        primaryConfig.cornerStyle = .large
+        primaryConfig.buttonSize = .large
 
-        let stack = UIStackView(arrangedSubviews: [label, button])
+        let primaryButton: UIButton
+        let cancelButton = UIButton(type: .system)
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
+        cancelButton.setTitle("Use fallback instead", for: .normal)
+        cancelButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+        cancelButton.tintColor = .white
+        cancelButton.addAction(UIAction { [weak self] _ in self?.onCancel?() }, for: .touchUpInside)
+
+        switch scanMode {
+        case .setup:
+            label.text = "Point at the \(expectedRole.title) spot, then save a photo"
+            primaryConfig.title = "📸 Save this place"
+            primaryConfig.baseBackgroundColor = .systemBlue
+            primaryButton = UIButton(configuration: primaryConfig, primaryAction: UIAction { [weak self] _ in
+                self?.capturePhoto()
+            })
+
+        case .verify:
+            label.text = "Are you standing at the \(expectedRole.title) spot?"
+            primaryConfig.title = "✓ That's my spot!"
+            primaryConfig.baseBackgroundColor = .systemGreen
+            primaryButton = UIButton(configuration: primaryConfig, primaryAction: UIAction { [weak self] _ in
+                guard let self, !self.hasResolved else { return }
+                self.hasResolved = true
+                self.captureSession.stopRunning()
+                self.onConfirm?()
+            })
+        }
+
+        primaryButton.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = UIStackView(arrangedSubviews: [label, primaryButton, cancelButton])
         stack.axis = .vertical
         stack.spacing = 16
+        stack.alignment = .center
         stack.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(stack)
 
         NSLayoutConstraint.activate([
             stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
             stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
-            stack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -32)
+            stack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -32),
+            primaryButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 88),
+            primaryButton.widthAnchor.constraint(equalTo: stack.widthAnchor)
         ])
     }
+
+    private func capturePhoto() {
+        guard !hasResolved else { return }
+        guard let photoOutput else {
+            onCancel?()
+            return
+        }
+        let settings = AVCapturePhotoSettings()
+        photoOutput.capturePhoto(with: settings, delegate: self)
+    }
+
+    // MARK: - AVCapturePhotoCaptureDelegate
+
+    nonisolated func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
+        guard error == nil, let jpegData = photo.fileDataRepresentation() else {
+            Task { @MainActor [weak self] in self?.onCancel?() }
+            return
+        }
+        Task { @MainActor [weak self] in
+            guard let self, !self.hasResolved else { return }
+            self.hasResolved = true
+            self.captureSession.stopRunning()
+            self.onPhoto?(jpegData)
+        }
+    }
+
+    // MARK: - AVCaptureMetadataOutputObjectsDelegate
 
     @MainActor
     private func presentARCelebration(for payload: String) {
@@ -197,7 +301,7 @@ final class ScannerViewController: UIViewController, @preconcurrency AVCaptureMe
         Task { @MainActor [weak self] in
             guard let self, !self.hasResolved else { return }
             self.hasResolved = true
-            self.session.stopRunning()
+            self.captureSession.stopRunning()
             self.presentARCelebration(for: payload)
         }
     }

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -79,7 +79,7 @@ struct RoomQuestEngineTests {
 
     @Test
     func markSetupCompleteTransitionsToFirstSpotAfterRegistration() async throws {
-        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role, _ in
             RoomQuestMarkerScanResult(role: role, markerPayload: "mather:roomquest:redRocket:v1", referenceImageJPEGData: nil, usedARCelebration: true)
         })
         engine.startSession()
@@ -94,7 +94,7 @@ struct RoomQuestEngineTests {
 
     @Test
     func stationVerificationTracksCameraVsManualFallback() async throws {
-        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role, _ in
             RoomQuestMarkerScanResult(role: role, markerPayload: "mather:roomquest:redRocket:v1", referenceImageJPEGData: nil, usedARCelebration: false)
         })
         engine.startSession()
@@ -112,7 +112,7 @@ struct RoomQuestEngineTests {
 
     @Test
     func cameraScanSuccessMarksStationAndCelebrates() async throws {
-        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role, _ in
             RoomQuestMarkerScanResult(role: role, markerPayload: "mather:roomquest:redRocket:v1", referenceImageJPEGData: nil, usedARCelebration: true)
         })
 
@@ -138,7 +138,7 @@ struct RoomQuestEngineTests {
 
     @Test
     func wrongMarkerLeavesStationUnregisteredAndShowsError() async throws {
-        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role, _ in
             throw RoomQuestScannerError.wrongMarker(expected: role, detected: .blueBubble)
         })
 
@@ -174,7 +174,7 @@ struct RoomQuestEngineTests {
 
     @Test
     func verifyCurrentSpotWithCameraUnlocksAndAdvances() async throws {
-        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role, _ in
             RoomQuestMarkerScanResult(role: role, markerPayload: role == .redRocket ? "mather:roomquest:redRocket:v1" : "mather:roomquest:blueBubble:v1", referenceImageJPEGData: nil, usedARCelebration: false)
         })
 
@@ -209,7 +209,7 @@ struct RoomQuestEngineTests {
 
     @Test
     func verifyCurrentSpotWithWrongMarkerDoesNotAdvance() async throws {
-        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role, _ in
             throw RoomQuestScannerError.wrongMarker(expected: role, detected: role == .redRocket ? .blueBubble : .redRocket)
         })
 
@@ -237,7 +237,7 @@ struct RoomQuestEngineTests {
 
     @Test
     func verifyCurrentSpotReportsAlmostWhenMarkerPayloadDoesNotMatchSavedReference() async throws {
-        let setupScanner = FakeRoomQuestScanner { role in
+        let setupScanner = FakeRoomQuestScanner { role, _ in
             RoomQuestMarkerScanResult(
                 role: role,
                 markerPayload: role == .redRocket ? "mather:roomquest:redRocket:v1" : "mather:roomquest:blueBubble:v1",
@@ -245,7 +245,7 @@ struct RoomQuestEngineTests {
                 usedARCelebration: false
             )
         }
-        let huntScanner = FakeRoomQuestScanner { role in
+        let huntScanner = FakeRoomQuestScanner { role, _ in
             RoomQuestMarkerScanResult(
                 role: role,
                 markerPayload: role == .redRocket ? "mather:roomquest:redRocket:DIFFERENT" : "mather:roomquest:blueBubble:v1",
@@ -350,25 +350,38 @@ struct RoomQuestEngineTests {
     }
 
     @Test
-    func spotFallbackStaysHiddenUntilCameraMisses() async throws {
-        let engine = makeEngine(scanner: FakeRoomQuestScanner { role in
+    func spotFallbackShownImmediatelyForManualFallbackStation() async throws {
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role, _ in
             throw RoomQuestScannerError.wrongMarker(expected: role, detected: .blueBubble)
         })
 
         engine.startSession()
-        engine.registerStation(.redRocket)
+        engine.registerStation(.redRocket)     // manual fallback — no camera reference
         engine.registerStation(.blueBubble)
         engine.markSetupComplete()
 
-        #expect(!engine.shouldShowSpotManualFallback)
-
-        engine.verifyCurrentSpotWithCamera()
-        await waitFor("spot fallback becomes visible after camera miss") {
-            engine.shouldShowSpotManualFallback
-        }
-
+        // Fallback must show immediately for manual-fallback stations — child was stuck before this fix
         #expect(engine.shouldShowSpotManualFallback)
-        #expect(engine.currentSpotSearchGuidance.localizedCaseInsensitiveContains("fallback"))
+        #expect(engine.currentSpotSearchGuidance.localizedCaseInsensitiveContains("found it"))
+    }
+
+    @Test
+    func spotFallbackStaysHiddenForCapturedStationUntilCameraMisses() async throws {
+        let expectedJPEGData = Data([0xFF, 0xD8, 0xFF, 0xD9])
+        let engine = makeEngine(scanner: FakeRoomQuestScanner { role, _ in
+            RoomQuestMarkerScanResult(role: role, markerPayload: "mather:roomquest:redRocket:v1", referenceImageJPEGData: expectedJPEGData, usedARCelebration: false)
+        })
+
+        engine.startSession()
+        engine.verifyStationWithCamera(.redRocket)
+        await waitFor("camera setup completes") {
+            engine.stations.first(where: { $0.role == .redRocket })?.referenceCaptureState == .captured
+        }
+        engine.registerStation(.blueBubble)
+        engine.markSetupComplete()
+
+        // Captured station — fallback hidden until camera misses
+        #expect(!engine.shouldShowSpotManualFallback)
     }
 
     @Test
@@ -377,7 +390,7 @@ struct RoomQuestEngineTests {
         let container = try! ModelContainer(for: StoredRoomQuestStationReference.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
         let sharedStationStore = RoomQuestStationStore(modelContext: container.mainContext, modelContainer: container)
         let engine = makeEngine(
-            scanner: FakeRoomQuestScanner { role in
+            scanner: FakeRoomQuestScanner { role, _ in
                 RoomQuestMarkerScanResult(
                     role: role,
                     markerPayload: "mather:roomquest:redRocket:v1",
@@ -413,7 +426,7 @@ struct RoomQuestEngineTests {
     @Test
     func verifyCurrentSpotIgnoresDuplicateScanRequestsWhileScanIsActive() async throws {
         let tracker = ScanTracker()
-        let scanner = FakeRoomQuestScanner { role in
+        let scanner = FakeRoomQuestScanner { role, _ in
             await tracker.markStarted()
             while !(await tracker.canFinish) {
                 try await Task.sleep(for: .milliseconds(20))
@@ -600,9 +613,9 @@ private actor ScanTracker {
 }
 
 private struct FakeRoomQuestScanner: RoomQuestScanner {
-    let handler: @MainActor (RoomQuestStationRole) async throws -> RoomQuestMarkerScanResult
+    let handler: @MainActor (RoomQuestStationRole, RoomQuestScanMode) async throws -> RoomQuestMarkerScanResult
 
-    func scanMarker(for role: RoomQuestStationRole) async throws -> RoomQuestMarkerScanResult {
-        try await handler(role)
+    func scanMarker(for role: RoomQuestStationRole, mode: RoomQuestScanMode) async throws -> RoomQuestMarkerScanResult {
+        try await handler(role, mode)
     }
 }

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -345,7 +345,7 @@ struct RoomQuestEngineTests {
 
         #expect(engine.currentSpotReferenceLabel.localizedCaseInsensitiveContains("saved camera place"))
         #expect(engine.currentSpotStatusTitle.localizedCaseInsensitiveContains("find the saved place"))
-        #expect(engine.currentSpotSearchGuidance.localizedCaseInsensitiveContains("hold the camera still"))
+        #expect(engine.currentSpotSearchGuidance.localizedCaseInsensitiveContains("recheck"))
         #expect(!engine.shouldShowSpotManualFallback)
     }
 


### PR DESCRIPTION
## Summary

- **Parent can now save a photo**: `ScannerViewController` had no `AVCapturePhotoOutput` and no save button — the camera was QR-scan-only. Added photo output, a mode-based overlay with a large `📸 Save this place` / `✓ That's my spot!` button (88pt+), and `resolveWithPhoto()` / `resolveWithConfirm()` on `RoomQuestLiveScanner`.
- **Child no longer stuck on manual-fallback stations**: `shouldShowSpotManualFallback` was returning `false` in `.idle` state even when the station had no camera reference. With the scan button also disabled for non-captured stations, the child had zero actionable controls. Fixed to surface the fallback button immediately for `.manualFallback` stations.
- **Child verify works without QR codes**: Verify-mode camera (`RoomQuestScanMode.verify`) shows a "That's my spot!" confirm button. `resolveWithConfirm()` resolves the continuation with the expected role + nil payload; the payload-match validation is skipped (nil short-circuits the guard), so the station unlocks cleanly.

## Root causes

| Bug | File | Problem |
|-----|------|---------|
| Parent can't save | `RoomQuestLiveScanner.swift` | `AVCapturePhotoOutput` never added; no save button in overlay |
| Parent save passes nil photo | `RoomQuestLiveScanner.swift` | `resolveScan()` always passed `referenceImageJPEGData: nil` |
| Child stuck (manual) | `RoomQuestEngine.swift` | `shouldShowSpotManualFallback` ignored `manualFallback` capture state |
| Child stuck (photo) | `RoomQuestLiveScanner.swift` | No confirm path for non-QR stations in verify mode |

## Test plan
- [ ] New test `spotFallbackShownImmediatelyForManualFallbackStation` — fallback visible on enter for manual stations
- [ ] New test `spotFallbackStaysHiddenForCapturedStationUntilCameraMisses` — fallback hidden for camera-captured stations
- [ ] Existing camera setup and spot-verify tests updated for new `RoomQuestScanMode` protocol parameter
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)