### PR TITLE
feat(home): Explorer Lab + remove per-game feature flags

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -62,6 +62,8 @@ struct RootView: View {
                     GravityArtistView(appModel: appModel)
                 case .compassAngles:
                     CompassAnglesView(appModel: appModel)
+                case .lab:
+                    LabView(appModel: appModel)
                 }
             }
             .navigationBarTitleDisplayMode(.inline)

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -16,6 +16,7 @@ enum AppRoute {
     case twoFingerProtractor
     case gravityArtist
     case compassAngles
+    case lab
 }
 
 @MainActor
@@ -115,6 +116,7 @@ final class VerticalSliceEngine {
     func showTwoFingerProtractor() { route = .twoFingerProtractor }
     func showGravityArtist() { route = .gravityArtist }
     func showCompassAngles() { route = .compassAngles }
+    func showLab() { route = .lab }
 
     func startSession() {
         // Freeze the active theme from the user's current selection — unless a custom

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+
+/// The Explorer Lab — a game picker for all physics and geometry activities.
+struct LabView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Bindable var appModel: AppModel
+
+    private struct GameTile {
+        let emoji: String
+        let name: String
+        let tagline: String
+        let fill: Color
+        let action: () -> Void
+    }
+
+    private var tiles: [GameTile] {
+        [
+            GameTile(emoji: "⚡", name: "Sum Sprint",
+                     tagline: "Race through sums 11–20",
+                     fill: MatherTheme.warm) {
+                appModel.engine.showSumSprint()
+                appModel.sumSprintEngine.showDifficultyPick()
+            },
+            GameTile(emoji: "🗺️", name: "Room Quest",
+                     tagline: "Collect tokens around the room",
+                     fill: MatherTheme.accent) {
+                appModel.engine.showRoomQuest()
+            },
+            GameTile(emoji: "🪞", name: "Symmetry Fold",
+                     tagline: "Tilt to fold shapes in half",
+                     fill: MatherTheme.coral) {
+                appModel.engine.showSymmetryFold()
+            },
+            GameTile(emoji: "🏭", name: "Rectangle Factory",
+                     tagline: "Drag frames to find factors",
+                     fill: MatherTheme.softBlue) {
+                appModel.engine.showRectangleFactory()
+            },
+            GameTile(emoji: "💥", name: "Angle Cannon",
+                     tagline: "Tilt to aim — hit the target",
+                     fill: MatherTheme.warm) {
+                appModel.engine.showAngleCannon()
+            },
+            GameTile(emoji: "📐", name: "Protractor",
+                     tagline: "Spread two fingers to measure angles",
+                     fill: MatherTheme.accent) {
+                appModel.engine.showTwoFingerProtractor()
+            },
+            GameTile(emoji: "🎨", name: "Gravity Artist",
+                     tagline: "Predict where the ball lands",
+                     fill: MatherTheme.panelDeep) {
+                appModel.engine.showGravityArtist()
+            },
+            GameTile(emoji: "🧭", name: "Compass Walk",
+                     tagline: "Turn your body to match the angle",
+                     fill: MatherTheme.softBlue) {
+                appModel.engine.showCompassAngles()
+            },
+        ]
+    }
+
+    var body: some View {
+        ZStack {
+            MatherTheme.background.ignoresSafeArea()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Explorer Lab")
+                                .font(.system(size: 36, weight: .black, design: .rounded))
+                                .foregroundStyle(MatherTheme.ink)
+                            Text("Pick a game and discover maths")
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                        }
+                        Spacer()
+                        Button {
+                            appModel.engine.showHome()
+                        } label: {
+                            Image(systemName: "house.fill")
+                                .font(.title2.weight(.semibold))
+                                .foregroundStyle(MatherTheme.accent)
+                                .frame(width: 44, height: 44)
+                        }
+                        .accessibilityLabel("Home")
+                    }
+
+                    LazyVGrid(columns: [GridItem(.flexible(), spacing: 16), GridItem(.flexible(), spacing: 16)], spacing: 16) {
+                        ForEach(Array(tiles.enumerated()), id: \.offset) { _, tile in
+                            gameTileButton(tile)
+                        }
+                    }
+                }
+                .padding(24)
+            }
+        }
+    }
+
+    private func gameTileButton(_ tile: GameTile) -> some View {
+        Button(action: tile.action) {
+            VStack(alignment: .leading, spacing: 0) {
+                ZStack {
+                    tile.fill.opacity(0.85)
+                    Text(tile.emoji)
+                        .font(.system(size: 52))
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 20)
+                }
+                .clipShape(
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 16, bottomLeadingRadius: 0,
+                        bottomTrailingRadius: 0, topTrailingRadius: 16,
+                        style: .continuous
+                    )
+                )
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(tile.name)
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                    Text(tile.tagline)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(MatherTheme.card)
+                .clipShape(
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 0, bottomLeadingRadius: 16,
+                        bottomTrailingRadius: 16, topTrailingRadius: 0,
+                        style: .continuous
+                    )
+                )
+            }
+            .shadow(
+                color: colorScheme == .dark ? .black.opacity(0.3) : .black.opacity(0.08),
+                radius: 8, y: 4
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(tile.name)
+    }
+}

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -8,20 +8,6 @@ struct SettingsView: View {
     @State private var showingClearConfirmation = false
     @State private var showingSafetyRules = false
 
-    private var verticalSliceBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.verticalSlice1Enabled },
-            set: { appModel.featureFlags.verticalSlice1Enabled = $0 }
-        )
-    }
-
-    private var testModeBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.testModeEnabled },
-            set: { appModel.featureFlags.testModeEnabled = $0 }
-        )
-    }
-
     private var audioBinding: Binding<Bool> {
         Binding(
             get: { appModel.featureFlags.audioEnabled },
@@ -64,38 +50,10 @@ struct SettingsView: View {
         )
     }
 
-    private var roomQuestBinding: Binding<Bool> {
+    private var testModeBinding: Binding<Bool> {
         Binding(
-            get: { appModel.featureFlags.roomQuestEnabled },
-            set: { appModel.featureFlags.roomQuestEnabled = $0 }
-        )
-    }
-
-    private var sumSprintBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.sumSprintEnabled },
-            set: { appModel.featureFlags.sumSprintEnabled = $0 }
-        )
-    }
-
-    private var symmetryFoldBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.symmetryFoldEnabled },
-            set: { appModel.featureFlags.symmetryFoldEnabled = $0 }
-        )
-    }
-
-    private var rectangleFactoryBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.rectangleFactoryEnabled },
-            set: { appModel.featureFlags.rectangleFactoryEnabled = $0 }
-        )
-    }
-
-    private var angleCannonBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.angleCannonEnabled },
-            set: { appModel.featureFlags.angleCannonEnabled = $0 }
+            get: { appModel.featureFlags.testModeEnabled },
+            set: { appModel.featureFlags.testModeEnabled = $0 }
         )
     }
 
