### PR TITLE
feat(settings): place-matching threshold sliders

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -39,6 +39,7 @@ final class AppModel {
         self.motionService = motionService
         self.soundDetectionService = soundDetectionService
         self.roomQuestScanner = roomQuestScanner
+        roomQuestScanner.featureFlags = featureFlags
 
         let vsEngine = VerticalSliceEngine(
             featureFlags: featureFlags,

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -154,6 +154,11 @@ struct SettingsView: View {
 
                             Divider()
 
+                            if appModel.featureFlags.roomQuestEnabled {
+                                PlaceMatchThresholdSection(featureFlags: appModel.featureFlags)
+                                Divider()
+                            }
+
                             Text("Physics & Geometry")
                                 .font(.caption.weight(.semibold))
                                 .foregroundStyle(.secondary)
@@ -292,6 +297,130 @@ struct SettingsView: View {
         } message: {
             Text("This removes saved summaries and local JSONL exports.")
         }
+    }
+}
+
+// MARK: - Place matching threshold sliders
+
+private struct PlaceMatchThresholdSection: View {
+    @Bindable var featureFlags: FeatureFlagService
+
+    private let defaults = PlaceMatchThresholds.default
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Text("Place matching")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Reset") { resetToDefaults() }
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(MatherTheme.accent)
+            }
+
+            Text("Tune how strictly the camera and GPS must agree that the child is at the right spot. Lower = stricter. Check the Xcode console for [PlaceMatch] lines to see live distances.")
+                .font(.caption)
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ThresholdSliderRow(
+                label: "Vision match",
+                unit: "",
+                value: $featureFlags.placeMatchVisionMatch,
+                range: 0.10...0.60,
+                step: 0.05,
+                defaultValue: Double(defaults.visionMatchDistance),
+                format: "%.2f",
+                hint: "Lower = more similar photos required. 0.25 rejects different rooms; 0.50 is lenient."
+            )
+
+            ThresholdSliderRow(
+                label: "Vision close",
+                unit: "",
+                value: $featureFlags.placeMatchVisionClose,
+                range: 0.20...1.00,
+                step: 0.05,
+                defaultValue: Double(defaults.visionCloseDistance),
+                format: "%.2f",
+                hint: "\"Almost there\" band. Should be above Vision match."
+            )
+
+            ThresholdSliderRow(
+                label: "GPS match",
+                unit: " m",
+                value: $featureFlags.placeMatchGPSMatch,
+                range: 3...20,
+                step: 1,
+                defaultValue: defaults.gpsMatchMetres,
+                format: "%.0f",
+                hint: "Metres. Outdoors: 8 m is reliable. Indoors: GPS is usually skipped by the accuracy cutoff."
+            )
+
+            ThresholdSliderRow(
+                label: "GPS close",
+                unit: " m",
+                value: $featureFlags.placeMatchGPSClose,
+                range: 10...50,
+                step: 2,
+                defaultValue: defaults.gpsCloseMetres,
+                format: "%.0f",
+                hint: "\"Almost there\" band for GPS. Should be above GPS match."
+            )
+
+            ThresholdSliderRow(
+                label: "GPS accuracy cutoff",
+                unit: " m",
+                value: $featureFlags.placeMatchGPSCutoff,
+                range: 3...20,
+                step: 1,
+                defaultValue: defaults.gpsAccuracyCutoff,
+                format: "%.0f",
+                hint: "Discard GPS fixes worse than this. 10 m blocks unreliable indoor readings."
+            )
+        }
+        .font(.subheadline)
+    }
+
+    private func resetToDefaults() {
+        featureFlags.placeMatchVisionMatch = Double(defaults.visionMatchDistance)
+        featureFlags.placeMatchVisionClose = Double(defaults.visionCloseDistance)
+        featureFlags.placeMatchGPSMatch    = defaults.gpsMatchMetres
+        featureFlags.placeMatchGPSClose    = defaults.gpsCloseMetres
+        featureFlags.placeMatchGPSCutoff   = defaults.gpsAccuracyCutoff
+    }
+}
+
+private struct ThresholdSliderRow: View {
+    let label: String
+    let unit: String
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    let step: Double
+    let defaultValue: Double
+    let format: String
+    let hint: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(label)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.ink)
+                Spacer()
+                Text(String(format: format, value) + unit)
+                    .font(.subheadline.weight(.black))
+                    .foregroundStyle(value == defaultValue ? MatherTheme.cardSubtitle : MatherTheme.accent)
+                    .monospacedDigit()
+            }
+            Slider(value: $value, in: range, step: step)
+                .tint(value == defaultValue ? MatherTheme.cardSubtitle : MatherTheme.accent)
+            Text(hint)
+                .font(.caption)
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 2)
     }
 }
 

