### PR TITLE
fix(ci): make release workflow idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ jobs:
 
       - name: Create GitHub Release
         run: |
+          if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Release ${{ steps.version.outputs.tag }} already exists, skipping create."
+            exit 0
+          fi
+
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "Mather ${{ steps.version.outputs.tag }}" \
             --generate-notes \


### PR DESCRIPTION
## Summary
- make the release workflow succeed on reruns when the GitHub release already exists
- avoid failing the release job just because the tagged release was already created

## Testing
- not run locally
