### PR TITLE
fix: keep session setup centered on iPad

### DIFF
--- a/Features/VerticalSlice1/SessionConfigView.swift
+++ b/Features/VerticalSlice1/SessionConfigView.swift
@@ -73,6 +73,8 @@ struct SessionConfigView: View {
                 }
                 .font(.headline.weight(.semibold))
             }
+            .frame(maxWidth: 760)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             .padding(24)
         }
     }


### PR DESCRIPTION
## Summary
- constrain `SessionConfigView` content to a centered regular-width column
- keep the session setup card and CTA shadows away from the tablet screen edge
- target the tiny clipped bottom-right artifact reported in TestFlight build 45

## Culprit hypothesis
The setup screen was stretching its card and CTA to the full regular-width layout. On iPad that leaves the rounded card/button shadows hugging the screen edge, which matches the tiny clipped black curve visible at the extreme bottom-right of the TestFlight screenshot.

## Validation
- not run locally: Linux workspace has no Swift/Xcode toolchain
- attempted remote Mac validation, but `ssh ganesh-mba` failed with `No route to host` during this run
