### PR TITLE
fix: tighten TestFlight compact layouts

### DIFF
--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -49,7 +49,7 @@ enum MemoryDeck {
         MemoryAnimal(id: "owl",        emoji: "🦉", name: "Owl"),
         MemoryAnimal(id: "penguin",    emoji: "🐧", name: "Penguin"),
         MemoryAnimal(id: "swan",       emoji: "🦢", name: "Swan"),
-        MemoryAnimal(id: "hummingbird",emoji: "🐦‍⬛", name: "Hummingbird"),
+        MemoryAnimal(id: "hummingbird",emoji: "🐦⬛", name: "Hummingbird"),
         MemoryAnimal(id: "cockatoo",   emoji: "🦜", name: "Cockatoo"),
         MemoryAnimal(id: "ibis",       emoji: "🦤", name: "Ibis"),
     ]
@@ -77,6 +77,14 @@ enum MemoryDifficulty: CaseIterable {
         case .easy:   return "Easy"
         case .medium: return "Medium"
         case .hard:   return "Flip!"
+        }
+    }
+
+    var menuLabel: String {
+        switch self {
+        case .easy: return "Easy"
+        case .medium: return "Medium"
+        case .hard: return "Flip mode"
         }
     }
 
@@ -115,6 +123,12 @@ struct MemoryView: View {
             case .tropical:  return "🦜 Birds"
             }
         }
