### PR TITLE
feat(vs1): embed micro sum sprint in loop-v2

### DIFF
--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -228,6 +228,73 @@ struct BondMatchState: Equatable {
     }
 }
 
+
+
+// MARK: - Embedded Sum Sprint models
+
+struct SumSprintBurstCard: Identifiable, Equatable {
+    let id: UUID
+    let prompt: String
+    let answer: Int
+    var typedAnswer: String = ""
+    var isCorrect: Bool = false
+}
+
+struct SumSprintBurstState: Equatable {
+    let target: Int
+    var cards: [SumSprintBurstCard]
+    var currentCardIndex: Int = 0
+
+    var currentCard: SumSprintBurstCard? {
+        guard cards.indices.contains(currentCardIndex) else { return nil }
+        return cards[currentCardIndex]
+    }
+
+    var isComplete: Bool {
+        currentCardIndex >= cards.count
+    }
+
+    var progressLabel: String {
+        guard !cards.isEmpty else { return "0 / 0" }
+        return "\(min(currentCardIndex + 1, cards.count)) / \(cards.count)"
+    }
+
+    static func make(for problem: SliceProblem) -> SumSprintBurstState {
+        let cards = makeFacts(for: problem).map { fact in
+            SumSprintBurstCard(
+                id: UUID(),
+                prompt: "\(fact.0) + \(fact.1)",
+                answer: fact.0 + fact.1
+            )
+        }
+        return SumSprintBurstState(target: problem.target, cards: cards)
+    }
+
+    private static func makeFacts(for problem: SliceProblem) -> [(Int, Int)] {
+        let target = problem.target
+        let first = (problem.decompositionA, problem.decompositionB)
+        let second = (max(1, target - 1), min(1, target))
+        let thirdLeft = max(1, target / 2)
+        let third = (thirdLeft, max(1, target - thirdLeft))
+
+        var facts: [(Int, Int)] = [first]
+        if target >= 4 {
+            facts.append(second)
+        }
+        if target >= 8 {
+            facts.append(third)
+        }
+
+        var deduped: [(Int, Int)] = []
+        for pair in facts {
+            if !deduped.contains(where: { $0.0 == pair.0 && $0.1 == pair.1 }) {
+                deduped.append(pair)
+            }
+        }
+        return deduped
+    }
+}
+
 // MARK: - Room Quest models
 
 enum RoomQuestStationRole: String, Codable, Equatable, CaseIterable {

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -41,6 +41,7 @@ final class VerticalSliceEngine {
     var transferRightCount = 0
     private(set) var bondMatchState: BondMatchState? = nil
     private(set) var gravitySplitState: GravitySplitState? = nil
+    private(set) var sumSprintBurstState: SumSprintBurstState? = nil
     /// Recorded on the first tilt sample after the stage becomes active.
     /// All subsequent tilt is computed as a delta from this neutral position,
     /// so the puzzle cannot be accidentally solved by simply picking up the device.
@@ -158,6 +159,7 @@ final class VerticalSliceEngine {
         transferRightCount = 0
         bondMatchState = nil
         gravitySplitState = nil
+        sumSprintBurstState = nil
         gravitySplitNeutralRoll = nil
         feedbackMessage = activeTheme.sessionStartFeedback()
         showCelebration = false
@@ -263,7 +265,7 @@ final class VerticalSliceEngine {
         case .gravitySplit:
             isCorrect = gravitySplitState?.isLocked == true
         case .sumSprint:
-            isCorrect = true
+            isCorrect = sumSprintBurstState?.isComplete == true
         case .bondMatch:
             // Bond Blast is not submitted via submitCurrentStage — pairs are matched
             // individually via matchPair(id:). This case is unreachable in practice.
@@ -284,6 +286,73 @@ final class VerticalSliceEngine {
 
     func replayPrompt() {
         speechService.speak(promptForCurrentStage(), enabled: featureFlags.audioEnabled)
+    }
+
+    func appendSumSprintDigit(_ digit: Int) {
+        guard currentStage == .sumSprint, var state = sumSprintBurstState,
+              state.cards.indices.contains(state.currentCardIndex) else { return }
+        let current = state.cards[state.currentCardIndex].typedAnswer
+        guard current.count < 2 else { return }
+        state.cards[state.currentCardIndex].typedAnswer = current + String(digit)
+        sumSprintBurstState = state
+    }
+
+    func deleteSumSprintDigit() {
+        guard currentStage == .sumSprint, var state = sumSprintBurstState,
+              state.cards.indices.contains(state.currentCardIndex) else { return }
+        let current = state.cards[state.currentCardIndex].typedAnswer
+        guard !current.isEmpty else { return }
+        state.cards[state.currentCardIndex].typedAnswer = String(current.dropLast())
+        sumSprintBurstState = state
+    }
+
+    func submitSumSprintCard() {
+        guard currentStage == .sumSprint, var state = sumSprintBurstState,
+              state.cards.indices.contains(state.currentCardIndex) else { return }
+        guard let entered = Int(state.cards[state.currentCardIndex].typedAnswer) else { return }
+        let card = state.cards[state.currentCardIndex]
+        let isCorrect = entered == card.answer
+        recordInteraction(action: "sum_sprint_submit", value: entered)
+
+        if isCorrect {
+            state.cards[state.currentCardIndex].isCorrect = true
+            try? telemetryWriter.append(
+                SliceEvent(type: .sumSprintCardAnswered, payload: [
+                    "problem_id": currentProblem?.id.uuidString ?? "",
+                    "card_index": String(state.currentCardIndex),
+                    "prompt": card.prompt,
+                    "correct": "true"
+                ])
+            )
+            state.currentCardIndex += 1
+            sumSprintBurstState = state
+            if state.isComplete, let problem = currentProblem {
+                completeStage(successMessage: successMessage(for: .sumSprint, problem: problem))
+            } else {
+                if let nextCard = state.currentCard {
+                    try? telemetryWriter.append(
+                        SliceEvent(type: .sumSprintCardShown, payload: [
+                            "problem_id": currentProblem?.id.uuidString ?? "",
+                            "card_index": String(state.currentCardIndex),
+                            "prompt": nextCard.prompt
+                        ])
+                    )
+                }
+                feedbackMessage = promptForCurrentStage()
+            }
+        } else {
+            try? telemetryWriter.append(
+                SliceEvent(type: .sumSprintCardAnswered, payload: [
+                    "problem_id": currentProblem?.id.uuidString ?? "",
+                    "card_index": String(state.currentCardIndex),
+                    "prompt": card.prompt,
+                    "correct": "false"
+                ])
+            )
+            feedbackMessage = "Try again. Solve this one before Bond Blast."
+            speechService.speak(feedbackMessage, enabled: featureFlags.audioEnabled)
+            hapticsService.failure(enabled: featureFlags.hapticsEnabled)
+        }
     }
 
     // MARK: - Bond Blast actions
@@ -460,6 +529,26 @@ final class VerticalSliceEngine {
         case .sumSprint:
             bondMatchState = nil
             gravitySplitState = nil
+            if let problem = currentProblem {
+                let burst = SumSprintBurstState.make(for: problem)
+                sumSprintBurstState = burst
+                try? telemetryWriter.append(
+                    SliceEvent(type: .sumSprintStarted, payload: [
+                        "problem_id": problem.id.uuidString,
+                        "target": String(problem.target),
+                        "card_count": String(burst.cards.count)
+                    ])
+                )
+                if let card = burst.currentCard {
+                    try? telemetryWriter.append(
+                        SliceEvent(type: .sumSprintCardShown, payload: [
+                            "problem_id": problem.id.uuidString,
+                            "card_index": "0",
+                            "prompt": card.prompt
+                        ])
+                    )
+                }
+            }
         case .bondMatch:
             if let problem = currentProblem {
                 bondMatchState = BondMatchState(
@@ -498,6 +587,7 @@ final class VerticalSliceEngine {
             transferRightCount = 0
             gravitySplitState = nil
             gravitySplitNeutralRoll = nil
+            sumSprintBurstState = nil
             problemStartedAt = .now
             feedbackMessage = promptForCurrentStage()
             logProblemPresented()
@@ -656,6 +746,9 @@ final class VerticalSliceEngine {
         case .pictorial, .bondMatch:
             return "Bond Blast! Match the pairs that make \(currentProblem.target)!"
         case .sumSprint:
+            if let card = sumSprintBurstState?.currentCard {
+                return "Quick Sum Sprint. Solve \(card.prompt), then finish with Bond Blast."
+            }
             return "Quick Sum Sprint! Solve a tiny burst, then finish with Bond Blast."
         case .abstract:
             return activeTheme.abstractPrompt()
@@ -706,7 +799,7 @@ final class VerticalSliceEngine {
         case .gravitySplit:
             return "Keep building the split. Put \(problem.decompositionA) on one side and \(problem.decompositionB) on the other."
         case .sumSprint:
-            return "Keep going. This quick sprint comes before Bond Blast."
+            return "Keep going. Finish this quick sprint before Bond Blast."
         case .done:
             return "Try again."
         }

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -148,18 +148,42 @@ struct SliceSessionView: View {
                 CardSurface { Text("Loading Balance...") }
             }
         case .sumSprint:
-            CardSurface {
-                VStack(alignment: .leading, spacing: 16) {
-                    Text("Sum Sprint")
-                        .font(.title.weight(.black))
-                    Text("PR2 placeholder: the loop now routes through a dedicated Sum Sprint stop before Bond Blast.")
-                        .font(.headline)
-                        .foregroundStyle(.secondary)
-                    Button("Sprint on") {
-                        appModel.engine.submitCurrentStage()
+            if let burst = appModel.engine.sumSprintBurstState,
+               let card = burst.currentCard {
+                CardSurface {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("Sum Sprint")
+                            .font(.title.weight(.black))
+                        Text("Card \(burst.progressLabel)")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text(card.prompt)
+                            .font(.system(size: 40, weight: .black, design: .rounded))
+                        Text(card.typedAnswer.isEmpty ? "?" : card.typedAnswer)
+                            .font(.system(size: 34, weight: .bold, design: .rounded))
+                            .foregroundStyle(MatherTheme.accent)
+                        VStack(spacing: 12) {
+                            ForEach([[1,2,3],[4,5,6],[7,8,9]], id: \.self) { row in
+                                HStack(spacing: 12) {
+                                    ForEach(row, id: \.self) { digit in
+                                        Button(String(digit)) { appModel.engine.appendSumSprintDigit(digit) }
+                                            .buttonStyle(PrimaryActionButtonStyle())
+                                    }
+                                }
+                            }
+                            HStack(spacing: 12) {
+                                Button("⌫") { appModel.engine.deleteSumSprintDigit() }
+                                    .buttonStyle(PrimaryActionButtonStyle())
+                                Button("0") { appModel.engine.appendSumSprintDigit(0) }
+                                    .buttonStyle(PrimaryActionButtonStyle())
+                                Button("Go") { appModel.engine.submitSumSprintCard() }
+                                    .buttonStyle(PrimaryActionButtonStyle())
+                            }
+                        }
                     }
-                    .buttonStyle(PrimaryActionButtonStyle())
                 }
+            } else {
+                CardSurface { Text("Loading Sum Sprint...") }
             }
         case .bondMatch:
             if let bondState = appModel.engine.bondMatchState {

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -12,6 +12,33 @@ struct VerticalSliceEngineTests {
         }
     }
 
+    private func lockGravitySplit(_ engine: VerticalSliceEngine, problem: SliceProblem) {
+        let currentLeft = engine.gravitySplitState?.leftCount ?? 0
+        let leftDelta = problem.decompositionA - currentLeft
+        if leftDelta > 0 {
+            for _ in 0..<leftDelta { engine.adjustGravitySplitByTap(delta: 1, side: .left) }
+        } else if leftDelta < 0 {
+            for _ in 0..<(-leftDelta) { engine.adjustGravitySplitByTap(delta: -1, side: .left) }
+        }
+
+        let currentRight = engine.gravitySplitState?.rightCount ?? 0
+        let rightDelta = problem.decompositionB - currentRight
+        if rightDelta > 0 {
+            for _ in 0..<rightDelta { engine.adjustGravitySplitByTap(delta: 1, side: .right) }
+        } else if rightDelta < 0 {
+            for _ in 0..<(-rightDelta) { engine.adjustGravitySplitByTap(delta: -1, side: .right) }
+        }
+    }
+
+    private func completeSumSprintBurst(_ engine: VerticalSliceEngine) {
+        while let card = engine.sumSprintBurstState?.currentCard {
+            for digit in String(card.answer) {
+                engine.appendSumSprintDigit(Int(String(digit))!)
+            }
+            engine.submitSumSprintCard()
+        }
+    }
+
     private func waitFor(_ description: String, timeoutNanoseconds: UInt64 = 2_000_000_000, condition: @escaping @MainActor () -> Bool) async {
         let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
         while DispatchTime.now().uptimeNanoseconds < deadline {
@@ -710,19 +737,12 @@ struct VerticalSliceEngineTests {
         await waitFor("gravity split after concrete") { engine.currentStage == .gravitySplit }
         #expect(engine.currentStage == .gravitySplit)
 
-        let currentLeft = engine.gravitySplitState?.leftCount ?? 0
-        let delta = problem.decompositionA - currentLeft
-        if delta > 0 {
-            for _ in 0..<delta { engine.adjustGravitySplitByTap(delta: 1, side: .left) }
-        } else if delta < 0 {
-            for _ in 0..<(-delta) { engine.adjustGravitySplitByTap(delta: -1, side: .left) }
-        }
-        for _ in 0..<(problem.decompositionB) { engine.adjustGravitySplitByTap(delta: 1, side: .right) }
+        lockGravitySplit(engine, problem: problem)
         await waitFor("gravity split lock") { engine.gravitySplitState?.isLocked == true }
         await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
         #expect(engine.currentStage == .sumSprint)
 
-        engine.submitCurrentStage()
+        completeSumSprintBurst(engine)
         await waitFor("bond blast after sum sprint") { engine.currentStage == .bondMatch }
         #expect(engine.currentStage == .bondMatch)
     }
@@ -749,12 +769,7 @@ struct VerticalSliceEngineTests {
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()
         await waitFor("gravity split after concrete") { engine.currentStage == .gravitySplit }
-        let delta = problem.decompositionA - (engine.gravitySplitState?.leftCount ?? 0)
-        if delta > 0 {
-            for _ in 0..<delta { engine.adjustGravitySplitByTap(delta: 1) }
-        } else if delta < 0 {
-            for _ in 0..<(-delta) { engine.adjustGravitySplitByTap(delta: -1) }
-        }
+        lockGravitySplit(engine, problem: problem)
         await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
         #expect((engine.sumSprintBurstState?.cards.count ?? 0) >= 1)
         #expect((engine.sumSprintBurstState?.cards.count ?? 0) <= 3)
@@ -780,22 +795,10 @@ struct VerticalSliceEngineTests {
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()
         await waitFor("gravity split after concrete") { engine.currentStage == .gravitySplit }
-        let delta = problem.decompositionA - (engine.gravitySplitState?.leftCount ?? 0)
-        if delta > 0 {
-            for _ in 0..<delta { engine.adjustGravitySplitByTap(delta: 1) }
-        } else if delta < 0 {
-            for _ in 0..<(-delta) { engine.adjustGravitySplitByTap(delta: -1) }
-        }
+        lockGravitySplit(engine, problem: problem)
         await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
 
-        while let card = engine.sumSprintBurstState?.currentCard {
-            for digit in String(card.answer) {
-                engine.appendSumSprintDigit(Int(String(digit))!)
-            }
-            engine.submitSumSprintCard()
-            await Task.yield()
-            if engine.currentStage == .bondMatch { break }
-        }
+        completeSumSprintBurst(engine)
 
         await waitFor("bond blast after sum sprint burst") { engine.currentStage == .bondMatch }
         #expect(engine.currentStage == .bondMatch)

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -727,4 +727,78 @@ struct VerticalSliceEngineTests {
         #expect(engine.currentStage == .bondMatch)
     }
 
+
+
+    @Test
+    func makeBreakLoopV2CreatesMicroSumSprintBurstPerTarget() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.verticalSlice1Enabled = true
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        guard let problem = engine.currentProblem else { return }
+        engine.adjustConcrete(by: problem.target)
+        engine.submitCurrentStage()
+        await waitFor("gravity split after concrete") { engine.currentStage == .gravitySplit }
+        let delta = problem.decompositionA - (engine.gravitySplitState?.leftCount ?? 0)
+        if delta > 0 {
+            for _ in 0..<delta { engine.adjustGravitySplitByTap(delta: 1) }
+        } else if delta < 0 {
+            for _ in 0..<(-delta) { engine.adjustGravitySplitByTap(delta: -1) }
+        }
+        await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
+        #expect((engine.sumSprintBurstState?.cards.count ?? 0) >= 1)
+        #expect((engine.sumSprintBurstState?.cards.count ?? 0) <= 3)
+    }
+
+    @Test
+    func makeBreakLoopV2AdvancesToBondBlastAfterBurstCards() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.verticalSlice1Enabled = true
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        guard let problem = engine.currentProblem else { return }
+        engine.adjustConcrete(by: problem.target)
+        engine.submitCurrentStage()
+        await waitFor("gravity split after concrete") { engine.currentStage == .gravitySplit }
+        let delta = problem.decompositionA - (engine.gravitySplitState?.leftCount ?? 0)
+        if delta > 0 {
+            for _ in 0..<delta { engine.adjustGravitySplitByTap(delta: 1) }
+        } else if delta < 0 {
+            for _ in 0..<(-delta) { engine.adjustGravitySplitByTap(delta: -1) }
+        }
+        await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
+
+        while let card = engine.sumSprintBurstState?.currentCard {
+            for digit in String(card.answer) {
+                engine.appendSumSprintDigit(Int(String(digit))!)
+            }
+            engine.submitSumSprintCard()
+            await Task.yield()
+            if engine.currentStage == .bondMatch { break }
+        }
+
+        await waitFor("bond blast after sum sprint burst") { engine.currentStage == .bondMatch }
+        #expect(engine.currentStage == .bondMatch)
+    }
+
 }


### PR DESCRIPTION
## Summary
- embed a 1-3 card Sum Sprint burst inside the loop-v2 per-target path
- keep the burst tied to the current target and return directly to Bond Blast when complete
- add engine and routing tests for burst sizing and loop re-entry

## Testing
- Not run in this environment (`swift` and `xcodebuild` are unavailable in the Linux sandbox)
- Static verification only
