### PR TITLE
fix(bond-blast): hide matches until a pick is made

### DIFF
--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -102,6 +102,9 @@ struct BondMatchView: View {
             Text("Make \(state.target)")
                 .font(.title2.weight(.bold))
                 .foregroundStyle(MatherTheme.warm)
+            Text(selectedPairId == nil ? "Pick a number first" : "Now find its match")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity)
     }
@@ -163,7 +166,7 @@ struct BondMatchView: View {
         } label: {
             ZStack(alignment: .topTrailing) {
                 numberCardFill(
-                    value: pair.left,
+                    value: String(pair.left),
                     textColor: isMatched ? MatherTheme.accent : .white,
                     background: isMatched
                         ? MatherTheme.accent.opacity(0.15)
@@ -240,6 +243,11 @@ struct BondMatchView: View {
         let isMatched   = state.pairs.first(where: { $0.right == value })?.isMatched == true
         let isWobbling  = mismatchedRightValue == value
         let isActivated = selectedPairId != nil && !isMatched
+        let shownValue = Self.visibleRightValue(
+            selectedPairId: selectedPairId,
+            rightValue: value,
+            state: state
+        )
 
         Button {
             guard let selId = selectedPairId,
@@ -255,8 +263,10 @@ struct BondMatchView: View {
             }
         } label: {
             numberCardFill(
-                value: value,
-                textColor: isMatched ? MatherTheme.softBlue : MatherTheme.ink,
+                value: shownValue.map(String.init) ?? "?",
+                textColor: isMatched
+                    ? MatherTheme.softBlue
+                    : (shownValue == nil ? .secondary : MatherTheme.ink),
                 background: isMatched
                     ? MatherTheme.softBlue.opacity(0.15)
                     : (isActivated ? MatherTheme.softBlue.opacity(0.18) : Color.secondary.opacity(0.08)),
@@ -277,22 +287,31 @@ struct BondMatchView: View {
                 : .default,
             value: isWobbling
         )
-        .accessibilityLabel("\(value)\(isMatched ? ", matched" : "")")
+        .accessibilityLabel(shownValue.map { "\($0)\(isMatched ? ", matched" : "")" } ?? "Hidden match")
         .accessibilityIdentifier("bond-right-\(value)")
     }
 
     // MARK: - Shared card fill
 
+    nonisolated static func visibleRightValue(
+        selectedPairId: UUID?,
+        rightValue: Int,
+        state: BondMatchState
+    ) -> Int? {
+        let isMatched = state.pairs.first(where: { $0.right == rightValue })?.isMatched == true
+        return (selectedPairId != nil || isMatched) ? rightValue : nil
+    }
+
     @ViewBuilder
     private func numberCardFill(
-        value: Int,
+        value: String,
         textColor: Color,
         background: Color,
         strokeColor: Color,
         strokeWidth: CGFloat,
         dashed: Bool
     ) -> some View {
-        Text("\(value)")
+        Text(value)
             .font(.system(size: 38, weight: .black, design: .rounded))
             .foregroundStyle(textColor)
             .frame(width: cardSize, height: cardSize)

--- a/Tests/MatherTests/BondMatchViewTests.swift
+++ b/Tests/MatherTests/BondMatchViewTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import Mather
+
+struct BondMatchViewTests {
+    @Test func hidesUnmatchedRightValuesUntilSelection() {
+        let state = BondMatchState(target: 6, pairs: BondMatchState.makePairs(for: 6))
+        let right = state.pairs[0].right
+        #expect(BondMatchView.visibleRightValue(selectedPairId: nil, rightValue: right, state: state) == nil)
+    }
+
+    @Test func revealsRightValuesAfterSelection() {
+        let state = BondMatchState(target: 6, pairs: BondMatchState.makePairs(for: 6))
+        let selected = state.pairs[0].id
+        let right = state.pairs[1].right
+        #expect(BondMatchView.visibleRightValue(selectedPairId: selected, rightValue: right, state: state) == right)
+    }
+
+    @Test func matchedRightValuesStayVisibleWithoutSelection() {
+        var state = BondMatchState(target: 6, pairs: BondMatchState.makePairs(for: 6))
+        state.pairs[0].isMatched = true
+        let right = state.pairs[0].right
+        #expect(BondMatchView.visibleRightValue(selectedPairId: nil, rightValue: right, state: state) == right)
+    }
+}


### PR DESCRIPTION
## Summary
- hide unmatched right-side Bond Blast values until the child picks a left card
- add lightweight coaching text so the two-step interaction is clearer
- add focused tests for right-side reveal behavior

## Testing
- unit tests added for reveal logic
- host validation only: `xcodebuild` is not available in this Linux coordinator environment, so GitHub CI will verify the iOS test run