### PR TITLE
fix(place-match): tighten GPS+Vision thresholds — stop false matches

### DIFF
--- a/Services/PlaceMatchService.swift
+++ b/Services/PlaceMatchService.swift
@@ -23,21 +23,30 @@ enum PlaceMatchService {
     // MARK: - Tunable thresholds
 
     /// Child must be within this many metres of the saved GPS coordinate (outdoor).
-    static let gpsMatchMetres: Double = 15.0
+    /// Kept tight (8 m) to avoid indoor false positives — two rooms in the same house
+    /// are often within 15 m of each other.
+    static let gpsMatchMetres: Double = 8.0
     /// GPS within this range shows "almost there" instead of "wrong place".
-    static let gpsCloseMetres: Double = 30.0
-    /// VNFeaturePrintObservation distance treated as same place (indoor).
-    static let visionMatchDistance: Float = 0.65
+    static let gpsCloseMetres: Double = 20.0
+    /// VNFeaturePrintObservation L2 distance treated as same place (indoor).
+    /// 0.65 was too lenient — different rooms in the same house routinely scored under 0.65
+    /// because VNFeaturePrintObservation is a semantic similarity metric, not a geometric one.
+    /// 0.25 requires photos to look very similar (same content, comparable framing).
+    static let visionMatchDistance: Float = 0.25
     /// VNFeaturePrintObservation distance treated as "almost" (indoor).
-    static let visionCloseDistance: Float = 1.0
+    static let visionCloseDistance: Float = 0.50
     /// Discard GPS fixes with horizontal accuracy worse than this (metres).
-    static let gpsAccuracyCutoff: Double = 20.0
+    /// Reduced from 20 m to 10 m — indoor fixes frequently report ~15 m accuracy
+    /// while actually being unreliable room-to-room.
+    static let gpsAccuracyCutoff: Double = 10.0
 
     // MARK: - Evaluation
 
     /// Evaluate whether `currentLocation` / `candidateImageData` match the saved reference.
-    /// - Returns: `(result, wasGPS)` where `wasGPS` is `true` when GPS was the decisive signal
-    ///   (used to tailor speech: "walk closer" vs "move closer").
+    /// - Returns: `(result, wasGPS, gpsMetres, visionDist)` where:
+    ///   - `wasGPS` is `true` when GPS was the decisive signal (tailor speech)
+    ///   - `gpsMetres` is the raw GPS distance in metres (nil when GPS was skipped)
+    ///   - `visionDist` is the raw VNFeaturePrintObservation distance (nil when Vision was skipped)
     static func evaluate(
         savedLatitude: Double?,
         savedLongitude: Double?,
@@ -45,18 +54,18 @@ enum PlaceMatchService {
         currentLocation: CLLocation?,
         savedImageData: Data?,
         candidateImageData: Data?
-    ) -> (result: PlaceMatchResult, wasGPS: Bool) {
+    ) -> (result: PlaceMatchResult, wasGPS: Bool, gpsMetres: Double?, visionDist: Float?) {
         let savedLoc = makeSavedLocation(lat: savedLatitude, lon: savedLongitude, accuracy: savedGPSAccuracy)
-        let gpsResult  = evaluateGPS(saved: savedLoc, current: currentLocation)
-        let visResult  = evaluateVision(reference: savedImageData, candidate: candidateImageData)
+        let (gpsResult, gpsMetres) = evaluateGPS(saved: savedLoc, current: currentLocation)
+        let (visResult, visionDist) = evaluateVision(reference: savedImageData, candidate: candidateImageData)
 
         // OR logic: either strong signal alone confirms place
         switch (gpsResult, visResult) {
-        case (.match, _):  return (.match,   true)
-        case (_, .match):  return (.match,   false)
-        case (.close, _):  return (.close,   true)
-        case (_, .close):  return (.close,   false)
-        default:           return (.noMatch, false)
+        case (.match, _):  return (.match,   true,  gpsMetres, visionDist)
+        case (_, .match):  return (.match,   false, gpsMetres, visionDist)
+        case (.close, _):  return (.close,   true,  gpsMetres, visionDist)
+        case (_, .close):  return (.close,   false, gpsMetres, visionDist)
+        default:           return (.noMatch, false, gpsMetres, visionDist)
         }
     }
 
@@ -73,33 +82,33 @@ enum PlaceMatchService {
         )
     }
 
-    private static func evaluateGPS(saved: CLLocation?, current: CLLocation?) -> PlaceMatchResult {
+    private static func evaluateGPS(saved: CLLocation?, current: CLLocation?) -> (PlaceMatchResult, Double?) {
         guard let saved, let current,
               saved.horizontalAccuracy > 0,   saved.horizontalAccuracy  <= gpsAccuracyCutoff,
               current.horizontalAccuracy > 0, current.horizontalAccuracy <= gpsAccuracyCutoff
-        else { return .noMatch }   // GPS unreliable — skip this signal
+        else { return (.noMatch, nil) }   // GPS unreliable — skip this signal
 
         let dist = current.distance(from: saved)
-        if dist <= gpsMatchMetres { return .match }
-        if dist <= gpsCloseMetres { return .close }
-        return .noMatch
+        if dist <= gpsMatchMetres { return (.match, dist) }
+        if dist <= gpsCloseMetres { return (.close, dist) }
+        return (.noMatch, dist)
     }
 
     // MARK: - Vision sub-evaluation
 
-    private static func evaluateVision(reference: Data?, candidate: Data?) -> PlaceMatchResult {
-        guard let refData = reference, let candData = candidate else { return .noMatch }
+    private static func evaluateVision(reference: Data?, candidate: Data?) -> (PlaceMatchResult, Float?) {
+        guard let refData = reference, let candData = candidate else { return (.noMatch, nil) }
         do {
             let refPrint  = try featurePrint(for: refData)
             let candPrint = try featurePrint(for: candData)
             var dist: Float = 0
             try refPrint.computeDistance(&dist, to: candPrint)
-            if dist <= visionMatchDistance { return .match }
-            if dist <= visionCloseDistance { return .close }
-            return .noMatch
+            if dist <= visionMatchDistance { return (.match, dist) }
+            if dist <= visionCloseDistance { return (.close, dist) }
+            return (.noMatch, dist)
         } catch {
             // Blurry / too-dark photo — treat as noMatch; grown-up fallback handles it
-            return .noMatch
+            return (.noMatch, nil)
         }
     }
 

--- a/Services/RoomQuestLiveScanner.swift
+++ b/Services/RoomQuestLiveScanner.swift
@@ -91,7 +91,7 @@ final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
             verifyFeedback = .evaluating
 
             Task.detached { [weak self, savedRef, currentLocation] in
-                let (result, wasGPS) = PlaceMatchService.evaluate(
+                let (result, wasGPS, gpsMetres, visionDist) = PlaceMatchService.evaluate(
                     savedLatitude: savedRef?.latitude,
                     savedLongitude: savedRef?.longitude,
                     savedGPSAccuracy: savedRef?.gpsAccuracy,
@@ -99,6 +99,10 @@ final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
                     savedImageData: savedRef?.imageJPEGData,
                     candidateImageData: jpegData
                 )
+                // Log raw distances — useful for threshold tuning.
+                let gpsStr   = gpsMetres.map   { String(format: "%.1f m", $0) } ?? "n/a"
+                let visStr   = visionDist.map  { String(format: "%.3f",   $0) } ?? "n/a"
+                print("[PlaceMatch] result=\(result) wasGPS=\(wasGPS) GPS=\(gpsStr) Vision=\(visStr)")
                 await MainActor.run { [weak self] in
                     guard let self, self.activeSession != nil else {
                         // Session was cancelled while PlaceMatchService ran — ignore.

--- a/Tests/MatherTests/PlaceMatchServiceTests.swift
+++ b/Tests/MatherTests/PlaceMatchServiceTests.swift
@@ -8,14 +8,14 @@ struct PlaceMatchServiceTests {
 
     @Test
     func gpsMatchWithinMatchRadius() {
-        // Two locations 10 metres apart — well inside 15 m match threshold
+        // Two locations ~6 m apart — inside the 8 m match threshold
         let result = PlaceMatchService.evaluate(
             savedLatitude: 51.5074,
             savedLongitude: -0.1278,
             savedGPSAccuracy: 5.0,
             currentLocation: CLLocation(
                 coordinate: CLLocationCoordinate2D(
-                    latitude: 51.5074 + 0.00009,   // ~10 m north
+                    latitude: 51.5074 + 0.000054,   // ~6 m north
                     longitude: -0.1278
                 ),
                 altitude: 0,
@@ -32,14 +32,14 @@ struct PlaceMatchServiceTests {
 
     @Test
     func gpsCloseInCloseRange() {
-        // ~25 m apart — between 15 m match and 30 m close thresholds
+        // ~15 m apart — between the 8 m match and 20 m close thresholds
         let result = PlaceMatchService.evaluate(
             savedLatitude: 51.5074,
             savedLongitude: -0.1278,
             savedGPSAccuracy: 5.0,
             currentLocation: CLLocation(
                 coordinate: CLLocationCoordinate2D(
-                    latitude: 51.5074 + 0.000225,   // ~25 m north
+                    latitude: 51.5074 + 0.000135,   // ~15 m north
                     longitude: -0.1278
                 ),
                 altitude: 0,
@@ -56,7 +56,7 @@ struct PlaceMatchServiceTests {
 
     @Test
     func gpsNoMatchBeyondCloseRange() {
-        // ~100 m apart — beyond 30 m close threshold
+        // ~100 m apart — beyond the 20 m close threshold
         let result = PlaceMatchService.evaluate(
             savedLatitude: 51.5074,
             savedLongitude: -0.1278,
@@ -79,18 +79,18 @@ struct PlaceMatchServiceTests {
 
     @Test
     func gpsIgnoredWhenAccuracyTooWeak() {
-        // GPS accuracy 50 m — above the 20 m cutoff, should be discarded
+        // GPS accuracy 15 m — above the 10 m cutoff, should be discarded
         let result = PlaceMatchService.evaluate(
             savedLatitude: 51.5074,
             savedLongitude: -0.1278,
-            savedGPSAccuracy: 50.0,
+            savedGPSAccuracy: 15.0,
             currentLocation: CLLocation(
                 coordinate: CLLocationCoordinate2D(
-                    latitude: 51.5074 + 0.00009,
+                    latitude: 51.5074 + 0.000054,
                     longitude: -0.1278
                 ),
                 altitude: 0,
-                horizontalAccuracy: 50.0,
+                horizontalAccuracy: 15.0,
                 verticalAccuracy: -1,
                 timestamp: .now
             ),
@@ -137,14 +137,14 @@ struct PlaceMatchServiceTests {
 
     @Test
     func gpsMatchWinsEvenWithNilImages() {
-        // GPS match + no vision → overall match via GPS
+        // GPS match (~6 m apart) + no vision → overall match via GPS
         let result = PlaceMatchService.evaluate(
             savedLatitude: 51.5074,
             savedLongitude: -0.1278,
             savedGPSAccuracy: 5.0,
             currentLocation: CLLocation(
                 coordinate: CLLocationCoordinate2D(
-                    latitude: 51.5074 + 0.00009,
+                    latitude: 51.5074 + 0.000054,   // ~6 m north
                     longitude: -0.1278
                 ),
                 altitude: 0,


### PR DESCRIPTION
## Problem

Photos from completely different rooms (and different places entirely) were being matched. Two root causes:

### Bug 1 — Vision threshold 0.65 was too lenient
`VNFeaturePrintObservation` is a **semantic** similarity metric, not a geometric one. It asks "does this look like a kitchen?" not "is this the same corner?". Different rooms in the same house share similar lighting, colour palettes, and furniture style — their semantic distance easily falls under 0.65. The correct threshold for "same physical spot" is around 0.25.

### Bug 2 — Indoor GPS false positives
- `gpsMatchMetres = 15.0` — a typical house floor is narrower than 15 m, so two rooms match by GPS
- `gpsAccuracyCutoff = 20.0` — indoor GPS commonly reports ~15 m accuracy while being room-to-room unreliable; the cutoff was letting these through

## Fix

| Threshold | Old | New | Reason |
|-----------|-----|-----|--------|
| `visionMatchDistance` | 0.65 | **0.25** | Require photos to look very similar, not just semantically related |
| `visionCloseDistance` | 1.00 | **0.50** | Consistent with tighter match band |
| `gpsMatchMetres` | 15.0 | **8.0** | Whole house often < 15 m across |
| `gpsCloseMetres` | 30.0 | **20.0** | |
| `gpsAccuracyCutoff` | 20.0 | **10.0** | Reject indoor GPS fixes that appear accurate but aren't |

## Debugging

`evaluate()` now returns raw `gpsMetres` and `visionDist` alongside the result. A `print("[PlaceMatch] ...")` line in the scanner logs these to the Xcode console on every check — useful for tuning if thresholds need adjusting further.

## Test plan
- [ ] Take reference photo at spot A. Go to a completely different room and check → should see **noMatch** (was: match)
- [ ] Take reference photo at spot A. Stand at spot A and check → should still **match**
- [ ] Check Xcode console for `[PlaceMatch]` lines — confirm Vision distances for correct spot are < 0.25 and wrong spots are > 0.25
- [ ] All existing tests pass with updated GPS distances

🤖 Generated with [Claude Code](https://claude.com/claude-code)