+        var menuLabel: String {
+            switch self {
+            case .domestic: return "Animals"
+            case .tropical: return "Birds"
+            }
+        }
         var animals: [MemoryAnimal] {
             switch self {
             case .domestic: return MemoryDeck.domesticAnimals
@@ -130,15 +144,17 @@ struct MemoryView: View {
     var body: some View {
         ZStack {
             MatherTheme.background.ignoresSafeArea()
-            VStack(spacing: 0) {
-                header
-                    .padding(.horizontal, 20)
-                    .padding(.top, 16)
-                    .padding(.bottom, 12)
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 0) {
+                    header
+                        .padding(.horizontal, 20)
+                        .padding(.top, 16)
+                        .padding(.bottom, 12)
 
-                cardGrid
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 20)
+                    cardGrid
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 20)
+                }
             }
 
             if showRoundComplete {
@@ -151,61 +167,93 @@ struct MemoryView: View {
     // MARK: - Header
 
     private var header: some View {
-        HStack(alignment: .center, spacing: 12) {
-            Button {
-                appModel.engine.showLab()
-            } label: {
-                Image(systemName: "chevron.left")
-                    .font(.title3.weight(.semibold))
-                    .foregroundStyle(MatherTheme.accent)
-                    .frame(width: 44, height: 44)
-            }
-            .accessibilityLabel("Back")
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Memory Match")
-                    .font(.title2.weight(.black))
-                    .foregroundStyle(MatherTheme.ink)
-                Text("\(matchedPairs)/\(totalPairs) pairs matched")
-                    .font(.subheadline.weight(.medium))
-                    .foregroundStyle(MatherTheme.cardSubtitle)
-            }
-
-            Spacer()
-
-            // Deck picker
-            HStack(spacing: 6) {
-                ForEach(DeckSelection.allCases, id: \.label) { d in
-                    Button(d.label) {
-                        deckSelection = d
-                        deck = d.animals
-                        dealRound()
-                    }
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(deckSelection == d ? .white : MatherTheme.ink)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(deckSelection == d ? MatherTheme.accent : MatherTheme.card)
-                    .clipShape(Capsule())
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 12) {
+                Button {
+                    appModel.engine.showLab()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(MatherTheme.accent)
+                        .frame(width: 44, height: 44)
                 }
+                .accessibilityLabel("Back")
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Memory Match")
+                        .font(.title2.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text("\(matchedPairs)/\(totalPairs) pairs matched")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                }
+
+                Spacer(minLength: 0)
             }
 
-            // Difficulty picker
-            HStack(spacing: 6) {
-                ForEach(MemoryDifficulty.allCases, id: \.label) { d in
-                    Button(d.label) {
-                        difficulty = d
-                        dealRound()
+            CardSurface {
+                VStack(alignment: .leading, spacing: 14) {
+                    Text("Choose a deck and level")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+
+                    VStack(spacing: 10) {
+                        Menu {
+                            ForEach(DeckSelection.allCases, id: \.label) { selectedDeck in
+                                Button(selectedDeck.label) {
+                                    deckSelection = selectedDeck
+                                    deck = selectedDeck.animals
+                                    dealRound()
+                                }
+                            }
+                        } label: {
+                            controlLabel(title: "Deck", value: deckSelection.menuLabel, tint: MatherTheme.accent)
+                        }
+                        .accessibilityIdentifier("memory-deck-menu")
+
+                        Menu {
+                            ForEach(MemoryDifficulty.allCases, id: \.label) { selectedDifficulty in
+                                Button(selectedDifficulty.label) {
+                                    difficulty = selectedDifficulty
+                                    dealRound()
+                                }
+                            }
+                        } label: {
+                            controlLabel(title: "Difficulty", value: difficulty.menuLabel, tint: MatherTheme.warm)
+                        }
+                        .accessibilityIdentifier("memory-difficulty-menu")
                     }
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(difficulty == d ? .white : MatherTheme.ink)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(difficulty == d ? MatherTheme.warm : MatherTheme.card)
-                    .clipShape(Capsule())
                 }
             }
         }
+    }
+
+    private func controlLabel(title: String, value: String, tint: Color) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                Text(value)
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(MatherTheme.ink)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+            }
+
+            Spacer(minLength: 12)
+
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(tint)
+                .padding(10)
+                .background(tint.opacity(colorScheme == .dark ? 0.24 : 0.12), in: Capsule())
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MatherTheme.background.opacity(colorScheme == .dark ? 0.4 : 1), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
     }
 
     // MARK: - Card grid

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -25,126 +25,65 @@ struct SpotPromptView: View {
             spotColour
                 .ignoresSafeArea()
 
-            VStack(spacing: 32) {
-                Spacer()
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 24) {
+                    Color.clear
+                        .frame(height: 88)
 
-                Text(spotLabel)
-                    .font(.system(size: 48, weight: .black, design: .rounded))
-                    .foregroundStyle(.white)
-
-                Text(station?.role.icon ?? "✨")
-                    .font(.system(size: 72))
-
-                if let station {
-                    Text(station.referenceCaptureState == .captured ? "Recheck the saved \(station.role.title) place." : "Scan to find \(station.role.title).")
-                        .font(.title3.weight(.bold))
-                        .foregroundStyle(.white.opacity(0.92))
+                    Text(spotLabel)
+                        .font(.system(size: 48, weight: .black, design: .rounded))
+                        .foregroundStyle(.white)
                         .multilineTextAlignment(.center)
-                        .padding(.horizontal, 28)
 
-                    Text("When the place matches, collect \(station.quantity) \(station.quantity == 1 ? "token" : "tokens").")
-                        .font(.title.weight(.semibold))
-                        .foregroundStyle(.white.opacity(0.84))
-                }
+                    Text(station?.role.icon ?? "✨")
+                        .font(.system(size: 72))
 
-                scanStatusCard
+                    if let station {
+                        Text(station.referenceCaptureState == .captured ? "Recheck the saved \(station.role.title) place." : "Scan to find \(station.role.title).")
+                            .font(.title3.weight(.bold))
+                            .foregroundStyle(.white.opacity(0.92))
+                            .multilineTextAlignment(.center)
 
-                CardSurface {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Label(engine.currentSpotReferenceLabel, systemImage: station?.referenceCaptureState == .captured ? "photo.badge.checkmark" : "photo")
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MatherTheme.ink)
-                        Divider()
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(engine.currentSpotStatusTitle)
-                                .font(.title3.weight(.black))
-                                .foregroundStyle(MatherTheme.ink)
-                            Text(engine.currentSpotSearchGuidance)
-                                .font(.subheadline)
-                                .foregroundStyle(MatherTheme.cardSubtitle)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
+                        Text("When the place matches, collect \(station.quantity) \(station.quantity == 1 ? "token" : "tokens").")
+                            .font(.title.weight(.semibold))
+                            .foregroundStyle(.white.opacity(0.84))
+                            .multilineTextAlignment(.center)
                     }
-                }
-                .padding(.horizontal, 24)
 
-                CardSurface {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Label("Grown-up helper", systemImage: "figure.and.child.holdinghands")
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MatherTheme.ink)
-                        Text("Kid steps: look, point, hold still, then collect.")
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(MatherTheme.ink)
-                        Text(engine.shouldShowSpotManualFallback
-                             ? "The camera missed this place. A grown-up can use fallback now."
-                             : "Start with a camera check. Fallback stays hidden unless the scan misses, so the camera feels like the real helper.")
-                            .font(.subheadline)
-                            .foregroundStyle(MatherTheme.cardSubtitle)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-                .padding(.horizontal, 24)
+                    scanStatusCard
 
-                Spacer()
+                    referenceCard
 
-                // Reference thumbnail — shows the saved photo so the child knows where to go
-                if let imageData = station?.referenceImageJPEGData,
-                   let uiImage = UIImage(data: imageData) {
-                    CardSurface {
-                        HStack(spacing: 12) {
-                            Image(uiImage: uiImage)
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: 80, height: 80)
-                                .clipShape(RoundedRectangle(cornerRadius: 10))
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Find this place")
-                                    .font(.headline.weight(.bold))
-                                    .foregroundStyle(MatherTheme.ink)
-                                Text("Walk to where this photo was taken")
-                                    .font(.subheadline)
-                                    .foregroundStyle(MatherTheme.cardSubtitle)
-                                    .fixedSize(horizontal: false, vertical: true)
+                    helperCard
+
+                    if let imageData = station?.referenceImageJPEGData,
+                       let uiImage = UIImage(data: imageData) {
+                        CardSurface {
+                            HStack(spacing: 12) {
+                                Image(uiImage: uiImage)
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: 80, height: 80)
+                                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Find this place")
+                                        .font(.headline.weight(.bold))
+                                        .foregroundStyle(MatherTheme.ink)
+                                    Text("Walk to where this photo was taken")
+                                        .font(.subheadline)
+                                        .foregroundStyle(MatherTheme.cardSubtitle)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
                             }
                         }
                     }
-                    .padding(.horizontal, 24)
                 }
-
-                // Camera scan button — only active for stations with a saved photo reference
-                if station?.referenceCaptureState == .captured {
-                    let isScanBusy: Bool = {
-                        switch engine.scanState {
-                        case .scanning, .celebrating: return true
-                        default: return false
-                        }
-                    }()
-                    Button {
-                        engine.verifyCurrentSpotWithCamera()
-                    } label: {
-                        Label("Recheck this place", systemImage: "camera.viewfinder")
-                    }
-                    .accessibilityIdentifier("room-spot-scan-button")
-                    .buttonStyle(RoomQuestPrimaryButtonStyle())
-                    .disabled(isScanBusy)
-                    .opacity(isScanBusy ? 0.7 : 1)
-                    .padding(.horizontal, 40)
-                }
-
-                if engine.shouldShowSpotManualFallback {
-                    Button(station?.role.fallbackButtonTitle ?? "I found it") {
-                        engine.markSpotVisited(index: spotIndex)
-                    }
-                    .accessibilityIdentifier("room-spot-confirm-button")
-                    .buttonStyle(.plain)
-                    .font(.headline.weight(.bold))
-                    .foregroundStyle(.white.opacity(0.92))
-                    .padding(.horizontal, 40)
-                    .padding(.bottom, 40)
-                } else {
-                    Spacer().frame(height: 40)
-                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 24)
+                .padding(.bottom, 24)
+            }
+            .safeAreaInset(edge: .bottom) {
+                actionBar
             }
 
             HStack(spacing: 12) {
@@ -160,6 +99,95 @@ struct SpotPromptView: View {
         }
     }
 
+    private var referenceCard: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                Label(engine.currentSpotReferenceLabel, systemImage: station?.referenceCaptureState == .captured ? "photo.badge.checkmark" : "photo")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.ink)
+                Divider()
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(engine.currentSpotStatusTitle)
+                        .font(.title3.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text(engine.currentSpotSearchGuidance)
+                        .font(.subheadline)
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    private var helperCard: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 10) {
+                Label("Grown-up helper", systemImage: "figure.and.child.holdinghands")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.ink)
+                Text("Kid steps: look, point, hold still, then collect.")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.ink)
+                Text(engine.shouldShowSpotManualFallback
+                     ? "The camera missed this place. A grown-up can use fallback now."
+                     : "Start with a camera check. Fallback stays hidden unless the scan misses, so the camera feels like the real helper.")
+                    .font(.subheadline)
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var actionBar: some View {
+        VStack(spacing: 12) {
+            if station?.referenceCaptureState == .captured {
+                let isScanBusy: Bool = {
+                    switch engine.scanState {
+                    case .scanning, .celebrating: return true
+                    default: return false
+                    }
+                }()
+
+                Button {
+                    engine.verifyCurrentSpotWithCamera()
+                } label: {
+                    Label("Recheck this place", systemImage: "camera.viewfinder")
+                }
+                .accessibilityIdentifier("room-spot-scan-button")
+                .buttonStyle(RoomQuestPrimaryButtonStyle())
+                .disabled(isScanBusy)
+                .opacity(isScanBusy ? 0.7 : 1)
+            }
+
+            if engine.shouldShowSpotManualFallback {
+                Button(station?.role.fallbackButtonTitle ?? "I found it") {
+                    engine.markSpotVisited(index: spotIndex)
+                }
+                .accessibilityIdentifier("room-spot-confirm-button")
+                .buttonStyle(.plain)
+                .font(.headline.weight(.bold))
+                .foregroundStyle(.white.opacity(0.92))
+            } else if station?.referenceCaptureState == .captured {
+                Text("Try the camera first. Fallback appears only if the scan misses.")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.white.opacity(0.88))
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 12)
+        .padding(.bottom, 24)
+        .background {
+            LinearGradient(
+                colors: [spotColour.opacity(0), spotColour.opacity(0.92), spotColour],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+        }
+    }
+
     @ViewBuilder
     private var scanStatusCard: some View {
         switch engine.scanState {
@@ -171,28 +199,24 @@ struct SpotPromptView: View {
                     .font(.headline.weight(.semibold))
                     .foregroundStyle(MatherTheme.ink)
             }
-            .padding(.horizontal, 24)
         case .celebrating(let role, _):
             CardSurface {
                 Label("\(role.title) unlocked!", systemImage: "sparkles")
                     .font(.headline.weight(.semibold))
                     .foregroundStyle(MatherTheme.accent)
             }
-            .padding(.horizontal, 24)
         case .almost(_, let message):
             CardSurface {
                 Label(message, systemImage: "scope")
                     .font(.headline.weight(.semibold))
                     .foregroundStyle(MatherTheme.warm)
             }
-            .padding(.horizontal, 24)
         case .failed(_, let message):
             CardSurface {
                 Label(message, systemImage: "exclamationmark.triangle.fill")
                     .font(.headline.weight(.semibold))
                     .foregroundStyle(MatherTheme.coral)
             }
-            .padding(.horizontal, 24)
         }
     }
 }

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -42,6 +42,98 @@ final class CompactLayoutTests: XCTestCase {
         XCTAssertTrue(rightFive.isHittable, "Expected Bond Blast actions to be reachable without additional scrolling")
     }
 
+    func testRoomQuestCompactSpotScreenKeepsPrimaryActionReachableWithoutSwipe() {
+        let app = launch()
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
+
+        openExplorerLab(app)
+        app.buttons["Room Quest"].tap()
+        _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 10)
+
+        configureRoomQuestSetupViaManualFallback(app)
+        app.buttons["Ready, start Room Quest!"].tap()
+
+        XCTAssertTrue(app.staticTexts["Red Rocket"].waitForExistence(timeout: 10))
+
+        let scanButton = app.buttons["room-spot-scan-button"]
+        let scanLabelButton = app.buttons["Recheck this place"]
+        let fallbackButton = app.buttons["room-spot-confirm-button"]
+
+        let foundPrimaryAction = scanButton.waitForExistence(timeout: 2)
+            || scanLabelButton.waitForExistence(timeout: 2)
+            || fallbackButton.waitForExistence(timeout: 2)
+        XCTAssertTrue(foundPrimaryAction, "Expected a Room Quest primary action to appear on the compact spot screen")
+
+        let visiblePrimaryAction = scanButton.exists ? scanButton : (scanLabelButton.exists ? scanLabelButton : fallbackButton)
+        XCTAssertTrue(visiblePrimaryAction.isHittable, "Expected Room Quest primary action to stay reachable without scrolling on compact layouts")
+    }
+
+    func testMemoryCompactHeaderKeepsControlsReachableWithoutCrowding() {
+        let app = launch()
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
+
+        openExplorerLab(app)
+        app.buttons["Memory Match"].tap()
+        _ = app.staticTexts["Memory Match"].waitForExistence(timeout: 10)
+
+        let deckMenu = app.buttons["memory-deck-menu"]
+        let difficultyMenu = app.buttons["memory-difficulty-menu"]
+        XCTAssertTrue(deckMenu.waitForExistence(timeout: 5))
+        XCTAssertTrue(difficultyMenu.waitForExistence(timeout: 5))
+        XCTAssertTrue(deckMenu.isHittable, "Expected Memory deck control to remain reachable on compact layouts")
+        XCTAssertTrue(difficultyMenu.isHittable, "Expected Memory difficulty control to remain reachable on compact layouts")
+    }
+
+    private func configureRoomQuestSetupViaManualFallback(_ app: XCUIApplication) {
+        let redCard = app.otherElements["room-station-card-redRocket"]
+        let blueCard = app.otherElements["room-station-card-blueBubble"]
+
+        XCTAssertTrue(redCard.waitForExistence(timeout: 5))
+        XCTAssertTrue(blueCard.waitForExistence(timeout: 5))
+
+        redCard.buttons["Scan station marker"].tap()
+        XCTAssertTrue(app.staticTexts["room-scan-status"].waitForExistence(timeout: 5))
+        tapWhenHittable(redCard.buttons["Save same-place fallback"], in: app)
+
+        blueCard.buttons["Scan station marker"].tap()
+        XCTAssertTrue(app.staticTexts["room-scan-status"].waitForExistence(timeout: 5))
+        tapWhenHittable(blueCard.buttons["Save same-place fallback"], in: app)
+    }
+
+    private func tapWhenHittable(_ element: XCUIElement, in app: XCUIApplication) {
+        XCTAssertTrue(element.waitForExistence(timeout: 5))
+        for _ in 0..<6 {
+            if element.isHittable {
+                element.tap()
+                return
+            }
+            app.swipeUp()
+        }
+        if element.exists {
+            element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+            return
+        }
+        XCTFail("Expected element to exist before tap fallback: \(element)")
+    }
+
+    private func openExplorerLab(_ app: XCUIApplication) {
+        app.buttons["ExplorerLab"].tap()
+        _ = app.staticTexts["Explorer Lab"].waitForExistence(timeout: 5)
+    }
+
+    private func launch() -> XCUIApplication {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.testModeEnabled", "YES",
+            "-feature.roomQuestSafetyAcknowledged", "YES"
+        ]
+        app.launch()
+        return app
+    }
+
     private func launchWithVS1() -> XCUIApplication {
         continueAfterFailure = false
         let app = XCUIApplication()


### PR DESCRIPTION
## Summary
- make Room Quest spot prompts resilient on compact layouts by scrolling content and pinning the primary action bar
- simplify Memory Match header controls into stacked menu rows so the pre-game header no longer crowds small layouts
- add compact-layout UI coverage for Room Quest and Memory Match using the generated-project test path

## Validation
- remote generated project: `/tmp/mather-fullscope-ET6DGV/repo`
- `/tmp/mather-fullscope-ET6DGV/xcodegen/bin/xcodegen generate`
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,id=3A1BD382-28BD-4285-83B4-B6913DF496C4" -only-testing:MatherUITests/RoomQuestUITests/testRoomQuestSpotPromptScreensAdvanceCorrectly -only-testing:MatherUITests/CompactLayoutTests/testRoomQuestCompactSpotScreenKeepsPrimaryActionReachableWithoutSwipe -only-testing:MatherUITests/CompactLayoutTests/testMemoryCompactHeaderKeepsControlsReachableWithoutCrowding`

## Notes
- validation was run against the same generated-project flow CI uses, not the stale checked-in project file
- compact Room Quest coverage uses the manual-fallback setup path to avoid the earlier brittle Settings toggle dependency