### PR TITLE
fix(vs1): default release sessions to random 1-20

### DIFF
--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -69,7 +69,7 @@ struct HomeView: View {
                             Text("Make & Break")
                                 .font(.title3.weight(.black))
                                 .foregroundStyle(.white)
-                            Text("to 10")
+                            Text("1–20")
                                 .font(.system(size: 36, weight: .black, design: .rounded))
                                 .foregroundStyle(.white)
                         }

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -138,7 +138,7 @@ final class FeatureFlagService {
         // which object(forKey:) as? Bool does not.
         defaults.register(defaults: [
             Keys.verticalSlice1Enabled: false,
-            Keys.testModeEnabled: true,
+            Keys.testModeEnabled: false,
             Keys.audioEnabled: true,
             Keys.hapticsEnabled: true,
             Keys.selectedThemeId: "classic",

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -30,7 +30,7 @@ struct FeatureFlagTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.selectedThemeId = "vehicle"
         // Defaults should still be what FeatureFlagService registers
-        #expect(flags.testModeEnabled == true)
+        #expect(flags.testModeEnabled == false)
         #expect(flags.audioEnabled == true)
         #expect(flags.hapticsEnabled == true)
     }


### PR DESCRIPTION
## Summary
- default Make & Break sessions to non-deterministic mode in normal builds
- update the home card copy to say `1–20` instead of `to 10`
- adjust the feature-flag default test to match the release-safe default

## Testing
- `git diff --check`
- not run: Xcode tests unavailable in this Linux coordinator workspace

## Context
- addresses TestFlight feedback issue #263 about VS1 feeling fixed to 1–10 and not starting from a random number