@@ -123,13 +81,10 @@ struct SettingsView: View {
                             Text("Settings")
                                 .font(.largeTitle.weight(.black))
 
-                            Text("Activities")
+                            Text("Make & Break")
                                 .font(.caption.weight(.semibold))
                                 .foregroundStyle(.secondary)
                                 .padding(.top, 4)
-                            Toggle("Make & Break to 10", isOn: verticalSliceBinding)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.85)
                             VS1ToggleRow(
                                 title: "Bond Blast finale",
                                 subtitle: "Adds a free-match bonus round after all bonds for a number are found.",
@@ -140,31 +95,23 @@ struct SettingsView: View {
                                 subtitle: "Replace the Show-it step with a tilt-powered balance scale activity.",
                                 isOn: gravitySplitBinding
                             )
-                            Toggle("Sum Sprint — sums 11–20", isOn: sumSprintBinding)
-                            Toggle("Room Quest (beta)", isOn: roomQuestBinding)
-                            if appModel.featureFlags.roomQuestEnabled {
-                                Button("Review Room Quest safety rules") {
-                                    showingSafetyRules = true
-                                }
-                                .font(.subheadline.weight(.medium))
-                                .foregroundStyle(MatherTheme.accent)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.leading, 4)
-                            }
 
                             Divider()
 
-                            if appModel.featureFlags.roomQuestEnabled {
-                                PlaceMatchThresholdSection(featureFlags: appModel.featureFlags)
-                                Divider()
-                            }
-
-                            Text("Physics & Geometry")
+                            Text("Room Quest")
                                 .font(.caption.weight(.semibold))
                                 .foregroundStyle(.secondary)
-                            Toggle("Symmetry Fold — ages 5–7", isOn: symmetryFoldBinding)
-                            Toggle("Rectangle Factory — ages 7–9", isOn: rectangleFactoryBinding)
-                            Toggle("Angle Cannon — ages 7–9", isOn: angleCannonBinding)
+                            Button("Review Room Quest safety rules") {
+                                showingSafetyRules = true
+                            }
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(MatherTheme.accent)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.leading, 4)
+
+                            Divider()
+
+                            PlaceMatchThresholdSection(featureFlags: appModel.featureFlags)
 
                             Divider()
 
@@ -252,11 +199,10 @@ struct SettingsView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(MatherTheme.cardSubtitle)
                             VStack(alignment: .leading, spacing: 8) {
-                                smokeStep("1. Enable Make & Break to 10 (toggle above).")
-                                smokeStep("2. Tap Home → Play → Start Session.")
-                                smokeStep("3. Complete one full problem (Make → Break → Write → Show).")
-                                smokeStep("4. Confirm Session Complete screen appears.")
-                                smokeStep("5. Return here and tap Share latest export to verify JSONL.")
+                                smokeStep("1. Tap Home → Play → Start Session.")
+                                smokeStep("2. Complete one full problem (Make → Break → Write → Show).")
+                                smokeStep("3. Confirm Session Complete screen appears.")
+                                smokeStep("4. Return here and tap Share latest export to verify JSONL.")
                             }
                         }
                     }

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -7,101 +7,42 @@ struct HomeView: View {
     var body: some View {
         ZStack {
             MatherTheme.background.ignoresSafeArea()
-            VStack(spacing: 20) {
-                // App wordmark — large, rounded, ink coloured
-                Text("Mather")
-                    .font(.system(size: 48, weight: .black, design: .rounded))
-                    .foregroundStyle(MatherTheme.ink)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            ScrollView {
+                VStack(spacing: 20) {
+                    Text("Mather")
+                        .font(.system(size: 48, weight: .black, design: .rounded))
+                        .foregroundStyle(MatherTheme.ink)
+                        .frame(maxWidth: .infinity, alignment: .leading)
 
-                if appModel.featureFlags.verticalSlice1Enabled {
-                    activeActivityCard
-                } else {
-                    lockedActivityCard
-                }
+                    makeAndBreakCard
+                    labCard
 
-                if appModel.featureFlags.rectangleFactoryEnabled {
-                    Button("Rectangle Factory") {
-                        appModel.engine.showRectangleFactory()
+                    HStack(spacing: 14) {
+                        Button("Parent Summary") {
+                            appModel.engine.showParentSummary()
+                        }
+                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.65)))
+
+                        Button("Settings") {
+                            appModel.engine.showSettings()
+                        }
+                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.55)))
                     }
-                    .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.accent.opacity(0.55)))
+
+                    Spacer(minLength: 0)
                 }
