### PR TITLE
test(ui): fix issue #222 screenshot burst expectation on target 9

### DIFF
--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -72,7 +72,9 @@ struct VerticalSliceEngineTests {
         #expect(engine.currentStage == .gravitySplit)
 
         lockGravitySplit(engine, problem: problem)
-        await waitFor("gravity split lock") { engine.gravitySplitState?.isLocked == true }
+        // Locking the split can auto-advance the stage immediately, which clears
+        // gravitySplitState before the assertion loop observes `isLocked == true`.
+        // Wait for the durable next-stage outcome instead of the transient lock bit.
         await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
         #expect(engine.currentStage == .sumSprint)
         #expect((engine.sumSprintBurstState?.cards.count ?? 0) >= 1)
@@ -779,7 +781,9 @@ struct VerticalSliceEngineTests {
         #expect(engine.currentStage == .gravitySplit)
 
         lockGravitySplit(engine, problem: problem)
-        await waitFor("gravity split lock") { engine.gravitySplitState?.isLocked == true }
+        // Locking the split can auto-advance the stage immediately, which clears
+        // gravitySplitState before the assertion loop observes `isLocked == true`.
+        // Wait for the durable next-stage outcome instead of the transient lock bit.
         await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
         #expect(engine.currentStage == .sumSprint)
 

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -282,7 +282,10 @@ final class ScreenshotTests: XCTestCase {
             concreteCellIndex: 8,
             leftPanCount: 4,
             rightPanCount: 5,
-            sumSprintAnswers: ["9", "9", "9"],
+            // The loop-v2 burst de-duplicates repeated facts for each target.
+            // In deterministic UI-test mode, target 9 currently yields two unique
+            // Sum Sprint cards, not three.
+            sumSprintAnswers: ["9", "9"],
             bondPairs: [(1, 8), (2, 7), (3, 6), (4, 5)],
             snapshotPrefix: "Issue222-Target9",
             skipInitialConcreteSnapshot: true


### PR DESCRIPTION
## Summary\n- fix the stale issue #222 screenshot expectation for the second deterministic target\n- align the target 9 Sum Sprint burst with the current de-duplicated fact generation\n- document why UI test mode currently produces two unique target 9 answers instead of three\n\n## Testing\n- not run locally (CI-only UI screenshot lane)\n\nCloses #259