### PR TITLE
WIP: issue #222 recovery via CI

### DIFF
--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -54,7 +54,7 @@ private extension MatherApp {
                 sessionId: sessionId,
                 startedAt: startedAt,
                 endedAt: startedAt.addingTimeInterval(300),
-                objectiveTitle: "Make & Break Numbers",
+                objectiveTitle: "Make & Break 1–20",
                 problemsCompleted: 4 + index,
                 firstAttemptAccuracy: index == 0 ? 0.75 : 0.5,
                 transferCorrectCount: 2 + (index % 2),

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -27,6 +27,11 @@ enum SliceStage: String, Codable, CaseIterable, Identifiable {
     }
 }
 
+enum SliceRouteMode: Equatable {
+    case legacy(showTransfer: Bool, showGravitySplit: Bool, showBondMatch: Bool)
+    case makeBreakLoopV2
+}
+
 enum SliceEventType: String, Codable {
     case sessionStart = "session_start"
     case problemPresented = "problem_presented"

--- a/Domain/SliceStateMachine.swift
+++ b/Domain/SliceStateMachine.swift
@@ -1,6 +1,33 @@
 import Foundation
 
 enum SliceStateMachine {
+    static func nextStage(
+        after stage: SliceStage,
+        success: Bool,
+        routeMode: SliceRouteMode
+    ) -> SliceStage {
+        guard success else { return stage }
+
+        switch routeMode {
+        case .makeBreakLoopV2:
+            switch stage {
+            case .concrete: return .gravitySplit
+            case .gravitySplit: return .sumSprint
+            case .sumSprint: return .bondMatch
+            case .bondMatch, .pictorial, .abstract, .transfer: return .done
+            case .done: return .done
+            }
+        case let .legacy(showTransfer, showGravitySplit, showBondMatch):
+            return nextStage(
+                after: stage,
+                success: success,
+                showTransfer: showTransfer,
+                showGravitySplit: showGravitySplit,
+                showBondMatch: showBondMatch
+            )
+        }
+    }
+
     /// Compute the next stage after `stage` succeeds.
     ///
     /// - Parameters:
@@ -44,6 +71,14 @@ enum SliceStateMachine {
         case .done:
             return .done
         }
+    }
+
+    static func canTransition(
+        from current: SliceStage,
+        to next: SliceStage,
+        routeMode: SliceRouteMode
+    ) -> Bool {
+        nextStage(after: current, success: true, routeMode: routeMode) == next
     }
 
     static func canTransition(

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -103,6 +103,7 @@ final class VerticalSliceEngine {
     }
 
     var concreteCount: Int { concreteWarmCount + concreteAccentCount }
+    var sumSprintStageCardCount: Int { sumSprintBurstState?.cards.count ?? 0 }
 
     func showSettings() { route = .settings }
     func showHome() { route = .home }

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -193,11 +193,11 @@ final class VerticalSliceEngine {
         guard let currentProblem else { return }
         switch side {
         case .warm:
-            let maxWarm = min(5, max(currentProblem.target - concreteAccentCount, 0))
+            let maxWarm = min(10, max(currentProblem.target - concreteAccentCount, 0))
             concreteWarmCount = min(max(concreteWarmCount + delta, 0), maxWarm)
             recordInteraction(action: "place_warm", value: concreteWarmCount)
         case .accent:
-            let maxAccent = min(5, max(currentProblem.target - concreteWarmCount, 0))
+            let maxAccent = min(10, max(currentProblem.target - concreteWarmCount, 0))
             concreteAccentCount = min(max(concreteAccentCount + delta, 0), maxAccent)
             recordInteraction(action: "place_accent", value: concreteAccentCount)
         }
@@ -361,21 +361,21 @@ final class VerticalSliceEngine {
 
     /// Called by BondMatchView when the child begins dragging or taps a left card.
     func bondDragStarted(pairId: UUID) {
-        guard currentStage == .pictorial || currentStage == .bondMatch else { return }
+        guard isBondBlastStage else { return }
         hapticsService.cardPickup(enabled: featureFlags.hapticsEnabled)
         logBondMatchTelemetry("pair_drag_started", extra: ["pair_id": pairId.uuidString])
     }
 
     /// Called by BondMatchView when a dragged card is hovering near a snap target.
     func bondNearTarget() {
-        guard currentStage == .pictorial || currentStage == .bondMatch else { return }
+        guard isBondBlastStage else { return }
         hapticsService.cardNearSnap(enabled: featureFlags.hapticsEnabled)
     }
 
     /// Called when the child successfully matches a complement pair.
     /// Advances to `.done` when all pairs are matched.
     func matchPair(id: UUID) {
-        guard (currentStage == .pictorial || currentStage == .bondMatch),
+        guard isBondBlastStage,
               let problem = currentProblem,
               var state = bondMatchState,
               let idx = state.pairs.firstIndex(where: { $0.id == id }) else { return }
@@ -399,7 +399,7 @@ final class VerticalSliceEngine {
 
     /// Called when the child drops a card on the wrong target.
     func mismatchPair() {
-        guard (currentStage == .pictorial || currentStage == .bondMatch), let problem = currentProblem else { return }
+        guard isBondBlastStage, let problem = currentProblem else { return }
         logBondMatchTelemetry("pair_mismatch", extra: [:])
         hapticsService.cardSnapMismatch(enabled: featureFlags.hapticsEnabled)
         let msg = "Try again! Find two numbers that make \(problem.target)."
@@ -454,20 +454,7 @@ final class VerticalSliceEngine {
         feedbackMessage = successMessage
         speechService.speak(successMessage, enabled: featureFlags.audioEnabled)
 
-        // Bond Blast fires only on the last problem of the session.
-        let isLastProblem = currentProblemIndex + 1 >= problems.count
-        let makeBreakLoopV2Enabled = featureFlags.makeBreakLoopV2Enabled
-        let showBondMatch = makeBreakLoopV2Enabled || (featureFlags.vs1BondMatchEnabled && isLastProblem)
-        let showGravitySplit = makeBreakLoopV2Enabled || featureFlags.vs1GravitySplitEnabled
-
-        let next = SliceStateMachine.nextStage(
-            after: currentStage,
-            success: true,
-            showTransfer: config.showTransfer,
-            showGravitySplit: showGravitySplit,
-            showBondMatch: showBondMatch,
-            makeBreakLoopV2Enabled: makeBreakLoopV2Enabled
-        )
+        let next = SliceStateMachine.nextStage(after: currentStage, success: true, routeMode: routeMode)
         recordStageTransition(from: currentStage, to: next)
 
         // A problem is complete when the next stage is .done (the last meaningful
@@ -634,7 +621,7 @@ final class VerticalSliceEngine {
         let accuracy = completed == 0 ? 0 : Double(firstTryCount) / Double(completed)
 
         return ParentDigest(
-            objectiveTitle: "Make & Break Numbers",
+            objectiveTitle: "Make & Break 1–20",
             firstAttemptAccuracy: accuracy,
             medianLatencyMs: median,
             problemsCompleted: completed,
@@ -760,13 +747,21 @@ final class VerticalSliceEngine {
             let a = currentProblem.decompositionA
             let b = currentProblem.decompositionB
             return "Use plus and minus to build \(a) on one side and \(b) on the other."
+        case .sumSprint:
+            if let card = sumSprintBurstState?.currentCard {
+                return "Quick Sum Sprint. Solve \(card.prompt), then finish with Bond Blast."
+            }
+            return "Quick Sum Sprint! Solve a tiny burst, then finish with Bond Blast."
         case .done:
             return "Nice work."
         }
     }
 
     private func successMessage(for stage: SliceStage, problem: SliceProblem) -> String {
-        activeTheme.stageSuccessPhrase(for: stage, target: problem.target)
+        if stage == .sumSprint {
+            return "Nice burst! Now finish with Bond Blast for \(problem.target)."
+        }
+        return activeTheme.stageSuccessPhrase(for: stage, target: problem.target)
     }
 
     private func feedbackMessageForFailure(stage: SliceStage, problem: SliceProblem) -> String {
@@ -821,19 +816,39 @@ final class VerticalSliceEngine {
     private func appendDigit(to string: String, digit: Int) -> String {
         let candidate = (string + String(digit)).prefix(2)
         let numeric = Int(candidate) ?? 0
-        return numeric > 10 ? string : String(candidate)
+        return numeric > 20 ? string : String(candidate)
     }
 
     private func setConcreteTotal(_ total: Int) {
         let maxTotal = currentProblem?.target ?? 10
         let clamped = min(max(total, 0), maxTotal)
-        concreteWarmCount = min(clamped, 5)
+        concreteWarmCount = min(clamped, 10)
         concreteAccentCount = max(clamped - concreteWarmCount, 0)
         recordInteraction(action: "place", value: concreteCount)
         #if targetEnvironment(simulator)
         print("[Mather][concrete] warm=\(concreteWarmCount) accent=\(concreteAccentCount) total=\(concreteCount)")
         #endif
     }
+
+    private var isBondBlastStage: Bool {
+        if featureFlags.makeBreakLoopV2Enabled {
+            return currentStage == .bondMatch
+        }
+        return currentStage == .pictorial || currentStage == .bondMatch
+    }
+
+    private var routeMode: SliceRouteMode {
+        if featureFlags.makeBreakLoopV2Enabled {
+            return .makeBreakLoopV2
+        }
+        let isLastProblem = currentProblemIndex + 1 >= problems.count
+        return .legacy(
+            showTransfer: config.showTransfer,
+            showGravitySplit: featureFlags.vs1GravitySplitEnabled,
+            showBondMatch: featureFlags.vs1BondMatchEnabled && isLastProblem
+        )
+    }
+
 }
 
 enum EquationSide {

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -36,6 +36,13 @@ struct SettingsView: View {
         )
     }
 
+    private var makeBreakLoopV2Binding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.makeBreakLoopV2Enabled },
+            set: { appModel.featureFlags.makeBreakLoopV2Enabled = $0 }
+        )
+    }
+
     private var motionBinding: Binding<Bool> {
         Binding(
             get: { appModel.featureFlags.motionControlsEnabled },
@@ -85,6 +92,14 @@ struct SettingsView: View {
                                 .font(.caption.weight(.semibold))
                                 .foregroundStyle(.secondary)
                                 .padding(.top, 4)
+                            Toggle("Make & Break 1–20", isOn: verticalSliceBinding)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.85)
+                            VS1ToggleRow(
+                                title: "Make & Break loop V2 (recovery)",
+                                subtitle: "Uses the reopened #222 route: Make it → Gravity Split → Sum Sprint → Bond Blast.",
+                                isOn: makeBreakLoopV2Binding
+                            )
                             VS1ToggleRow(
                                 title: "Bond Blast finale",
                                 subtitle: "Adds a free-match bonus round after all bonds for a number are found.",
@@ -199,10 +214,11 @@ struct SettingsView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(MatherTheme.cardSubtitle)
                             VStack(alignment: .leading, spacing: 8) {
-                                smokeStep("1. Tap Home → Play → Start Session.")
-                                smokeStep("2. Complete one full problem (Make → Break → Write → Show).")
-                                smokeStep("3. Confirm Session Complete screen appears.")
-                                smokeStep("4. Return here and tap Share latest export to verify JSONL.")
+                                smokeStep("1. Enable Make & Break 1–20 (toggle above).")
+                                smokeStep("2. Tap Home → Play → Start Session.")
+                                smokeStep("3. If loop V2 is on, verify Make → Gravity Split → Sum Sprint → Bond Blast.")
+                                smokeStep("4. Confirm Session Complete screen appears.")
+                                smokeStep("5. Return here and tap Share latest export to verify JSONL.")
                             }
                         }
                     }

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -64,6 +64,13 @@ struct SettingsView: View {
         )
     }
 
+    private var verticalSliceBinding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.verticalSlice1Enabled },
+            set: { appModel.featureFlags.verticalSlice1Enabled = $0 }
+        )
+    }
+
     private func smokeStep(_ text: String) -> some View {
         Label(text, systemImage: "checkmark.circle")
             .font(.subheadline)

--- a/Features/VerticalSlice1/ConcreteBuildView.swift
+++ b/Features/VerticalSlice1/ConcreteBuildView.swift
@@ -8,9 +8,9 @@ struct ConcreteBuildView: View {
     let onSubmit: () -> Void
     var theme: any SliceTheme = ClassicTheme()
 
-    // Ten-frame is always 5 columns × 2 rows — invariant across device sizes.
-    // The 2×5 structure is what enables subitizing: 7 is instantly seen as
-    // "a full row of 5 + 2 more", not counted one-by-one.
+    // For issue #222 recovery the concrete stage must genuinely support 1...20.
+    // We keep 5 columns so the child still sees familiar subitizing-friendly rows,
+    // but expand the surface to 4 rows when needed.
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 10), count: 5)
 
     var body: some View {
@@ -31,19 +31,19 @@ struct ConcreteBuildView: View {
                 // Cells are capped at 72pt so on wide screens (iPad) they don't grow
                 // to 130pt+ — "bigger circles" feedback and scrolling are eliminated.
                 LazyVGrid(columns: columns, spacing: 10) {
-                    ForEach(0..<10, id: \.self) { index in
+                    ForEach(0..<min(max(target, 1), 20), id: \.self) { index in
                         counterCell(index: index)
                             .frame(maxWidth: 72, maxHeight: 72)
                             .accessibilityIdentifier("counter-cell-\(index)")
                             .accessibilityLabel("Counter \(index + 1)")
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                let isWarm = index < 5
-                                let rowIndex = index % 5
-                                // Accent row is locked until the warm row is filled to capacity
-                                // (min(target, 5) circles). Enforces CPA warm-first pedagogy:
-                                // the first addend must be established before the complement.
-                                guard isWarm || warmCount >= min(target, 5) else { return }
+                                let isWarm = index < 10
+                                let rowIndex = index % 10
+                                // Accent half is locked until the warm half is filled to capacity
+                                // (up to 10 counters). This preserves the warm-first pedagogy
+                                // while allowing genuine 11...20 targets.
+                                guard isWarm || warmCount >= min(target, 10) else { return }
                                 onAdjust(
                                     (rowIndex + 1) - (isWarm ? warmCount : accentCount),
                                     isWarm ? .warm : .accent
@@ -89,8 +89,8 @@ struct ConcreteBuildView: View {
 
     @ViewBuilder
     private func counterCell(index: Int) -> some View {
-        let isFirstRow = index < 5
-        let rowIndex = index % 5
+        let isFirstRow = index < 10
+        let rowIndex = index % 10
         let filled = isFirstRow ? rowIndex < warmCount : rowIndex < accentCount
         CounterView(index: index, filled: filled, theme: theme)
     }

--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -200,7 +200,7 @@ struct GravitySplitView: View {
     private func panView(count: Int, fill: Color, side: String) -> some View {
         VStack(spacing: 6) {
             // Counter dots in the pan (up to target, max display 10)
-            let display = min(state.target, 10)
+            let display = min(state.target, 20)
             LazyVGrid(
                 columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 5),
                 spacing: 4

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -128,6 +128,19 @@ struct HomeView: View {
         .accessibilityIdentifier("Play")
     }
 
+    private var lockedActivityCard: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 14) {
+                Text("Make & Break 1–20")
+                    .font(.title2.weight(.bold))
+                Text("Enable the activity in Settings before handing the iPad to your child.")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
     // MARK: - Explorer Lab card
 
     private var labCard: some View {

--- a/Features/VerticalSlice1/RouteSupportViews.swift
+++ b/Features/VerticalSlice1/RouteSupportViews.swift
@@ -69,6 +69,12 @@ struct VS1SettingsPlaceholderView: View {
         )
     }
 
+    private var verticalSliceBinding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.verticalSlice1Enabled },
+            set: { appModel.featureFlags.verticalSlice1Enabled = $0 }
+        )
+    }
 
     private var makeBreakLoopV2Binding: Binding<Bool> {
         Binding(

--- a/Features/VerticalSlice1/RouteSupportViews.swift
+++ b/Features/VerticalSlice1/RouteSupportViews.swift
@@ -89,6 +89,11 @@ struct VS1SettingsPlaceholderView: View {
                 VS1Card {
                     VStack(alignment: .leading, spacing: 12) {
                         VS1ToggleRow(
+                            title: "Make & Break 1–20",
+                            subtitle: "Enable the Make & Break 1–20 activity for your child.",
+                            isOn: verticalSliceBinding
+                        )
+                        VS1ToggleRow(
                             title: "Audio enabled",
                             subtitle: "Keep prompts and neutral feedback audible.",
                             isOn: audioBinding

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -54,7 +54,9 @@ final class FeatureFlagService {
         didSet { defaults.set(vs1GravitySplitEnabled, forKey: Keys.vs1GravitySplitEnabled) }
     }
 
-    /// Enables the issue #222 per-target loop: Make it -> Gravity Split -> Sum Sprint -> Bond Blast.
+    /// Enables the reopened issue #222 per-target loop:
+    /// Make it -> Gravity Split -> Sum Sprint -> Bond Blast.
+    /// Default false until recovery QA signs off.
     var makeBreakLoopV2Enabled: Bool {
         didSet { defaults.set(makeBreakLoopV2Enabled, forKey: Keys.makeBreakLoopV2Enabled) }
     }

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -4,6 +4,7 @@ import Observation
 @Observable
 final class FeatureFlagService {
     private enum Keys {
+        static let verticalSlice1Enabled = "feature.verticalSlice1Enabled"
         // Place-matching thresholds (tunable from Settings)
         static let placeMatchGPSMatch     = "placeMatch.gpsMatchMetres"
         static let placeMatchGPSClose     = "placeMatch.gpsCloseMetres"
@@ -22,6 +23,10 @@ final class FeatureFlagService {
         static let roomQuestSafetyAcknowledged = "feature.roomQuestSafetyAcknowledged"
         static let roomQuestMarkerSetupEnabled = "feature.roomQuestMarkerSetupEnabled"
         static let roomQuestReferenceCaptureEnabled = "feature.roomQuestReferenceCaptureEnabled"
+    }
+
+    var verticalSlice1Enabled: Bool {
+        didSet { defaults.set(verticalSlice1Enabled, forKey: Keys.verticalSlice1Enabled) }
     }
 
     var testModeEnabled: Bool {
@@ -132,6 +137,7 @@ final class FeatureFlagService {
         // "YES"/"NO"/"1"/"0" string values injected via -key value launch arguments,
         // which object(forKey:) as? Bool does not.
         defaults.register(defaults: [
+            Keys.verticalSlice1Enabled: false,
             Keys.testModeEnabled: true,
             Keys.audioEnabled: true,
             Keys.hapticsEnabled: true,
@@ -150,6 +156,7 @@ final class FeatureFlagService {
             Keys.placeMatchVisionMatch: Double(PlaceMatchThresholds.default.visionMatchDistance),
             Keys.placeMatchVisionClose: Double(PlaceMatchThresholds.default.visionCloseDistance),
         ])
+        verticalSlice1Enabled = defaults.bool(forKey: Keys.verticalSlice1Enabled)
         testModeEnabled = defaults.bool(forKey: Keys.testModeEnabled)
         audioEnabled = defaults.bool(forKey: Keys.audioEnabled)
         hapticsEnabled = defaults.bool(forKey: Keys.hapticsEnabled)

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -35,15 +35,17 @@ struct FeatureFlagTests {
         #expect(flags.hapticsEnabled == true)
     }
 
-
-    @Test func loopV2FlagDefaultsOffAndPersists() {
-        let defaults = UserDefaults(suiteName: #function)!
-        let flags = FeatureFlagService(defaults: defaults)
+    @Test func makeBreakLoopV2DefaultsFalse() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         #expect(flags.makeBreakLoopV2Enabled == false)
-        flags.makeBreakLoopV2Enabled = true
-
-        let reloaded = FeatureFlagService(defaults: defaults)
-        #expect(reloaded.makeBreakLoopV2Enabled)
     }
 
+    @Test func makeBreakLoopV2PersistsAcrossInstances() {
+        let defaults = UserDefaults(suiteName: #function)!
+        let flags1 = FeatureFlagService(defaults: defaults)
+        flags1.makeBreakLoopV2Enabled = true
+
+        let flags2 = FeatureFlagService(defaults: defaults)
+        #expect(flags2.makeBreakLoopV2Enabled)
+    }
 }

--- a/Tests/MatherTests/SessionHistoryTests.swift
+++ b/Tests/MatherTests/SessionHistoryTests.swift
@@ -26,7 +26,7 @@ private func makeDraft(
         sessionId: sessionId,
         startedAt: startedAt,
         endedAt: startedAt.addingTimeInterval(300),
-        objectiveTitle: "Make & Break Numbers",
+        objectiveTitle: "Make & Break 1–20",
         problemsCompleted: problemsCompleted,
         firstAttemptAccuracy: accuracy,
         transferCorrectCount: transferCorrect,

--- a/Tests/MatherTests/SliceStateMachineTests.swift
+++ b/Tests/MatherTests/SliceStateMachineTests.swift
@@ -3,6 +3,14 @@ import Testing
 
 struct SliceStateMachineTests {
     @Test
+    func loopV2TransitionsAdvanceInRecoveryOrder() {
+        #expect(SliceStateMachine.nextStage(after: .concrete, success: true, routeMode: .makeBreakLoopV2) == .gravitySplit)
+        #expect(SliceStateMachine.nextStage(after: .gravitySplit, success: true, routeMode: .makeBreakLoopV2) == .sumSprint)
+        #expect(SliceStateMachine.nextStage(after: .sumSprint, success: true, routeMode: .makeBreakLoopV2) == .bondMatch)
+        #expect(SliceStateMachine.nextStage(after: .bondMatch, success: true, routeMode: .makeBreakLoopV2) == .done)
+    }
+
+    @Test
     func validTransitionsAdvanceInOrder() {
         #expect(SliceStateMachine.nextStage(after: .concrete, success: true, showTransfer: true) == .pictorial)
         #expect(SliceStateMachine.nextStage(after: .pictorial, success: true, showTransfer: true) == .abstract)
@@ -15,6 +23,8 @@ struct SliceStateMachineTests {
         #expect(SliceStateMachine.canTransition(from: .concrete, to: .abstract, showTransfer: true) == false)
         #expect(SliceStateMachine.canTransition(from: .abstract, to: .done, showTransfer: true) == false)
         #expect(SliceStateMachine.canTransition(from: .abstract, to: .done, showTransfer: false))
+        #expect(SliceStateMachine.canTransition(from: .concrete, to: .abstract, routeMode: .makeBreakLoopV2) == false)
+        #expect(SliceStateMachine.canTransition(from: .gravitySplit, to: .bondMatch, routeMode: .makeBreakLoopV2) == false)
     }
 
     // MARK: - Bond Blast transitions

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -50,6 +50,51 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
+    func loopV2RoutesConcreteToGravitySplitToSumSprintToBondBlast() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.verticalSlice1Enabled = true
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        let target = engine.currentProblem?.target ?? 0
+        engine.adjustConcrete(by: target)
+        engine.submitCurrentStage()
+        await waitFor("gravity split stage after concrete") { engine.currentStage == .gravitySplit }
+        #expect(engine.currentStage == .gravitySplit)
+
+        let desiredLeft = engine.currentProblem?.decompositionA ?? 0
+        engine.adjustGravitySplitByTap(delta: desiredLeft)
+        await waitFor("sum sprint stage after gravity split") { engine.currentStage == .sumSprint }
+        #expect(engine.currentStage == .sumSprint)
+        #expect((1...3).contains(engine.sumSprintStageCardCount))
+
+        engine.submitCurrentStage()
+        await waitFor("bond blast after sum sprint") { engine.currentStage == .bondMatch }
+        #expect(engine.currentStage == .bondMatch)
+
+        let pairIds = engine.bondMatchState?.pairs.map(\.id) ?? []
+        #expect(!pairIds.isEmpty)
+        for id in pairIds {
+            engine.matchPair(id: id)
+        }
+
+        await waitFor("advance to next problem after loop v2 bond blast") {
+            engine.currentProblemIndex == 1 && engine.currentStage == .concrete
+        }
+        #expect(engine.currentProblemIndex == 1)
+        #expect(engine.currentStage == .concrete)
+    }
+
+    @Test
     func sessionRoutesThroughBondBlastThenWriteItThenTransfer() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -52,7 +52,6 @@ struct VerticalSliceEngineTests {
     @Test
     func loopV2RoutesConcreteToGravitySplitToSumSprintToBondBlast() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
         flags.makeBreakLoopV2Enabled = true
 
@@ -65,19 +64,21 @@ struct VerticalSliceEngineTests {
         )
 
         engine.startSession()
-        let target = engine.currentProblem?.target ?? 0
-        engine.adjustConcrete(by: target)
+        guard let problem = engine.currentProblem else { return }
+
+        engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()
-        await waitFor("gravity split stage after concrete") { engine.currentStage == .gravitySplit }
+        await waitFor("gravity split after concrete") { engine.currentStage == .gravitySplit }
         #expect(engine.currentStage == .gravitySplit)
 
-        let desiredLeft = engine.currentProblem?.decompositionA ?? 0
-        engine.adjustGravitySplitByTap(delta: desiredLeft)
-        await waitFor("sum sprint stage after gravity split") { engine.currentStage == .sumSprint }
+        lockGravitySplit(engine, problem: problem)
+        await waitFor("gravity split lock") { engine.gravitySplitState?.isLocked == true }
+        await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
         #expect(engine.currentStage == .sumSprint)
-        #expect((1...3).contains(engine.sumSprintStageCardCount))
+        #expect((engine.sumSprintBurstState?.cards.count ?? 0) >= 1)
+        #expect((engine.sumSprintBurstState?.cards.count ?? 0) <= 3)
 
-        engine.submitCurrentStage()
+        completeSumSprintBurst(engine)
         await waitFor("bond blast after sum sprint") { engine.currentStage == .bondMatch }
         #expect(engine.currentStage == .bondMatch)
 

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -57,7 +57,7 @@ final class ScreenshotTests: XCTestCase {
         _ = app.staticTexts["Settings"].waitForExistence(timeout: 3)
         snapshot(app, "Settings-BeforeEnableVS1")
 
-        let vs1Toggle = app.switches["Make & Break to 10"]
+        let vs1Toggle = app.switches["Make & Break 1–20"]
         if vs1Toggle.waitForExistence(timeout: 3) {
             vs1Toggle.tap()
         }
@@ -317,6 +317,22 @@ final class ScreenshotTests: XCTestCase {
         }
         app.launch()
         return app
+    }
+
+    /// Navigates to Settings, enables VS1, returns to Home.
+    private func enableVS1(_ app: XCUIApplication) {
+        let settingsButton = app.buttons["Settings"]
+        _ = settingsButton.waitForExistence(timeout: 5)
+        settingsButton.tap()
+        _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
+        let toggle = app.switches["Make & Break 1–20"]
+        if toggle.waitForExistence(timeout: 10), toggle.value as? String == "0" {
+            toggle.tap()
+        }
+        let homeButton = app.buttons["Home"]
+        _ = homeButton.waitForExistence(timeout: 5)
+        homeButton.tap()
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
     }
 
     /// Launches with VS1 pre-enabled and haptics on — use for tests that exercise success/failure feedback.


### PR DESCRIPTION
## Summary
- move issue #222 recovery work onto a clean branch from `main`
- stage RX1 copy cleanup and RX2 loop-v2 routing behind a new recovery flag
- use this PR as the CI validation surface instead of local/mac-only validation

## What is in this PR
- visible `Make & Break 1–20` copy cleanup across app and tests
- new `makeBreakLoopV2Enabled` feature flag
- explicit loop-v2 routing in the state machine
- recovery engine wiring for `concrete -> gravitySplit -> sumSprint -> bondMatch`
- concrete/gravity surfaces adjusted for real 1..20 support
- recovery-focused unit test updates for flags, routing, and engine flow

## Honest status
- this is a WIP recovery PR, not a claim that #222 is complete
- CI is the next source of truth for compile/test status
- follow-on RX3-RX6 work and validation evidence still need to be driven from the PR results
