### PR TITLE
fix: prevent stale Sum Sprint X feedback after timer race

### DIFF
--- a/Domain/SumSprintEngine.swift
+++ b/Domain/SumSprintEngine.swift
@@ -180,8 +180,7 @@ final class SumSprintEngine {
     private func handleCorrect(isFirstTry: Bool) {
         timerTask?.cancel()
         timerTask = nil
-        feedbackTask?.cancel()
-        feedbackTask = nil
+        resetFeedbackState()
         let card = cards[currentCardIndex]
         cards[currentCardIndex].result = .correct(firstTry: isFirstTry)
 
@@ -220,8 +219,7 @@ final class SumSprintEngine {
     private func handleIncorrect() {
         timerTask?.cancel()
         timerTask = nil
-        feedbackTask?.cancel()
-        feedbackTask = nil
+        resetFeedbackState()
         let card = cards[currentCardIndex]
         let attempts = cards[currentCardIndex].attemptCount
         cards[currentCardIndex].result = .incorrect(attempts: attempts)
@@ -257,8 +255,7 @@ final class SumSprintEngine {
         guard phase == .session, currentCardIndex < cards.count else { return }
         timerTask?.cancel()
         timerTask = nil
-        feedbackTask?.cancel()
-        feedbackTask = nil
+        resetFeedbackState()
         cardTimeRemaining = 0
 
         let card = cards[currentCardIndex]
@@ -297,6 +294,14 @@ final class SumSprintEngine {
             self.feedbackTask = nil
             self.advanceCard()
         }
+    }
+
+    private func resetFeedbackState() {
+        feedbackTask?.cancel()
+        feedbackTask = nil
+        showCorrectFeedback = false
+        showIncorrectFeedback = false
+        showTimeoutFeedback = false
     }
 
     // MARK: - Private: card advancement
@@ -357,11 +362,15 @@ final class SumSprintEngine {
             cardTimeRemaining = 0
             return
         }
+        let cardID = cards.indices.contains(currentCardIndex) ? cards[currentCardIndex].id : nil
         cardTimeRemaining = secs
         timerTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 guard let self else { break }
                 try? await Task.sleep(nanoseconds: 100_000_000)  // 0.1 s tick
+                guard !Task.isCancelled else { break }
+                guard self.phase == .session, self.cards.indices.contains(self.currentCardIndex) else { break }
+                guard self.cards[self.currentCardIndex].id == cardID else { break }
                 self.cardTimeRemaining = max(0, self.cardTimeRemaining - 0.1)
                 if self.cardTimeRemaining <= 0 {
                     self.handleTimeout()

--- a/Tests/MatherTests/SumSprintEngineTests.swift
+++ b/Tests/MatherTests/SumSprintEngineTests.swift
@@ -394,6 +394,23 @@ struct SumSprintEngineTests {
     }
 
     @Test
+    func wrongAnswerNearExpiryDoesNotAlsoTriggerTimeout() async throws {
+        let (engine, _) = try makeEngine(feedbackDuration: 0.2)
+        engine.selectDifficulty(.standard)
+
+        engine.appendDigit(1)
+        engine.setCardTimeRemainingForTests(0.05)
+        engine.submitAnswer()
+
+        try await Task.sleep(for: .milliseconds(350))
+
+        #expect(engine.cards[0].timedOut == false)
+        #expect(engine.currentCardIndex == 0)
+        #expect(engine.showIncorrectFeedback == false)
+        #expect(engine.showTimeoutFeedback == false)
+    }
+
+    @Test
     func sprintTimeoutMarksCardForRequeueFlow() async throws {
         let (engine, _) = try makeEngine(feedbackDuration: 0)
         engine.selectDifficulty(.sprint)


### PR DESCRIPTION
## Summary
- stop the per-card timer task from mutating state after cancellation during the sleep boundary
- tie timer ticks to the active card id so an old task cannot time out a replaced card
- clear prior feedback flags before presenting new feedback, and add a regression test for wrong-submit near expiry

## Testing
- Not run in this environment (`swift` and `xcodebuild` are unavailable on this Linux host)
