### PR TITLE
fix(room-quest): speak verify feedback + fix .notCaptured dead-end

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -60,6 +60,24 @@ final class AppModel {
         self.roomQuestEngine = roomQuestEngine
         roomQuestEngine.onExitToHome = { [weak vsEngine] in vsEngine?.showHome() }
 
+        roomQuestScanner.onVerifyFeedback = { [weak speechService, weak featureFlags] feedback in
+            guard let speechService, let featureFlags else { return }
+            switch feedback {
+            case .close(let wasGPS):
+                let msg = wasGPS
+                    ? "Almost there! Walk a little closer, then check again."
+                    : "Almost! Try to match the saved photo."
+                speechService.speak(msg, enabled: featureFlags.audioEnabled)
+            case .noMatch(let wasGPS):
+                let msg = wasGPS
+                    ? "Wrong place. Keep looking around."
+                    : "That doesn't look right. Keep searching."
+                speechService.speak(msg, enabled: featureFlags.audioEnabled)
+            default:
+                break
+            }
+        }
+
         let factStore = FactRecordStore(modelContext: modelContext)
         let sumSprintEngine = SumSprintEngine(
             featureFlags: featureFlags,

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -252,8 +252,9 @@ final class RoomQuestEngine {
         case .almost, .failed:
             return true
         case .idle:
-            // Show fallback immediately when no camera reference was saved
+            // Show fallback immediately when no camera reference was saved or setup was skipped
             return station.referenceCaptureState == .manualFallback
+                || station.referenceCaptureState == .notCaptured
         case .scanning, .celebrating:
             return false
         }

--- a/Features/RoomQuest/RoomSessionView.swift
+++ b/Features/RoomQuest/RoomSessionView.swift
@@ -87,12 +87,51 @@ struct RoomSessionView: View {
 
     // MARK: - On-screen CPA views (reuse VS1 views)
 
+    /// Compact token-collection recap shown at the top of every on-screen CPA stage.
+    /// Bridges the physical room phase ("you picked up 3 and 5") to the abstract math work.
+    @ViewBuilder
+    private var roomContextBanner: some View {
+        if let p = engine.problem {
+            CardSurface {
+                VStack(spacing: 4) {
+                    Text("tokens you collected")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                    HStack(spacing: 10) {
+                        Spacer(minLength: 0)
+                        Text(RoomQuestStationRole.redRocket.icon).font(.title2)
+                        Text("\(p.decompositionA)")
+                            .font(.title2.weight(.black))
+                            .foregroundStyle(MatherTheme.warm)
+                        Text("+")
+                            .font(.title2.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                        Text(RoomQuestStationRole.blueBubble.icon).font(.title2)
+                        Text("\(p.decompositionB)")
+                            .font(.title2.weight(.black))
+                            .foregroundStyle(MatherTheme.accent)
+                        Text("=")
+                            .font(.title2.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                        Text("\(p.target)")
+                            .font(.title2.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Spacer(minLength: 0)
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+        }
+    }
+
     @ViewBuilder
     private var onScreenPictorialView: some View {
         if let p = engine.problem {
             ScrollView {
                 VStack(spacing: 20) {
                     FeedbackBannerView(message: engine.feedbackMessage, isCelebrating: engine.showCelebration)
+                    roomContextBanner
                     SplitView(
                         target: p.target,
                         leftCount: engine.splitLeftCount,
@@ -113,6 +152,7 @@ struct RoomSessionView: View {
             ScrollView {
                 VStack(spacing: 20) {
                     FeedbackBannerView(message: engine.feedbackMessage, isCelebrating: engine.showCelebration)
+                    roomContextBanner
                     EquationResolveView(
                         target: p.target,
                         leftInput: engine.equationLeftInput,
@@ -146,6 +186,7 @@ struct RoomSessionView: View {
             ScrollView {
                 VStack(spacing: 20) {
                     FeedbackBannerView(message: engine.feedbackMessage, isCelebrating: engine.showCelebration)
+                    roomContextBanner
                     TransferCheckView(
                         problem: p,
                         leftCount: engine.transferLeftCount,

--- a/Features/RoomQuest/RoomSessionView.swift
+++ b/Features/RoomQuest/RoomSessionView.swift
@@ -12,7 +12,45 @@ struct RoomSessionView: View {
             MatherTheme.background.ignoresSafeArea()
             phaseContent
         }
+        .overlay(alignment: .topTrailing) {
+            sessionChromeOverlay
+        }
         .onAppear { engine.startSession() }
+    }
+
+    /// Home / Pause chrome buttons overlaid on top of phases that don't manage their own chrome.
+    @ViewBuilder
+    private var sessionChromeOverlay: some View {
+        switch engine.phase {
+
+        case .safetyAck:
+            // Parent-only screen — Home only (can't pause, session barely started)
+            roomLightChromeButton(title: "Home", systemImage: "house.circle.fill", accessibilityID: "room-home-safetyack") {
+                engine.onExitToHome?()
+            }
+            .padding(24)
+
+        case .setup, .onScreenPictorial, .onScreenAbstract, .onScreenTransfer:
+            HStack(spacing: 12) {
+                roomLightChromeButton(title: "Pause", systemImage: "pause.circle.fill", accessibilityID: "room-pause-session") {
+                    engine.pauseSession()
+                }
+                roomLightChromeButton(title: "Home", systemImage: "house.circle.fill", accessibilityID: "room-home-session") {
+                    engine.abandonSession(reason: "parent_home")
+                }
+            }
+            .padding(24)
+
+        case .paused:
+            roomLightChromeButton(title: "Home", systemImage: "house.circle.fill", accessibilityID: "room-home-paused") {
+                engine.abandonSession(reason: "parent_home")
+            }
+            .padding(24)
+
+        case .spot, .returning, .complete:
+            // These views manage their own chrome buttons
+            EmptyView()
+        }
     }
 
     @ViewBuilder
@@ -248,6 +286,22 @@ private struct ReturningView: View {
     }
 }
 
+/// Chrome button for light-background Room Quest screens (dark ink, white pill).
+/// Used for Safety Ack, Setup, CPA phases, and Paused screen.
+private func roomLightChromeButton(title: String, systemImage: String, accessibilityID: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+        Label(title, systemImage: systemImage)
+            .font(.title2.weight(.semibold))
+            .foregroundStyle(MatherTheme.ink)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(.black.opacity(0.06), in: Capsule())
+    }
+    .accessibilityIdentifier(accessibilityID)
+    .accessibilityLabel(title)
+    .accessibilityAddTraits(.isButton)
+}
+
 /// Hard pause screen — resume or abandon.
 private func roomReturningChromeButton(title: String, systemImage: String, accessibilityID: String, action: @escaping () -> Void) -> some View {
     Button(action: action) {
@@ -292,7 +346,7 @@ private struct RoomPausedView: View {
                 }
                 .buttonStyle(PrimaryActionButtonStyle())
 
-                Button("Stop session") {
+                Button("End session & go home") {
                     engine.abandonSession(reason: "parent_abort")
                 }
                 .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.danger.opacity(0.45)))

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -142,13 +142,6 @@ struct SpotPromptView: View {
                     .foregroundStyle(.white.opacity(0.92))
                     .padding(.horizontal, 40)
                     .padding(.bottom, 40)
-                } else if station?.referenceCaptureState != .captured {
-                    // Station has no reference yet — scan button is hidden, fallback not yet triggered
-                    Text("Start a camera check to unlock collect.")
-                        .font(.headline.weight(.bold))
-                        .foregroundStyle(.white.opacity(0.92))
-                        .padding(.horizontal, 40)
-                        .padding(.bottom, 40)
                 } else {
                     Spacer().frame(height: 40)
                 }

--- a/Services/RoomQuestLiveScanner.swift
+++ b/Services/RoomQuestLiveScanner.swift
@@ -32,6 +32,10 @@ final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
     private(set) var activeSession: Session?
     private(set) var verifyFeedback: VerifyFeedback? = nil
 
+    /// Called whenever the verify result changes to `.close` or `.noMatch` so the engine
+    /// can fire speech. Set by `AppModel` at startup.
+    var onVerifyFeedback: ((VerifyFeedback) -> Void)? = nil
+
     /// Location service — owned here so GPS coordinates are captured at the exact photo moment.
     let locationService = LocationService()
 
@@ -112,9 +116,13 @@ final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
                         self.locationService.stopUpdates()
                         self.activeSession = nil
                     case .close:
-                        self.verifyFeedback = .close(wasGPS: wasGPS)
+                        let feedback = VerifyFeedback.close(wasGPS: wasGPS)
+                        self.verifyFeedback = feedback
+                        self.onVerifyFeedback?(feedback)
                     case .noMatch:
-                        self.verifyFeedback = .noMatch(wasGPS: wasGPS)
+                        let feedback = VerifyFeedback.noMatch(wasGPS: wasGPS)
+                        self.verifyFeedback = feedback
+                        self.onVerifyFeedback?(feedback)
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- **Speech during verify feedback**: `RoomQuestLiveScanner` now exposes an `onVerifyFeedback` callback. `AppModel` wires it to `SpeechService` so the child hears audio guidance when a place-check returns *close* or *noMatch*. Previously the scanner sheet showed text-only banners — entirely silent for a 5-year-old.
  - GPS close → *"Almost there! Walk a little closer, then check again."*
  - GPS noMatch → *"Wrong place. Keep looking around."*
  - Vision close/noMatch → equivalent camera-framing copy

- **`.notCaptured` dead-end removed**: `shouldShowSpotManualFallback` now returns `true` for `.notCaptured` stations (same as `.manualFallback`). The SpotPromptView previously showed an unactionable *"Start a camera check to unlock collect."* text label with no button — children and parents had no way to proceed. The "I found it" fallback button now appears immediately when no reference was saved.

## Test plan
- [ ] Enable Room Quest, run setup without scanning a station (leave it `.notCaptured`) → verify "I found it" fallback button appears immediately on that spot screen
- [ ] Enable audio, run a verify scan at the wrong location → confirm speech fires ("Wrong place…")
- [ ] Enable audio, run a verify scan nearby → confirm speech fires ("Almost there…")
- [ ] Correct verify scan still resolves silently (match speech fires from the existing success path)
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)