### PR TITLE
Clean up parent settings rollout flags

### DIFF
--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -22,27 +22,6 @@ struct SettingsView: View {
         )
     }
 
-    private var bondMatchBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.vs1BondMatchEnabled },
-            set: { appModel.featureFlags.vs1BondMatchEnabled = $0 }
-        )
-    }
-
-    private var gravitySplitBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.vs1GravitySplitEnabled },
-            set: { appModel.featureFlags.vs1GravitySplitEnabled = $0 }
-        )
-    }
-
-    private var makeBreakLoopV2Binding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.makeBreakLoopV2Enabled },
-            set: { appModel.featureFlags.makeBreakLoopV2Enabled = $0 }
-        )
-    }
-
     private var motionBinding: Binding<Bool> {
         Binding(
             get: { appModel.featureFlags.motionControlsEnabled },
@@ -54,20 +33,6 @@ struct SettingsView: View {
         Binding(
             get: { appModel.featureFlags.soundReactionEnabled },
             set: { appModel.featureFlags.soundReactionEnabled = $0 }
-        )
-    }
-
-    private var testModeBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.testModeEnabled },
-            set: { appModel.featureFlags.testModeEnabled = $0 }
-        )
-    }
-
-    private var verticalSliceBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.verticalSlice1Enabled },
-            set: { appModel.featureFlags.verticalSlice1Enabled = $0 }
         )
     }
 
@@ -99,24 +64,10 @@ struct SettingsView: View {
                                 .font(.caption.weight(.semibold))
                                 .foregroundStyle(.secondary)
                                 .padding(.top, 4)
-                            Toggle("Make & Break 1–20", isOn: verticalSliceBinding)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.85)
-                            VS1ToggleRow(
-                                title: "Make & Break loop V2 (recovery)",
-                                subtitle: "Uses the reopened #222 route: Make it → Gravity Split → Sum Sprint → Bond Blast.",
-                                isOn: makeBreakLoopV2Binding
-                            )
-                            VS1ToggleRow(
-                                title: "Bond Blast finale",
-                                subtitle: "Adds a free-match bonus round after all bonds for a number are found.",
-                                isOn: bondMatchBinding
-                            )
-                            VS1ToggleRow(
-                                title: "Gravity Split (beta)",
-                                subtitle: "Replace the Show-it step with a tilt-powered balance scale activity.",
-                                isOn: gravitySplitBinding
-                            )
+                            Text("Make & Break, Bond Blast, Gravity Split, and the current loop ship on by default.")
+                                .font(.subheadline)
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                                .fixedSize(horizontal: false, vertical: true)
 
                             Divider()
 
@@ -158,7 +109,6 @@ struct SettingsView: View {
                                 subtitle: "Listens for a clap to trigger celebrations (uses microphone).",
                                 isOn: soundReactionBinding
                             )
-                            Toggle("Test mode", isOn: testModeBinding)
                         }
                         .font(.title3.weight(.semibold))
                     }
@@ -221,11 +171,10 @@ struct SettingsView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(MatherTheme.cardSubtitle)
                             VStack(alignment: .leading, spacing: 8) {
-                                smokeStep("1. Enable Make & Break 1–20 (toggle above).")
-                                smokeStep("2. Tap Home → Play → Start Session.")
-                                smokeStep("3. If loop V2 is on, verify Make → Gravity Split → Sum Sprint → Bond Blast.")
-                                smokeStep("4. Confirm Session Complete screen appears.")
-                                smokeStep("5. Return here and tap Share latest export to verify JSONL.")
+                                smokeStep("1. Tap Home → Play → Start Session.")
+                                smokeStep("2. Verify Make → Gravity Split → Sum Sprint → Bond Blast.")
+                                smokeStep("3. Confirm Session Complete screen appears.")
+                                smokeStep("4. Return here and tap Share latest export to verify JSONL.")
                             }
                         }
                     }

--- a/Features/VerticalSlice1/RouteSupportViews.swift
+++ b/Features/VerticalSlice1/RouteSupportViews.swift
@@ -62,27 +62,6 @@ struct VS1SettingsPlaceholderView: View {
         )
     }
 
