### PR TITLE
docs: recover stalled issue 222 planning notes

### DIFF
--- a/wiki/Research/Room-Quest-Camera-Flow-UX-Review.md
+++ b/wiki/Research/Room-Quest-Camera-Flow-UX-Review.md
@@ -1,0 +1,79 @@
+# Room Quest Camera Flow UX Review
+
+**Date**: 2026-04-18  
+**Scope**: `Features/RoomQuest/*`, `Domain/RoomQuestEngine.swift`, `Services/RoomQuestLiveScanner.swift`
+
+## Summary
+
+The current Room Quest flow technically includes camera steps, but the camera does not yet feel like the core of the experience. In setup, the parent is asked to "camera verify" a station, but what is actually being verified is a QR marker, not a hiding place. In hunt/recheck, the child sees language about finding a saved place, but the implementation still mainly checks marker payload equality. That creates a mismatch between product promise and felt experience.
+
+## What is confusing in setup
+
+1. **The setup goal is unclear**  
+   The UI mixes three concepts: placing tokens, verifying a marker, and saving a place reference. Parents are told to "camera-verify each one" and later see "reference saved," but there is no explicit capture/review moment that explains what was actually saved.
+
+2. **"Camera verify" sounds stronger than the feature is**  
+   The button implies the app understands the physical location. In code, setup scanning only reads a QR payload and then marks the station as camera verified.
+
+3. **Manual fallback is too co-equal with the primary path**  
+   "Same-place fallback" appears immediately beside the main action, which makes the primary camera path feel optional and procedural rather than magical.
+
+4. **Ready-state friction**  
+   The parent cannot continue until both stations are registered, but the screen does not strongly communicate the two-step checklist per station beyond button states and badges.
+
+## What is confusing in hunt / recheck
+
+1. **Child copy promises place recheck, but the mechanic is still marker check**  
+   Copy like "Recheck the saved place" and "Look for the saved place" suggests scene recognition. The scanner still resolves QR payloads.
+
+2. **Fallback bypass is too easy**  
+   On the child screen, "I found it" is always available even before any meaningful camera attempt. That weakens the sense that the camera matters.
+
+3. **The recheck outcome language is better than the underlying truth**  
+   States like "almost" and "found the saved place" are emotionally right, but they are attached to marker matching, not a place-confidence model.
+
+4. **No visible camera continuity**  
+   The scanner is a separate sheet with a QR prompt and short AR celebration. There is no persistent sense that the app is helping the child search the room in real time.
+
+## Why the camera feels not useful
+
+1. **It confirms markers, not places**  
+   The most important gap. The experience reads like hide-and-seek, but the camera checks codes.
+
+2. **The useful camera moment is hidden behind implementation detail**  
+   Parents never review a captured reference image, and children never see a live comparison against something previously saved.
+
+3. **The fallback path carries the actual progress power**  
+   Because manual confirm is always nearby and low-cost, the camera feels decorative.
+
+4. **The AR sparkle is celebratory, not informative**  
+   It rewards a scan, but does not help the user understand why the app believed the place was correct.
+
+## Smallest feel-changing UX improvements
+
+1. **Rename setup actions to match reality now**  
+   If this release is QR-first, change copy from "camera verify" / "saved place" to "scan station marker" unless a true place reference is being captured.
+
+2. **Add an explicit parent reference step only when reference capture really exists**  
+   A tiny review card like "Saved reference for Red Rocket" with thumbnail/retake would make the camera feel purposeful.
+
+3. **Gate fallback slightly harder in hunt**  
+   Hide or de-emphasize "I found it" until one scan attempt fails, or relabel it to a parent-only fallback. This alone would make the camera feel more central.
+
+4. **Make progress per station more legible in setup**  
+   Add a simple 2-item checklist: marker scanned / fallback used, ready. Reduce ambiguity around why the Ready button is disabled.
+
+5. **Keep child language honest**  
+   If the system is matching markers, say marker. If it is matching a saved place, show the saved reference and use confidence wording consistently.
+
+6. **Turn the scanner into guidance, not just a modal checkpoint**  
+   Even a lightweight overlay like "Find Red Rocket marker" with clearer success/failure framing would feel more useful than a generic scan sheet.
+
+## Strongest recommendation
+
+For the next iteration, pick one honest story and commit to it in copy and UI:
+
+- **QR-marker story**: fast, reliable, honest, but less magical
+- **Saved-place recheck story**: more magical, but requires a real capture/review/recheck loop
+
+Right now the product language is closer to the second story while the implementation is mostly the first. That mismatch is the main UX problem.

