### PR TITLE
feat(vs1): start gravity split from zero

### DIFF
--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -168,7 +168,7 @@ struct GravitySplitState: Equatable {
     let decompositionA: Int   // expected left-pan count
     let decompositionB: Int   // expected right-pan count
     var leftCount: Int        // current left-pan count (starts at 0)
-    var rightCount: Int       // always target − leftCount
+    var rightCount: Int       // current right-pan count (starts at 0)
 
     var isLocked: Bool {
         leftCount == decompositionA && rightCount == decompositionB
@@ -178,16 +178,16 @@ struct GravitySplitState: Equatable {
         target         = problem.target
         decompositionA = problem.decompositionA
         decompositionB = problem.decompositionB
-        // Start with target−1 on the left pan (far-left imbalance) so the beam
-        // is visibly unbalanced and the answer is never the starting position.
-        leftCount      = max(0, problem.target - 1)
-        rightCount     = 1
+        leftCount      = 0
+        rightCount     = 0
     }
 
-    /// Sets `leftCount` to `count` (clamped 0…target) and derives `rightCount`.
-    mutating func setLeft(_ count: Int) {
-        leftCount  = min(max(count, 0), target)
-        rightCount = target - leftCount
+    mutating func adjustLeft(by delta: Int) {
+        leftCount = min(max(leftCount + delta, 0), decompositionA)
+    }
+
+    mutating func adjustRight(by delta: Int) {
+        rightCount = min(max(rightCount + delta, 0), decompositionB)
     }
 }
 

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -338,61 +338,40 @@ final class VerticalSliceEngine {
 
     // MARK: - Gravity Split actions
 
-    /// Called each time tiltRoll updates (≈30 Hz from MotionService).
-    /// Uses neutral-relative tilt: the first sample records the device's natural
-    /// hold position as neutral (Δ=0). All subsequent tilt is a delta from neutral,
-    /// so symmetric decompositions (e.g. 6=3+3) cannot be accidentally solved by
-    /// picking up the iPad in a flat/natural position.
     func adjustGravitySplitByTilt(_ tiltRoll: Double) {
-        guard currentStage == .gravitySplit, let state = gravitySplitState,
-              !state.isLocked else { return }
-        // Record neutral on the very first sample after stage entry.
-        if gravitySplitNeutralRoll == nil {
-            gravitySplitNeutralRoll = tiltRoll
-        }
-        let delta = tiltRoll - gravitySplitNeutralRoll!
-        let clamped = max(-Double.pi / 4, min(delta, Double.pi / 4))
-        let fraction = 0.5 - clamped / (Double.pi / 4) * 0.5
-        let newLeft = Int((Double(state.target) * fraction).rounded())
-        setGravitySplit(leftCount: newLeft)
-    }
-
-    /// Called by the ±1 tap fallback buttons in GravitySplitView.
-    func adjustGravitySplitByTap(delta: Int) {
-        guard currentStage == .gravitySplit, let state = gravitySplitState,
-              !state.isLocked else { return }
-        setGravitySplit(leftCount: state.leftCount + delta)
-    }
-
-    /// Resets all counters back to the starting position (shake gesture).
-    /// Also clears the neutral roll so the next tilt re-calibrates from the
-    /// current hold position.
-    func resetGravitySplit() {
         guard currentStage == .gravitySplit else { return }
-        gravitySplitState?.setLeft(max(0, (gravitySplitState?.target ?? 1) - 1))
-        gravitySplitNeutralRoll = nil
+        gravitySplitNeutralRoll = tiltRoll
     }
 
-    private func setGravitySplit(leftCount: Int) {
-        guard var state = gravitySplitState else { return }
-        let previousCount = state.leftCount
-        state.setLeft(leftCount)
+    func adjustGravitySplitByTap(delta: Int, side: TransferSide = .left) {
+        guard currentStage == .gravitySplit, var state = gravitySplitState,
+              !state.isLocked else { return }
+
+        let previousLeft = state.leftCount
+        let previousRight = state.rightCount
+        switch side {
+        case .left:
+            state.adjustLeft(by: delta)
+        case .right:
+            state.adjustRight(by: delta)
+        }
         gravitySplitState = state
 
-        if state.leftCount != previousCount {
+        if state.leftCount != previousLeft || state.rightCount != previousRight {
             hapticsService.counterSettle(enabled: featureFlags.hapticsEnabled)
             hapticsService.counterSlide(enabled: featureFlags.hapticsEnabled)
-        }
-
-        // Whisper tick when passing through the balanced midpoint.
-        if previousCount != state.target / 2 && state.leftCount == state.target / 2 {
-            hapticsService.tiltNeutral(enabled: featureFlags.hapticsEnabled)
         }
 
         if state.isLocked, let problem = currentProblem {
             hapticsService.balanceLock(enabled: featureFlags.hapticsEnabled)
             completeStage(successMessage: successMessage(for: .gravitySplit, problem: problem))
         }
+    }
+
+    func resetGravitySplit() {
+        guard currentStage == .gravitySplit, let problem = currentProblem else { return }
+        gravitySplitState = GravitySplitState(problem: problem)
+        gravitySplitNeutralRoll = nil
     }
 
     private func validateEquation(for problem: SliceProblem) -> Bool {
@@ -685,7 +664,7 @@ final class VerticalSliceEngine {
         case .gravitySplit:
             let a = currentProblem.decompositionA
             let b = currentProblem.decompositionB
-            return "Tilt to put \(a) on one side and \(b) on the other!"
+            return "Use plus and minus to build \(a) on one side and \(b) on the other."
         case .done:
             return "Nice work."
         }
@@ -725,7 +704,7 @@ final class VerticalSliceEngine {
                 return "Build the same equation again with counters, one group on each side."
             }
         case .gravitySplit:
-            return "Keep tilting! Get \(problem.decompositionA) on one side and \(problem.decompositionB) on the other."
+            return "Keep building the split. Put \(problem.decompositionA) on one side and \(problem.decompositionB) on the other."
         case .sumSprint:
             return "Keep going. This quick sprint comes before Bond Blast."
         case .done:

--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -1,12 +1,10 @@
 import SwiftUI
 
-/// Balance-scale stage where the child tilts the iPad to slide counters
-/// between two pans until the split matches the problem's decomposition.
+/// Balance-scale stage where the child uses plus and minus controls to build
+/// the requested split from zero.
 ///
-/// Tilt input arrives via `tiltRoll` (radians) and is forwarded to the engine
-/// through `onAdjustTilt`. Tap buttons provide a fallback for cases where
-/// motion is unavailable. When `state.isLocked` becomes true the beam snaps
-/// level and the view auto-advances after 0.6 s via `onSubmit`.
+/// Tilt is ignored in V1 loop mode and kept only for future polish hooks.
+/// When `state.isLocked` becomes true the view auto-advances after 0.6 s.
 struct GravitySplitView: View {
 
     // MARK: - Inputs
@@ -15,7 +13,7 @@ struct GravitySplitView: View {
     let tiltRoll: Double
     let shakeDetected: Bool
     let onAdjustTilt: (Double) -> Void
-    let onTap: (Int) -> Void            // delta ±1 for the left pan; right = target − left
+    let onTap: (Int, TransferSide) -> Void
     let onShakeHandled: () -> Void
     let onSubmit: () -> Void
 
@@ -35,8 +33,9 @@ struct GravitySplitView: View {
     private var beamAngle: Double {
         guard state.target > 0 else { return 0 }
         if state.isLocked { return 0 }
-        let fraction = Double(state.leftCount - state.rightCount) / Double(state.target)
-        return fraction * maxBeamAngle
+        let solvedBias = Double(state.decompositionA - state.decompositionB) / Double(max(state.target, 1))
+        let builtBias = Double(state.leftCount - state.rightCount) / Double(max(state.target, 1))
+        return (solvedBias - builtBias) * maxBeamAngle
     }
 
     // MARK: - Body
@@ -53,7 +52,7 @@ struct GravitySplitView: View {
             }
         }
         .onChange(of: tiltRoll) { _, roll in
-            guard !showGoScrim else { return }   // block tilt until GO is tapped
+            guard !showGoScrim else { return }
             onAdjustTilt(roll)
         }
         .onChange(of: shakeDetected) { _, shook in
@@ -85,7 +84,7 @@ struct GravitySplitView: View {
     private var headerRow: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Balance it!")
+                Text("Gravity Split")
                     .font(.title2.weight(.black))
                     .foregroundStyle(MatherTheme.coral)
 
@@ -93,8 +92,8 @@ struct GravitySplitView: View {
                     counterPill(value: state.leftCount, fill: MatherTheme.warm)
                     Text("+").font(.title3.weight(.black)).foregroundStyle(.secondary)
                     counterPill(value: state.rightCount, fill: MatherTheme.accent)
-                    Text("=").font(.title3.weight(.black)).foregroundStyle(.secondary)
-                    Text("\(state.target)")
+                    Text("/").font(.title3.weight(.black)).foregroundStyle(.secondary)
+                    Text("\(state.decompositionA) + \(state.decompositionB)")
                         .font(.system(size: 28, weight: .black, design: .rounded))
                         .foregroundStyle(MatherTheme.ink)
                 }
@@ -240,9 +239,9 @@ struct GravitySplitView: View {
                 fill: MatherTheme.warm,
                 side: "left",
                 canDecrement: state.leftCount > 0 && !state.isLocked,
-                canIncrement: state.leftCount < state.target && !state.isLocked
+                canIncrement: state.leftCount < state.decompositionA && !state.isLocked
             ) { delta in
-                onTap(delta)
+                onTap(delta, .left)
             }
 
             panControlButtons(
@@ -250,9 +249,9 @@ struct GravitySplitView: View {
                 fill: MatherTheme.accent,
                 side: "right",
                 canDecrement: state.rightCount > 0 && !state.isLocked,
-                canIncrement: state.rightCount < state.target && !state.isLocked
+                canIncrement: state.rightCount < state.decompositionB && !state.isLocked
             ) { delta in
-                onTap(-delta)   // right + → left −
+                onTap(delta, .right)
             }
         }
     }
@@ -313,7 +312,7 @@ struct GravitySplitView: View {
             Image(systemName: "gyroscope")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MatherTheme.coral.opacity(0.8))
-            Text("Tilt the iPad to slide the counters")
+            Text("Use plus and minus to build the split from zero")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MatherTheme.cardSubtitle)
         }

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -533,9 +533,8 @@ struct VerticalSliceEngineTests {
 
         guard let target = engine.currentProblem?.target else { return }
         #expect(engine.gravitySplitState != nil)
-        // Starts far-left (target − 1) so the scale is visibly unbalanced on entry.
-        #expect(engine.gravitySplitState?.leftCount == max(0, target - 1))
-        #expect(engine.gravitySplitState?.rightCount == 1)
+        #expect(engine.gravitySplitState?.leftCount == 0)
+        #expect(engine.gravitySplitState?.rightCount == 0)
     }
 
     @Test
@@ -554,25 +553,16 @@ struct VerticalSliceEngineTests {
         engine.startSession()
         try await advanceToGravitySplit(engine)
 
-        // Stage starts far-left (target − 1); decrement moves counters right.
-        guard let target = engine.currentProblem?.target else { return }
-        let startLeft = max(0, target - 1)
-        #expect(engine.gravitySplitState?.leftCount == startLeft)
+        #expect(engine.gravitySplitState?.leftCount == 0)
 
-        engine.adjustGravitySplitByTap(delta: -1)
-        #expect(engine.gravitySplitState?.leftCount == startLeft - 1)
-        engine.adjustGravitySplitByTap(delta: -1)
-        #expect(engine.gravitySplitState?.leftCount == startLeft - 2)
+        engine.adjustGravitySplitByTap(delta: 1, side: .left)
+        #expect(engine.gravitySplitState?.leftCount == 1)
+        engine.adjustGravitySplitByTap(delta: 1, side: .left)
+        #expect(engine.gravitySplitState?.leftCount == 2)
     }
 
-    // Neutral-relative tilt: the first tilt sample records the hold position as
-    // neutral (Δ=0). A second sample at the SAME value produces zero delta,
-    // leaving leftCount unchanged regardless of the absolute device roll.
-    // Note: for the symmetric 6=3+3 deterministic problem, the first tilt at Δ=0
-    // maps to the midpoint (3) which equals decompositionA → the stage locks.
-    // The second call then returns early via the isLocked guard, so count stays stable.
     @Test
-    func gravitySplitTiltRecordsNeutralOnFirstSample() async throws {
+    func gravitySplitTiltDoesNotAutoSolveStage() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1GravitySplitEnabled = true
@@ -587,46 +577,39 @@ struct VerticalSliceEngineTests {
         engine.startSession()
         try await advanceToGravitySplit(engine)
 
-        // First call records neutral; Δ=0 maps to midpoint.
         engine.adjustGravitySplitByTilt(0.3)
         let countAfterFirst = engine.gravitySplitState?.leftCount
+        let rightAfterFirst = engine.gravitySplitState?.rightCount
 
-        // Second call at the SAME value → Δ=0 → count is unchanged.
         engine.adjustGravitySplitByTilt(0.3)
         #expect(engine.gravitySplitState?.leftCount == countAfterFirst)
-    }
-
-    // The scale starts at target−1 (far-left, visibly unbalanced) so the child
-    // cannot accidentally win just by picking up the device without tapping GO first.
-    @Test
-    func gravitySplitSymmetricProblemCannotBeAccidentallySolvedBeforeFirstTilt() async throws {
-        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        flags.testModeEnabled = true
-        flags.vs1GravitySplitEnabled = true
-
-        let engine = VerticalSliceEngine(
-            featureFlags: flags,
-            telemetryWriter: TelemetryWriter(),
-            speechService: SpeechService(),
-            celebrationDuration: 0,
-            saveSummary: { _ in }
-        )
-        engine.startSession()
-        try await advanceToGravitySplit(engine)
-
-        guard let problem = engine.currentProblem else { return }
-
-        // Stage starts far-left (target−1 / 1), not at the balanced midpoint.
+        #expect(engine.gravitySplitState?.rightCount == rightAfterFirst)
         #expect(engine.gravitySplitState?.isLocked == false)
-        #expect(engine.gravitySplitState?.leftCount == max(0, problem.target - 1))
     }
 
-    // For a symmetric problem (6=3+3) the correct answer IS the midpoint.
-    // After GO is tapped and the first tilt sample is observed (Δ=0 from neutral),
-    // the scale snaps to the midpoint = the correct decomposition → locks.
-    // This is DELIBERATE: the child held the device steady and tapped GO.
     @Test
-    func gravitySplitSymmetricProblemLocksWhenHeldAtNeutral() async throws {
+    func gravitySplitStartsFromZeroAndUnsolved() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.vs1GravitySplitEnabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        try await advanceToGravitySplit(engine)
+
+        #expect(engine.gravitySplitState?.isLocked == false)
+        #expect(engine.gravitySplitState?.leftCount == 0)
+        #expect(engine.gravitySplitState?.rightCount == 0)
+    }
+
+    @Test
+    func gravitySplitRequiresTapAdjustmentToLock() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1GravitySplitEnabled = true
@@ -642,14 +625,12 @@ struct VerticalSliceEngineTests {
         try await advanceToGravitySplit(engine)
 
         guard let problem = engine.currentProblem else { return }
-        #expect(problem.decompositionA == problem.decompositionB,
-                "Test requires a symmetric decomposition — first deterministic problem is 6=3+3")
-
-        // Tilt at any value: first call records that value as neutral, Δ=0 → midpoint = decompositionA → locked.
         engine.adjustGravitySplitByTilt(0.3)
-        #expect(engine.gravitySplitState?.isLocked == true)
+        #expect(engine.gravitySplitState?.isLocked == false)
 
-        await waitFor("gravity split auto-advance after neutral lock") {
+        for _ in 0..<problem.decompositionA { engine.adjustGravitySplitByTap(delta: 1, side: .left) }
+        for _ in 0..<problem.decompositionB { engine.adjustGravitySplitByTap(delta: 1, side: .right) }
+        await waitFor("gravity split auto-advance after tap lock") {
             engine.currentStage != .gravitySplit
         }
         #expect(engine.currentStage != .gravitySplit)
@@ -672,9 +653,8 @@ struct VerticalSliceEngineTests {
         try await advanceToGravitySplit(engine)
 
         guard let problem = engine.currentProblem else { return }
-        guard let startLeft = engine.gravitySplitState?.leftCount else { return }
-        // Tap from the branch's far-left start state to the exact decomposition.
-        engine.adjustGravitySplitByTap(delta: problem.decompositionA - startLeft)
+        for _ in 0..<problem.decompositionA { engine.adjustGravitySplitByTap(delta: 1, side: .left) }
+        for _ in 0..<problem.decompositionB { engine.adjustGravitySplitByTap(delta: 1, side: .right) }
         await waitFor("gravity split auto-advance after tap lock") {
             engine.currentStage != .gravitySplit
         }
@@ -733,10 +713,11 @@ struct VerticalSliceEngineTests {
         let currentLeft = engine.gravitySplitState?.leftCount ?? 0
         let delta = problem.decompositionA - currentLeft
         if delta > 0 {
-            for _ in 0..<delta { engine.adjustGravitySplitByTap(delta: 1) }
+            for _ in 0..<delta { engine.adjustGravitySplitByTap(delta: 1, side: .left) }
         } else if delta < 0 {
-            for _ in 0..<(-delta) { engine.adjustGravitySplitByTap(delta: -1) }
+            for _ in 0..<(-delta) { engine.adjustGravitySplitByTap(delta: -1, side: .left) }
         }
+        for _ in 0..<(problem.decompositionB) { engine.adjustGravitySplitByTap(delta: 1, side: .right) }
         await waitFor("gravity split lock") { engine.gravitySplitState?.isLocked == true }
         await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
         #expect(engine.currentStage == .sumSprint)


### PR DESCRIPTION
## Summary
- change Gravity Split to start from an empty zero-state instead of a near-solved split
- require plus/minus child-built adjustment on each side before the stage can lock
- update engine and tests so tilt no longer auto-solves the stage on entry

## Testing
- Not run in this environment (`swift` and `xcodebuild` are unavailable in the Linux sandbox)
- Static verification only
