### PR TITLE
feat(vs1): add loop-v2 stage routing scaffold

### DIFF
--- a/Domain/ClassicTheme.swift
+++ b/Domain/ClassicTheme.swift
@@ -30,6 +30,7 @@ struct ClassicTheme: SliceTheme {
         case .abstract:   return "Your equation matches the split."
         case .transfer:   return "You matched the same equation with counters."
         case .gravitySplit: return "Perfect balance!"
+        case .sumSprint:  return "Nice sprint!"
         case .bondMatch:  return "Bond Blast complete!"
         case .done:       return "Problem complete."
         }

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -7,6 +7,7 @@ enum SliceStage: String, Codable, CaseIterable, Identifiable {
     case abstract
     case transfer
     case gravitySplit
+    case sumSprint
     case bondMatch
     case done
 
@@ -18,7 +19,8 @@ enum SliceStage: String, Codable, CaseIterable, Identifiable {
         case .pictorial:    "Bond Blast!"
         case .abstract:     "Write it"
         case .transfer:     "Show it"
-        case .gravitySplit: "Balance it!"
+        case .gravitySplit: "Gravity Split"
+        case .sumSprint:    "Sum Sprint"
         case .bondMatch:    "Bond Blast!"
         case .done:         "Done"
         }

--- a/Domain/SliceStateMachine.swift
+++ b/Domain/SliceStateMachine.swift
@@ -18,12 +18,14 @@ enum SliceStateMachine {
         success: Bool,
         showTransfer: Bool,
         showGravitySplit: Bool = false,
-        showBondMatch: Bool = false
+        showBondMatch: Bool = false,
+        makeBreakLoopV2Enabled: Bool = false
     ) -> SliceStage {
         guard success else { return stage }
 
         switch stage {
         case .concrete:
+            if makeBreakLoopV2Enabled { return .gravitySplit }
             return .pictorial
         case .pictorial:
             return .abstract
@@ -32,7 +34,9 @@ enum SliceStateMachine {
             if showTransfer     { return .transfer }
             return showBondMatch ? .bondMatch : .done
         case .gravitySplit:
-            return showBondMatch ? .bondMatch : .done
+            return makeBreakLoopV2Enabled ? .sumSprint : (showBondMatch ? .bondMatch : .done)
+        case .sumSprint:
+            return .bondMatch
         case .transfer:
             return showBondMatch ? .bondMatch : .done
         case .bondMatch:
@@ -47,14 +51,16 @@ enum SliceStateMachine {
         to next: SliceStage,
         showTransfer: Bool,
         showGravitySplit: Bool = false,
-        showBondMatch: Bool = false
+        showBondMatch: Bool = false,
+        makeBreakLoopV2Enabled: Bool = false
     ) -> Bool {
         nextStage(
             after: current,
             success: true,
             showTransfer: showTransfer,
             showGravitySplit: showGravitySplit,
-            showBondMatch: showBondMatch
+            showBondMatch: showBondMatch,
+            makeBreakLoopV2Enabled: makeBreakLoopV2Enabled
         ) == next
     }
 }

--- a/Domain/VehicleSpec.swift
+++ b/Domain/VehicleSpec.swift
@@ -41,6 +41,7 @@ extension VehicleSpec {
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "You parked them perfectly."
             case .gravitySplit: return "Perfect balance!"
+            case .sumSprint:  return "Nice sprint!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -65,6 +66,7 @@ extension VehicleSpec {
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Trucks delivered perfectly."
             case .gravitySplit: return "Perfect balance!"
+            case .sumSprint:  return "Nice sprint!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -89,6 +91,7 @@ extension VehicleSpec {
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Vans delivered!"
             case .gravitySplit: return "Perfect balance!"
+            case .sumSprint:  return "Nice sprint!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -113,6 +116,7 @@ extension VehicleSpec {
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Buses on route!"
             case .gravitySplit: return "Perfect balance!"
+            case .sumSprint:  return "Nice sprint!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -137,6 +141,7 @@ extension VehicleSpec {
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Bulldozers in position!"
             case .gravitySplit: return "Perfect balance!"
+            case .sumSprint:  return "Nice sprint!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -161,6 +166,7 @@ extension VehicleSpec {
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Helicopters landed perfectly."
             case .gravitySplit: return "Perfect balance!"
+            case .sumSprint:  return "Nice sprint!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }
@@ -185,6 +191,7 @@ extension VehicleSpec {
             case .abstract:   return "Your equation matches the split."
             case .transfer:   return "Planes ready for take-off!"
             case .gravitySplit: return "Perfect balance!"
+            case .sumSprint:  return "Nice sprint!"
             case .bondMatch:  return "Bond Blast complete!"
             case .done:       return "Problem complete."
             }

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -262,6 +262,8 @@ final class VerticalSliceEngine {
                 && transferRightCount == currentProblem.decompositionB
         case .gravitySplit:
             isCorrect = gravitySplitState?.isLocked == true
+        case .sumSprint:
+            isCorrect = true
         case .bondMatch:
             // Bond Blast is not submitted via submitCurrentStage — pairs are matched
             // individually via matchPair(id:). This case is unreachable in practice.
@@ -404,15 +406,17 @@ final class VerticalSliceEngine {
 
         // Bond Blast fires only on the last problem of the session.
         let isLastProblem = currentProblemIndex + 1 >= problems.count
-        let showBondMatch = featureFlags.vs1BondMatchEnabled && isLastProblem
-        let showGravitySplit = featureFlags.vs1GravitySplitEnabled
+        let makeBreakLoopV2Enabled = featureFlags.makeBreakLoopV2Enabled
+        let showBondMatch = makeBreakLoopV2Enabled || (featureFlags.vs1BondMatchEnabled && isLastProblem)
+        let showGravitySplit = makeBreakLoopV2Enabled || featureFlags.vs1GravitySplitEnabled
 
         let next = SliceStateMachine.nextStage(
             after: currentStage,
             success: true,
             showTransfer: config.showTransfer,
             showGravitySplit: showGravitySplit,
-            showBondMatch: showBondMatch
+            showBondMatch: showBondMatch,
+            makeBreakLoopV2Enabled: makeBreakLoopV2Enabled
         )
         recordStageTransition(from: currentStage, to: next)
 
@@ -474,6 +478,9 @@ final class VerticalSliceEngine {
                 gravitySplitState = GravitySplitState(problem: problem)
                 gravitySplitNeutralRoll = nil   // re-calibrate on first tilt after stage entry
             }
+        case .sumSprint:
+            bondMatchState = nil
+            gravitySplitState = nil
         case .bondMatch:
             if let problem = currentProblem {
                 bondMatchState = BondMatchState(
@@ -669,6 +676,8 @@ final class VerticalSliceEngine {
             return activeTheme.concretePrompt(target: currentProblem.target)
         case .pictorial, .bondMatch:
             return "Bond Blast! Match the pairs that make \(currentProblem.target)!"
+        case .sumSprint:
+            return "Quick Sum Sprint! Solve a tiny burst, then finish with Bond Blast."
         case .abstract:
             return activeTheme.abstractPrompt()
         case .transfer:
@@ -717,6 +726,8 @@ final class VerticalSliceEngine {
             }
         case .gravitySplit:
             return "Keep tilting! Get \(problem.decompositionA) on one side and \(problem.decompositionB) on the other."
+        case .sumSprint:
+            return "Keep going. This quick sprint comes before Bond Blast."
         case .done:
             return "Try again."
         }

--- a/Features/VerticalSlice1/RouteSupportViews.swift
+++ b/Features/VerticalSlice1/RouteSupportViews.swift
@@ -76,6 +76,14 @@ struct VS1SettingsPlaceholderView: View {
         )
     }
 
+
+    private var makeBreakLoopV2Binding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.makeBreakLoopV2Enabled },
+            set: { appModel.featureFlags.makeBreakLoopV2Enabled = $0 }
+        )
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
@@ -106,6 +114,11 @@ struct VS1SettingsPlaceholderView: View {
                             title: "Test mode",
                             subtitle: "Deterministic ordering for repeatable pilot checks.",
                             isOn: testModeBinding
+                        )
+                        VS1ToggleRow(
+                            title: "Make & Break loop V2",
+                            subtitle: "Use the issue #222 per-target route: Make it, Gravity Split, Sum Sprint, Bond Blast.",
+                            isOn: makeBreakLoopV2Binding
                         )
                     }
                 }

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -147,6 +147,20 @@ struct SliceSessionView: View {
             } else {
                 CardSurface { Text("Loading Balance...") }
             }
+        case .sumSprint:
+            CardSurface {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Sum Sprint")
+                        .font(.title.weight(.black))
+                    Text("PR2 placeholder: the loop now routes through a dedicated Sum Sprint stop before Bond Blast.")
+                        .font(.headline)
+                        .foregroundStyle(.secondary)
+                    Button("Sprint on") {
+                        appModel.engine.submitCurrentStage()
+                    }
+                    .buttonStyle(PrimaryActionButtonStyle())
+                }
+            }
         case .bondMatch:
             if let bondState = appModel.engine.bondMatchState {
                 BondMatchView(
@@ -250,6 +264,7 @@ struct SliceSessionView: View {
         case .abstract:  MatherTheme.accent
         case .transfer:      MatherTheme.coral
         case .gravitySplit:  MatherTheme.coral
+        case .sumSprint:     MatherTheme.softBlue
         case .bondMatch:     MatherTheme.accent
         case .done:          .secondary
         }

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -11,6 +11,7 @@ final class FeatureFlagService {
         static let selectedThemeId = "feature.selectedThemeId"
         static let vs1BondMatchEnabled = "feature.vs1BondMatchEnabled"
         static let vs1GravitySplitEnabled = "feature.vs1GravitySplitEnabled"
+        static let makeBreakLoopV2Enabled = "feature.makeBreakLoopV2Enabled"
         static let motionControlsEnabled = "feature.motionControlsEnabled"
         static let soundReactionEnabled = "feature.soundReactionEnabled"
         static let roomQuestEnabled = "feature.roomQuestEnabled"
@@ -58,6 +59,11 @@ final class FeatureFlagService {
     /// Default false — parent opts in via Settings.
     var vs1GravitySplitEnabled: Bool {
         didSet { defaults.set(vs1GravitySplitEnabled, forKey: Keys.vs1GravitySplitEnabled) }
+    }
+
+    /// Enables the issue #222 per-target loop: Make it -> Gravity Split -> Sum Sprint -> Bond Blast.
+    var makeBreakLoopV2Enabled: Bool {
+        didSet { defaults.set(makeBreakLoopV2Enabled, forKey: Keys.makeBreakLoopV2Enabled) }
     }
 
     /// Enables CMMotionManager tilt drift and shake-to-shuffle in Bond Blast.
@@ -144,6 +150,7 @@ final class FeatureFlagService {
             Keys.selectedThemeId: "classic",
             Keys.vs1BondMatchEnabled: false,
             Keys.vs1GravitySplitEnabled: false,
+            Keys.makeBreakLoopV2Enabled: false,
             Keys.motionControlsEnabled: true,
             Keys.soundReactionEnabled: false,
             Keys.roomQuestEnabled: false,
@@ -165,6 +172,7 @@ final class FeatureFlagService {
         selectedThemeId = defaults.string(forKey: Keys.selectedThemeId) ?? "classic"
         vs1BondMatchEnabled = defaults.bool(forKey: Keys.vs1BondMatchEnabled)
         vs1GravitySplitEnabled = defaults.bool(forKey: Keys.vs1GravitySplitEnabled)
+        makeBreakLoopV2Enabled = defaults.bool(forKey: Keys.makeBreakLoopV2Enabled)
         motionControlsEnabled = defaults.bool(forKey: Keys.motionControlsEnabled)
         soundReactionEnabled = defaults.bool(forKey: Keys.soundReactionEnabled)
         roomQuestEnabled = defaults.bool(forKey: Keys.roomQuestEnabled)

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -34,4 +34,16 @@ struct FeatureFlagTests {
         #expect(flags.audioEnabled == true)
         #expect(flags.hapticsEnabled == true)
     }
+
+
+    @Test func loopV2FlagDefaultsOffAndPersists() {
+        let defaults = UserDefaults(suiteName: #function)!
+        let flags = FeatureFlagService(defaults: defaults)
+        #expect(flags.makeBreakLoopV2Enabled == false)
+        flags.makeBreakLoopV2Enabled = true
+
+        let reloaded = FeatureFlagService(defaults: defaults)
+        #expect(reloaded.makeBreakLoopV2Enabled)
+    }
+
 }

--- a/Tests/MatherTests/SliceStateMachineTests.swift
+++ b/Tests/MatherTests/SliceStateMachineTests.swift
@@ -71,4 +71,14 @@ struct SliceStateMachineTests {
         // Default: showGravitySplit omitted → falls back to Transfer
         #expect(SliceStateMachine.nextStage(after: .abstract, success: true, showTransfer: true) == .transfer)
     }
+
+
+    @Test
+    func makeBreakLoopV2UsesFourStagePerTargetRoute() {
+        #expect(SliceStateMachine.nextStage(after: .concrete, success: true, showTransfer: true, makeBreakLoopV2Enabled: true) == .gravitySplit)
+        #expect(SliceStateMachine.nextStage(after: .gravitySplit, success: true, showTransfer: true, showBondMatch: true, makeBreakLoopV2Enabled: true) == .sumSprint)
+        #expect(SliceStateMachine.nextStage(after: .sumSprint, success: true, showTransfer: true, showBondMatch: true, makeBreakLoopV2Enabled: true) == .bondMatch)
+        #expect(SliceStateMachine.nextStage(after: .bondMatch, success: true, showTransfer: true, showBondMatch: true, makeBreakLoopV2Enabled: true) == .done)
+    }
+
 }

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -705,4 +705,45 @@ struct VerticalSliceEngineTests {
 
         #expect(engine.currentProblemState.isCorrect)
     }
+
+
+    @Test
+    func makeBreakLoopV2RoutesConcreteToGravitySplitToSumSprintToBondBlast() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.verticalSlice1Enabled = true
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        guard let problem = engine.currentProblem else { return }
+
+        engine.adjustConcrete(by: problem.target)
+        engine.submitCurrentStage()
+        await waitFor("gravity split after concrete") { engine.currentStage == .gravitySplit }
+        #expect(engine.currentStage == .gravitySplit)
+
+        let currentLeft = engine.gravitySplitState?.leftCount ?? 0
+        let delta = problem.decompositionA - currentLeft
+        if delta > 0 {
+            for _ in 0..<delta { engine.adjustGravitySplitByTap(delta: 1) }
+        } else if delta < 0 {
+            for _ in 0..<(-delta) { engine.adjustGravitySplitByTap(delta: -1) }
+        }
+        await waitFor("gravity split lock") { engine.gravitySplitState?.isLocked == true }
+        await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
+        #expect(engine.currentStage == .sumSprint)
+
+        engine.submitCurrentStage()
+        await waitFor("bond blast after sum sprint") { engine.currentStage == .bondMatch }
+        #expect(engine.currentStage == .bondMatch)
+    }
+
 }


### PR DESCRIPTION
## Summary
- add a dedicated `makeBreakLoopV2Enabled` flag and route the engine/state machine through `Make it -> Gravity Split -> Sum Sprint -> Bond Blast`
- keep the legacy VS1 route intact when the new flag is off
- add placeholder Sum Sprint UI plus tests for the new per-target stage order

## Testing
- Not run in this environment (`swift` and `xcodebuild` are unavailable in the Linux sandbox)
- Static verification only