--- a/wiki/Specs/Issue-222-Execution-Board.md
+++ b/wiki/Specs/Issue-222-Execution-Board.md
@@ -1,0 +1,337 @@
+# Issue #222 Execution Board
+
+Source issue: https://github.com/ganesh47/mather/issues/222
+
+## Goal
+Ship issue #222 as a controlled sequence of small PRs that converts VS1 from its current mostly VS1-style flow into a repeatable per-target loop:
+
+1. Make it
+2. Gravity Split
+3. Standard Sum Sprint
+4. Bond Blast
+
+across randomized targets in the 1-20 range, while keeping session pacing short and validation visible at each merge point.
+
+---
+
+## Remaining execution checklist after PR #234
+
+Legend: `DONE`, `IN PR`, `NEXT`, `BLOCKED`, `GATE`
+
+| Work item | Owner role | Status | Depends on | Merge gate |
+| --- | --- | --- | --- | --- |
+| PR #234, target range and randomized sequencing groundwork | Engine owner | IN PR | None | Review merged, generator tests green, no fixed 6 anchor in samples |
+| PR2, per-target loop routing in engine/state machine | Engine owner | NEXT | PR #234 | Exact order is `Make it -> Gravity Split -> Sum Sprint -> Bond Blast`, old route remains safe behind flag or replacement is complete |
+| PR3, Gravity Split zero-state plus/minus interaction | Gameplay owner | BLOCKED | PR2 | Starts from zero, never enters solved, success only after child action |
+| PR4, embedded Sum Sprint micro-burst per target | Fluency systems owner | BLOCKED | PR2 | Present in every loop, 1-3 facts, returns to same target loop, pacing stays tight |
+| PR5, per-target Bond Blast micro-capstone | Gameplay owner | BLOCKED | PR2, preferably after PR4 for pacing tune | Present in every loop, short capstone, returns to next target cleanly |
+| PR6, release hardening and cutover | QA and release owner | BLOCKED | PR3, PR4, PR5 | Full 4-stage loop works across 1-20, copy updated, telemetry reviewed, rollout flag decision made |
+
+### Merge order
+1. Merge PR #234.
+2. Land PR2 as the architecture hinge.
+3. Run PR3 and PR4 in parallel once PR2 lands.
+4. Land PR5 after PR4 is visible enough to tune total loop pacing.
+5. Finish with PR6 and rollout review.
+
+### Non-negotiable gates before closing #222
+- No session is anchored to 6 by default.
+- Every target runs all 4 stages in order.
+- Gravity Split never feels pre-solved.
+- Sum Sprint and Bond Blast are both loop-sized, not standalone-length.
+- Session duration remains inside pacing budget on repeated targets.
+- New flow is protected by a rollout flag until QA signoff.
+
+## Recommended release strategy
+- Use a temporary umbrella flag for the new loop, for example `feature.makeBreakLoopV2Enabled`.
+- Keep existing shipped VS1 flow intact until the full loop passes QA.
+- Merge each phase behind flags where needed, then enable only after the final integration checkpoint.
+- Prefer 5 small PRs plus 1 release-hardening PR, rather than one large rewrite.
+
+---
+
+## Dependency map
+
+### Hard dependencies
+1. PR1 session model and generator expansion must land before any loop integration PR.
+2. PR2 stage-routing refactor must land before Sum Sprint and per-target Bond Blast can be inserted cleanly.
+3. PR3 Gravity Split zero-state fix depends on PR2 routing contract.
+4. PR4 Sum Sprint micro-burst embedding depends on PR2 routing and PR1 target generation.
+5. PR5 Bond Blast per-target capstone depends on PR2 routing and should integrate after PR4 so pacing can be tuned with the full loop visible.
+6. PR6 release hardening depends on all previous PRs.
+
+### Can be developed in parallel after PR2
+- Gravity Split implementation work
+- Sum Sprint micro-session work
+- Bond Blast micro-capstone work
+
+---
+
+## Execution board
+
+## Phase 0, spec lock and instrumentation contract
+
+### Outcome
+Freeze the exact loop contract before touching flow logic.
+
+### PR0 scope
+- Add or update a spec note covering:
+  - loop order is exactly `Make it -> Gravity Split -> Sum Sprint -> Bond Blast`
+  - loop repeats per target
+  - targets span 1-20
+  - target order is randomized with repeat control
+  - Sum Sprint is 1-3 facts per target in V1
+  - Bond Blast is micro-sized per target, not last-problem-only
+- Define telemetry names for:
+  - target presented
+  - stage entered/completed
+  - loop completed
+  - session completed
+  - stage duration by target
+- Add acceptance matrix rows for issue #222.
+
+### Validation gate
+- Product and engineering agree on stage order and pacing budget.
+- No unresolved ambiguity around whether Bond Blast remains last-problem-only. For #222 V1, it should not.
+
+### Merge checkpoint
+- Spec approved.
+- Telemetry/event names agreed.
+
+---
+
+## Phase 1, expand session model from VS1 6-10 into randomized 1-20 targets
+
+### Outcome
+The engine can produce sane target sequences for the new loop without yet changing the UI flow.
+
+### PR1 scope
+- Update `SliceConfig` defaults and labels from 6-10 / to 10 language to 1-20 language where appropriate.
+- Replace the current deterministic seed and random generator behavior in `ProblemGenerator` so it:
+  - supports 1-20
+  - avoids boring immediate repeats
+  - avoids wild difficulty whiplash where possible
+  - still supports deterministic test mode
+- Add generator rules for decomposition quality:
+  - avoid too many trivial `0 + n` cases unless intentionally sampled
+  - include both symmetric and asymmetric decompositions
+  - preserve reproducibility in tests
+- Update session-summary titles and parent-facing strings that still say "Make & Break to 10".
+
+### Suggested tests
+- generator returns only 1-20 targets
+- deterministic mode snapshot covers the new range
+- randomized sessions do not always start at 6
+- repeat suppression works
+- decomposition invariants always sum to target
+
+### Validation gate
+- A 20-30 session sample looks varied by inspection.
+- No regressions in existing session start or summary flows.
+
+### Merge checkpoint
+- Safe to merge independently because it only broadens problem generation and copy.
+
+---
+
+## Phase 2, refactor stage routing to support a true per-target 4-stage loop
+
+### Outcome
+The state machine and engine can express the new loop directly instead of forcing it through current VS1 assumptions.
+
+### PR2 scope
+- Refactor `SliceStage`, `SliceStateMachine`, and `VerticalSliceEngine` so one target can route through:
+  - concrete make stage
+  - gravity split stage
+  - sum sprint micro-stage
+  - bond blast micro-stage
+  - next target
+- Remove the current "Bond Blast only on last problem" assumption from stage progression.
+- Decide whether current `pictorial` maps to Bond Blast micro-capstone or whether a new dedicated stage enum is cleaner. Recommendation: introduce explicit stage naming now if it simplifies future maintenance.
+- Decide what happens to `abstract` and `transfer` in loop V2. Recommendation: do not leave them half-alive in the same path. Either gate old VS1 route vs new loop route, or fully define their role in V2.
+- Add a dedicated loop-progress model so per-target completion is explicit.
+
+### Suggested tests
+- state machine transitions for new loop order
+- each target advances to next target only after Bond Blast completion
+- feature-flagged old route still works until cutover
+- session completion occurs after final target loop, not after a leftover legacy stage condition
+
+### Validation gate
+- Engine can run the new order with placeholder implementations for later stages.
+- Team agrees the migration path from legacy stage names is understandable.
+
+### Merge checkpoint
+- This is the architecture PR. Do not merge unless old and new routes are both testable or the replacement is complete enough to keep the app usable.
+
+---
+
+## Phase 3, fix Gravity Split so it starts from zero and feels earned
+
+### Outcome
+Gravity Split becomes playable and child-driven.
+
+### PR3 scope
+- Change `GravitySplitState` initialization so the split starts from 0, not near-solved.
+- Make plus/minus taps the required V1 interaction path.
+- Keep tilt only as optional polish behind a separate flag if retained.
+- Prevent auto-solve on stage entry and on first sensor sample.
+- Tune prompts and success logic so the child clearly understands they are building the split.
+- Add simple reset behavior if needed.
+
+### Suggested tests
+- stage starts with left/right at zeroed child-built state per approved rule
+- entering Gravity Split never begins solved
+- taps can reach all valid split values
+- success only triggers after child adjustment reaches target decomposition
+- tilt, if still enabled, cannot instantly solve on entry
+
+### Validation gate
+- Manual playtest: 10 consecutive entries should never feel pre-solved.
+- 5-year-old comprehension check: controls are understandable without explanation overload.
+
+### Merge checkpoint
+- Merge only after playability signoff, because this is the issue's sharpest defect.
+
+---
+
+## Phase 4, embed Sum Sprint as a micro-burst inside every target loop
+
+### Outcome
+Sum Sprint appears in every loop without turning the session into a long fluency detour.
+
+### PR4 scope
+- Reuse `SumSprintEngine` as a per-target embedded micro-session, not a standalone route.
+- Add a loop-scoped session builder that selects 1-3 facts tied to the current target or current difficulty band.
+- Define completion contract clearly:
+  - one correct answer may be enough for target 1-5
+  - two to three facts for higher targets if pacing still holds
+- Keep existing standalone Sum Sprint capability intact unless intentionally retired.
+- Record telemetry separately for embedded vs standalone Sum Sprint.
+
+### Suggested tests
+- every target loop enters Sum Sprint when loop V2 flag is on
+- embedded Sum Sprint exits back to the same target loop, not home or standalone summary
+- card count stays within V1 limit
+- total loop time remains within pacing budget in tests or instrumentation
+
+### Validation gate
+- Median added time per target stays inside agreed budget, recommended 10-20 seconds.
+- Fluency content feels like reinforcement, not mode-switch whiplash.
+
+### Merge checkpoint
+- Merge when embedded flow is stable, even if fact-selection tuning remains modest.
+
+---
+
+## Phase 5, make Bond Blast a per-target micro-capstone
+
+### Outcome
+Bond Blast happens on every target as the playful finish, instead of only at the session end.
+
+### PR5 scope
+- Rework Bond Blast entry criteria so it fires once per target loop.
+- Scale pair count and animation length down to loop-sized pacing.
+- Preserve delight, but shorten completion time and celebration hold time.
+- Ensure target-specific prompts and pair generation still match the active target.
+- Review whether motion/clap enhancements remain sensible in a per-target cadence. Recommendation: tap-first baseline, sensors optional.
+
+### Suggested tests
+- Bond Blast appears for every target in loop V2
+- target-specific pair generation stays correct across 1-20
+- completion returns to next target, not legacy summary path
+- pacing does not stack excessive delays across multi-target sessions
+
+### Validation gate
+- End-to-end sessions feel consistent across at least 6 targets.
+- Total session duration still fits the product window.
+
+### Merge checkpoint
+- Merge after real-device playtest, because delight and pacing matter more than unit coverage alone here.
+
+---
+
+## Phase 6, release hardening and cutover
+
+### Outcome
+The new loop is ready to ship broadly.
+
+### PR6 scope
+- Update screenshots, UI tests, and settings labels.
+- Clean up stale "to 10" copy and obsolete route assumptions.
+- Add or update parent summary language for the new loop.
+- Run end-to-end QA with flags on and off.
+- Remove dead legacy code only if the new loop is clearly stable. Otherwise keep one release of dual-path safety.
+
+### Required validation matrix
+- Unit tests pass
+- UI smoke tests pass
+- deterministic mode remains stable
+- manual test on small targets 1-5
+- manual test on large targets 16-20
+- no stage starts solved
+- no session starts anchored to 6
+- every target shows all 4 stages in order
+- total session duration still acceptable
+- summaries and telemetry remain coherent
+
+### Release checkpoint
+- Enable the umbrella flag for internal testing first.
+- Ship to a limited audience or test cohort.
+- Review telemetry for:
+  - loop completion rate
+  - stage abandonment rate
+  - median stage duration
+  - session duration
+  - high-friction targets
+- Only then promote to default-on.
+
+---
+
+## Recommended PR sequence
+1. PR0 spec lock and acceptance matrix
+2. PR1 generator and 1-20 session groundwork
+3. PR2 loop routing/state-machine refactor
+4. PR3 Gravity Split zero-state fix
+5. PR4 embedded Sum Sprint micro-burst
+6. PR5 per-target Bond Blast micro-capstone
+7. PR6 release hardening, QA, and cutover
+
+If parallelizing after PR2:
+- Track A: PR3 Gravity Split
+- Track B: PR4 Sum Sprint embedding
+- Track C: PR5 Bond Blast resizing
+- Final integrator PR: PR6
+
+---
+
+## Recommended ownership split
+- Product/design: pacing budget, target randomization rules, micro-stage success criteria
+- Engine/state owner: PR2 integration contract
+- Gameplay owner: PR3 and PR5 feel tuning
+- Fluency/learning systems owner: PR4 fact-selection and pacing
+- QA/release owner: PR6 validation matrix and rollout gates
+
+---
+
+## Key risks and mitigations
+
+### Risk: loop becomes too long
+Mitigation: lock stage-level time budgets before implementation, keep Sum Sprint to 1-3 facts, reduce Bond Blast pair count and celebration delays.
+
+### Risk: legacy VS1 assumptions fight the new architecture
+Mitigation: use a loop V2 flag and isolate routing changes in PR2 before feature work branches off.
+
+### Risk: Gravity Split is still confusing
+Mitigation: tap-first V1, no preloaded solved state, manual playability signoff before broader merge.
+
+### Risk: 1-20 randomization feels chaotic
+Mitigation: generator should suppress immediate repeats and optionally band jumps, plus keep deterministic fixtures for testing.
+
+### Risk: telemetry becomes incomparable with old VS1 sessions
+Mitigation: version the loop mode in session payloads and distinguish embedded vs standalone Sum Sprint.
+
+---
+
+## Definition of done for issue #222
+Issue #222 is done when a child can run a session in which each randomized target from the 1-20 range follows the same four-stage order, Gravity Split starts unsolved from zero and requires active adjustment, Sum Sprint and Bond Blast both appear as short per-target stages, and the resulting session still feels short, legible, and repeatable.