-
-                if appModel.featureFlags.sumSprintEnabled {
-                    Button("Sum Sprint") {
-                        appModel.engine.showSumSprint()
-                        appModel.sumSprintEngine.showDifficultyPick()
-                    }
-                    .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.65)))
-                }
-
-                if appModel.featureFlags.symmetryFoldEnabled {
-                    Button("Symmetry Fold") {
-                        appModel.engine.showSymmetryFold()
-                    }
-                    .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.coral.opacity(0.65)))
-                }
-
-                if appModel.featureFlags.roomQuestEnabled {
-                    Button("Start Room Quest") {
-                        appModel.engine.showRoomQuest()
-                    }
-                    .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.accent.opacity(0.65)))
-                }
-
-                if appModel.featureFlags.angleCannonEnabled {
-                    Button("Angle Cannon") {
-                        appModel.engine.showAngleCannon()
-                    }
-                    .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.65)))
-                }
-
-                if appModel.featureFlags.twoFingerProtractorEnabled {
-                    Button("Two-Finger Protractor") {
-                        appModel.engine.showTwoFingerProtractor()
-                    }
-                    .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.65)))
-                }
-
-                if appModel.featureFlags.gravityArtistEnabled {
-                    Button("Gravity Artist") {
-                        appModel.engine.showGravityArtist()
-                    }
-                    .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.panelDeep.opacity(0.65)))
-                }
-
-                if appModel.featureFlags.compassAnglesEnabled {
-                    Button("Compass Angles") {
-                        appModel.engine.showCompassAngles()
-                    }
-                    .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.65)))
-                }
-
-                HStack(spacing: 14) {
-                    Button("Parent Summary") {
-                        appModel.engine.showParentSummary()
-                    }
-                    .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.65)))
-
-                    Button("Settings") {
-                        appModel.engine.showSettings()
-                    }
-                    .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.55)))
-                }
-
-                Spacer()
+                .padding(24)
             }
-            .padding(24)
         }
     }
 
