### PR TITLE
ci(ui): narrow main screenshot review scope

### DIFF
--- a/.github/workflows/ios-ui-review-main.yml
+++ b/.github/workflows/ios-ui-review-main.yml
@@ -95,11 +95,15 @@ jobs:
             ci-videos/ui-tests.mp4 &
           VIDEO_PID=$!
 
+          # Keep screenshot review focused on artifact-producing flows.
+          # Slower behavioral UI assertions belong in the main test lane.
           xcodebuild test-without-building \
             -project Mather.xcodeproj \
             -scheme Mather \
             -destination "$SIM_DESTINATION" \
-            -only-testing MatherUITests \
+            -only-testing MatherUITests/ScreenshotTests \
+            -skip-testing MatherUITests/ScreenshotTests/testConcreteBuild_AccentRowLockedUntilWarmFull \
+            -skip-testing MatherUITests/ScreenshotTests/testSessionHistoryShowsMultipleSavedSessionsInParentSummaryAndSettings \
             -resultBundlePath UITestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO
           XCODE_EXIT=$?


### PR DESCRIPTION
Closes #239

## Why
The `iOS UI Review (main)` workflow timed out after 15 minutes on main. It was running non-screenshot UI assertions inside the screenshot review lane.

## What changed
- keep the workflow focused on `MatherUITests/ScreenshotTests`
- skip the slower behavioral checks that do not produce screenshot artifacts:
  - `testConcreteBuild_AccentRowLockedUntilWarmFull`
  - `testSessionHistoryShowsMultipleSavedSessionsInParentSummaryAndSettings`

## Result
The post-merge screenshot review lane should stay within budget while still producing the visual artifacts it exists to review.