### PR TITLE
feat(memory): expand Memory Match variety across rounds

### DIFF
--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -37,6 +37,12 @@ enum MemoryDeck {
         MemoryAnimal(id: "goat",     emoji: "🐐", name: "Goat"),
         MemoryAnimal(id: "turkey",   emoji: "🦃", name: "Turkey"),
         MemoryAnimal(id: "goldfish", emoji: "🐟", name: "Goldfish"),
+        MemoryAnimal(id: "mouse",    emoji: "🐁", name: "Mouse"),
+        MemoryAnimal(id: "frog",     emoji: "🐸", name: "Frog"),
+        MemoryAnimal(id: "camel",    emoji: "🐪", name: "Camel"),
+        MemoryAnimal(id: "llama",    emoji: "🦙", name: "Llama"),
+        MemoryAnimal(id: "donkey",   emoji: "🫏", name: "Donkey"),
+        MemoryAnimal(id: "ox",       emoji: "🐂", name: "Ox"),
     ]
 
     static let birds: [MemoryAnimal] = [
@@ -52,6 +58,12 @@ enum MemoryDeck {
         MemoryAnimal(id: "turkey",    emoji: "🦃", name: "Turkey"),
         MemoryAnimal(id: "dove",      emoji: "🕊️", name: "Dove"),
         MemoryAnimal(id: "blackbird", emoji: "🐦⬛", name: "Blackbird"),
+        MemoryAnimal(id: "babychick", emoji: "🐤", name: "Chick"),
+        MemoryAnimal(id: "hatchedchick", emoji: "🐥", name: "Hatchling"),
+        MemoryAnimal(id: "chicken",   emoji: "🐔", name: "Chicken"),
+        MemoryAnimal(id: "phoenix",   emoji: "🐦🔥", name: "Firebird"),
+        MemoryAnimal(id: "goose",     emoji: "🪿", name: "Goose"),
+        MemoryAnimal(id: "duckling",  emoji: "🦤", name: "Runner Bird"),
     ]
 
     static let vehicles: [MemoryAnimal] = [
@@ -129,6 +141,7 @@ struct MemoryView: View {
     @State private var isProcessingMismatch: Bool = false
     @State private var showRoundComplete: Bool = false
     @State private var deckSelection: DeckSelection = .domestic
+    @State private var recentPairHistory: [String] = []
 
     enum DeckSelection: CaseIterable {
         case domestic, birds, vehicles
@@ -437,13 +450,34 @@ struct MemoryView: View {
 
     // MARK: - Game logic
 
+    static func preferredRoundAnimals(from deck: [MemoryAnimal], pairCount: Int, recentPairHistory: [String]) -> [MemoryAnimal] {
+        let recentSet = Set(recentPairHistory)
+        let freshPool = deck.filter { !recentSet.contains($0.id) }
+        let primaryPool = freshPool.count >= pairCount ? freshPool : deck
+
+        var chosen = Array(primaryPool.shuffled().prefix(pairCount))
+        if chosen.count < pairCount {
+            let chosenIds = Set(chosen.map(\.id))
+            let fallback = deck.filter { !chosenIds.contains($0.id) }.shuffled()
+            chosen.append(contentsOf: fallback.prefix(pairCount - chosen.count))
+        }
+        return chosen
+    }
+
+    static func updatedRecentPairHistory(previous: [String], newRoundAnimals: [MemoryAnimal], pairCount: Int) -> [String] {
+        let historyWindow = max(pairCount * 2, pairCount)
+        let combined = previous + newRoundAnimals.map(\.id)
+        return Array(combined.suffix(historyWindow))
+    }
+
     private func dealRound() {
-        let shuffled = deck.shuffled().prefix(totalPairs)
+        let roundAnimals = Self.preferredRoundAnimals(from: deck, pairCount: totalPairs, recentPairHistory: recentPairHistory)
         var newCards: [MemoryCard] = []
-        for animal in shuffled {
+        for animal in roundAnimals {
             newCards.append(MemoryCard(pairId: animal.id, content: .picture(emoji: animal.emoji)))
             newCards.append(MemoryCard(pairId: animal.id, content: .label(name: animal.name)))
         }
+        recentPairHistory = Self.updatedRecentPairHistory(previous: recentPairHistory, newRoundAnimals: roundAnimals, pairCount: totalPairs)
         cards = newCards.shuffled()
         firstSelected = nil
         matchedPairs = 0

--- a/Tests/MatherTests/MemoryTextFitTests.swift
+++ b/Tests/MatherTests/MemoryTextFitTests.swift
@@ -26,8 +26,8 @@ struct MemoryTextFitTests {
     @Test func longestCurrentLabelsHaveFallbackHeadroom() {
         let labels = (MemoryDeck.domesticAnimals + MemoryDeck.birds + MemoryDeck.vehicles).map(\.name)
         let longestLabel = labels.max { $0.count < $1.count }
-        #expect(longestLabel == "Blackbird")
-        #expect(longestLabel?.count == 9)
+        #expect(longestLabel == "Runner Bird")
+        #expect(longestLabel?.count == 11)
         #expect(MemoryView.labelMinimumScaleFactor(for: .hard) >= 0.68)
     }
 }

--- a/Tests/MatherTests/MemoryVarietyTests.swift
+++ b/Tests/MatherTests/MemoryVarietyTests.swift
@@ -1,0 +1,42 @@
+import Testing
+@testable import Mather
+
+@Suite("MemoryVariety")
+struct MemoryVarietyTests {
+
+    @Test func domesticAndBirdDecksHaveExpandedPools() {
+        #expect(MemoryDeck.domesticAnimals.count >= 18)
+        #expect(MemoryDeck.birds.count >= 18)
+    }
+
+    @Test func preferredRoundAnimalsAvoidsRecentHistoryWhenFreshPoolIsLargeEnough() {
+        let deck = MemoryDeck.domesticAnimals
+        let recent = Array(deck.prefix(6).map(\.id))
+
+        let round = MemoryView.preferredRoundAnimals(from: deck, pairCount: 4, recentPairHistory: recent)
+
+        #expect(round.count == 4)
+        #expect(Set(round.map(\.id)).count == 4)
+        #expect(round.allSatisfy { !recent.contains($0.id) })
+    }
+
+    @Test func preferredRoundAnimalsFallsBackToDeckWhenRecentHistoryCoversMostOptions() {
+        let deck = Array(MemoryDeck.birds.prefix(6))
+        let recent = deck.map(\.id)
+
+        let round = MemoryView.preferredRoundAnimals(from: deck, pairCount: 4, recentPairHistory: recent)
+
+        #expect(round.count == 4)
+        #expect(Set(round.map(\.id)).count == 4)
+    }
+
+    @Test func updatedRecentPairHistoryKeepsRecentWindowBounded() {
+        let previous = ["a", "b", "c", "d", "e", "f", "g", "h"]
+        let round = Array(MemoryDeck.vehicles.prefix(4))
+
+        let updated = MemoryView.updatedRecentPairHistory(previous: previous, newRoundAnimals: round, pairCount: 4)
+
+        #expect(updated.count == 8)
+        #expect(updated.suffix(4).elementsEqual(round.map(\.id)))
+    }
+}

--- a/Tests/MatherTests/MemoryVarietyTests.swift
+++ b/Tests/MatherTests/MemoryVarietyTests.swift
@@ -9,7 +9,7 @@ struct MemoryVarietyTests {
         #expect(MemoryDeck.birds.count >= 18)
     }
 
-    @Test func preferredRoundAnimalsAvoidsRecentHistoryWhenFreshPoolIsLargeEnough() {
+    @MainActor @Test func preferredRoundAnimalsAvoidsRecentHistoryWhenFreshPoolIsLargeEnough() {
         let deck = MemoryDeck.domesticAnimals
         let recent = Array(deck.prefix(6).map(\.id))
 
@@ -20,7 +20,7 @@ struct MemoryVarietyTests {
         #expect(round.allSatisfy { !recent.contains($0.id) })
     }
 
-    @Test func preferredRoundAnimalsFallsBackToDeckWhenRecentHistoryCoversMostOptions() {
+    @MainActor @Test func preferredRoundAnimalsFallsBackToDeckWhenRecentHistoryCoversMostOptions() {
         let deck = Array(MemoryDeck.birds.prefix(6))
         let recent = deck.map(\.id)
 
@@ -30,7 +30,7 @@ struct MemoryVarietyTests {
         #expect(Set(round.map(\.id)).count == 4)
     }
 
-    @Test func updatedRecentPairHistoryKeepsRecentWindowBounded() {
+    @MainActor @Test func updatedRecentPairHistoryKeepsRecentWindowBounded() {
         let previous = ["a", "b", "c", "d", "e", "f", "g", "h"]
         let round = Array(MemoryDeck.vehicles.prefix(4))
 


### PR DESCRIPTION
## Summary
- expand the animal and bird card pools for Memory Match
- avoid immediately reusing recently seen pairs when enough fresh options exist
- add tests covering expanded pools and recent-history round selection

## Why
- addresses #290 from the remaining TestFlight Memory Match bundle
- makes repeated rounds feel less repetitive without changing the core mechanic

## Testing
- added `MemoryVarietyTests` for pool size, recent-history avoidance, and bounded history behavior