--- a/Services/PlaceMatchService.swift
+++ b/Services/PlaceMatchService.swift
@@ -10,6 +10,30 @@ enum PlaceMatchResult: Equatable {
     case noMatch    // clearly wrong location
 }
 
+// MARK: - Thresholds
+
+/// All tunable knobs for place-matching in one value type.
+/// Stored in `FeatureFlagService` (UserDefaults) so parents can adjust from Settings
+/// without recompiling. The static `.default` reflects the values chosen after v2.3.2
+/// field testing.
+struct PlaceMatchThresholds: Equatable {
+    /// Child must be within this many metres of the saved GPS coordinate (outdoor).
+    var gpsMatchMetres: Double   = 8.0
+    /// GPS within this range shows "almost there" instead of "wrong place".
+    var gpsCloseMetres: Double   = 20.0
+    /// Discard GPS fixes with horizontal accuracy worse than this (metres).
+    /// 10 m prevents indoor GPS fixes (~15 m accuracy) from causing false positives.
+    var gpsAccuracyCutoff: Double = 10.0
+    /// VNFeaturePrintObservation L2 distance treated as same place (indoor).
+    /// 0.25 requires photos to look very similar — different rooms in the same house
+    /// typically score 0.40–0.80, which is why the original 0.65 caused false matches.
+    var visionMatchDistance: Float = 0.25
+    /// VNFeaturePrintObservation distance treated as "almost" (indoor).
+    var visionCloseDistance: Float = 0.50
+
+    static let `default` = PlaceMatchThresholds()
+}
+
 // MARK: - Service
 
 /// Pure namespace — stateless, no actor isolation.