--- a/wiki/Specs/Issue-222-Recovery-Execution-Lane.md
+++ b/wiki/Specs/Issue-222-Recovery-Execution-Lane.md
@@ -1,0 +1,126 @@
+# Issue #222 Recovery Execution Lane
+
+Date: 2026-04-19
+Status: recovery / reopened against shipped product truth
+
+## Why this exists
+Issue #222 was previously closed, but shipped product truth does not satisfy the promised scope.
+Current released behavior still presents Make & Break as 1-10 in real UI surfaces and does not yet deliver the promised repeated 4-stage per-target loop end to end.
+
+This document resets execution against what is actually shipped, not prior planning or bookkeeping.
+
+## Shipped truth baseline
+Observed/reported and corroborated from current code:
+- Make & Break still presents as "Make & Break to 10" in live UI surfaces.
+- Current stage routing still reflects the older path and semantics.
+- Bond Blast semantics are still split awkwardly across `pictorial` and `bondMatch`.
+- Gravity Split zero-start child-built behavior is not established as shipped truth.
+- Sum Sprint exists as a standalone route, but not yet as the promised embedded per-target loop stage in shipped behavior.
+
+## What actually landed from the prior #222 lane
+### Merged PRs tied to the prior execution lane
+- PR #234 — `feat(vs1): expand 1-20 target generation groundwork`
+- PR #235 — `feat(vs1): add loop-v2 stage routing scaffold`
+
+### What that means
+These PRs are real, but they appear to have landed as groundwork/scaffolding rather than full shipped product completion.
+The user-observed release behavior is the source of truth: the end-to-end promised delta is still missing.
+
+## Missing product delta still required
+1. 1-20 range in real UI and real shipped behavior
+2. repeated 4-stage loop per target:
+   - Make it
+   - Gravity Split
+   - Sum Sprint
+   - Bond Blast
+3. Gravity Split zero-start child-built behavior
+4. Sum Sprint + Bond Blast integrated in every target loop
+5. release-truth validation before reclosing #222
+
+## Recovery execution slices
+
+### RX1 — surface and configuration truth
+Goal:
+- make the real product present as 1-20, not 1-10
+
+Scope:
+- update live UI strings still saying "Make & Break to 10"
+- verify/configure actual target generation used in shipped sessions
+- verify V2 path can be reached in the real product path, not only in code scaffolding
+
+Done when:
+- shipped/tested UI shows 1-20 language where appropriate
+- real session targets demonstrably include the broader range
+
+### RX2 — route truth
+Goal:
+- make the actual shipped stage order follow the promised repeated loop
+
+Scope:
+- connect the real child-facing route to the V2 loop path
+- remove dependence on old semantics where `pictorial` still acts like Bond Blast
+- ensure every target follows the same four-stage order
+
+Done when:
+- end-to-end session trace proves per-target loop order in simulator/device runs
+
+### RX3 — Gravity Split truth
+Goal:
+- fix Gravity Split to start unsolved from zero and require child-built adjustment
+
+Scope:
+- zero-start state
+- child-controlled plus/minus interaction
+- no effectively pre-solved entry state
+- no accidental auto-complete
+
+Done when:
+- repeated launches across multiple targets prove unsolved entry and child-built completion
+
+### RX4 — embedded Sum Sprint truth
+Goal:
+- integrate Sum Sprint into each target cycle as a short embedded stage
+
+Scope:
+- replace placeholder behavior with real embedded micro-session
+- ensure pacing is short and repeatable
+- preserve standalone Sum Sprint route if desired, but do not rely on it for #222 closure
+
+Done when:
+- every target loop includes a short Sum Sprint stage in real product behavior
+
+### RX5 — embedded Bond Blast truth
+Goal:
+- make Bond Blast appear per target, not only under older/ambiguous semantics
+
+Scope:
+- clean up stage semantics
+- make Bond Blast a true per-target micro-capstone
+- verify pacing across multiple targets
+
+Done when:
+- every target loop includes Bond Blast in the intended position and pacing remains acceptable
+
+### RX6 — release-truth validation and honest re-close
+Goal:
+- validate the actual release behavior before reclosing #222
+
+Required evidence:
+- green CI on final recovery PRs
+- simulator trace showing multiple target loops in correct order
+- current main/release screen recording or screenshots demonstrating the corrected flow
+- real-device smoke validation if release candidate behavior is still uncertain
+- issue close comment explicitly referencing shipped truth and validation evidence
+
+## Non-goal
+Do not treat issue closure, merged scaffolding PRs, or planning artifacts as completion evidence by themselves.
+Only shipped behavior and validation evidence count.
+
+## Coordinator note
+Future status updates should clearly separate:
+- scaffolding landed
+- code path exists behind flag
+- shipped product truth
+- validated release truth
+
+#222 should only be reclosed after RX1–RX6 are satisfied.

