### PR TITLE
fix(protractor): clear sticky success state after drift

### DIFF
--- a/Features/TwoFingerProtractor/TwoFingerProtractorView.swift
+++ b/Features/TwoFingerProtractor/TwoFingerProtractorView.swift
@@ -24,6 +24,14 @@ enum ProtractorMath {
     static func isInSnapZone(measured: Double, target: Double, tolerance: Double = 5) -> Bool {
         abs(measured - target) <= tolerance
     }
+
+    static func matchTransition(previouslyMatched: Bool,
+                                measured: Double,
+                                target: Double,
+                                tolerance: Double = 5) -> (matched: Bool, newlyMatched: Bool) {
+        let matched = isInSnapZone(measured: measured, target: target, tolerance: tolerance)
+        return (matched, matched && !previouslyMatched)
+    }
 }
 
 // MARK: - UIKit multi-touch view
@@ -373,10 +381,13 @@ struct TwoFingerProtractorView: View {
         measuredAngle = angle
         showDegreeLabel = true
 
-        let snapped = ProtractorMath.isInSnapZone(measured: angle, target: level.targetAngle,
-                                                   tolerance: level.snapTolerance)
-        if snapped && !matched {
-            matched = true
+        let transition = ProtractorMath.matchTransition(previouslyMatched: matched,
+                                                        measured: angle,
+                                                        target: level.targetAngle,
+                                                        tolerance: level.snapTolerance)
+        matched = transition.matched
+
+        if transition.newlyMatched {
             wonCount += 1
             appModel.hapticsService.success(enabled: appModel.featureFlags.hapticsEnabled)
             appModel.speechService.speak(

--- a/Tests/MatherTests/TwoFingerProtractorTests.swift
+++ b/Tests/MatherTests/TwoFingerProtractorTests.swift
@@ -129,4 +129,20 @@ struct TwoFingerProtractorTests {
         #expect(ProtractorMath.isInSnapZone(measured: 86, target: 90, tolerance: 4))
         #expect(!ProtractorMath.isInSnapZone(measured: 85, target: 90, tolerance: 4))
     }
+
+    @Test func matchTransitionClearsStickySuccessWhenAngleDriftsOut() {
+        let entered = ProtractorMath.matchTransition(previouslyMatched: false,
+                                                     measured: 90,
+                                                     target: 90,
+                                                     tolerance: 5)
+        #expect(entered.matched)
+        #expect(entered.newlyMatched)
+
+        let drifted = ProtractorMath.matchTransition(previouslyMatched: true,
+                                                     measured: 104,
+                                                     target: 90,
+                                                     tolerance: 5)
+        #expect(!drifted.matched)
+        #expect(!drifted.newlyMatched)
+    }
 }


### PR DESCRIPTION
## Summary\n- clear the Two-Finger Protractor success state immediately when the live angle leaves the snap tolerance\n- keep the celebration/haptic path one-shot by tracking only fresh snap entries\n- add a regression test for the enter-snap then drift-out sequence\n\n## Testing\n- not run (Linux workspace, no Xcode available)\n\n## Context\n- addresses TestFlight feedback issue #266 ("Even The angle is wrong it says it is right")