### PR TITLE
test(ui): align screenshot flow with incremental concrete taps

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -429,9 +429,11 @@ final class ScreenshotTests: XCTestCase {
             snapshot(app, "\(snapshotPrefix)-Concrete")
         }
 
-        let concreteCell = app.otherElements["counter-cell-\(concreteCellIndex)"]
-        XCTAssertTrue(concreteCell.waitForExistence(timeout: 5), "Expected concrete cell \(concreteCellIndex) for target \(target)")
-        concreteCell.tap()
+        for index in 0...concreteCellIndex {
+            let concreteCell = app.otherElements["counter-cell-\(index)"]
+            XCTAssertTrue(concreteCell.waitForExistence(timeout: 5), "Expected concrete cell \(index) for target \(target)")
+            concreteCell.tap()
+        }
         concreteSubmit.tap()
 
         let gravityTitle = app.staticTexts["Gravity Split"]


### PR DESCRIPTION
## Summary
- update the Issue 222 screenshot helper to tap concrete counters sequentially
- keep the concrete-build product behavior from #262 unchanged
- repair the recurring post-merge iOS UI review expectation on main

## Testing
- GitHub CI will validate the iOS screenshot lane