@@ -20,29 +44,11 @@ enum PlaceMatchResult: Equatable {
 /// **Outdoor play** → GPS reliable (±3–5 m); either signal can confirm.
 enum PlaceMatchService {
 
-    // MARK: - Tunable thresholds
-
-    /// Child must be within this many metres of the saved GPS coordinate (outdoor).
-    /// Kept tight (8 m) to avoid indoor false positives — two rooms in the same house
-    /// are often within 15 m of each other.
-    static let gpsMatchMetres: Double = 8.0
-    /// GPS within this range shows "almost there" instead of "wrong place".
-    static let gpsCloseMetres: Double = 20.0
-    /// VNFeaturePrintObservation L2 distance treated as same place (indoor).
-    /// 0.65 was too lenient — different rooms in the same house routinely scored under 0.65
-    /// because VNFeaturePrintObservation is a semantic similarity metric, not a geometric one.
-    /// 0.25 requires photos to look very similar (same content, comparable framing).
-    static let visionMatchDistance: Float = 0.25
-    /// VNFeaturePrintObservation distance treated as "almost" (indoor).
-    static let visionCloseDistance: Float = 0.50
-    /// Discard GPS fixes with horizontal accuracy worse than this (metres).
-    /// Reduced from 20 m to 10 m — indoor fixes frequently report ~15 m accuracy
-    /// while actually being unreliable room-to-room.
-    static let gpsAccuracyCutoff: Double = 10.0
-
     // MARK: - Evaluation
 
     /// Evaluate whether `currentLocation` / `candidateImageData` match the saved reference.
+    /// - Parameter thresholds: Tunable knobs — defaults to `PlaceMatchThresholds.default`.
+    ///   Pass `featureFlags.placeMatchThresholds` to use the parent's in-app settings.
     /// - Returns: `(result, wasGPS, gpsMetres, visionDist)` where:
     ///   - `wasGPS` is `true` when GPS was the decisive signal (tailor speech)
     ///   - `gpsMetres` is the raw GPS distance in metres (nil when GPS was skipped)
@@ -53,11 +59,12 @@ enum PlaceMatchService {
         savedGPSAccuracy: Double?,
         currentLocation: CLLocation?,
         savedImageData: Data?,
-        candidateImageData: Data?
+        candidateImageData: Data?,
+        thresholds: PlaceMatchThresholds = .default
     ) -> (result: PlaceMatchResult, wasGPS: Bool, gpsMetres: Double?, visionDist: Float?) {
         let savedLoc = makeSavedLocation(lat: savedLatitude, lon: savedLongitude, accuracy: savedGPSAccuracy)
-        let (gpsResult, gpsMetres) = evaluateGPS(saved: savedLoc, current: currentLocation)
-        let (visResult, visionDist) = evaluateVision(reference: savedImageData, candidate: candidateImageData)
+        let (gpsResult, gpsMetres) = evaluateGPS(saved: savedLoc, current: currentLocation, thresholds: thresholds)
+        let (visResult, visionDist) = evaluateVision(reference: savedImageData, candidate: candidateImageData, thresholds: thresholds)
 
         // OR logic: either strong signal alone confirms place
         switch (gpsResult, visResult) {
@@ -82,29 +89,29 @@ enum PlaceMatchService {
         )
     }
 
-    private static func evaluateGPS(saved: CLLocation?, current: CLLocation?) -> (PlaceMatchResult, Double?) {
+    private static func evaluateGPS(saved: CLLocation?, current: CLLocation?, thresholds: PlaceMatchThresholds) -> (PlaceMatchResult, Double?) {
         guard let saved, let current,
-              saved.horizontalAccuracy > 0,   saved.horizontalAccuracy  <= gpsAccuracyCutoff,
-              current.horizontalAccuracy > 0, current.horizontalAccuracy <= gpsAccuracyCutoff
+              saved.horizontalAccuracy > 0,   saved.horizontalAccuracy  <= thresholds.gpsAccuracyCutoff,
+              current.horizontalAccuracy > 0, current.horizontalAccuracy <= thresholds.gpsAccuracyCutoff
         else { return (.noMatch, nil) }   // GPS unreliable — skip this signal
 
         let dist = current.distance(from: saved)
-        if dist <= gpsMatchMetres { return (.match, dist) }
-        if dist <= gpsCloseMetres { return (.close, dist) }
+        if dist <= thresholds.gpsMatchMetres { return (.match, dist) }
+        if dist <= thresholds.gpsCloseMetres { return (.close, dist) }
         return (.noMatch, dist)
     }
 
     // MARK: - Vision sub-evaluation
 
-    private static func evaluateVision(reference: Data?, candidate: Data?) -> (PlaceMatchResult, Float?) {
+    private static func evaluateVision(reference: Data?, candidate: Data?, thresholds: PlaceMatchThresholds) -> (PlaceMatchResult, Float?) {
         guard let refData = reference, let candData = candidate else { return (.noMatch, nil) }
         do {
             let refPrint  = try featurePrint(for: refData)
             let candPrint = try featurePrint(for: candData)
             var dist: Float = 0
             try refPrint.computeDistance(&dist, to: candPrint)
-            if dist <= visionMatchDistance { return (.match, dist) }
-            if dist <= visionCloseDistance { return (.close, dist) }
+            if dist <= thresholds.visionMatchDistance { return (.match, dist) }
+            if dist <= thresholds.visionCloseDistance { return (.close, dist) }
             return (.noMatch, dist)
         } catch {
             // Blurry / too-dark photo — treat as noMatch; grown-up fallback handles it

--- a/Services/RoomQuestLiveScanner.swift
+++ b/Services/RoomQuestLiveScanner.swift
@@ -36,6 +36,10 @@ final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
     /// can fire speech. Set by `AppModel` at startup.
     var onVerifyFeedback: ((VerifyFeedback) -> Void)? = nil
 
+    /// Threshold settings — injected from `AppModel` so parents can tune from Settings.
+    /// Reads `featureFlags.placeMatchThresholds` at scan time (each photo tap).
+    var featureFlags: FeatureFlagService? = nil
+
     /// Location service — owned here so GPS coordinates are captured at the exact photo moment.
     let locationService = LocationService()
 
@@ -88,16 +92,18 @@ final class RoomQuestLiveScanner: NSObject, RoomQuestScanner {
             let currentLocation = locationService.lastLocation
             let expectedRole = session.expectedRole
             let continuation = session.continuation
+            let thresholds = featureFlags?.placeMatchThresholds ?? .default
             verifyFeedback = .evaluating
 
-            Task.detached { [weak self, savedRef, currentLocation] in
+            Task.detached { [weak self, savedRef, currentLocation, thresholds] in
                 let (result, wasGPS, gpsMetres, visionDist) = PlaceMatchService.evaluate(
                     savedLatitude: savedRef?.latitude,
                     savedLongitude: savedRef?.longitude,
                     savedGPSAccuracy: savedRef?.gpsAccuracy,
                     currentLocation: currentLocation,
                     savedImageData: savedRef?.imageJPEGData,
-                    candidateImageData: jpegData
+                    candidateImageData: jpegData,
+                    thresholds: thresholds
                 )
                 // Log raw distances — useful for threshold tuning.
                 let gpsStr   = gpsMetres.map   { String(format: "%.1f m", $0) } ?? "n/a"

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -4,7 +4,13 @@ import Observation
 @Observable
 final class FeatureFlagService {
     private enum Keys {
-        static let verticalSlice1Enabled = "feature.verticalSlice1Enabled"
+        static let verticalSlice1Enabled  = "feature.verticalSlice1Enabled"
+        // Place-matching thresholds (tunable from Settings)
+        static let placeMatchGPSMatch     = "placeMatch.gpsMatchMetres"
+        static let placeMatchGPSClose     = "placeMatch.gpsCloseMetres"
+        static let placeMatchGPSCutoff    = "placeMatch.gpsAccuracyCutoff"
+        static let placeMatchVisionMatch  = "placeMatch.visionMatchDistance"
+        static let placeMatchVisionClose  = "placeMatch.visionCloseDistance"
         static let testModeEnabled = "feature.testModeEnabled"
         static let audioEnabled = "feature.audioEnabled"
         static let hapticsEnabled = "feature.hapticsEnabled"
@@ -134,6 +140,40 @@ final class FeatureFlagService {
         didSet { defaults.set(compassAnglesEnabled, forKey: Keys.compassAnglesEnabled) }
     }
 
+    // MARK: - Place-matching thresholds
+
+    /// GPS match radius in metres. Default 8 m. Tighter = harder to get false match indoors.
+    var placeMatchGPSMatch: Double {
+        didSet { defaults.set(placeMatchGPSMatch, forKey: Keys.placeMatchGPSMatch) }
+    }
+    /// GPS "close" radius in metres. Must be greater than `placeMatchGPSMatch`. Default 20 m.
+    var placeMatchGPSClose: Double {
+        didSet { defaults.set(placeMatchGPSClose, forKey: Keys.placeMatchGPSClose) }
+    }
+    /// Discard GPS fixes with horizontal accuracy worse than this (metres). Default 10 m.
+    var placeMatchGPSCutoff: Double {
+        didSet { defaults.set(placeMatchGPSCutoff, forKey: Keys.placeMatchGPSCutoff) }
+    }
+    /// VNFeaturePrintObservation match distance. Default 0.25. Lower = stricter.
+    var placeMatchVisionMatch: Double {
+        didSet { defaults.set(placeMatchVisionMatch, forKey: Keys.placeMatchVisionMatch) }
+    }
+    /// VNFeaturePrintObservation "close" distance. Default 0.50.
+    var placeMatchVisionClose: Double {
+        didSet { defaults.set(placeMatchVisionClose, forKey: Keys.placeMatchVisionClose) }
+    }
+
+    /// Live snapshot of thresholds — read by `RoomQuestLiveScanner` at scan time.
+    var placeMatchThresholds: PlaceMatchThresholds {
+        PlaceMatchThresholds(
+            gpsMatchMetres:    placeMatchGPSMatch,
+            gpsCloseMetres:    placeMatchGPSClose,
+            gpsAccuracyCutoff: placeMatchGPSCutoff,
+            visionMatchDistance: Float(placeMatchVisionMatch),
+            visionCloseDistance: Float(placeMatchVisionClose)
+        )
+    }
+
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard) {
@@ -164,6 +204,11 @@ final class FeatureFlagService {
             Keys.twoFingerProtractorEnabled: false,
             Keys.gravityArtistEnabled: false,
             Keys.compassAnglesEnabled: false,
+            Keys.placeMatchGPSMatch:    PlaceMatchThresholds.default.gpsMatchMetres,
+            Keys.placeMatchGPSClose:    PlaceMatchThresholds.default.gpsCloseMetres,
+            Keys.placeMatchGPSCutoff:   PlaceMatchThresholds.default.gpsAccuracyCutoff,
+            Keys.placeMatchVisionMatch: Double(PlaceMatchThresholds.default.visionMatchDistance),
+            Keys.placeMatchVisionClose: Double(PlaceMatchThresholds.default.visionCloseDistance),
         ])
         verticalSlice1Enabled = defaults.bool(forKey: Keys.verticalSlice1Enabled)
         testModeEnabled = defaults.bool(forKey: Keys.testModeEnabled)
@@ -186,5 +231,10 @@ final class FeatureFlagService {
         twoFingerProtractorEnabled = defaults.bool(forKey: Keys.twoFingerProtractorEnabled)
         gravityArtistEnabled = defaults.bool(forKey: Keys.gravityArtistEnabled)
         compassAnglesEnabled = defaults.bool(forKey: Keys.compassAnglesEnabled)
+        placeMatchGPSMatch   = defaults.double(forKey: Keys.placeMatchGPSMatch)
+        placeMatchGPSClose   = defaults.double(forKey: Keys.placeMatchGPSClose)
+        placeMatchGPSCutoff  = defaults.double(forKey: Keys.placeMatchGPSCutoff)
+        placeMatchVisionMatch = defaults.double(forKey: Keys.placeMatchVisionMatch)
+        placeMatchVisionClose = defaults.double(forKey: Keys.placeMatchVisionClose)
     }
 }


### PR DESCRIPTION
## What this does

Adds a **Place matching** section to Settings (visible only when Room Quest is enabled) with live sliders for all 5 `PlaceMatchService` thresholds:

| Slider | Range | Step | Default | What it controls |
|--------|-------|------|---------|-----------------|
| Vision match | 0.10–0.60 | 0.05 | **0.25** | VNFeaturePrintObservation distance for "same spot" — lower = stricter |
| Vision close | 0.20–1.00 | 0.05 | **0.50** | "Almost there" band for Vision |
| GPS match | 3–20 m | 1 m | **8 m** | Must be within this radius outdoors |
| GPS close | 10–50 m | 2 m | **20 m** | "Almost there" band for GPS |
| GPS cutoff | 3–20 m | 1 m | **10 m** | Discards GPS fixes worse than this accuracy |

- Sliders turn **accent colour** when changed from default so you can see at a glance what's been tweaked
- **Reset** button restores all 5 values to defaults in one tap
- Values persist to UserDefaults — survive app restarts
- Each scan captures a **snapshot** of thresholds at tap time, so mid-scan changes are safe

## Architecture

`PlaceMatchThresholds` is now a dedicated struct (single source of truth for defaults). `PlaceMatchService.evaluate()` accepts it as a parameter (defaults to `.default`). `RoomQuestLiveScanner` reads thresholds from `FeatureFlagService` at scan time via the `featureFlags` property injected from `AppModel`.

## Test plan
- [ ] Open Settings with Room Quest enabled → "Place matching" section appears
- [ ] Move Vision match slider → value turns accent, console shows updated threshold on next scan
- [ ] Tap Reset → all sliders return to defaults, values turn grey
- [ ] Kill/relaunch app → changed values persist
- [ ] Room Quest scan with defaults still matches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)