### PR TITLE
docs/test: issue #222 closeout validation lane

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -272,8 +272,8 @@ final class ScreenshotTests: XCTestCase {
             snapshotPrefix: "Issue222-Target6"
         )
 
-        let nextProblemLabel = app.staticTexts.element(matching: NSPredicate(format: "label BEGINSWITH 'Make 9'"))
-        XCTAssertTrue(nextProblemLabel.waitForExistence(timeout: 15), "Expected the second deterministic target to load after finishing the first loop")
+        let nextProblemSubmit = app.buttons["That is 9"]
+        XCTAssertTrue(nextProblemSubmit.waitForExistence(timeout: 15), "Expected the second deterministic target to load after finishing the first loop")
         snapshot(app, "Issue222-Target9-Concrete")
 
         completeLoopV2Problem(
@@ -420,8 +420,8 @@ final class ScreenshotTests: XCTestCase {
         snapshotPrefix: String,
         skipInitialConcreteSnapshot: Bool = false
     ) {
-        let makeLabel = app.staticTexts.element(matching: NSPredicate(format: "label BEGINSWITH 'Make \(target)'"))
-        XCTAssertTrue(makeLabel.waitForExistence(timeout: 15), "Expected concrete stage for target \(target)")
+        let concreteSubmit = app.buttons["That is \(target)"]
+        XCTAssertTrue(concreteSubmit.waitForExistence(timeout: 15), "Expected concrete stage for target \(target)")
         if !skipInitialConcreteSnapshot {
             snapshot(app, "\(snapshotPrefix)-Concrete")
         }
@@ -429,9 +429,6 @@ final class ScreenshotTests: XCTestCase {
         let concreteCell = app.otherElements["counter-cell-\(concreteCellIndex)"]
         XCTAssertTrue(concreteCell.waitForExistence(timeout: 5), "Expected concrete cell \(concreteCellIndex) for target \(target)")
         concreteCell.tap()
-
-        let concreteSubmit = app.buttons.element(matching: NSPredicate(format: "label BEGINSWITH 'That is '"))
-        XCTAssertTrue(concreteSubmit.waitForExistence(timeout: 5))
         concreteSubmit.tap()
 
         let gravityTitle = app.staticTexts["Gravity Split"]

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -246,6 +246,49 @@ final class ScreenshotTests: XCTestCase {
         snapshot(app, "iPhone-SplitView")
     }
 
+    // MARK: - Issue #222 validation lane
+
+    /// Captures deterministic evidence for the reopened issue #222 route:
+    /// Make it -> Gravity Split -> Sum Sprint -> Bond Blast.
+    ///
+    /// The test clears two full loop iterations in one session so the xcresult
+    /// includes screenshots and assertions across multiple problem targets.
+    func testScreenshot_Issue222LoopV2_AcrossTwoTargets() {
+        let app = launchWithLoopV2()
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
+
+        app.buttons["Play"].tap()
+        _ = app.staticTexts["Session setup"].waitForExistence(timeout: 10)
+        app.buttons["Start Session"].tap()
+
+        completeLoopV2Problem(
+            in: app,
+            target: 6,
+            concreteCellIndex: 5,
+            leftPanCount: 3,
+            rightPanCount: 3,
+            sumSprintAnswers: ["6", "6"],
+            bondPairs: [(1, 5), (2, 4), (3, 3)],
+            snapshotPrefix: "Issue222-Target6"
+        )
+
+        let nextProblemLabel = app.staticTexts.element(matching: NSPredicate(format: "label BEGINSWITH 'Make 9'"))
+        XCTAssertTrue(nextProblemLabel.waitForExistence(timeout: 15), "Expected the second deterministic target to load after finishing the first loop")
+        snapshot(app, "Issue222-Target9-Concrete")
+
+        completeLoopV2Problem(
+            in: app,
+            target: 9,
+            concreteCellIndex: 8,
+            leftPanCount: 4,
+            rightPanCount: 5,
+            sumSprintAnswers: ["9", "9", "9"],
+            bondPairs: [(1, 8), (2, 7), (3, 6), (4, 5)],
+            snapshotPrefix: "Issue222-Target9",
+            skipInitialConcreteSnapshot: true
+        )
+    }
+
     // MARK: - Helpers
 
     /// Launches the app with CI-appropriate flags pre-configured via UserDefaults injection.
@@ -269,6 +312,24 @@ final class ScreenshotTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
+        ]
+        if let appearance {
+            app.launchArguments += ["-uiTest.appearance", appearance.launchValue]
+        }
+        app.launch()
+        return app
+    }
+
+    private func launchWithLoopV2(appearance: UIAppearanceMode? = nil) -> XCUIApplication {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.motionControlsEnabled", "NO",
+            "-feature.soundReactionEnabled", "NO",
+            "-feature.testModeEnabled", "YES",
+            "-feature.makeBreakLoopV2Enabled", "YES",
         ]
         if let appearance {
             app.launchArguments += ["-uiTest.appearance", appearance.launchValue]
@@ -346,6 +407,72 @@ final class ScreenshotTests: XCTestCase {
         attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
+
+    private func completeLoopV2Problem(
+        in app: XCUIApplication,
+        target: Int,
+        concreteCellIndex: Int,
+        leftPanCount: Int,
+        rightPanCount: Int,
+        sumSprintAnswers: [String],
+        bondPairs: [(Int, Int)],
+        snapshotPrefix: String,
+        skipInitialConcreteSnapshot: Bool = false
+    ) {
+        let makeLabel = app.staticTexts.element(matching: NSPredicate(format: "label BEGINSWITH 'Make \(target)'"))
+        XCTAssertTrue(makeLabel.waitForExistence(timeout: 15), "Expected concrete stage for target \(target)")
+        if !skipInitialConcreteSnapshot {
+            snapshot(app, "\(snapshotPrefix)-Concrete")
+        }
+
+        let concreteCell = app.otherElements["counter-cell-\(concreteCellIndex)"]
+        XCTAssertTrue(concreteCell.waitForExistence(timeout: 5), "Expected concrete cell \(concreteCellIndex) for target \(target)")
+        concreteCell.tap()
+
+        let concreteSubmit = app.buttons.element(matching: NSPredicate(format: "label BEGINSWITH 'That is '"))
+        XCTAssertTrue(concreteSubmit.waitForExistence(timeout: 5))
+        concreteSubmit.tap()
+
+        let gravityTitle = app.staticTexts["Gravity Split"]
+        XCTAssertTrue(gravityTitle.waitForExistence(timeout: 15), "Expected Gravity Split after concrete target \(target)")
+        snapshot(app, "\(snapshotPrefix)-GravitySplit")
+
+        let gravityGoButton = app.buttons["gravity-go-button"]
+        if gravityGoButton.waitForExistence(timeout: 3) {
+            gravityGoButton.tap()
+        }
+
+        for _ in 0..<leftPanCount {
+            app.buttons["gravity-left-plus"].tap()
+        }
+        for _ in 0..<rightPanCount {
+            app.buttons["gravity-right-plus"].tap()
+        }
+
+        let sumSprintTitle = app.staticTexts["Sum Sprint"]
+        XCTAssertTrue(sumSprintTitle.waitForExistence(timeout: 15), "Expected Sum Sprint after Gravity Split target \(target)")
+        snapshot(app, "\(snapshotPrefix)-SumSprint")
+
+        for answer in sumSprintAnswers {
+            for digit in answer {
+                app.buttons[String(digit)].tap()
+            }
+            app.buttons["Go"].tap()
+        }
+
+        let bondBlastTitle = app.staticTexts["Bond Blast!"]
+        XCTAssertTrue(bondBlastTitle.waitForExistence(timeout: 15), "Expected Bond Blast after Sum Sprint target \(target)")
+        snapshot(app, "\(snapshotPrefix)-BondBlast")
+
+        for (left, right) in bondPairs {
+            let leftCard = app.buttons["bond-left-\(left)"]
+            let rightCard = app.buttons["bond-right-\(right)"]
+            XCTAssertTrue(leftCard.waitForExistence(timeout: 5), "Missing left Bond Blast card \(left) for target \(target)")
+            XCTAssertTrue(rightCard.waitForExistence(timeout: 5), "Missing right Bond Blast card \(right) for target \(target)")
+            leftCard.tap()
+            rightCard.tap()
+        }
     }
 
     private func waitForHistoryRow(_ app: XCUIApplication, identifier: String, fallbackLabel: String, timeout: TimeInterval) -> Bool {

--- a/scripts/run_issue222_closeout_validation.sh
+++ b/scripts/run_issue222_closeout_validation.sh
@@ -26,7 +26,14 @@ if command -v xcodegen >/dev/null 2>&1; then
   echo "Generating Xcode project..."
   xcodegen generate
 elif [[ -f "$ROOT_DIR/Mather.xcodeproj/project.pbxproj" ]]; then
-  echo "xcodegen not found; using the checked-in Mather.xcodeproj."
+  if grep -q 'BlueprintName = "MatherUITests"' "$ROOT_DIR/Mather.xcodeproj/xcshareddata/xcschemes/Mather.xcscheme" 2>/dev/null || \
+     grep -q 'MatherUITests' "$ROOT_DIR/Mather.xcodeproj/project.pbxproj"; then
+    echo "xcodegen not found; using the checked-in Mather.xcodeproj."
+  else
+    echo "error: xcodegen is not installed and the checked-in Mather.xcodeproj does not include MatherUITests." >&2
+    echo "hint: install xcodegen or prepend a temporary xcodegen binary to PATH before running this script." >&2
+    exit 1
+  fi
 else
   echo "error: xcodegen is not installed and Mather.xcodeproj is missing." >&2
   exit 1

--- a/scripts/run_issue222_closeout_validation.sh
+++ b/scripts/run_issue222_closeout_validation.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SCHEME="Mather"
+TEST_ID="MatherUITests/ScreenshotTests/testScreenshot_Issue222LoopV2_AcrossTwoTargets"
+TIMESTAMP="$(date -u +"%Y%m%dT%H%M%SZ")"
+ARTIFACT_DIR="$ROOT_DIR/artifacts/issue222-closeout-validation/$TIMESTAMP"
+
+DESTINATIONS=(
+  "platform=iOS Simulator,name=iPhone 16,OS=latest"
+  "platform=iOS Simulator,name=iPad Pro 13-inch (M4),OS=latest"
+)
+
+mkdir -p "$ARTIFACT_DIR"
+
+if ! command -v xcodebuild >/dev/null 2>&1; then
+  echo "error: xcodebuild is required to run simulator validation." >&2
+  exit 1
+fi
+
+if command -v xcodegen >/dev/null 2>&1; then
+  echo "Generating Xcode project..."
+  xcodegen generate
+elif [[ -f "$ROOT_DIR/Mather.xcodeproj/project.pbxproj" ]]; then
+  echo "xcodegen not found; using the checked-in Mather.xcodeproj."
+else
+  echo "error: xcodegen is not installed and Mather.xcodeproj is missing." >&2
+  exit 1
+fi
+
+for destination in "${DESTINATIONS[@]}"; do
+  simulator_name="$(sed -E 's/.*name=([^,]+).*/\1/' <<<"$destination")"
+  result_name="${simulator_name// /-}"
+  result_bundle="$ARTIFACT_DIR/${result_name}.xcresult"
+
+  echo
+  echo "Running $TEST_ID on $simulator_name"
+  echo "Result bundle: $result_bundle"
+
+  xcodebuild test \
+    -project Mather.xcodeproj \
+    -scheme "$SCHEME" \
+    -destination "$destination" \
+    -only-testing:"$TEST_ID" \
+    -resultBundlePath "$result_bundle" \
+    CODE_SIGNING_ALLOWED=NO
+done
+
+echo
+echo "Issue #222 closeout validation complete."
+echo "xcresult bundles:"
+find "$ARTIFACT_DIR" -maxdepth 1 -name '*.xcresult' -print | sort

--- a/scripts/run_issue222_closeout_validation.sh
+++ b/scripts/run_issue222_closeout_validation.sh
@@ -10,9 +10,9 @@ TEST_ID="MatherUITests/ScreenshotTests/testScreenshot_Issue222LoopV2_AcrossTwoTa
 TIMESTAMP="$(date -u +"%Y%m%dT%H%M%SZ")"
 ARTIFACT_DIR="$ROOT_DIR/artifacts/issue222-closeout-validation/$TIMESTAMP"
 
-DESTINATIONS=(
-  "platform=iOS Simulator,name=iPhone 16,OS=latest"
-  "platform=iOS Simulator,name=iPad Pro 13-inch (M4),OS=latest"
+SIMULATOR_NAMES=(
+  "iPhone 16"
+  "iPad Pro 13-inch (M4)"
 )
 
 mkdir -p "$ARTIFACT_DIR"
@@ -32,19 +32,36 @@ else
   exit 1
 fi
 
-for destination in "${DESTINATIONS[@]}"; do
-  simulator_name="$(sed -E 's/.*name=([^,]+).*/\1/' <<<"$destination")"
+resolve_simulator_id() {
+  local simulator_name="$1"
+  xcrun simctl list devices available | awk -v name="$simulator_name" '
+    index($0, name " (") {
+      if (match($0, /\(([0-9A-F-]+)\)/)) {
+        print substr($0, RSTART + 1, RLENGTH - 2)
+        exit
+      }
+    }
+  '
+}
+
+for simulator_name in "${SIMULATOR_NAMES[@]}"; do
+  simulator_id="$(resolve_simulator_id "$simulator_name")"
+  if [[ -z "$simulator_id" ]]; then
+    echo "error: could not find an available simulator named '$simulator_name'." >&2
+    exit 1
+  fi
+
   result_name="${simulator_name// /-}"
   result_bundle="$ARTIFACT_DIR/${result_name}.xcresult"
 
   echo
-  echo "Running $TEST_ID on $simulator_name"
+  echo "Running $TEST_ID on $simulator_name ($simulator_id)"
   echo "Result bundle: $result_bundle"
 
   xcodebuild test \
     -project Mather.xcodeproj \
     -scheme "$SCHEME" \
-    -destination "$destination" \
+    -destination "id=$simulator_id" \
     -only-testing:"$TEST_ID" \
     -resultBundlePath "$result_bundle" \
     CODE_SIGNING_ALLOWED=NO

--- a/wiki/Specs/Issue-222-Closeout-Checklist.md
+++ b/wiki/Specs/Issue-222-Closeout-Checklist.md
@@ -1,0 +1,62 @@
+# Issue #222 Closeout Checklist
+
+**Issue:** [#222](https://github.com/ganesh47/mather/issues/222)  
+**Audit date:** 2026-04-19  
+**Scope:** current worktree only (`chore/issue-222-closeout-evidence`)  
+**Purpose:** map reopened recovery slices `RX1` through `RX6` and closeout validation criteria to concrete repo evidence, separating implemented repo truth from still-missing closeout evidence.
+
+## Audit basis
+- Repo code, tests, and wiki content were audited in this worktree.
+- The `RX1`...`RX6` labels come from the reopened issue recovery comment:
+  - `RX1` surface and configuration truth
+  - `RX2` route truth
+  - `RX3` Gravity Split truth
+  - `RX4` embedded Sum Sprint truth
+  - `RX5` embedded Bond Blast truth
+  - `RX6` release-truth validation and honest re-close
+- No fresh local `xcodebuild` run was possible in this environment because `xcodebuild` is not installed here. Closeout status below therefore relies on source, tests already in repo, and prior GitHub issue/CI notes rather than a new simulator or device pass from this worktree.
+
+## RX Status
+
+| Slice | Status | Done in repo | Still missing for closeout |
+|---|---|---|---|
+| `RX1` surface and configuration truth | Partial | `SliceConfig` now clamps targets to `1...20` in `Domain/SliceModels.swift`. Problem generation spans `1...20` and avoids immediate repeats in `Domain/ProblemGenerator.swift`. Child and parent surfaces say `Make & Break 1–20` in `Features/VerticalSlice1/HomeView.swift`, `Features/ParentSummary/SettingsView.swift`, and `App/MatherApp.swift`. Tests cover `1...20` range and non-anchored starts in `Tests/MatherTests/ProblemGeneratorTests.swift`. | Legacy specs still present old milestone framing and naming in `wiki/Specs/VS1-Make-and-Break-to-10.md`, `wiki/Specs/VS1-Acceptance-Evidence-Matrix.md`, and `wiki/Specs/VS1-Closeout-Validation-Note.md`. No fresh release-surface proof from this worktree. |
+| `RX2` route truth | Done in repo | `makeBreakLoopV2Enabled` explicitly gates the reopened route in `Shared/FeatureFlags.swift`. The recovery route is encoded as `concrete -> gravitySplit -> sumSprint -> bondMatch -> done` in `Domain/SliceStateMachine.swift`, selected by `routeMode` in `Domain/VerticalSliceEngine.swift`, and exercised by `loopV2RoutesConcreteToGravitySplitToSumSprintToBondBlast` in `Tests/MatherTests/VerticalSliceEngineTests.swift` plus route-order assertions in `Tests/MatherTests/SliceStateMachineTests.swift`. | No new end-to-end simulator trace artifact or real-device artifact is checked into the repo for closeout. |
+| `RX3` Gravity Split truth | Done in repo | Gravity Split is reset from a zero state via `GravitySplitState(problem:)` on stage entry in `Domain/VerticalSliceEngine.swift`. Tests verify zero start, unsolved entry, no tilt auto-solve, and tap-built completion in `Tests/MatherTests/VerticalSliceEngineTests.swift`. Settings and smoke-check copy call out the stage in `Features/ParentSummary/SettingsView.swift`. | No manual multi-launch or multi-target validation note is present in repo. |
+| `RX4` embedded Sum Sprint truth | Done in repo | Loop V2 advances `gravitySplit -> sumSprint` in `Domain/SliceStateMachine.swift`. The engine creates a per-problem micro-burst in `Domain/VerticalSliceEngine.swift`, backed by `SumSprintBurstState.make(for:)` in `Domain/SliceModels.swift`. Tests assert that each embedded burst stays within `1...3` cards in `Tests/MatherTests/VerticalSliceEngineTests.swift`. | No explicit pacing note or measured timing evidence across multiple loops is present in repo. |
+| `RX5` embedded Bond Blast truth | Done in repo | Loop V2 advances `sumSprint -> bondMatch` in `Domain/SliceStateMachine.swift`. The engine initializes a per-problem `BondMatchState` in `Domain/VerticalSliceEngine.swift`. `Tests/MatherTests/VerticalSliceEngineTests.swift` verifies transition into Bond Blast and advancement to the next problem after all pairs are matched. Compact-layout UI coverage keeps Bond Blast actions reachable in `Tests/MatherUITests/CompactLayoutTests.swift`. | No checked-in pacing artifact from a longer run demonstrates Bond Blast staying loop-sized in actual session play. |
+| `RX6` release-truth validation and honest re-close | Missing | The repo contains smoke-test guidance and export verification steps in `Features/ParentSummary/SettingsView.swift`. Issue comments record that draft PR `#247` was green in GitHub CI and that CI instability was no longer the blocker. | This worktree does not contain the recovery-board docs referenced in issue comments (`wiki/Specs/Issue-222-Execution-Board.md`, `wiki/Specs/Issue-222-Validation-Lane.md`, `wiki/Specs/Issue-222-Recovery-Execution-Lane.md`). No fresh green local simulator run, no real-device E2E note, no pacing signoff, no rollout recommendation, and no concise closeout note are present in repo. |
+
+## Validation Criteria
+
+| Validation criterion | Status | Evidence | Gap |
+|---|---|---|---|
+| Targets span `1...20` | Done in repo | `Domain/SliceModels.swift`, `Domain/ProblemGenerator.swift`, `Tests/MatherTests/ProblemGeneratorTests.swift` | No fresh runtime validation note from this worktree |
+| Session no longer always starts at `6` | Done in repo | randomized-start test in `Tests/MatherTests/ProblemGeneratorTests.swift` | Deterministic test mode still intentionally starts with `6`; closeout should distinguish test fixture behavior from shipped runtime behavior |
+| Exact 4-stage loop per target | Done in repo | `Domain/SliceStateMachine.swift`, `Domain/VerticalSliceEngine.swift`, `Tests/MatherTests/VerticalSliceEngineTests.swift`, `Tests/MatherTests/SliceStateMachineTests.swift` | No checked-in simulator trace or screen recording proving the loop outside unit tests |
+| Gravity Split starts at zero and is child-built | Done in repo | `Domain/VerticalSliceEngine.swift`, `Tests/MatherTests/VerticalSliceEngineTests.swift` | No manual validation note across multiple targets |
+| Sum Sprint appears in every loop in short form | Done in repo | `Domain/VerticalSliceEngine.swift`, `Domain/SliceModels.swift`, `Tests/MatherTests/VerticalSliceEngineTests.swift` | No pacing evidence across at least 5 loops |
+| Bond Blast appears in every loop as short capstone | Done in repo | `Domain/SliceStateMachine.swift`, `Domain/VerticalSliceEngine.swift`, `Tests/MatherTests/VerticalSliceEngineTests.swift` | No pacing evidence from a longer session run |
+| Session pacing still feels good | Missing closeout evidence | existing smoke-test checklist in `Features/ParentSummary/SettingsView.swift` | No measured session-duration or pilot note in repo |
+| Rollout remains gated until QA signoff | Done in repo | `makeBreakLoopV2Enabled` defaults to off in `Shared/FeatureFlags.swift`; settings expose the gate in `Features/ParentSummary/SettingsView.swift` | No explicit rollout recommendation note yet |
+| Honest re-close backed by release-truth evidence | Missing | none beyond source/test audit and prior issue comments | Need a concise validation note with CI result, simulator/device evidence, pacing signoff, and close recommendation |
+
+## Missing Artifacts Blocking Honest Close
+
+- A short release-truth validation note for issue `#222` that records:
+  - latest CI status
+  - one simulator end-to-end result
+  - one real-device end-to-end result
+  - pacing/signoff result
+  - rollout recommendation for `makeBreakLoopV2Enabled`
+- Recovery-board docs referenced in the issue comments are absent from this worktree:
+  - `wiki/Specs/Issue-222-Execution-Board.md`
+  - `wiki/Specs/Issue-222-Validation-Lane.md`
+  - `wiki/Specs/Issue-222-Recovery-Execution-Lane.md`
+- Legacy VS1 spec docs still describe the old `"Make & Break to 10"` framing and should not be treated as issue `#222` closeout evidence without an explicit update or supersession note.
+
+## Close Recommendation
+
+Do **not** close issue `#222` from this worktree alone.
+
+The reopened loop is substantially implemented in repo code and tests (`RX2` through `RX5`, with most of `RX1`), but `RX6` remains open because the repo still lacks a concise release-truth evidence package. The next honest closeout step is to add a short validation note after a fresh simulator pass, a real-device pass, pacing confirmation, and a rollout recommendation for the recovery flag.

--- a/wiki/Specs/VS1-Closeout-Validation-Note.md
+++ b/wiki/Specs/VS1-Closeout-Validation-Note.md
@@ -12,6 +12,10 @@ VS1 is implemented and represented in code, tests, and CI, but final milestone c
 ## What is validated
 - Core child flow exists and is testable end-to-end:
   - Home -> Session setup -> Concrete -> Pictorial -> Abstract -> Transfer -> Session complete
+- Reopened issue #222 loop now has a deterministic simulator evidence lane:
+  - `Tests/MatherUITests/ScreenshotTests.swift` includes `testScreenshot_Issue222LoopV2_AcrossTwoTargets`
+  - It clears `Make it -> Gravity Split -> Sum Sprint -> Bond Blast` twice in one session for deterministic targets 6 and 9
+  - Each pass attaches screenshots to the `.xcresult`, so the route is inspectable without reconstructing the session manually
 - Parent-facing flows exist:
   - Parent Summary
   - Settings
@@ -33,8 +37,24 @@ VS1 is implemented and represented in code, tests, and CI, but final milestone c
 ## Recommended next closeout inputs
 1. Run or summarize real pilot sessions.
 2. Record median duration and major observations.
-3. Confirm iPad + iPhone smoke-test outcome in one short note.
+3. Run `scripts/run_issue222_closeout_validation.sh` and confirm the iPhone + iPad result bundles contain the issue #222 loop screenshots.
 4. Then decide whether to close the milestone.
+
+## Practical runner
+Use the local runner when you need fresh simulator evidence for issue #222:
+
+```bash
+scripts/run_issue222_closeout_validation.sh
+```
+
+It will:
+- regenerate the project with `xcodegen` when available, otherwise reuse the checked-in `Mather.xcodeproj`
+- run the deterministic issue #222 screenshot test on `iPhone 16` and `iPad Pro 13-inch (M4)` simulators
+- write per-device `.xcresult` bundles under `artifacts/issue222-closeout-validation/<timestamp>/`
+
+Open the `.xcresult` bundles in Xcode's report navigator to review the attached screenshots for:
+- target 6 concrete, gravity split, sum sprint, and bond blast
+- target 9 concrete, gravity split, sum sprint, and bond blast
 
 ## Important note
 This page is a staging note only. It should support milestone review, not replace it.


### PR DESCRIPTION
## Summary
- add an issue #222 closeout checklist that separates repo truth from remaining proof obligations
- add a deterministic two-target Loop V2 UI validation test and runner for simulator evidence
- harden the runner for real Macs by resolving simulator IDs and failing clearly when xcodegen fallback is stale

## Why
Issue #222 closeout still needs honest release-truth evidence, not just source-level confidence. This branch creates the coordinator artifacts and executable simulator lane needed to finish that cleanly.

## Validation
- remote `ganesh@mba` validation lane in progress
- branch pushed incrementally for coordinator tracking