### PR TITLE
feat(vs1): expand 1-20 target generation groundwork

### DIFF
--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -54,7 +54,7 @@ private extension MatherApp {
                 sessionId: sessionId,
                 startedAt: startedAt,
                 endedAt: startedAt.addingTimeInterval(300),
-                objectiveTitle: "Make & Break to 10",
+                objectiveTitle: "Make & Break Numbers",
                 problemsCompleted: 4 + index,
                 firstAttemptAccuracy: index == 0 ? 0.75 : 0.5,
                 transferCorrectCount: 2 + (index % 2),

--- a/Domain/ProblemGenerator.swift
+++ b/Domain/ProblemGenerator.swift
@@ -1,20 +1,30 @@
 import Foundation
 
 enum ProblemGenerator {
-    // Seed covers varied decomposition patterns:
-    // - spread pairs (large difference: 1+5, 1+6, 2+7) reveal the range of a number
-    // - mid pairs (3+4, 3+6) are the "non-round" preferred by the spec
-    // - symmetric pairs (3+3, 4+4) test understanding that a+a is valid
-    // - reversed pairs (6+2 after 2+6) expose commutativity across problems
+    // Ordered fixture for deterministic mode. It spans the full 1...20 band while
+    // mixing small/large targets and symmetric/asymmetric decompositions so tests
+    // stay reproducible without every session feeling anchored to a simple climb.
     private static let deterministicSeed: [(Int, Int, Int)] = [
-        (6, 3, 3),  // symmetric — 6 = 3+3
-        (7, 3, 4),  // mid spread
-        (8, 2, 6),  // wider spread
-        (9, 4, 5),  // near-equal
-        (10, 4, 6), // non-round, not anchored to 5
-        (6, 1, 5),  // extreme spread
-        (8, 6, 2),  // reversed of (8,2,6) — commutativity
-        (7, 6, 1),  // high-low reversed
+        (6, 3, 3),
+        (9, 4, 5),
+        (4, 1, 3),
+        (12, 5, 7),
+        (7, 2, 5),
+        (15, 7, 8),
+        (3, 1, 2),
+        (18, 8, 10),
+        (10, 4, 6),
+        (1, 1, 0),
+        (14, 6, 8),
+        (5, 2, 3),
+        (20, 9, 11),
+        (8, 6, 2),
+        (16, 8, 8),
+        (2, 1, 1),
+        (11, 5, 6),
+        (19, 9, 10),
+        (13, 4, 9),
+        (17, 3, 14),
     ]
 
     static func generateProblems(config: SliceConfig) -> [SliceProblem] {
@@ -30,16 +40,65 @@ enum ProblemGenerator {
                 target: tuple.0,
                 decompositionA: tuple.1,
                 decompositionB: tuple.2,
-                difficultyTier: index < 3 ? 1 : 2
+                difficultyTier: difficultyTier(for: tuple.0, index: index)
             )
         }
     }
 
     private static func randomTuples(in range: ClosedRange<Int>, count: Int) -> [(Int, Int, Int)] {
-        (0..<count).map { _ in
-            let target = Int.random(in: range)
-            let left = Int.random(in: 0...target)
-            return (target, left, target - left)
+        guard count > 0 else { return [] }
+
+        var tuples: [(Int, Int, Int)] = []
+        var previousTarget: Int? = nil
+
+        while tuples.count < count {
+            let target = nextTarget(in: range, previousTarget: previousTarget)
+            let decomposition = makeDecomposition(for: target, favorZero: tuples.isEmpty && target <= 2)
+            tuples.append((target, decomposition.0, decomposition.1))
+            previousTarget = target
         }
+
+        return tuples
+    }
+
+    private static func nextTarget(in range: ClosedRange<Int>, previousTarget: Int?) -> Int {
+        let candidates = Array(range).filter { $0 != previousTarget }
+        guard let previousTarget else { return candidates.randomElement() ?? range.lowerBound }
+        guard !candidates.isEmpty else { return previousTarget }
+
+        let nearby = candidates.filter { abs($0 - previousTarget) <= 4 }
+        let preferred = nearby.isEmpty ? candidates : nearby
+        return preferred.randomElement() ?? candidates[0]
+    }
+
+    private static func makeDecomposition(for target: Int, favorZero: Bool = false) -> (Int, Int) {
+        guard target > 0 else { return (0, 0) }
+
+        let nonZeroPairs = (1..<target).map { ($0, target - $0) }
+        if nonZeroPairs.isEmpty || favorZero {
+            let left = Int.random(in: 0...target)
+            return (left, target - left)
+        }
+
+        let symmetricPairs = nonZeroPairs.filter { $0.0 == $0.1 }
+        let asymmetricPairs = nonZeroPairs.filter { $0.0 != $0.1 }
+
+        let basePair: (Int, Int)
+        switch Int.random(in: 0..<100) {
+        case 0..<25 where !symmetricPairs.isEmpty:
+            basePair = symmetricPairs.randomElement() ?? nonZeroPairs[0]
+        case 25..<85 where !asymmetricPairs.isEmpty:
+            basePair = asymmetricPairs.randomElement() ?? nonZeroPairs[0]
+        default:
+            basePair = nonZeroPairs.randomElement() ?? nonZeroPairs[0]
+        }
+
+        return Bool.random() ? basePair : (basePair.1, basePair.0)
+    }
+
+    private static func difficultyTier(for target: Int, index: Int) -> Int {
+        if target <= 5 { return 1 }
+        if target <= 10 { return index < 2 ? 1 : 2 }
+        return 2
     }
 }

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -48,14 +48,20 @@ enum SliceEventType: String, Codable {
 }
 
 struct SliceConfig: Codable, Equatable {
+    private static let allowedTargets = 1...20
+
     var maxProblems: Int = 6
-    var minTarget: Int = 6
-    var maxTarget: Int = 10
+    var minTarget: Int = allowedTargets.lowerBound
+    var maxTarget: Int = allowedTargets.upperBound
     var showTransfer: Bool = true
     var audioEnabled: Bool = true
     var deterministicMode: Bool = true
 
-    var targetRange: ClosedRange<Int> { minTarget...maxTarget }
+    var targetRange: ClosedRange<Int> {
+        let lower = min(max(minTarget, Self.allowedTargets.lowerBound), Self.allowedTargets.upperBound)
+        let upper = min(max(maxTarget, Self.allowedTargets.lowerBound), Self.allowedTargets.upperBound)
+        return min(lower, upper)...max(lower, upper)
+    }
 }
 
 struct SliceProblem: Identifiable, Codable, Equatable {

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -556,7 +556,7 @@ final class VerticalSliceEngine {
         let accuracy = completed == 0 ? 0 : Double(firstTryCount) / Double(completed)
 
         return ParentDigest(
-            objectiveTitle: "Make & Break to 10",
+            objectiveTitle: "Make & Break Numbers",
             firstAttemptAccuracy: accuracy,
             medianLatencyMs: median,
             problemsCompleted: completed,
@@ -576,15 +576,15 @@ final class VerticalSliceEngine {
             return "Your child found the reverse (equation → counters) harder. Try this at home: write '3 + 4 =' on paper and ask them to show it with grapes or blocks."
         }
         if accuracy < 0.5 {
-            return "The concept is still new. Keep sessions short, use physical objects at home (10 buttons, 10 pebbles), and don't rush to the written equation."
+            return "The concept is still new. Keep sessions short, use physical objects at home (up to 20 buttons or pebbles), and don't rush to the written equation."
         }
         if accuracy < 0.7 {
-            return "Repeat the same range with spoken prompts. At home, practise splitting 6–9 objects into two groups and counting each."
+            return "Repeat the same range with spoken prompts. At home, practise splitting groups of 4–12 objects into two parts and counting each."
         }
         if accuracy < 0.9 {
             return "Solid progress! Try increasing to 7–8 problems next session when they seem relaxed."
         }
-        return "Excellent mastery. Try the full 1–10 range or introduce writing the equation on paper first before using the app."
+        return "Excellent mastery. Try the full 1–20 range or introduce writing the equation on paper first before using the app."
     }
 
     private func logProblemPresented() {

--- a/Persistence/TelemetryWriter.swift
+++ b/Persistence/TelemetryWriter.swift
@@ -107,7 +107,7 @@ final class TelemetryWriter {
     func digest(from summaries: [StoredSessionSummary]) -> ParentDigest {
         guard !summaries.isEmpty else {
             return ParentDigest(
-                objectiveTitle: "Make & Break to 10",
+                objectiveTitle: "Make & Break Numbers",
                 firstAttemptAccuracy: 0,
                 medianLatencyMs: 0,
                 problemsCompleted: 0,
@@ -133,7 +133,7 @@ final class TelemetryWriter {
         let transferCorrect = sorted.map(\.transferCorrectCount).reduce(0, +)
 
         return ParentDigest(
-            objectiveTitle: sorted.first?.objectiveTitle ?? "Make & Break to 10",
+            objectiveTitle: sorted.first?.objectiveTitle ?? "Make & Break Numbers",
             firstAttemptAccuracy: accuracy,
             medianLatencyMs: median,
             problemsCompleted: completed,

--- a/Tests/MatherTests/ProblemGeneratorTests.swift
+++ b/Tests/MatherTests/ProblemGeneratorTests.swift
@@ -3,15 +3,64 @@ import Testing
 
 struct ProblemGeneratorTests {
     @Test
-    func deterministicGenerationIsStable() {
-        let config = SliceConfig(maxProblems: 4, minTarget: 6, maxTarget: 10, showTransfer: true, audioEnabled: true, deterministicMode: true)
+    func deterministicGenerationIsStableAcrossExpandedRange() {
+        let config = SliceConfig(maxProblems: 8, minTarget: 1, maxTarget: 20, showTransfer: true, audioEnabled: true, deterministicMode: true)
 
         let first = ProblemGenerator.generateProblems(config: config)
         let second = ProblemGenerator.generateProblems(config: config)
 
-        #expect(first.map(\.target) == [6, 7, 8, 9])
+        #expect(first.map(\.target) == [6, 9, 4, 12, 7, 15, 3, 18])
         #expect(first.map(\.target) == second.map(\.target))
         #expect(first.map(\.decompositionA) == second.map(\.decompositionA))
         #expect(first.map(\.decompositionB) == second.map(\.decompositionB))
+        #expect(Set(first.map(\.target)).count == first.count)
+    }
+
+    @Test
+    func defaultConfigSupportsFullOneToTwentyRange() {
+        let config = SliceConfig()
+        #expect(config.targetRange == 1...20)
+    }
+
+    @Test
+    func randomGenerationUsesRequestedRangeAndAvoidsImmediateRepeats() {
+        let config = SliceConfig(maxProblems: 12, minTarget: 1, maxTarget: 20, showTransfer: true, audioEnabled: true, deterministicMode: false)
+
+        let problems = ProblemGenerator.generateProblems(config: config)
+        let targets = problems.map(\.target)
+
+        #expect(problems.count == 12)
+        #expect(targets.allSatisfy { (1...20).contains($0) })
+        #expect(targets.adjacentPairs().allSatisfy { $0 != $1 })
+    }
+
+    @Test
+    func randomizedSessionsDoNotAllStartAtSix() {
+        let config = SliceConfig(maxProblems: 6, minTarget: 1, maxTarget: 20, showTransfer: true, audioEnabled: true, deterministicMode: false)
+
+        let starts = (0..<24).compactMap { _ in
+            ProblemGenerator.generateProblems(config: config).first?.target
+        }
+
+        #expect(starts.count == 24)
+        #expect(Set(starts).count > 1)
+        #expect(starts.contains(where: { $0 != 6 }))
+    }
+
+    @Test
+    func generatedDecompositionsAlwaysSumToTarget() {
+        let config = SliceConfig(maxProblems: 24, minTarget: 1, maxTarget: 20, showTransfer: true, audioEnabled: true, deterministicMode: false)
+
+        let problems = ProblemGenerator.generateProblems(config: config)
+
+        #expect(problems.allSatisfy { $0.decompositionA + $0.decompositionB == $0.target })
+        #expect(problems.allSatisfy { $0.decompositionA >= 0 && $0.decompositionB >= 0 })
+    }
+}
+
+private extension Array where Element == Int {
+    func adjacentPairs() -> [(Int, Int)] {
+        guard count > 1 else { return [] }
+        return zip(self, dropFirst()).map { ($0, $1) }
     }
 }

--- a/Tests/MatherTests/SessionHistoryTests.swift
+++ b/Tests/MatherTests/SessionHistoryTests.swift
@@ -26,7 +26,7 @@ private func makeDraft(
         sessionId: sessionId,
         startedAt: startedAt,
         endedAt: startedAt.addingTimeInterval(300),
-        objectiveTitle: "Make & Break to 10",
+        objectiveTitle: "Make & Break Numbers",
         problemsCompleted: problemsCompleted,
         firstAttemptAccuracy: accuracy,
         transferCorrectCount: transferCorrect,

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -503,11 +503,7 @@ struct VerticalSliceEngineTests {
         guard let problem = engine.currentProblem else { return }
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()
-<<<<<<< HEAD
         await waitFor("pictorial stage after concrete") { engine.currentStage == .pictorial }
-=======
-        try await Task.sleep(for: .milliseconds(200))
->>>>>>> ce4f5c6 (test(vs1): wait for async stage transitions in engine tests)
         await waitFor("bond match state in pictorial") { engine.bondMatchState != nil }
         let pairIds = engine.bondMatchState?.pairs.map(\.id) ?? []
         for id in pairIds { engine.matchPair(id: id) }

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -503,7 +503,11 @@ struct VerticalSliceEngineTests {
         guard let problem = engine.currentProblem else { return }
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()
+<<<<<<< HEAD
         await waitFor("pictorial stage after concrete") { engine.currentStage == .pictorial }
+=======
+        try await Task.sleep(for: .milliseconds(200))
+>>>>>>> ce4f5c6 (test(vs1): wait for async stage transitions in engine tests)
         await waitFor("bond match state in pictorial") { engine.bondMatchState != nil }
         let pairIds = engine.bondMatchState?.pairs.map(\.id) ?? []
         for id in pairIds { engine.matchPair(id: id) }


### PR DESCRIPTION
## Summary
- expand VS1 target config defaults to clamp within the new 1...20 session range
- replace the old linear/random problem generation with deterministic full-range fixtures plus randomized sequencing that avoids immediate repeats and softens target jumps
- update session summary copy and generator tests for the broader make-and-break number range

## Testing
- Not run in this environment (`xcodebuild` and `swift` are unavailable in the Linux sandbox)
- Static verification only