--- a/wiki/Specs/Issue-222-Validation-Lane.md
+++ b/wiki/Specs/Issue-222-Validation-Lane.md
@@ -1,0 +1,158 @@
+# Issue #222 Validation Lane
+
+Source issue: https://github.com/ganesh47/mather/issues/222
+
+This is the QA and release lane for the remaining work after PR #234 (PR1 groundwork).
+
+## Baseline after PR #234
+PR #234 establishes the generator/session groundwork. The remaining validation lane starts at PR2.
+
+## CI gates required on every remaining PR
+A PR is not done until all of the following are green on the PR branch:
+
+- `CI / Build & Test`
+- `CodeQL / Analyze Actions Workflows`
+- `Dependency Review / Dependency Review`
+- `Workflow Lint / actionlint` when workflow files change
+
+Required PR evidence:
+- link or screenshot of green GitHub checks
+- short test note listing any added or updated automated coverage
+- explicit note if simulator-only validation was done and which device/runtime was used
+
+## Device-validation checkpoints
+Because #222 changes learning flow and pacing, automated checks alone are not enough.
+
+### Required manual validation environments before issue close
+- 1 iPhone simulator run on the current CI-supported runtime
+- 1 real-device run on iPhone or iPad before PR6 is called done
+
+### Manual validation target bands
+Use at least these target samples:
+- low: 1, 2, 5
+- mid: 8, 10, 12
+- high: 16, 18, 20
+
+### Core manual assertions
+- session does not anchor on 6
+- each target follows `Make it -> Gravity Split -> Sum Sprint -> Bond Blast`
+- no stage appears pre-solved on entry
+- stage exits return to the same target loop until Bond Blast completes
+- pacing still feels short and legible across a multi-target session
+- summary/copy/telemetry still make sense
+
+## Evidence package expected on each PR
+Post this in the PR body or a review comment before marking ready to merge:
+
+- `Automated:` tests added/updated, plus green checks
+- `Simulator:` device + OS + what was exercised
+- `Manual:` observed behavior against the PR-specific checklist below
+- `Artifacts:` screenshot, short screen recording, or xcresult/artifact link when UI changed
+- `Risks left:` anything deferred to a later PR
+
+---
+
+## PR2, loop routing/state-machine refactor
+
+### Done only if
+- automated tests prove the per-target route order is exactly 4 stages
+- old path remains safe behind flag, or replacement path is fully coherent
+- session completion happens only after final target Bond Blast
+- no legacy last-problem-only Bond Blast assumption remains in the new route
+
+### Required evidence
+- unit test coverage for state-machine transitions and loop completion
+- one simulator trace or screen recording showing 2 full target loops back-to-back
+- note naming the flag/path used for old-vs-new routing
+
+### Release risk to watch
+- silent routing regressions that skip or duplicate a stage
+
+---
+
+## PR3, Gravity Split zero-state fix
+
+### Done only if
+- Gravity Split always enters unsolved from zero-state per approved contract
+- plus/minus interaction can reach valid decompositions across low and high targets
+- success never fires on entry or first idle sensor sample
+- any retained tilt behavior cannot auto-solve the stage
+
+### Required evidence
+- tests covering unsolved entry and success-only-after-child-action
+- manual validation on targets 2, 5, 10, 18, 20
+- short recording or screenshots proving entry state is unsolved on at least 3 separate launches
+
+### Release risk to watch
+- stage still feels pre-solved or confusing despite passing unit tests
+
+---
+
+## PR4, embedded Sum Sprint micro-burst
+
+### Done only if
+- every target loop enters Sum Sprint in loop V2
+- embedded Sum Sprint returns to the same target loop, not summary/home
+- fact count stays within 1-3 cards per target in V1
+- added time per target stays within the agreed micro-burst budget
+
+### Required evidence
+- tests proving loop entry/exit and card-count bounds
+- simulator validation on low, mid, and high target bands
+- timing evidence from instrumentation, logs, or measured playthrough notes for at least 5 loops
+
+### Release risk to watch
+- fluency stage bloats session length or feels like a separate mode switch
+
+---
+
+## PR5, Bond Blast per-target micro-capstone
+
+### Done only if
+- Bond Blast appears for every target, not only the last one
+- completion returns to next target instead of a legacy summary path
+- target-specific pair generation remains correct through 20
+- celebration timing is shortened enough to preserve session pacing
+
+### Required evidence
+- tests for per-target entry and correct target-specific content
+- real UI evidence, screenshot or recording, from at least 3 different targets including one in 16-20
+- manual pacing note from a 6-target end-to-end run
+
+### Release risk to watch
+- delight is preserved, but cumulative animation delay makes sessions drag
+
+---
+
+## PR6, release hardening and cutover
+
+### Done only if
+- all prior PR gates are satisfied together in one end-to-end flagged run
+- copy, summaries, screenshots, and labels no longer contradict the 1-20 loop
+- flag-off legacy path still works if dual-path safety remains
+- flag-on path completes full sessions across low and high targets without stage-order defects
+- telemetry or session logs are coherent enough to review rollout health
+
+### Required evidence
+- full green CI on the release PR
+- one simulator end-to-end run with artifacts
+- one real-device end-to-end run with artifacts
+- release checklist comment including: target sample set used, total session duration, any friction points, and ship recommendation
+
+### Ship recommendation threshold
+PR6 should only be called done when QA can state all of the following:
+- loop order is stable
+- Gravity Split is no longer pre-solved
+- Sum Sprint and Bond Blast are present on every target
+- pacing is acceptable across a full session
+- no blocker remains for limited-flag rollout
+
+---
+
+## Issue #222 close criteria
+Issue #222 is ready to close only after PR6 supplies:
+- green CI
+- real-device validation evidence
+- end-to-end 1-20 loop proof
+- pacing signoff
+- rollout recommendation for the loop flag


### PR DESCRIPTION
## Summary
- recover the planning and validation docs that were stranded in the stale local `feat/issue-222-pr1-foundation` lane
- preserve them on a clean branch from current `main`
- keep the old mixed code recovery separate from these docs so future salvage can happen safely by theme

## Why
The issue #222 closeout work moved on, but four repo docs still existed only inside a stale local branch with a large mixed worktree. These notes were at risk of getting lost during cleanup.

This PR preserves that planning/QA intent without reviving the stale code delta.

## Included docs
- `wiki/Specs/Issue-222-Execution-Board.md`
- `wiki/Specs/Issue-222-Recovery-Execution-Lane.md`
- `wiki/Specs/Issue-222-Validation-Lane.md`
- `wiki/Research/Room-Quest-Camera-Flow-UX-Review.md`

## Follow-up
Any code recovery from the old branch should happen separately, in smaller fresh branches off current `main`, using the salvage artifacts in `artifacts/mather-stalled-work/`.
