### PR TITLE
feat(room-quest): GPS + Vision place verification (#226-230)

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -22,6 +22,8 @@
 	<string>Mather listens for claps to celebrate with you! Enable in Settings → Clap reaction.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Room Quest uses the camera to scan station markers and unlock playful AR moments for kids.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Mather uses your location outdoors to help your child find the right spot during Room Quest.</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchScreen</key>

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -115,7 +115,7 @@ final class RoomQuestEngine {
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let result = try await scanner.scanMarker(for: role, mode: .setup)
+                let result = try await scanner.scanMarker(for: role, mode: .setup, savedReference: nil)
                 guard self.captureReference(for: result) else {
                     self.feedbackMessage = "We found \(result.role.title), but could not save its hiding-place reference yet. Try again."
                     self.scanState = .failed(role: role, message: self.feedbackMessage)
@@ -308,10 +308,20 @@ final class RoomQuestEngine {
             ? "Rechecking the saved \(station.role.title) place."
             : "Scan \(station.role.title) to unlock the collect step."
 
+        // Build saved-place reference so the scanner can do photo + GPS comparison.
+        let savedRef: RoomQuestSavedReference? = station.referenceCaptureState == .captured
+            ? RoomQuestSavedReference(
+                imageJPEGData: station.referenceImageJPEGData,
+                latitude: station.referenceLatitude,
+                longitude: station.referenceLongitude,
+                gpsAccuracy: station.referenceGPSAccuracy
+              )
+            : nil
+
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let result = try await scanner.scanMarker(for: station.role, mode: .verify)
+                let result = try await scanner.scanMarker(for: station.role, mode: .verify, savedReference: savedRef)
 
                 if let savedReference = try? stationStore.reference(for: station.role),
                    let expectedRole = savedReference.role,
@@ -473,6 +483,9 @@ final class RoomQuestEngine {
             for: result.role,
             markerPayload: result.markerPayload,
             referenceImageJPEGData: result.referenceImageJPEGData,
+            referenceLatitude: result.referenceLatitude,
+            referenceLongitude: result.referenceLongitude,
+            referenceGPSAccuracy: result.referenceGPSAccuracy,
             note: result.referenceImageJPEGData == nil
                 ? "Reference saved for \(result.role.title)"
                 : "Photo saved for \(result.role.title)"
@@ -480,11 +493,23 @@ final class RoomQuestEngine {
     }
 
     @discardableResult
-    private func persistReferenceState(_ state: RoomQuestReferenceCaptureState, for role: RoomQuestStationRole, markerPayload: String?, referenceImageJPEGData: Data? = nil, note: String) -> Bool {
+    private func persistReferenceState(
+        _ state: RoomQuestReferenceCaptureState,
+        for role: RoomQuestStationRole,
+        markerPayload: String?,
+        referenceImageJPEGData: Data? = nil,
+        referenceLatitude: Double? = nil,
+        referenceLongitude: Double? = nil,
+        referenceGPSAccuracy: Double? = nil,
+        note: String
+    ) -> Bool {
         let draft = RoomQuestStationReferenceDraft(
             role: role,
             markerPayload: markerPayload,
             referenceImageJPEGData: referenceImageJPEGData,
+            referenceLatitude: referenceLatitude,
+            referenceLongitude: referenceLongitude,
+            referenceGPSAccuracy: referenceGPSAccuracy,
             capturedAt: .now,
             note: note,
             captureState: state
@@ -492,7 +517,7 @@ final class RoomQuestEngine {
 
         do {
             try stationStore.save(draft)
-            setReferenceState(state, for: role, note: note, referenceImageJPEGData: referenceImageJPEGData)
+            setReferenceState(state, for: role, note: note, referenceImageJPEGData: referenceImageJPEGData, referenceLatitude: referenceLatitude, referenceLongitude: referenceLongitude, referenceGPSAccuracy: referenceGPSAccuracy)
             try? telemetryWriter.append(SliceEvent(
                 type: .roomQuestReferenceCaptureCompleted,
                 payload: [
@@ -500,7 +525,8 @@ final class RoomQuestEngine {
                     "saved": String(state == .captured),
                     "capture_state": state.rawValue,
                     "reference_image_present": String(referenceImageJPEGData != nil),
-                    "marker_payload_present": String(markerPayload != nil)
+                    "marker_payload_present": String(markerPayload != nil),
+                    "gps_present": String(referenceLatitude != nil)
                 ]
             ))
             return true
@@ -518,18 +544,37 @@ final class RoomQuestEngine {
         }
     }
 
-    private func setReferenceState(_ state: RoomQuestReferenceCaptureState, for role: RoomQuestStationRole, note: String, referenceImageJPEGData: Data?) {
+    private func setReferenceState(
+        _ state: RoomQuestReferenceCaptureState,
+        for role: RoomQuestStationRole,
+        note: String,
+        referenceImageJPEGData: Data?,
+        referenceLatitude: Double? = nil,
+        referenceLongitude: Double? = nil,
+        referenceGPSAccuracy: Double? = nil
+    ) {
         guard let idx = stations.firstIndex(where: { $0.role == role }) else { return }
         stations[idx].referenceCaptureState = state
         stations[idx].referenceNote = note
         stations[idx].referenceImageJPEGData = referenceImageJPEGData
+        stations[idx].referenceLatitude = referenceLatitude
+        stations[idx].referenceLongitude = referenceLongitude
+        stations[idx].referenceGPSAccuracy = referenceGPSAccuracy
     }
 
     private func loadSavedReferenceState() {
         for role in RoomQuestStationRole.allCases {
             guard let savedReference = try? stationStore.reference(for: role),
                   let captureState = savedReference.captureState else { continue }
-            setReferenceState(captureState, for: role, note: savedReference.note, referenceImageJPEGData: savedReference.referenceImageJPEGData)
+            setReferenceState(
+                captureState,
+                for: role,
+                note: savedReference.note,
+                referenceImageJPEGData: savedReference.referenceImageJPEGData,
+                referenceLatitude: savedReference.referenceLatitude,
+                referenceLongitude: savedReference.referenceLongitude,
+                referenceGPSAccuracy: savedReference.referenceGPSAccuracy
+            )
         }
     }
 

--- a/Domain/RoomQuestScanner.swift
+++ b/Domain/RoomQuestScanner.swift
@@ -5,11 +5,40 @@ enum RoomQuestScanMode {
     case verify   // child confirming they are standing at the right spot
 }
 
+/// Reference data passed to verify-mode scanner so it can compare the saved place.
+struct RoomQuestSavedReference: Equatable {
+    let imageJPEGData: Data?
+    let latitude: Double?
+    let longitude: Double?
+    let gpsAccuracy: Double?
+}
+
 struct RoomQuestMarkerScanResult: Equatable {
     let role: RoomQuestStationRole
     let markerPayload: String?
     let referenceImageJPEGData: Data?
+    let referenceLatitude: Double?
+    let referenceLongitude: Double?
+    let referenceGPSAccuracy: Double?
     let usedARCelebration: Bool
+
+    init(
+        role: RoomQuestStationRole,
+        markerPayload: String?,
+        referenceImageJPEGData: Data?,
+        referenceLatitude: Double? = nil,
+        referenceLongitude: Double? = nil,
+        referenceGPSAccuracy: Double? = nil,
+        usedARCelebration: Bool
+    ) {
+        self.role = role
+        self.markerPayload = markerPayload
+        self.referenceImageJPEGData = referenceImageJPEGData
+        self.referenceLatitude = referenceLatitude
+        self.referenceLongitude = referenceLongitude
+        self.referenceGPSAccuracy = referenceGPSAccuracy
+        self.usedARCelebration = usedARCelebration
+    }
 }
 
 enum RoomQuestScannerError: Error, Equatable {
@@ -20,11 +49,22 @@ enum RoomQuestScannerError: Error, Equatable {
 
 @MainActor
 protocol RoomQuestScanner {
-    func scanMarker(for role: RoomQuestStationRole, mode: RoomQuestScanMode) async throws -> RoomQuestMarkerScanResult
+    func scanMarker(
+        for role: RoomQuestStationRole,
+        mode: RoomQuestScanMode,
+        savedReference: RoomQuestSavedReference?
+    ) async throws -> RoomQuestMarkerScanResult
+}
+
+extension RoomQuestScanner {
+    /// Convenience — callers that don't need to pass a saved reference.
+    func scanMarker(for role: RoomQuestStationRole, mode: RoomQuestScanMode) async throws -> RoomQuestMarkerScanResult {
+        try await scanMarker(for: role, mode: mode, savedReference: nil)
+    }
 }
 
 struct NoopRoomQuestScanner: RoomQuestScanner {
-    func scanMarker(for role: RoomQuestStationRole, mode: RoomQuestScanMode) async throws -> RoomQuestMarkerScanResult {
+    func scanMarker(for role: RoomQuestStationRole, mode: RoomQuestScanMode, savedReference: RoomQuestSavedReference?) async throws -> RoomQuestMarkerScanResult {
         throw RoomQuestScannerError.unavailable
     }
 }

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -271,6 +271,9 @@ struct RoomQuestStation: Equatable, Codable, Identifiable {
     var referenceCaptureState: RoomQuestReferenceCaptureState = .notCaptured
     var referenceNote: String? = nil
     var referenceImageJPEGData: Data? = nil
+    var referenceLatitude: Double? = nil
+    var referenceLongitude: Double? = nil
+    var referenceGPSAccuracy: Double? = nil
 
     var isReadyForRoomQuest: Bool {
         isRegistered && referenceCaptureState != .notCaptured
@@ -315,9 +318,34 @@ struct RoomQuestStationReferenceDraft: Equatable, Codable {
     let role: RoomQuestStationRole
     let markerPayload: String?
     let referenceImageJPEGData: Data?
+    let referenceLatitude: Double?
+    let referenceLongitude: Double?
+    let referenceGPSAccuracy: Double?
     let capturedAt: Date
     let note: String
     let captureState: RoomQuestReferenceCaptureState
+
+    init(
+        role: RoomQuestStationRole,
+        markerPayload: String?,
+        referenceImageJPEGData: Data?,
+        referenceLatitude: Double? = nil,
+        referenceLongitude: Double? = nil,
+        referenceGPSAccuracy: Double? = nil,
+        capturedAt: Date,
+        note: String,
+        captureState: RoomQuestReferenceCaptureState
+    ) {
+        self.role = role
+        self.markerPayload = markerPayload
+        self.referenceImageJPEGData = referenceImageJPEGData
+        self.referenceLatitude = referenceLatitude
+        self.referenceLongitude = referenceLongitude
+        self.referenceGPSAccuracy = referenceGPSAccuracy
+        self.capturedAt = capturedAt
+        self.note = note
+        self.captureState = captureState
+    }
 }
 
 @Model
@@ -325,14 +353,22 @@ final class StoredRoomQuestStationReference {
     var roleRawValue: String
     var markerPayload: String?
     var referenceImageJPEGData: Data?
+    var referenceLatitude: Double?
+    var referenceLongitude: Double?
+    var referenceGPSAccuracy: Double?
     var capturedAt: Date
     var note: String
     var captureStateRawValue: String
 
-    init(role: RoomQuestStationRole, markerPayload: String?, referenceImageJPEGData: Data?, capturedAt: Date, note: String, captureState: RoomQuestReferenceCaptureState) {
+    init(role: RoomQuestStationRole, markerPayload: String?, referenceImageJPEGData: Data?,
+         referenceLatitude: Double?, referenceLongitude: Double?, referenceGPSAccuracy: Double?,
+         capturedAt: Date, note: String, captureState: RoomQuestReferenceCaptureState) {
         self.roleRawValue = role.rawValue
         self.markerPayload = markerPayload
         self.referenceImageJPEGData = referenceImageJPEGData
+        self.referenceLatitude = referenceLatitude
+        self.referenceLongitude = referenceLongitude
+        self.referenceGPSAccuracy = referenceGPSAccuracy
         self.capturedAt = capturedAt
         self.note = note
         self.captureStateRawValue = captureState.rawValue

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -88,6 +88,30 @@ struct SpotPromptView: View {
 
                 Spacer()
 
+                // Reference thumbnail — shows the saved photo so the child knows where to go
+                if let imageData = station?.referenceImageJPEGData,
+                   let uiImage = UIImage(data: imageData) {
+                    CardSurface {
+                        HStack(spacing: 12) {
+                            Image(uiImage: uiImage)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 80, height: 80)
+                                .clipShape(RoundedRectangle(cornerRadius: 10))
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Find this place")
+                                    .font(.headline.weight(.bold))
+                                    .foregroundStyle(MatherTheme.ink)
+                                Text("Walk to where this photo was taken")
+                                    .font(.subheadline)
+                                    .foregroundStyle(MatherTheme.cardSubtitle)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 24)
+                }
+
                 // Camera scan button — only active for stations with a saved photo reference
                 if station?.referenceCaptureState == .captured {
                     let isScanBusy: Bool = {

--- a/Persistence/RoomQuestStationStore.swift
+++ b/Persistence/RoomQuestStationStore.swift
@@ -20,6 +20,9 @@ final class RoomQuestStationStore {
         if let existing = try modelContext.fetch(descriptor).first {
             existing.markerPayload = draft.markerPayload
             existing.referenceImageJPEGData = draft.referenceImageJPEGData
+            existing.referenceLatitude = draft.referenceLatitude
+            existing.referenceLongitude = draft.referenceLongitude
+            existing.referenceGPSAccuracy = draft.referenceGPSAccuracy
             existing.capturedAt = draft.capturedAt
             existing.note = draft.note
             existing.captureStateRawValue = draft.captureState.rawValue
@@ -29,6 +32,9 @@ final class RoomQuestStationStore {
                     role: draft.role,
                     markerPayload: draft.markerPayload,
                     referenceImageJPEGData: draft.referenceImageJPEGData,
+                    referenceLatitude: draft.referenceLatitude,
+                    referenceLongitude: draft.referenceLongitude,
+                    referenceGPSAccuracy: draft.referenceGPSAccuracy,
                     capturedAt: draft.capturedAt,
                     note: draft.note,
                     captureState: draft.captureState

--- a/Services/LocationService.swift
+++ b/Services/LocationService.swift
@@ -1,0 +1,46 @@
+import CoreLocation
+import Observation
+
+/// Thin CoreLocation wrapper — requests when-in-use authorisation and vends the
+/// most recent fix. Used by RoomQuestLiveScanner to attach GPS coordinates when
+/// a parent saves a station reference photo, and to compare location at verify time.
+@MainActor
+@Observable
+final class LocationService: NSObject, CLLocationManagerDelegate {
+    private let manager = CLLocationManager()
+    private(set) var lastLocation: CLLocation? = nil
+    private(set) var authorizationStatus: CLAuthorizationStatus = .notDetermined
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+        authorizationStatus = manager.authorizationStatus
+    }
+
+    /// Requests when-in-use permission only when status is .notDetermined.
+    /// Safe to call repeatedly.
+    func requestWhenInUseIfNeeded() {
+        guard authorizationStatus == .notDetermined else { return }
+        manager.requestWhenInUseAuthorization()
+    }
+
+    func startUpdates() {
+        manager.startUpdatingLocation()
+    }
+
+    func stopUpdates() {
+        manager.stopUpdatingLocation()
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        guard let loc = locations.last else { return }
+        Task { @MainActor [weak self] in self?.lastLocation = loc }
+    }
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        Task { @MainActor [weak self] in
+            self?.authorizationStatus = manager.authorizationStatus
+        }
+    }
+}

--- a/Services/LocationService.swift
+++ b/Services/LocationService.swift
@@ -39,8 +39,9 @@ final class LocationService: NSObject, CLLocationManagerDelegate {
     }
 
     nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        let status = manager.authorizationStatus
         Task { @MainActor [weak self] in
-            self?.authorizationStatus = manager.authorizationStatus
+            self?.authorizationStatus = status
         }
     }
 }

--- a/Services/PlaceMatchService.swift
+++ b/Services/PlaceMatchService.swift
@@ -23,15 +23,15 @@ enum PlaceMatchService {
     // MARK: - Tunable thresholds
 
     /// Child must be within this many metres of the saved GPS coordinate (outdoor).
-    static var gpsMatchMetres: Double = 15.0
+    static let gpsMatchMetres: Double = 15.0
     /// GPS within this range shows "almost there" instead of "wrong place".
-    static var gpsCloseMetres: Double = 30.0
+    static let gpsCloseMetres: Double = 30.0
     /// VNFeaturePrintObservation distance treated as same place (indoor).
-    static var visionMatchDistance: Float = 0.65
+    static let visionMatchDistance: Float = 0.65
     /// VNFeaturePrintObservation distance treated as "almost" (indoor).
-    static var visionCloseDistance: Float = 1.0
+    static let visionCloseDistance: Float = 1.0
     /// Discard GPS fixes with horizontal accuracy worse than this (metres).
-    static var gpsAccuracyCutoff: Double = 20.0
+    static let gpsAccuracyCutoff: Double = 20.0
 
     // MARK: - Evaluation
 

--- a/Services/PlaceMatchService.swift
+++ b/Services/PlaceMatchService.swift
@@ -1,0 +1,119 @@
+import CoreLocation
+import UIKit
+import Vision
+
+// MARK: - Result types
+
+enum PlaceMatchResult: Equatable {
+    case match      // confident — child is at the right place
+    case close      // nearby but not quite — encourage small adjustment
+    case noMatch    // clearly wrong location
+}
+
+// MARK: - Service
+
+/// Pure namespace — stateless, no actor isolation.
+/// Runs Vision feature-print comparison AND GPS distance check, then combines
+/// them with OR logic so either strong signal alone is enough to confirm.
+///
+/// **Indoor play** → GPS unreliable; Vision drives the verdict.
+/// **Outdoor play** → GPS reliable (±3–5 m); either signal can confirm.
+enum PlaceMatchService {
+
+    // MARK: - Tunable thresholds
+
+    /// Child must be within this many metres of the saved GPS coordinate (outdoor).
+    static var gpsMatchMetres: Double = 15.0
+    /// GPS within this range shows "almost there" instead of "wrong place".
+    static var gpsCloseMetres: Double = 30.0
+    /// VNFeaturePrintObservation distance treated as same place (indoor).
+    static var visionMatchDistance: Float = 0.65
+    /// VNFeaturePrintObservation distance treated as "almost" (indoor).
+    static var visionCloseDistance: Float = 1.0
+    /// Discard GPS fixes with horizontal accuracy worse than this (metres).
+    static var gpsAccuracyCutoff: Double = 20.0
+
+    // MARK: - Evaluation
+
+    /// Evaluate whether `currentLocation` / `candidateImageData` match the saved reference.
+    /// - Returns: `(result, wasGPS)` where `wasGPS` is `true` when GPS was the decisive signal
+    ///   (used to tailor speech: "walk closer" vs "move closer").
+    static func evaluate(
+        savedLatitude: Double?,
+        savedLongitude: Double?,
+        savedGPSAccuracy: Double?,
+        currentLocation: CLLocation?,
+        savedImageData: Data?,
+        candidateImageData: Data?
+    ) -> (result: PlaceMatchResult, wasGPS: Bool) {
+        let savedLoc = makeSavedLocation(lat: savedLatitude, lon: savedLongitude, accuracy: savedGPSAccuracy)
+        let gpsResult  = evaluateGPS(saved: savedLoc, current: currentLocation)
+        let visResult  = evaluateVision(reference: savedImageData, candidate: candidateImageData)
+
+        // OR logic: either strong signal alone confirms place
+        switch (gpsResult, visResult) {
+        case (.match, _):  return (.match,   true)
+        case (_, .match):  return (.match,   false)
+        case (.close, _):  return (.close,   true)
+        case (_, .close):  return (.close,   false)
+        default:           return (.noMatch, false)
+        }
+    }
+
+    // MARK: - GPS sub-evaluation
+
+    private static func makeSavedLocation(lat: Double?, lon: Double?, accuracy: Double?) -> CLLocation? {
+        guard let lat, let lon, let accuracy, accuracy > 0 else { return nil }
+        return CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: lat, longitude: lon),
+            altitude: 0,
+            horizontalAccuracy: accuracy,
+            verticalAccuracy: -1,
+            timestamp: .distantPast
+        )
+    }
+
+    private static func evaluateGPS(saved: CLLocation?, current: CLLocation?) -> PlaceMatchResult {
+        guard let saved, let current,
+              saved.horizontalAccuracy > 0,   saved.horizontalAccuracy  <= gpsAccuracyCutoff,
+              current.horizontalAccuracy > 0, current.horizontalAccuracy <= gpsAccuracyCutoff
+        else { return .noMatch }   // GPS unreliable — skip this signal
+
+        let dist = current.distance(from: saved)
+        if dist <= gpsMatchMetres { return .match }
+        if dist <= gpsCloseMetres { return .close }
+        return .noMatch
+    }
+
+    // MARK: - Vision sub-evaluation
+
+    private static func evaluateVision(reference: Data?, candidate: Data?) -> PlaceMatchResult {
+        guard let refData = reference, let candData = candidate else { return .noMatch }
+        do {
+            let refPrint  = try featurePrint(for: refData)
+            let candPrint = try featurePrint(for: candData)
+            var dist: Float = 0
+            try refPrint.computeDistance(&dist, to: candPrint)
+            if dist <= visionMatchDistance { return .match }
+            if dist <= visionCloseDistance { return .close }
+            return .noMatch
+        } catch {
+            // Blurry / too-dark photo — treat as noMatch; grown-up fallback handles it
+            return .noMatch
+        }
+    }
+
+    private static func featurePrint(for imageData: Data) throws -> VNFeaturePrintObservation {
+        guard let cgImage = UIImage(data: imageData)?.cgImage else {
+            throw PlaceMatchError.badImage
+        }
+        let request = VNGenerateImageFeaturePrintRequest()
+        try VNImageRequestHandler(cgImage: cgImage).perform([request])
+        guard let result = request.results?.first as? VNFeaturePrintObservation else {
+            throw PlaceMatchError.noResult
+        }
+        return result
+    }
+}
+
+enum PlaceMatchError: Error { case badImage, noResult }

--- a/Services/RoomQuestLiveScanner.swift
+++ b/Services/RoomQuestLiveScanner.swift
@@ -5,6 +5,19 @@ import Observation
 import RealityKit
 import SwiftUI
 
+// MARK: - Verify feedback
+
+/// Result of a place-comparison attempt in `.verify` mode.
+/// Drives the feedback overlay inside the scanner sheet.
+enum VerifyFeedback: Equatable {
+    case evaluating                   // PlaceMatchService is running
+    case match                        // confirmed — continuation already resolved
+    case close(wasGPS: Bool)          // almost there
+    case noMatch(wasGPS: Bool)        // wrong place
+}
+
+// MARK: - Live scanner
+
 @MainActor
 @Observable
 final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
@@ -12,46 +25,127 @@ final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
         let id = UUID()
         let expectedRole: RoomQuestStationRole
         let mode: RoomQuestScanMode
+        let savedReference: RoomQuestSavedReference?
         let continuation: CheckedContinuation<RoomQuestMarkerScanResult, Error>
     }
 
     private(set) var activeSession: Session?
+    private(set) var verifyFeedback: VerifyFeedback? = nil
 
-    func scanMarker(for role: RoomQuestStationRole, mode: RoomQuestScanMode) async throws -> RoomQuestMarkerScanResult {
-        try await withCheckedThrowingContinuation { continuation in
-            activeSession = Session(expectedRole: role, mode: mode, continuation: continuation)
+    /// Location service — owned here so GPS coordinates are captured at the exact photo moment.
+    let locationService = LocationService()
+
+    // MARK: - Protocol
+
+    func scanMarker(
+        for role: RoomQuestStationRole,
+        mode: RoomQuestScanMode,
+        savedReference: RoomQuestSavedReference?
+    ) async throws -> RoomQuestMarkerScanResult {
+        verifyFeedback = nil
+        locationService.requestWhenInUseIfNeeded()
+        locationService.startUpdates()
+        return try await withCheckedThrowingContinuation { continuation in
+            activeSession = Session(
+                expectedRole: role,
+                mode: mode,
+                savedReference: savedReference,
+                continuation: continuation
+            )
         }
     }
 
+    // MARK: - Resolution paths
+
+    /// Called from `ScannerViewController` when a photo is taken.
+    /// • Setup mode: include GPS from `locationService`, resolve immediately.
+    /// • Verify mode: run PlaceMatchService; resolve on `.match`, set `verifyFeedback` otherwise.
+    func resolveWithPhoto(_ jpegData: Data) {
+        guard let session = activeSession else { return }
+
+        switch session.mode {
+
+        case .setup:
+            let loc = locationService.lastLocation
+            session.continuation.resume(returning: RoomQuestMarkerScanResult(
+                role: session.expectedRole,
+                markerPayload: nil,
+                referenceImageJPEGData: jpegData,
+                referenceLatitude: loc?.coordinate.latitude,
+                referenceLongitude: loc?.coordinate.longitude,
+                referenceGPSAccuracy: loc?.horizontalAccuracy,
+                usedARCelebration: false
+            ))
+            locationService.stopUpdates()
+            activeSession = nil
+
+        case .verify:
+            let savedRef = session.savedReference
+            let currentLocation = locationService.lastLocation
+            let expectedRole = session.expectedRole
+            let continuation = session.continuation
+            verifyFeedback = .evaluating
+
+            Task.detached { [weak self, savedRef, currentLocation] in
+                let (result, wasGPS) = PlaceMatchService.evaluate(
+                    savedLatitude: savedRef?.latitude,
+                    savedLongitude: savedRef?.longitude,
+                    savedGPSAccuracy: savedRef?.gpsAccuracy,
+                    currentLocation: currentLocation,
+                    savedImageData: savedRef?.imageJPEGData,
+                    candidateImageData: jpegData
+                )
+                await MainActor.run { [weak self] in
+                    guard let self, self.activeSession != nil else {
+                        // Session was cancelled while PlaceMatchService ran — ignore.
+                        return
+                    }
+                    switch result {
+                    case .match:
+                        self.verifyFeedback = .match
+                        continuation.resume(returning: RoomQuestMarkerScanResult(
+                            role: expectedRole,
+                            markerPayload: nil,
+                            referenceImageJPEGData: nil,
+                            usedARCelebration: false
+                        ))
+                        self.locationService.stopUpdates()
+                        self.activeSession = nil
+                    case .close:
+                        self.verifyFeedback = .close(wasGPS: wasGPS)
+                    case .noMatch:
+                        self.verifyFeedback = .noMatch(wasGPS: wasGPS)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Called when the QR scanner detects a valid marker (setup mode only).
     func resolveScan(payload: String) {
         guard let session = activeSession else { return }
         guard let detectedRole = Self.role(from: payload) else {
             session.continuation.resume(throwing: RoomQuestScannerError.unavailable)
+            locationService.stopUpdates()
             activeSession = nil
             return
         }
         guard detectedRole == session.expectedRole else {
             session.continuation.resume(throwing: RoomQuestScannerError.wrongMarker(expected: session.expectedRole, detected: detectedRole))
+            locationService.stopUpdates()
             activeSession = nil
             return
         }
-        session.continuation.resume(returning: RoomQuestMarkerScanResult(role: detectedRole, markerPayload: payload, referenceImageJPEGData: nil, usedARCelebration: true))
-        activeSession = nil
-    }
-
-    /// Called when parent takes a photo to save this place as the station reference.
-    func resolveWithPhoto(_ jpegData: Data) {
-        guard let session = activeSession else { return }
         session.continuation.resume(returning: RoomQuestMarkerScanResult(
-            role: session.expectedRole,
-            markerPayload: nil,
-            referenceImageJPEGData: jpegData,
-            usedARCelebration: false
+            role: detectedRole,
+            markerPayload: payload,
+            referenceImageJPEGData: nil,
+            usedARCelebration: true
         ))
+        locationService.stopUpdates()
         activeSession = nil
     }
 
-    /// Called when child confirms they are at the correct spot (no QR required).
     func resolveWithConfirm() {
         guard let session = activeSession else { return }
         session.continuation.resume(returning: RoomQuestMarkerScanResult(
@@ -60,26 +154,30 @@ final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
             referenceImageJPEGData: nil,
             usedARCelebration: false
         ))
+        locationService.stopUpdates()
         activeSession = nil
     }
 
     func cancelScan() {
         guard let session = activeSession else { return }
         session.continuation.resume(throwing: RoomQuestScannerError.cancelled)
+        locationService.stopUpdates()
         activeSession = nil
+        verifyFeedback = nil
     }
+
+    // MARK: - Helpers
 
     private static func role(from payload: String) -> RoomQuestStationRole? {
         switch payload.trimmingCharacters(in: .whitespacesAndNewlines) {
-        case "mather:roomquest:redRocket:v1":
-            return .redRocket
-        case "mather:roomquest:blueBubble:v1":
-            return .blueBubble
-        default:
-            return nil
+        case "mather:roomquest:redRocket:v1":  return .redRocket
+        case "mather:roomquest:blueBubble:v1": return .blueBubble
+        default: return nil
         }
     }
 }
+
+// MARK: - Sheet wrapper
 
 struct RoomQuestScannerSheet: View {
     @Bindable var scanner: RoomQuestLiveScanner
@@ -91,6 +189,8 @@ struct RoomQuestScannerSheet: View {
                     RoomQuestCameraScannerView(
                         expectedRole: session.expectedRole,
                         scanMode: session.mode,
+                        savedImageData: session.savedReference?.imageJPEGData,
+                        verifyFeedback: scanner.verifyFeedback,
                         onPayload: { payload in scanner.resolveScan(payload: payload) },
                         onPhoto: { jpegData in scanner.resolveWithPhoto(jpegData) },
                         onConfirm: { scanner.resolveWithConfirm() },
@@ -106,9 +206,13 @@ struct RoomQuestScannerSheet: View {
     }
 }
 
+// MARK: - UIViewControllerRepresentable bridge
+
 private struct RoomQuestCameraScannerView: UIViewControllerRepresentable {
     let expectedRole: RoomQuestStationRole
     let scanMode: RoomQuestScanMode
+    let savedImageData: Data?
+    let verifyFeedback: VerifyFeedback?
     let onPayload: (String) -> Void
     let onPhoto: (Data) -> Void
     let onConfirm: () -> Void
@@ -118,6 +222,7 @@ private struct RoomQuestCameraScannerView: UIViewControllerRepresentable {
         let controller = ScannerViewController()
         controller.expectedRole = expectedRole
         controller.scanMode = scanMode
+        controller.savedImageData = savedImageData
         controller.onPayload = onPayload
         controller.onPhoto = onPhoto
         controller.onConfirm = onConfirm
@@ -125,8 +230,14 @@ private struct RoomQuestCameraScannerView: UIViewControllerRepresentable {
         return controller
     }
 
-    func updateUIViewController(_ uiViewController: ScannerViewController, context: Context) {}
+    func updateUIViewController(_ uiViewController: ScannerViewController, context: Context) {
+        if let feedback = verifyFeedback {
+            uiViewController.applyVerifyFeedback(feedback)
+        }
+    }
 }
+
+// MARK: - ScannerViewController
 
 final class ScannerViewController: UIViewController,
     @preconcurrency AVCaptureMetadataOutputObjectsDelegate,
@@ -134,6 +245,7 @@ final class ScannerViewController: UIViewController,
 
     var expectedRole: RoomQuestStationRole = .redRocket
     var scanMode: RoomQuestScanMode = .setup
+    var savedImageData: Data? = nil
     var onPayload: ((String) -> Void)?
     var onPhoto: ((Data) -> Void)?
     var onConfirm: (() -> Void)?
@@ -143,6 +255,13 @@ final class ScannerViewController: UIViewController,
     private var previewLayer: AVCaptureVideoPreviewLayer?
     private var photoOutput: AVCapturePhotoOutput?
     private var hasResolved = false
+    private var isEvaluating = false     // verify mode: prevents re-tap while PlaceMatch runs
+
+    // Verify mode overlays
+    private var thumbnailContainer: UIView?
+    private var feedbackBanner: UIView?
+    private var feedbackLabel: UILabel?
+    private var primaryButton: UIButton?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -171,14 +290,15 @@ final class ScannerViewController: UIViewController,
         }
         captureSession.addInput(input)
 
-        let metadataOutput = AVCaptureMetadataOutput()
-        guard captureSession.canAddOutput(metadataOutput) else {
-            onCancel?()
-            return
+        // QR metadata only needed in setup mode (verify uses photo comparison)
+        if scanMode == .setup {
+            let metadataOutput = AVCaptureMetadataOutput()
+            if captureSession.canAddOutput(metadataOutput) {
+                captureSession.addOutput(metadataOutput)
+                metadataOutput.setMetadataObjectsDelegate(self, queue: .main)
+                metadataOutput.metadataObjectTypes = [.qr]
+            }
         }
-        captureSession.addOutput(metadataOutput)
-        metadataOutput.setMetadataObjectsDelegate(self, queue: .main)
-        metadataOutput.metadataObjectTypes = [.qr]
 
         let photoOut = AVCapturePhotoOutput()
         if captureSession.canAddOutput(photoOut) {
@@ -199,49 +319,39 @@ final class ScannerViewController: UIViewController,
     }
 
     private func addOverlay() {
+        switch scanMode {
+        case .setup:
+            addSetupOverlay()
+        case .verify:
+            addVerifyOverlay()
+        }
+    }
+
+    // MARK: Setup overlay
+
+    private func addSetupOverlay() {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.textAlignment = .center
         label.numberOfLines = 0
         label.textColor = .white
         label.font = .preferredFont(forTextStyle: .title2)
+        label.text = "Point at the \(expectedRole.title) spot, then save a photo"
 
-        var primaryConfig = UIButton.Configuration.filled()
-        primaryConfig.cornerStyle = .large
-        primaryConfig.buttonSize = .large
+        var config = UIButton.Configuration.filled()
+        config.cornerStyle = .large
+        config.buttonSize = .large
+        config.title = "📸 Save this place"
+        config.baseBackgroundColor = .systemBlue
 
-        let primaryButton: UIButton
-        let cancelButton = UIButton(type: .system)
-        cancelButton.translatesAutoresizingMaskIntoConstraints = false
-        cancelButton.setTitle("Use fallback instead", for: .normal)
-        cancelButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
-        cancelButton.tintColor = .white
-        cancelButton.addAction(UIAction { [weak self] _ in self?.onCancel?() }, for: .touchUpInside)
+        let btn = UIButton(configuration: config, primaryAction: UIAction { [weak self] _ in
+            self?.capturePhoto()
+        })
+        btn.translatesAutoresizingMaskIntoConstraints = false
 
-        switch scanMode {
-        case .setup:
-            label.text = "Point at the \(expectedRole.title) spot, then save a photo"
-            primaryConfig.title = "📸 Save this place"
-            primaryConfig.baseBackgroundColor = .systemBlue
-            primaryButton = UIButton(configuration: primaryConfig, primaryAction: UIAction { [weak self] _ in
-                self?.capturePhoto()
-            })
+        let cancelButton = makeCancelButton()
 
-        case .verify:
-            label.text = "Are you standing at the \(expectedRole.title) spot?"
-            primaryConfig.title = "✓ That's my spot!"
-            primaryConfig.baseBackgroundColor = .systemGreen
-            primaryButton = UIButton(configuration: primaryConfig, primaryAction: UIAction { [weak self] _ in
-                guard let self, !self.hasResolved else { return }
-                self.hasResolved = true
-                self.captureSession.stopRunning()
-                self.onConfirm?()
-            })
-        }
-
-        primaryButton.translatesAutoresizingMaskIntoConstraints = false
-
-        let stack = UIStackView(arrangedSubviews: [label, primaryButton, cancelButton])
+        let stack = UIStackView(arrangedSubviews: [label, btn, cancelButton])
         stack.axis = .vertical
         stack.spacing = 16
         stack.alignment = .center
@@ -252,10 +362,175 @@ final class ScannerViewController: UIViewController,
             stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
             stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
             stack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -32),
-            primaryButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 88),
-            primaryButton.widthAnchor.constraint(equalTo: stack.widthAnchor)
+            btn.heightAnchor.constraint(greaterThanOrEqualToConstant: 88),
+            btn.widthAnchor.constraint(equalTo: stack.widthAnchor)
         ])
     }
+
+    // MARK: Verify overlay
+
+    private func addVerifyOverlay() {
+        // --- Reference thumbnail (top-left) ---
+        if let imageData = savedImageData, let uiImage = UIImage(data: imageData) {
+            let container = makeThumbnailContainer(image: uiImage)
+            view.addSubview(container)
+            thumbnailContainer = container
+            NSLayoutConstraint.activate([
+                container.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+                container.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 16),
+                container.widthAnchor.constraint(equalToConstant: 130),
+            ])
+        }
+
+        // --- Primary action button ---
+        var config = UIButton.Configuration.filled()
+        config.cornerStyle = .large
+        config.buttonSize = .large
+        config.title = "📸 Check my spot"
+        config.baseBackgroundColor = .systemGreen
+
+        let btn = UIButton(configuration: config, primaryAction: UIAction { [weak self] _ in
+            guard let self, !self.hasResolved, !self.isEvaluating else { return }
+            self.isEvaluating = true
+            self.updatePrimaryButton(enabled: false)
+            self.capturePhoto()
+        })
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        self.primaryButton = btn
+
+        let cancelButton = makeCancelButton()
+
+        // --- Feedback banner (hidden until feedback arrives) ---
+        let bannerView = UIView()
+        bannerView.translatesAutoresizingMaskIntoConstraints = false
+        bannerView.layer.cornerRadius = 14
+        bannerView.clipsToBounds = true
+        bannerView.isHidden = true
+        self.feedbackBanner = bannerView
+
+        let bannerLabel = UILabel()
+        bannerLabel.translatesAutoresizingMaskIntoConstraints = false
+        bannerLabel.textAlignment = .center
+        bannerLabel.numberOfLines = 0
+        bannerLabel.textColor = .white
+        bannerLabel.font = .preferredFont(forTextStyle: .headline)
+        bannerView.addSubview(bannerLabel)
+        self.feedbackLabel = bannerLabel
+
+        NSLayoutConstraint.activate([
+            bannerLabel.leadingAnchor.constraint(equalTo: bannerView.leadingAnchor, constant: 16),
+            bannerLabel.trailingAnchor.constraint(equalTo: bannerView.trailingAnchor, constant: -16),
+            bannerLabel.topAnchor.constraint(equalTo: bannerView.topAnchor, constant: 12),
+            bannerLabel.bottomAnchor.constraint(equalTo: bannerView.bottomAnchor, constant: -12)
+        ])
+
+        let stack = UIStackView(arrangedSubviews: [bannerView, btn, cancelButton])
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.alignment = .center
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            stack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -32),
+            btn.heightAnchor.constraint(greaterThanOrEqualToConstant: 88),
+            btn.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            bannerView.widthAnchor.constraint(equalTo: stack.widthAnchor)
+        ])
+    }
+
+    private func makeThumbnailContainer(image: UIImage) -> UIView {
+        let container = UIView()
+        container.translatesAutoresizingMaskIntoConstraints = false
+        container.backgroundColor = UIColor.black.withAlphaComponent(0.55)
+        container.layer.cornerRadius = 12
+        container.clipsToBounds = true
+
+        let imageView = UIImageView(image: image)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 10
+
+        let caption = UILabel()
+        caption.translatesAutoresizingMaskIntoConstraints = false
+        caption.text = "Find this place"
+        caption.textColor = .white
+        caption.font = .preferredFont(forTextStyle: .caption1)
+        caption.textAlignment = .center
+
+        container.addSubview(imageView)
+        container.addSubview(caption)
+
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 8),
+            imageView.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
+            imageView.topAnchor.constraint(equalTo: container.topAnchor, constant: 8),
+            imageView.heightAnchor.constraint(equalToConstant: 90),
+            caption.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 8),
+            caption.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -8),
+            caption.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 4),
+            caption.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -8)
+        ])
+        return container
+    }
+
+    private func makeCancelButton() -> UIButton {
+        let btn = UIButton(type: .system)
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        btn.setTitle("Use fallback instead", for: .normal)
+        btn.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+        btn.tintColor = .white
+        btn.addAction(UIAction { [weak self] _ in self?.onCancel?() }, for: .touchUpInside)
+        return btn
+    }
+
+    // MARK: Verify feedback
+
+    /// Called from `updateUIViewController` when `verifyFeedback` changes.
+    func applyVerifyFeedback(_ feedback: VerifyFeedback) {
+        switch feedback {
+        case .evaluating:
+            updatePrimaryButton(enabled: false)
+            feedbackBanner?.isHidden = true
+
+        case .match:
+            // Sheet auto-dismisses when `activeSession` is set to nil in scanner.
+            // Camera stops in `viewWillDisappear`. Nothing to do here.
+            break
+
+        case .close(let wasGPS):
+            isEvaluating = false
+            updatePrimaryButton(enabled: true)
+            let msg = wasGPS
+                ? "Almost there! Walk a bit closer, then tap again."
+                : "Almost! Move the camera to look more like the saved photo."
+            showFeedbackBanner(message: msg, color: UIColor.systemOrange)
+
+        case .noMatch(let wasGPS):
+            isEvaluating = false
+            updatePrimaryButton(enabled: true)
+            let msg = wasGPS
+                ? "Wrong place — keep walking and looking around."
+                : "Wrong place — the camera view looks different. Keep searching."
+            showFeedbackBanner(message: msg, color: UIColor.systemRed.withAlphaComponent(0.85))
+        }
+    }
+
+    private func showFeedbackBanner(message: String, color: UIColor) {
+        feedbackLabel?.text = message
+        feedbackBanner?.backgroundColor = color
+        feedbackBanner?.isHidden = false
+    }
+
+    private func updatePrimaryButton(enabled: Bool) {
+        primaryButton?.isEnabled = enabled
+        primaryButton?.alpha = enabled ? 1.0 : 0.6
+    }
+
+    // MARK: Photo capture
 
     private func capturePhoto() {
         guard !hasResolved else { return }
@@ -276,13 +551,19 @@ final class ScannerViewController: UIViewController,
         }
         Task { @MainActor [weak self] in
             guard let self, !self.hasResolved else { return }
-            self.hasResolved = true
-            self.captureSession.stopRunning()
-            self.onPhoto?(jpegData)
+            if self.scanMode == .setup {
+                // Setup: stop camera now, resolve immediately
+                self.hasResolved = true
+                self.captureSession.stopRunning()
+                self.onPhoto?(jpegData)
+            } else {
+                // Verify: keep camera running for retries; scanner drives resolution
+                self.onPhoto?(jpegData)
+            }
         }
     }
 
-    // MARK: - AVCaptureMetadataOutputObjectsDelegate
+    // MARK: - AVCaptureMetadataOutputObjectsDelegate (setup only)
 
     @MainActor
     private func presentARCelebration(for payload: String) {
@@ -306,6 +587,8 @@ final class ScannerViewController: UIViewController,
         }
     }
 }
+
+// MARK: - AR Celebration
 
 @MainActor
 private final class RoomQuestARCelebrationViewController: UIViewController {

--- a/Tests/MatherTests/PlaceMatchServiceTests.swift
+++ b/Tests/MatherTests/PlaceMatchServiceTests.swift
@@ -1,0 +1,161 @@
+import CoreLocation
+import Testing
+@testable import Mather
+
+struct PlaceMatchServiceTests {
+
+    // MARK: - GPS evaluation
+
+    @Test
+    func gpsMatchWithinMatchRadius() {
+        // Two locations 10 metres apart — well inside 15 m match threshold
+        let result = PlaceMatchService.evaluate(
+            savedLatitude: 51.5074,
+            savedLongitude: -0.1278,
+            savedGPSAccuracy: 5.0,
+            currentLocation: CLLocation(
+                coordinate: CLLocationCoordinate2D(
+                    latitude: 51.5074 + 0.00009,   // ~10 m north
+                    longitude: -0.1278
+                ),
+                altitude: 0,
+                horizontalAccuracy: 5.0,
+                verticalAccuracy: -1,
+                timestamp: .now
+            ),
+            savedImageData: nil,
+            candidateImageData: nil
+        )
+        #expect(result.result == .match)
+        #expect(result.wasGPS == true)
+    }
+
+    @Test
+    func gpsCloseInCloseRange() {
+        // ~25 m apart — between 15 m match and 30 m close thresholds
+        let result = PlaceMatchService.evaluate(
+            savedLatitude: 51.5074,
+            savedLongitude: -0.1278,
+            savedGPSAccuracy: 5.0,
+            currentLocation: CLLocation(
+                coordinate: CLLocationCoordinate2D(
+                    latitude: 51.5074 + 0.000225,   // ~25 m north
+                    longitude: -0.1278
+                ),
+                altitude: 0,
+                horizontalAccuracy: 5.0,
+                verticalAccuracy: -1,
+                timestamp: .now
+            ),
+            savedImageData: nil,
+            candidateImageData: nil
+        )
+        #expect(result.result == .close)
+        #expect(result.wasGPS == true)
+    }
+
+    @Test
+    func gpsNoMatchBeyondCloseRange() {
+        // ~100 m apart — beyond 30 m close threshold
+        let result = PlaceMatchService.evaluate(
+            savedLatitude: 51.5074,
+            savedLongitude: -0.1278,
+            savedGPSAccuracy: 5.0,
+            currentLocation: CLLocation(
+                coordinate: CLLocationCoordinate2D(
+                    latitude: 51.5074 + 0.0009,   // ~100 m north
+                    longitude: -0.1278
+                ),
+                altitude: 0,
+                horizontalAccuracy: 5.0,
+                verticalAccuracy: -1,
+                timestamp: .now
+            ),
+            savedImageData: nil,
+            candidateImageData: nil
+        )
+        #expect(result.result == .noMatch)
+    }
+
+    @Test
+    func gpsIgnoredWhenAccuracyTooWeak() {
+        // GPS accuracy 50 m — above the 20 m cutoff, should be discarded
+        let result = PlaceMatchService.evaluate(
+            savedLatitude: 51.5074,
+            savedLongitude: -0.1278,
+            savedGPSAccuracy: 50.0,
+            currentLocation: CLLocation(
+                coordinate: CLLocationCoordinate2D(
+                    latitude: 51.5074 + 0.00009,
+                    longitude: -0.1278
+                ),
+                altitude: 0,
+                horizontalAccuracy: 50.0,
+                verticalAccuracy: -1,
+                timestamp: .now
+            ),
+            savedImageData: nil,
+            candidateImageData: nil
+        )
+        // No image data either → noMatch, wasGPS false
+        #expect(result.result == .noMatch)
+        #expect(result.wasGPS == false)
+    }
+
+    @Test
+    func noMatchWhenBothSignalsMissing() {
+        let result = PlaceMatchService.evaluate(
+            savedLatitude: nil,
+            savedLongitude: nil,
+            savedGPSAccuracy: nil,
+            currentLocation: nil,
+            savedImageData: nil,
+            candidateImageData: nil
+        )
+        #expect(result.result == .noMatch)
+        #expect(result.wasGPS == false)
+    }
+
+    // MARK: - Vision evaluation
+
+    @Test
+    func visionNoMatchWhenOnlyOneSideHasData() {
+        // Saved image present but no candidate — should degrade gracefully
+        let fakeImageData = Data([0xFF, 0xD8, 0xFF, 0xD9])  // minimal JPEG header (not a real image)
+        let result = PlaceMatchService.evaluate(
+            savedLatitude: nil,
+            savedLongitude: nil,
+            savedGPSAccuracy: nil,
+            currentLocation: nil,
+            savedImageData: fakeImageData,
+            candidateImageData: nil
+        )
+        #expect(result.result == .noMatch)
+    }
+
+    // MARK: - OR logic
+
+    @Test
+    func gpsMatchWinsEvenWithNilImages() {
+        // GPS match + no vision → overall match via GPS
+        let result = PlaceMatchService.evaluate(
+            savedLatitude: 51.5074,
+            savedLongitude: -0.1278,
+            savedGPSAccuracy: 5.0,
+            currentLocation: CLLocation(
+                coordinate: CLLocationCoordinate2D(
+                    latitude: 51.5074 + 0.00009,
+                    longitude: -0.1278
+                ),
+                altitude: 0,
+                horizontalAccuracy: 5.0,
+                verticalAccuracy: -1,
+                timestamp: .now
+            ),
+            savedImageData: nil,
+            candidateImageData: nil
+        )
+        #expect(result.result == .match)
+        #expect(result.wasGPS == true)
+    }
+}

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -615,7 +615,7 @@ private actor ScanTracker {
 private struct FakeRoomQuestScanner: RoomQuestScanner {
     let handler: @MainActor (RoomQuestStationRole, RoomQuestScanMode) async throws -> RoomQuestMarkerScanResult
 
-    func scanMarker(for role: RoomQuestStationRole, mode: RoomQuestScanMode) async throws -> RoomQuestMarkerScanResult {
+    func scanMarker(for role: RoomQuestStationRole, mode: RoomQuestScanMode, savedReference: RoomQuestSavedReference?) async throws -> RoomQuestMarkerScanResult {
         try await handler(role, mode)
     }
 }


### PR DESCRIPTION
## Summary

- **Child's hunt phase is now real**: photos taken during setup are compared against photos taken during the hunt using Apple Vision's `VNFeaturePrintObservation` feature-print distance (indoor) **and** CoreLocation GPS distance (outdoor) — whichever fires first wins (OR logic).
- **Scanner sheet stays open for retries**: on `.close` / `.noMatch` the continuation is NOT resolved; a colour-coded feedback banner appears ("Almost! Walk a bit closer" / "Wrong place — keep looking") and the child can retake without reopening the camera.
- **Reference thumbnail** ("Find this place") shown on both the SpotPromptView iPad screen and inside the scanner sheet overlay, so the child always sees the target photo.

## What's in this PR

| File | Change |
|---|---|
| `Services/LocationService.swift` | New — CoreLocation wrapper owned by scanner |
| `Services/PlaceMatchService.swift` | New — GPS + Vision hybrid evaluator |
| `Tests/MatherTests/PlaceMatchServiceTests.swift` | New — 7 tests |
| `Domain/RoomQuestScanner.swift` | `RoomQuestSavedReference` struct + updated protocol |
| `Domain/SliceModels.swift` | GPS-defaulting init on `RoomQuestStationReferenceDraft` |
| `Domain/RoomQuestEngine.swift` | GPS threaded through full persistence chain; saved ref passed to scanner |
| `Services/RoomQuestLiveScanner.swift` | Major rewrite — mode-aware photo handling, verify overlay |
| `Features/RoomQuest/SpotPromptView.swift` | Reference thumbnail card above scan button |
| `App/Info.plist` | `NSLocationWhenInUseUsageDescription` |

Closes #226, #227, #228, #229, #230, #221

## Test plan

- [ ] CI green (xcodegen + build + unit tests)
- [ ] Setup: parent opens camera → takes photo → GPS + photo saved in SwiftData
- [ ] Hunt: child taps "Recheck this place" → scanner opens with reference thumbnail
- [ ] At correct spot: `.match` → sheet dismisses → collect step unlocks
- [ ] Nearby: `.close` → banner "Almost! Walk closer" → camera stays open
- [ ] Wrong spot: `.noMatch` → banner "Wrong place" → camera stays open
- [ ] Outdoor: GPS drives verdict (GPS accuracy < 20 m required)
- [ ] Indoor: Vision drives verdict (GPS ignored when accuracy > 20 m)
- [ ] Manual-fallback stations: immediate fallback button, no camera required

🤖 Generated with [Claude Code](https://claude.ai/claude-code)