-    // Active state: colourful hero card — number is the visual centrepiece
-    private var activeActivityCard: some View {
+    // MARK: - Make & Break card
+
+    private var makeAndBreakCard: some View {
         Button {
             appModel.engine.showSessionConfig()
         } label: {
             VStack(spacing: 0) {
-                // Colourful header strip — draws the child's eye immediately
                 ZStack {
                     LinearGradient(
                         colors: [MatherTheme.warm, MatherTheme.accent],
@@ -110,7 +51,7 @@ struct HomeView: View {
                     )
 
                     HStack(spacing: 16) {
-                        // Mini ten-frame preview — the activity's visual identity
+                        // Mini ten-frame preview
                         VStack(spacing: 5) {
                             ForEach(0..<2, id: \.self) { row in
                                 HStack(spacing: 5) {
@@ -147,7 +88,6 @@ struct HomeView: View {
                     )
                 )
 
-                // Play CTA strip
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Ready to play?")
@@ -178,27 +118,94 @@ struct HomeView: View {
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
                     .strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1)
             )
-            .shadow(color: colorScheme == .dark ? MatherTheme.coral.opacity(0.12) : .black.opacity(0.08), radius: colorScheme == .dark ? 18 : 12, y: colorScheme == .dark ? 8 : 5)
+            .shadow(
+                color: colorScheme == .dark ? MatherTheme.coral.opacity(0.12) : .black.opacity(0.08),
+                radius: colorScheme == .dark ? 18 : 12,
+                y: colorScheme == .dark ? 8 : 5
+            )
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("Play")
     }
 
-    private var lockedActivityCard: some View {
-        CardSurface {
-            VStack(alignment: .leading, spacing: 14) {
-                Text("Make & Break to 10")
-                    .font(.title2.weight(.bold))
-                Text("Enable the activity in Settings before handing the iPad to your child.")
-                    .font(.headline)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+    // MARK: - Explorer Lab card
 
-                Button("Open Settings") {
-                    appModel.engine.showSettings()
+    private var labCard: some View {
+        Button {
+            appModel.engine.showLab()
+        } label: {
+            VStack(spacing: 0) {
+                ZStack {
+                    LinearGradient(
+                        colors: [MatherTheme.softBlue, MatherTheme.coral.opacity(0.8)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+
+                    HStack(spacing: 16) {
+                        Text("🔬")
+                            .font(.system(size: 48))
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Explorer Lab")
+                                .font(.title3.weight(.black))
+                                .foregroundStyle(.white)
+                            Text("8 games inside")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(.white.opacity(0.85))
+                        }
+                        .layoutPriority(1)
+
+                        Spacer()
+                    }
+                    .padding(20)
                 }
-                .buttonStyle(PrimaryActionButtonStyle())
+                .frame(height: 110)
+                .clipShape(
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 20, bottomLeadingRadius: 0,
+                        bottomTrailingRadius: 0, topTrailingRadius: 20,
+                        style: .continuous
+                    )
+                )
+
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Physics · Geometry · Angles")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                        Text("Tap to explore all activities")
+                            .font(.headline.weight(.bold))
+                            .foregroundStyle(MatherTheme.ink)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right.circle.fill")
+                        .font(.system(size: 44))
+                        .foregroundStyle(MatherTheme.softBlue)
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
+                .background(MatherTheme.card)
+                .clipShape(
+                    UnevenRoundedRectangle(
+                        topLeadingRadius: 0, bottomLeadingRadius: 20,
+                        bottomTrailingRadius: 20, topTrailingRadius: 0,
+                        style: .continuous
+                    )
+                )
             }
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1)
+            )
+            .shadow(
+                color: colorScheme == .dark ? MatherTheme.softBlue.opacity(0.12) : .black.opacity(0.08),
+                radius: colorScheme == .dark ? 18 : 12,
+                y: colorScheme == .dark ? 8 : 5
+            )
         }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("ExplorerLab")
     }
 }

--- a/Features/VerticalSlice1/RouteSupportViews.swift
+++ b/Features/VerticalSlice1/RouteSupportViews.swift
@@ -48,13 +48,6 @@ struct VS1SettingsPlaceholderView: View {
     let summaries: [StoredSessionSummary]
     @State private var confirmClear = false
 
-    private var verticalSliceBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.verticalSlice1Enabled },
-            set: { appModel.featureFlags.verticalSlice1Enabled = $0 }
-        )
-    }
-
     private var audioBinding: Binding<Bool> {
         Binding(
             get: { appModel.featureFlags.audioEnabled },
@@ -95,11 +88,6 @@ struct VS1SettingsPlaceholderView: View {
 
                 VS1Card {
                     VStack(alignment: .leading, spacing: 12) {
-                        VS1ToggleRow(
-                            title: "Make & Break to 10",
-                            subtitle: "Enable the Make & Break to 10 activity for your child.",
-                            isOn: verticalSliceBinding
-                        )
                         VS1ToggleRow(
                             title: "Audio enabled",
                             subtitle: "Keep prompts and neutral feedback audible.",

--- a/Persistence/TelemetryWriter.swift
+++ b/Persistence/TelemetryWriter.swift
@@ -37,7 +37,6 @@ final class TelemetryWriter {
                 type: .sessionStart,
                 payload: [
                     "schema_version": String(Self.schemaVersion),
-                    "feature_verticalSlice1Enabled": String(featureFlags.verticalSlice1Enabled),
                     "feature_testModeEnabled": String(featureFlags.testModeEnabled),
                     "feature_audioEnabled": String(featureFlags.audioEnabled),
                     "theme_id": featureFlags.selectedThemeId

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -4,7 +4,6 @@ import Observation
 @Observable
 final class FeatureFlagService {
     private enum Keys {
-        static let verticalSlice1Enabled  = "feature.verticalSlice1Enabled"
         // Place-matching thresholds (tunable from Settings)
         static let placeMatchGPSMatch     = "placeMatch.gpsMatchMetres"
         static let placeMatchGPSClose     = "placeMatch.gpsCloseMetres"
@@ -20,21 +19,9 @@ final class FeatureFlagService {
         static let makeBreakLoopV2Enabled = "feature.makeBreakLoopV2Enabled"
         static let motionControlsEnabled = "feature.motionControlsEnabled"
         static let soundReactionEnabled = "feature.soundReactionEnabled"
-        static let roomQuestEnabled = "feature.roomQuestEnabled"
         static let roomQuestSafetyAcknowledged = "feature.roomQuestSafetyAcknowledged"
         static let roomQuestMarkerSetupEnabled = "feature.roomQuestMarkerSetupEnabled"
         static let roomQuestReferenceCaptureEnabled = "feature.roomQuestReferenceCaptureEnabled"
-        static let sumSprintEnabled = "feature.sumSprintEnabled"
-        static let symmetryFoldEnabled = "feature.symmetryFoldEnabled"
-        static let rectangleFactoryEnabled = "feature.rectangleFactoryEnabled"
-        static let angleCannonEnabled = "feature.angleCannonEnabled"
-        static let twoFingerProtractorEnabled = "feature.twoFingerProtractorEnabled"
-        static let gravityArtistEnabled = "feature.gravityArtistEnabled"
-        static let compassAnglesEnabled = "feature.compassAnglesEnabled"
-    }
-
-    var verticalSlice1Enabled: Bool {
-        didSet { defaults.set(verticalSlice1Enabled, forKey: Keys.verticalSlice1Enabled) }
     }
 
     var testModeEnabled: Bool {
@@ -84,11 +71,6 @@ final class FeatureFlagService {
         didSet { defaults.set(soundReactionEnabled, forKey: Keys.soundReactionEnabled) }
     }
 
-    /// Gates the Room Quest companion slice. Default false; parent enables in Settings.
-    var roomQuestEnabled: Bool {
-        didSet { defaults.set(roomQuestEnabled, forKey: Keys.roomQuestEnabled) }
-    }
-
     /// Persists whether the parent has acknowledged the Room Quest safety checklist.
     /// Shown once before the first Room Quest session.
     var roomQuestSafetyAcknowledged: Bool {
@@ -103,41 +85,6 @@ final class FeatureFlagService {
     /// Enables saving a lightweight station reference during camera verification.
     var roomQuestReferenceCaptureEnabled: Bool {
         didSet { defaults.set(roomQuestReferenceCaptureEnabled, forKey: Keys.roomQuestReferenceCaptureEnabled) }
-    }
-
-    /// Gates the Sum Sprint fluency activity (sums 11–20). Default false; parent enables in Settings.
-    var sumSprintEnabled: Bool {
-        didSet { defaults.set(sumSprintEnabled, forKey: Keys.sumSprintEnabled) }
-    }
-
-    /// Gates the Symmetry Fold geometry activity (ages 5–7). Default false; parent enables in Settings.
-    var symmetryFoldEnabled: Bool {
-        didSet { defaults.set(symmetryFoldEnabled, forKey: Keys.symmetryFoldEnabled) }
-    }
-
-    /// Gates the Rectangle Factory factor-discovery activity (ages 7–9). Default false; parent enables in Settings.
-    var rectangleFactoryEnabled: Bool {
-        didSet { defaults.set(rectangleFactoryEnabled, forKey: Keys.rectangleFactoryEnabled) }
-    }
-
-    /// Gates the Angle Cannon geometry activity (ages 7–9). Default false; parent enables in Settings.
-    var angleCannonEnabled: Bool {
-        didSet { defaults.set(angleCannonEnabled, forKey: Keys.angleCannonEnabled) }
-    }
-
-    /// Gates the Two-Finger Protractor angle-measurement activity (ages 7–9). Default false; parent enables in Settings.
-    var twoFingerProtractorEnabled: Bool {
-        didSet { defaults.set(twoFingerProtractorEnabled, forKey: Keys.twoFingerProtractorEnabled) }
-    }
-
-    /// Gates the Gravity Artist predict-then-fire projectile activity (ages 8–10). Default false; parent enables in Settings.
-    var gravityArtistEnabled: Bool {
-        didSet { defaults.set(gravityArtistEnabled, forKey: Keys.gravityArtistEnabled) }
-    }
-
-    /// Gates the Compass Angles body-rotation activity (ages 7–9). Default false; parent enables in Settings.
-    var compassAnglesEnabled: Bool {
-        didSet { defaults.set(compassAnglesEnabled, forKey: Keys.compassAnglesEnabled) }
     }
 
     // MARK: - Place-matching thresholds
@@ -183,7 +130,6 @@ final class FeatureFlagService {
         // "YES"/"NO"/"1"/"0" string values injected via -key value launch arguments,
         // which object(forKey:) as? Bool does not.
         defaults.register(defaults: [
-            Keys.verticalSlice1Enabled: false,
             Keys.testModeEnabled: true,
             Keys.audioEnabled: true,
             Keys.hapticsEnabled: true,
@@ -193,24 +139,15 @@ final class FeatureFlagService {
             Keys.makeBreakLoopV2Enabled: false,
             Keys.motionControlsEnabled: true,
             Keys.soundReactionEnabled: false,
-            Keys.roomQuestEnabled: false,
             Keys.roomQuestSafetyAcknowledged: false,
             Keys.roomQuestMarkerSetupEnabled: true,
             Keys.roomQuestReferenceCaptureEnabled: true,
-            Keys.sumSprintEnabled: false,
-            Keys.symmetryFoldEnabled: false,
-            Keys.rectangleFactoryEnabled: false,
-            Keys.angleCannonEnabled: false,
-            Keys.twoFingerProtractorEnabled: false,
-            Keys.gravityArtistEnabled: false,
-            Keys.compassAnglesEnabled: false,
             Keys.placeMatchGPSMatch:    PlaceMatchThresholds.default.gpsMatchMetres,
             Keys.placeMatchGPSClose:    PlaceMatchThresholds.default.gpsCloseMetres,
             Keys.placeMatchGPSCutoff:   PlaceMatchThresholds.default.gpsAccuracyCutoff,
             Keys.placeMatchVisionMatch: Double(PlaceMatchThresholds.default.visionMatchDistance),
             Keys.placeMatchVisionClose: Double(PlaceMatchThresholds.default.visionCloseDistance),
         ])
-        verticalSlice1Enabled = defaults.bool(forKey: Keys.verticalSlice1Enabled)
         testModeEnabled = defaults.bool(forKey: Keys.testModeEnabled)
         audioEnabled = defaults.bool(forKey: Keys.audioEnabled)
         hapticsEnabled = defaults.bool(forKey: Keys.hapticsEnabled)
@@ -220,17 +157,9 @@ final class FeatureFlagService {
         makeBreakLoopV2Enabled = defaults.bool(forKey: Keys.makeBreakLoopV2Enabled)
         motionControlsEnabled = defaults.bool(forKey: Keys.motionControlsEnabled)
         soundReactionEnabled = defaults.bool(forKey: Keys.soundReactionEnabled)
-        roomQuestEnabled = defaults.bool(forKey: Keys.roomQuestEnabled)
         roomQuestSafetyAcknowledged = defaults.bool(forKey: Keys.roomQuestSafetyAcknowledged)
         roomQuestMarkerSetupEnabled = defaults.bool(forKey: Keys.roomQuestMarkerSetupEnabled)
         roomQuestReferenceCaptureEnabled = defaults.bool(forKey: Keys.roomQuestReferenceCaptureEnabled)
-        sumSprintEnabled = defaults.bool(forKey: Keys.sumSprintEnabled)
-        symmetryFoldEnabled = defaults.bool(forKey: Keys.symmetryFoldEnabled)
-        rectangleFactoryEnabled = defaults.bool(forKey: Keys.rectangleFactoryEnabled)
-        angleCannonEnabled = defaults.bool(forKey: Keys.angleCannonEnabled)
-        twoFingerProtractorEnabled = defaults.bool(forKey: Keys.twoFingerProtractorEnabled)
-        gravityArtistEnabled = defaults.bool(forKey: Keys.gravityArtistEnabled)
-        compassAnglesEnabled = defaults.bool(forKey: Keys.compassAnglesEnabled)
         placeMatchGPSMatch   = defaults.double(forKey: Keys.placeMatchGPSMatch)
         placeMatchGPSClose   = defaults.double(forKey: Keys.placeMatchGPSClose)
         placeMatchGPSCutoff  = defaults.double(forKey: Keys.placeMatchGPSCutoff)

--- a/Tests/MatherTests/SumSprintEngineTests.swift
+++ b/Tests/MatherTests/SumSprintEngineTests.swift
@@ -10,7 +10,6 @@ struct SumSprintEngineTests {
 
     private func makeEngine(feedbackDuration: TimeInterval = 0) throws -> (SumSprintEngine, FeatureFlagService) {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        flags.sumSprintEnabled = true
         flags.audioEnabled = false
         flags.hapticsEnabled = false
 
@@ -284,13 +283,6 @@ struct SumSprintEngineTests {
         #expect(engine.phase == .idle)
     }
 
-    // MARK: - Feature flag
-
-    @Test
-    func sumSprintEnabledDefaultsFalse() {
-        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        #expect(flags.sumSprintEnabled == false)
-    }
 
     // MARK: - Cards contain valid sums
 

--- a/Tests/MatherTests/TransferExactRebuildTests.swift
+++ b/Tests/MatherTests/TransferExactRebuildTests.swift
@@ -72,7 +72,6 @@ struct TransferExactRebuildTests {
 
     private func makeEngine() -> VerticalSliceEngine {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
         return VerticalSliceEngine(
             featureFlags: flags,

--- a/Tests/MatherTests/TransferIntentTests.swift
+++ b/Tests/MatherTests/TransferIntentTests.swift
@@ -45,7 +45,6 @@ struct TransferIntentTests {
 
     private func makeEngine() -> VerticalSliceEngine {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
         return VerticalSliceEngine(
             featureFlags: flags,

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -52,7 +52,6 @@ struct VerticalSliceEngineTests {
     @Test
     func sessionRoutesThroughBondBlastThenWriteItThenTransfer() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
         flags.vs1BondMatchEnabled = true
 
@@ -88,9 +87,7 @@ struct VerticalSliceEngineTests {
     @Test
     func roomQuestRouteDoesNotForceTransferStageInVs1Engine() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
-        flags.roomQuestEnabled = true
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -108,7 +105,6 @@ struct VerticalSliceEngineTests {
     @Test
     func bondBlastStartsWhenConcreteStageClears() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
 
         let engine = VerticalSliceEngine(
@@ -717,7 +713,6 @@ struct VerticalSliceEngineTests {
     @Test
     func makeBreakLoopV2RoutesConcreteToGravitySplitToSumSprintToBondBlast() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
         flags.makeBreakLoopV2Enabled = true
 
@@ -752,7 +747,6 @@ struct VerticalSliceEngineTests {
     @Test
     func makeBreakLoopV2CreatesMicroSumSprintBurstPerTarget() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
         flags.makeBreakLoopV2Enabled = true
 
@@ -778,7 +772,6 @@ struct VerticalSliceEngineTests {
     @Test
     func makeBreakLoopV2AdvancesToBondBlastAfterBurstCards() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        flags.verticalSlice1Enabled = true
         flags.testModeEnabled = true
         flags.makeBreakLoopV2Enabled = true
 

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -48,8 +48,7 @@ final class CompactLayoutTests: XCTestCase {
         app.launchArguments = [
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
-            "-feature.testModeEnabled", "YES",
-            "-feature.verticalSlice1Enabled", "YES"
+            "-feature.testModeEnabled", "YES"
         ]
         app.launch()
         return app

--- a/Tests/MatherUITests/RoomQuestUITests.swift
+++ b/Tests/MatherUITests/RoomQuestUITests.swift
@@ -2,8 +2,7 @@ import XCTest
 
 /// UI tests for the Room Quest companion slice.
 ///
-/// These tests now focus on stable companion-slice checkpoints:
-/// - Feature flag toggle surfaces the button on Home
+/// These tests focus on stable companion-slice checkpoints:
 /// - Safety acknowledgement screen renders and can be accepted
 /// - Setup screen shows station cards and saved fallback state
 /// - Hunt entry reaches the first spot with the expected scan/pause affordances
@@ -11,36 +10,13 @@ import XCTest
 @MainActor
 final class RoomQuestUITests: XCTestCase {
 
-    // MARK: - Flag visibility
-
-    func testRoomQuestToggleShowsStartButtonOnHome() {
-        let app = launch()
-        _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
-
-        // Button absent by default
-        XCTAssertFalse(app.buttons["Start Room Quest"].exists)
-
-        // Enable Room Quest in Settings
-        app.buttons["Settings"].tap()
-        _ = app.staticTexts["Settings"].waitForExistence(timeout: 5)
-        let rqToggle = app.switches["Room Quest (beta)"]
-        XCTAssertTrue(rqToggle.waitForExistence(timeout: 5))
-        if rqToggle.value as? String == "0" { rqToggle.tap() }
-
-        app.buttons["Home"].tap()
-        _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
-        XCTAssertTrue(app.buttons["Start Room Quest"].waitForExistence(timeout: 5))
-
-        snapshot(app, "RoomQuest-HomeWithButton")
-    }
-
     // MARK: - Safety acknowledgement (first launch)
 
     func testRoomQuestSafetyAckScreenAppearsAndCanBeAccepted() {
         let app = launchWithRoomQuestEnabled()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
-        app.buttons["Start Room Quest"].tap()
+        openRoomQuest(app)
 
         // Safety ack screen
         XCTAssertTrue(app.staticTexts["Before you start"].waitForExistence(timeout: 5))
@@ -61,7 +37,7 @@ final class RoomQuestUITests: XCTestCase {
         let app = launchWithRoomQuestAndSafetyAck()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
-        app.buttons["Start Room Quest"].tap()
+        openRoomQuest(app)
         XCTAssertTrue(app.staticTexts["Set up the room"].waitForExistence(timeout: 5))
 
         XCTAssertTrue(app.staticTexts["Red Rocket"].waitForExistence(timeout: 3))
@@ -77,7 +53,7 @@ final class RoomQuestUITests: XCTestCase {
         let app = launchWithRoomQuestAndSafetyAck()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
-        app.buttons["Start Room Quest"].tap()
+        openRoomQuest(app)
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
         completeSetupViaManualFallback(app)
 
@@ -93,7 +69,7 @@ final class RoomQuestUITests: XCTestCase {
         let app = launchWithRoomQuestAndSafetyAck()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
-        app.buttons["Start Room Quest"].tap()
+        openRoomQuest(app)
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
         completeSetupViaManualFallback(app)
 
@@ -108,7 +84,7 @@ final class RoomQuestUITests: XCTestCase {
         let app = launchWithRoomQuestAndSafetyAck()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
-        app.buttons["Start Room Quest"].tap()
+        openRoomQuest(app)
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
 
         XCTAssertTrue(app.staticTexts["Finish setup for both stations before you start."].waitForExistence(timeout: 5))
@@ -125,7 +101,7 @@ final class RoomQuestUITests: XCTestCase {
         let app = launchWithRoomQuestAndSafetyAck()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
-        app.buttons["Start Room Quest"].tap()
+        openRoomQuest(app)
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
         completeSetupViaManualFallback(app)
 
@@ -138,7 +114,7 @@ final class RoomQuestUITests: XCTestCase {
         let app = launchWithRoomQuestAndSafetyAck()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
-        app.buttons["Start Room Quest"].tap()
+        openRoomQuest(app)
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
         completeSetupViaManualFallback(app)
 
@@ -153,7 +129,7 @@ final class RoomQuestUITests: XCTestCase {
         let app = launchWithRoomQuestAndSafetyAck()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
-        app.buttons["Start Room Quest"].tap()
+        openRoomQuest(app)
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
         completeSetupViaManualFallback(app)
 
@@ -185,6 +161,12 @@ final class RoomQuestUITests: XCTestCase {
 
     // MARK: - Helpers
 
+    /// Navigates from Home → Explorer Lab → Room Quest.
+    private func openRoomQuest(_ app: XCUIApplication) {
+        app.buttons["ExplorerLab"].tap()
+        _ = app.staticTexts["Explorer Lab"].waitForExistence(timeout: 5)
+        app.buttons["Room Quest"].tap()
+    }
 
     private func completeSetupViaManualFallback(_ app: XCUIApplication) {
         configureSetupViaManualFallback(app)
@@ -254,7 +236,6 @@ final class RoomQuestUITests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
-            "-feature.roomQuestEnabled", "NO",
             "-feature.roomQuestSafetyAcknowledged", "NO"
         ]
         app.launch()
@@ -262,20 +243,10 @@ final class RoomQuestUITests: XCTestCase {
     }
 
     private func launchWithRoomQuestEnabled() -> XCUIApplication {
-        continueAfterFailure = false
-        let app = XCUIApplication()
-        app.launchArguments = [
-            "-feature.audioEnabled", "NO",
-            "-feature.hapticsEnabled", "NO",
-            "-feature.testModeEnabled", "YES",
-            "-feature.roomQuestEnabled", "YES",
-            "-feature.roomQuestSafetyAcknowledged", "NO"
-        ]
-        app.launch()
-        return app
+        launch()
     }
 
-    /// Launches with Room Quest enabled and safety already acknowledged —
+    /// Launches with safety already acknowledged —
     /// skips the one-time SafetyAckView so tests land directly on Setup.
     private func launchWithRoomQuestAndSafetyAck() -> XCUIApplication {
         continueAfterFailure = false
@@ -284,7 +255,6 @@ final class RoomQuestUITests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
-            "-feature.roomQuestEnabled", "YES",
             "-feature.roomQuestSafetyAcknowledged", "YES"
         ]
         app.launch()

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -85,9 +85,6 @@ final class ScreenshotTests: XCTestCase {
     // MARK: - Concrete stage
 
     func testScreenshot_ConcreteBuildView() {
-        // Pre-enable VS1 via launch argument to skip Settings navigation.
-        // This test runs first alphabetically and bears cold-start overhead;
-        // removing the enableVS1() round-trip keeps it within CI time budget.
         let app = launchWithVS1()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
 
@@ -307,10 +304,6 @@ final class ScreenshotTests: XCTestCase {
         return app
     }
 
-    /// Launches with VS1 pre-enabled via launch argument.
-    /// Use this instead of launch() + enableVS1() when the test doesn't need
-    /// to exercise the Settings toggle flow — it removes 3 screen navigations
-    /// from the critical path, which matters for the first (cold) test in CI.
     private func launchWithVS1(appearance: UIAppearanceMode? = nil) -> XCUIApplication {
         continueAfterFailure = false
         let app = XCUIApplication()
@@ -318,29 +311,12 @@ final class ScreenshotTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
-            "-feature.verticalSlice1Enabled", "YES"
         ]
         if let appearance {
             app.launchArguments += ["-uiTest.appearance", appearance.launchValue]
         }
         app.launch()
         return app
-    }
-
-    /// Navigates to Settings, enables VS1, returns to Home.
-    private func enableVS1(_ app: XCUIApplication) {
-        let settingsButton = app.buttons["Settings"]
-        _ = settingsButton.waitForExistence(timeout: 5)
-        settingsButton.tap()
-        _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
-        let toggle = app.switches["Make & Break to 10"]
-        if toggle.waitForExistence(timeout: 10), toggle.value as? String == "0" {
-            toggle.tap()
-        }
-        let homeButton = app.buttons["Home"]
-        _ = homeButton.waitForExistence(timeout: 5)
-        homeButton.tap()
-        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
     }
 
     /// Launches with VS1 pre-enabled and haptics on — use for tests that exercise success/failure feedback.
@@ -351,7 +327,6 @@ final class ScreenshotTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "YES",
             "-feature.testModeEnabled", "YES",
-            "-feature.verticalSlice1Enabled", "YES"
         ]
         if let appearance {
             app.launchArguments += ["-uiTest.appearance", appearance.launchValue]
@@ -381,7 +356,6 @@ final class ScreenshotTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
-            "-feature.verticalSlice1Enabled", "YES",
             "-feature.selectedThemeId", "vehicle"
         ]
         if let appearance {


### PR DESCRIPTION
## Summary

- Replaces the flat feature-gated game list on Home with two hero cards: **Make & Break to 10** and **Explorer Lab**
- **Explorer Lab** (`LabView`) is a new 2-column game-picker grid with all 8 activities (Sum Sprint, Room Quest, Symmetry Fold, Rectangle Factory, Angle Cannon, Two-Finger Protractor, Gravity Artist, Compass Walk) — each tile has an emoji, name, and tagline
- Home is now wrapped in a `ScrollView`, fixing the height overflow reported in issue #246
- Removes 9 per-game enable flags — all games are permanently available; no parent opt-in needed
- `SettingsView` retains behavioral toggles (audio, haptics, motion controls, Bond Blast finale, Gravity Split beta) + Room Quest threshold sliders (always visible)
- Room Quest UI tests updated to navigate via ExplorerLab → Room Quest tile

## Test plan

- [ ] `xcodegen generate && xcodebuild test` — CI green
- [ ] Home shows exactly two cards: Make & Break + Explorer Lab
- [ ] Tapping Explorer Lab shows all 8 game tiles in a 2-column grid
- [ ] Tapping each tile navigates to the correct game
- [ ] Home button in LabView returns to Home
- [ ] Settings no longer shows Activities section or Physics & Geometry section
- [ ] Settings shows Room Quest safety rules button and threshold sliders unconditionally

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)