### PR TITLE
fix(memory): keep labels readable on one line

### DIFF
--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -347,11 +347,41 @@ struct MemoryView: View {
                 RoundedRectangle(cornerRadius: 16, style: .continuous)
                     .fill(card.isMatched ? Color.green.opacity(0.15) : MatherTheme.softBlue.opacity(0.18))
                 Text(name)
-                    .font(.system(size: 20, weight: .black, design: .rounded))
+                    .font(.system(size: Self.labelFontSize(for: difficulty), weight: .black, design: .rounded))
                     .foregroundStyle(MatherTheme.ink)
+                    .lineLimit(1)
+                    .minimumScaleFactor(Self.labelMinimumScaleFactor(for: difficulty))
+                    .allowsTightening(true)
+                    .truncationMode(.tail)
                     .multilineTextAlignment(.center)
-                    .padding(8)
+                    .padding(.horizontal, Self.labelHorizontalPadding(for: difficulty))
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity)
             }
+        }
+    }
+
+    static func labelFontSize(for difficulty: MemoryDifficulty) -> CGFloat {
+        switch difficulty {
+        case .easy: return 22
+        case .medium: return 20
+        case .hard: return 18
+        }
+    }
+
+    static func labelMinimumScaleFactor(for difficulty: MemoryDifficulty) -> CGFloat {
+        switch difficulty {
+        case .easy: return 0.82
+        case .medium: return 0.76
+        case .hard: return 0.68
+        }
+    }
+
+    static func labelHorizontalPadding(for difficulty: MemoryDifficulty) -> CGFloat {
+        switch difficulty {
+        case .easy: return 10
+        case .medium: return 8
+        case .hard: return 6
         }
     }
 

--- a/Tests/MatherTests/MemoryTextFitTests.swift
+++ b/Tests/MatherTests/MemoryTextFitTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import Mather
+
+@Suite("MemoryTextFit")
+struct MemoryTextFitTests {
+
+    @Test func labelFontSizeStepsDownAsGridGetsTighter() {
+        #expect(MemoryView.labelFontSize(for: .easy) > MemoryView.labelFontSize(for: .medium))
+        #expect(MemoryView.labelFontSize(for: .medium) > MemoryView.labelFontSize(for: .hard))
+    }
+
+    @Test func labelPaddingShrinksForDenserLayouts() {
+        #expect(MemoryView.labelHorizontalPadding(for: .easy) > MemoryView.labelHorizontalPadding(for: .medium))
+        #expect(MemoryView.labelHorizontalPadding(for: .medium) > MemoryView.labelHorizontalPadding(for: .hard))
+    }
+
+    @Test func minimumScaleFactorGetsMorePermissiveInHardMode() {
+        #expect(MemoryView.labelMinimumScaleFactor(for: .easy) > MemoryView.labelMinimumScaleFactor(for: .medium))
+        #expect(MemoryView.labelMinimumScaleFactor(for: .medium) > MemoryView.labelMinimumScaleFactor(for: .hard))
+    }
+
+    @Test func longestCurrentLabelsHaveFallbackHeadroom() {
+        let labels = (MemoryDeck.domesticAnimals + MemoryDeck.birds + MemoryDeck.vehicles).map(\.name)
+        let longestLabel = labels.max { $0.count < $1.count }
+        #expect(longestLabel == "Blackbird")
+        #expect(longestLabel?.count == 10)
+        #expect(MemoryView.labelMinimumScaleFactor(for: .hard) >= 0.68)
+    }
+}

--- a/Tests/MatherTests/MemoryTextFitTests.swift
+++ b/Tests/MatherTests/MemoryTextFitTests.swift
@@ -4,21 +4,25 @@ import Testing
 @Suite("MemoryTextFit")
 struct MemoryTextFitTests {
 
+    @MainActor
     @Test func labelFontSizeStepsDownAsGridGetsTighter() {
         #expect(MemoryView.labelFontSize(for: .easy) > MemoryView.labelFontSize(for: .medium))
         #expect(MemoryView.labelFontSize(for: .medium) > MemoryView.labelFontSize(for: .hard))
     }
 
+    @MainActor
     @Test func labelPaddingShrinksForDenserLayouts() {
         #expect(MemoryView.labelHorizontalPadding(for: .easy) > MemoryView.labelHorizontalPadding(for: .medium))
         #expect(MemoryView.labelHorizontalPadding(for: .medium) > MemoryView.labelHorizontalPadding(for: .hard))
     }
 
+    @MainActor
     @Test func minimumScaleFactorGetsMorePermissiveInHardMode() {
         #expect(MemoryView.labelMinimumScaleFactor(for: .easy) > MemoryView.labelMinimumScaleFactor(for: .medium))
         #expect(MemoryView.labelMinimumScaleFactor(for: .medium) > MemoryView.labelMinimumScaleFactor(for: .hard))
     }
 
+    @MainActor
     @Test func longestCurrentLabelsHaveFallbackHeadroom() {
         let labels = (MemoryDeck.domesticAnimals + MemoryDeck.birds + MemoryDeck.vehicles).map(\.name)
         let longestLabel = labels.max { $0.count < $1.count }

--- a/Tests/MatherTests/MemoryTextFitTests.swift
+++ b/Tests/MatherTests/MemoryTextFitTests.swift
@@ -27,7 +27,7 @@ struct MemoryTextFitTests {
         let labels = (MemoryDeck.domesticAnimals + MemoryDeck.birds + MemoryDeck.vehicles).map(\.name)
         let longestLabel = labels.max { $0.count < $1.count }
         #expect(longestLabel == "Blackbird")
-        #expect(longestLabel?.count == 10)
+        #expect(longestLabel?.count == 9)
         #expect(MemoryView.labelMinimumScaleFactor(for: .hard) >= 0.68)
     }
 }


### PR DESCRIPTION
## Summary
- make Memory Match label cards prefer a single-line presentation
- tune label font size, scaling, and padding by difficulty
- add tests covering the text-fit helper behavior

## Why
- addresses #287, split from TestFlight feedback bundle #272
- keeps text cards cleaner on compact layouts without changing deck content

## Testing
- added `MemoryTextFitTests` for difficulty-aware font sizing, padding, and scaling behavior