-    private var testModeBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.testModeEnabled },
-            set: { appModel.featureFlags.testModeEnabled = $0 }
-        )
-    }
-
-    private var verticalSliceBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.verticalSlice1Enabled },
-            set: { appModel.featureFlags.verticalSlice1Enabled = $0 }
-        )
-    }
-
-    private var makeBreakLoopV2Binding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.makeBreakLoopV2Enabled },
-            set: { appModel.featureFlags.makeBreakLoopV2Enabled = $0 }
-        )
-    }
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
@@ -94,11 +73,9 @@ struct VS1SettingsPlaceholderView: View {
 
                 VS1Card {
                     VStack(alignment: .leading, spacing: 12) {
-                        VS1ToggleRow(
-                            title: "Make & Break 1–20",
-                            subtitle: "Enable the Make & Break 1–20 activity for your child.",
-                            isOn: verticalSliceBinding
-                        )
+                        Text("Make & Break and the current Bond Blast loop are on by default.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
                         VS1ToggleRow(
                             title: "Audio enabled",
                             subtitle: "Keep prompts and neutral feedback audible.",
@@ -108,16 +85,6 @@ struct VS1SettingsPlaceholderView: View {
                             title: "Haptics enabled",
                             subtitle: "Reserved for later implementation, kept as a visible setting.",
                             isOn: hapticsBinding
-                        )
-                        VS1ToggleRow(
-                            title: "Test mode",
-                            subtitle: "Deterministic ordering for repeatable pilot checks.",
-                            isOn: testModeBinding
-                        )
-                        VS1ToggleRow(
-                            title: "Make & Break loop V2",
-                            subtitle: "Use the issue #222 per-target route: Make it, Gravity Split, Sum Sprint, Bond Blast.",
-                            isOn: makeBreakLoopV2Binding
                         )
                     }
                 }

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -48,20 +48,18 @@ final class FeatureFlagService {
         didSet { defaults.set(selectedThemeId, forKey: Keys.selectedThemeId) }
     }
 
-    /// Gates the Bond Blast complement-match finale stage at the end of each VS1 session.
+    /// Enables the Bond Blast complement-match finale stage at the end of each VS1 session.
     var vs1BondMatchEnabled: Bool {
         didSet { defaults.set(vs1BondMatchEnabled, forKey: Keys.vs1BondMatchEnabled) }
     }
 
     /// Replaces the Transfer (Show it) stepper stage with the tilt-powered balance activity.
-    /// Default false — parent opts in via Settings.
     var vs1GravitySplitEnabled: Bool {
         didSet { defaults.set(vs1GravitySplitEnabled, forKey: Keys.vs1GravitySplitEnabled) }
     }
 
-    /// Enables the reopened issue #222 per-target loop:
+    /// Enables the issue #222 per-target loop:
     /// Make it -> Gravity Split -> Sum Sprint -> Bond Blast.
-    /// Default false until recovery QA signs off.
     var makeBreakLoopV2Enabled: Bool {
         didSet { defaults.set(makeBreakLoopV2Enabled, forKey: Keys.makeBreakLoopV2Enabled) }
     }
@@ -137,14 +135,14 @@ final class FeatureFlagService {
         // "YES"/"NO"/"1"/"0" string values injected via -key value launch arguments,
         // which object(forKey:) as? Bool does not.
         defaults.register(defaults: [
-            Keys.verticalSlice1Enabled: false,
+            Keys.verticalSlice1Enabled: true,
             Keys.testModeEnabled: false,
             Keys.audioEnabled: true,
             Keys.hapticsEnabled: true,
             Keys.selectedThemeId: "classic",
-            Keys.vs1BondMatchEnabled: false,
-            Keys.vs1GravitySplitEnabled: false,
-            Keys.makeBreakLoopV2Enabled: false,
+            Keys.vs1BondMatchEnabled: true,
+            Keys.vs1GravitySplitEnabled: true,
+            Keys.makeBreakLoopV2Enabled: true,
             Keys.motionControlsEnabled: true,
             Keys.soundReactionEnabled: false,
             Keys.roomQuestSafetyAcknowledged: false,

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -35,9 +35,12 @@ struct FeatureFlagTests {
         #expect(flags.hapticsEnabled == true)
     }
 
-    @Test func makeBreakLoopV2DefaultsFalse() {
+    @Test func stableFeatureRolloutDefaultsAreEnabled() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        #expect(flags.makeBreakLoopV2Enabled == false)
+        #expect(flags.verticalSlice1Enabled)
+        #expect(flags.vs1BondMatchEnabled)
+        #expect(flags.vs1GravitySplitEnabled)
+        #expect(flags.makeBreakLoopV2Enabled)
     }
 
     @Test func makeBreakLoopV2PersistsAcrossInstances() {

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -49,23 +49,17 @@ final class ScreenshotTests: XCTestCase {
 
     // MARK: - Settings screen
 
-    func testScreenshot_Settings_EnableVS1() {
+    func testScreenshot_Settings_DefaultRolloutState() {
         let app = launch()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
         app.buttons["Settings"].tap()
         _ = app.staticTexts["Settings"].waitForExistence(timeout: 3)
-        snapshot(app, "Settings-BeforeEnableVS1")
-
-        let vs1Toggle = app.switches["Make & Break 1–20"]
-        if vs1Toggle.waitForExistence(timeout: 3) {
-            vs1Toggle.tap()
-        }
-        snapshot(app, "Settings-AfterEnableVS1")
+        snapshot(app, "Settings-DefaultRolloutState")
 
         app.buttons["Home"].tap()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 3)
-        snapshot(app, "Home-VS1Enabled")
+        snapshot(app, "Home-DefaultRolloutState")
     }
 
     // MARK: - Session Config screen
@@ -339,22 +333,6 @@ final class ScreenshotTests: XCTestCase {
         }
         app.launch()
         return app
-    }
-
-    /// Navigates to Settings, enables VS1, returns to Home.
-    private func enableVS1(_ app: XCUIApplication) {
-        let settingsButton = app.buttons["Settings"]
-        _ = settingsButton.waitForExistence(timeout: 5)
-        settingsButton.tap()
-        _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
-        let toggle = app.switches["Make & Break 1–20"]
-        if toggle.waitForExistence(timeout: 10), toggle.value as? String == "0" {
-            toggle.tap()
-        }
-        let homeButton = app.buttons["Home"]
-        _ = homeButton.waitForExistence(timeout: 5)
-        homeButton.tap()
-        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
     }
 
     /// Launches with VS1 pre-enabled and haptics on — use for tests that exercise success/failure feedback.


### PR DESCRIPTION
## Summary
- default the shipped Make & Break rollout flags on in `FeatureFlagService`
- remove parent-facing rollout/test toggles from settings surfaces while keeping real preferences and Room Quest controls
- update focused defaults/UI screenshot tests for the new settings surface

## Testing
- `xcodebuild -project Mather.xcodeproj -scheme Mather -showdestinations` *(not run in this Linux OpenClaw environment: `xcodebuild` unavailable)*

Closes #317