### PR TITLE
fix: prevent blank Bond Blast screen for target 1

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -183,8 +183,15 @@ final class VerticalSliceEngine {
         route = .session
     }
 
-    func updateConfig(problemCount: Int? = nil, audioEnabled: Bool? = nil) {
+    func updateConfig(
+        problemCount: Int? = nil,
+        minTarget: Int? = nil,
+        maxTarget: Int? = nil,
+        audioEnabled: Bool? = nil
+    ) {
         if let problemCount { config.maxProblems = problemCount }
+        if let minTarget { config.minTarget = minTarget }
+        if let maxTarget { config.maxTarget = maxTarget }
         if let audioEnabled { config.audioEnabled = audioEnabled }
     }
 
@@ -457,7 +464,7 @@ final class VerticalSliceEngine {
         feedbackMessage = successMessage
         speechService.speak(successMessage, enabled: featureFlags.audioEnabled)
 
-        let next = SliceStateMachine.nextStage(after: currentStage, success: true, routeMode: routeMode)
+        let next = resolvedNextStage(after: currentStage)
         recordStageTransition(from: currentStage, to: next)
 
         // A problem is complete when the next stage is .done (the last meaningful
@@ -750,13 +757,25 @@ final class VerticalSliceEngine {
             let a = currentProblem.decompositionA
             let b = currentProblem.decompositionB
             return "Use plus and minus to build \(a) on one side and \(b) on the other."
-        case .sumSprint:
-            if let card = sumSprintBurstState?.currentCard {
-                return "Quick Sum Sprint. Solve \(card.prompt), then finish with Bond Blast."
-            }
-            return "Quick Sum Sprint! Solve a tiny burst, then finish with Bond Blast."
         case .done:
             return "Nice work."
+        }
+    }
+
+    private func resolvedNextStage(after stage: SliceStage) -> SliceStage {
+        let candidate = SliceStateMachine.nextStage(after: stage, success: true, routeMode: routeMode)
+        guard let problem = currentProblem else { return candidate }
+
+        let hasBondPairs = !BondMatchState.makePairs(for: problem.target).isEmpty
+        guard !hasBondPairs else { return candidate }
+
+        switch candidate {
+        case .pictorial:
+            return .abstract
+        case .bondMatch:
+            return .done
+        default:
+            return candidate
         }
     }
 

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -492,6 +492,73 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
+    func targetOneSkipsBlankPictorialBondBlastStage() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.updateConfig(problemCount: 1, minTarget: 1, maxTarget: 1)
+        engine.startSession()
+
+        #expect(engine.currentProblem?.target == 1)
+
+        engine.adjustConcrete(by: 1)
+        engine.submitCurrentStage()
+
+        await waitFor("abstract stage after target-1 concrete") { engine.currentStage == .abstract }
+        #expect(engine.currentStage == .abstract)
+        #expect(engine.bondMatchState == nil)
+    }
+
+    @Test
+    func targetOneSkipsBlankBondBlastFinaleInLoopV2() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.updateConfig(problemCount: 1, minTarget: 1, maxTarget: 1)
+        engine.startSession()
+
+        #expect(engine.currentProblem?.target == 1)
+
+        engine.adjustConcrete(by: 1)
+        engine.submitCurrentStage()
+        await waitFor("gravity split after concrete") { engine.currentStage == .gravitySplit }
+
+        engine.adjustGravitySplitByTap(delta: 1, side: .left)
+        await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
+
+        while engine.currentStage == .sumSprint, let card = engine.sumSprintBurstState?.currentCard {
+            for digit in String(card.answer).compactMap(\.wholeNumberValue) {
+                engine.appendSumSprintDigit(digit)
+            }
+            engine.submitSumSprintCard()
+            if engine.currentStage == .sumSprint {
+                await waitFor("advance sum sprint card") {
+                    engine.sumSprintBurstState?.currentCard?.id != card.id || engine.currentStage != .sumSprint
+                }
+            }
+        }
+
+        await waitFor("session summary after target-1 loop") { engine.route == .sessionSummary }
+        #expect(engine.currentStage == .done)
+        #expect(engine.bondMatchState == nil)
+    }
+
+    @Test
     func matchPairGracefullyIgnoresUnknownPairId() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true


### PR DESCRIPTION
## Summary
- fix VerticalSliceEngine stage progression for target-1 Bond Blast flows so the game does not land on a blank first-pick screen
- add regression coverage around the target-1 path in VerticalSliceEngineTests
- keep the Bond Blast issue tracked via TestFlight feedback #307

## Notes
- This branch was pushed from the active fix investigation lane.
- Remote Mac validation was attempted but could not complete because SSH to `mba` was unreachable (`No route to host`), so GitHub CI is the first clean validation pass for this patch.

Closes #307