### PR TITLE
cleanup: remove shipped VS1 rollout toggles

### DIFF
--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -22,27 +22,6 @@ struct SettingsView: View {
         )
     }
 
-    private var bondMatchBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.vs1BondMatchEnabled },
-            set: { appModel.featureFlags.vs1BondMatchEnabled = $0 }
-        )
-    }
-
-    private var gravitySplitBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.vs1GravitySplitEnabled },
-            set: { appModel.featureFlags.vs1GravitySplitEnabled = $0 }
-        )
-    }
-
-    private var makeBreakLoopV2Binding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.makeBreakLoopV2Enabled },
-            set: { appModel.featureFlags.makeBreakLoopV2Enabled = $0 }
-        )
-    }
-
     private var motionBinding: Binding<Bool> {
         Binding(
             get: { appModel.featureFlags.motionControlsEnabled },
@@ -54,20 +33,6 @@ struct SettingsView: View {
         Binding(
             get: { appModel.featureFlags.soundReactionEnabled },
             set: { appModel.featureFlags.soundReactionEnabled = $0 }
-        )
-    }
-
-    private var testModeBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.testModeEnabled },
-            set: { appModel.featureFlags.testModeEnabled = $0 }
-        )
-    }
-
-    private var verticalSliceBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.verticalSlice1Enabled },
-            set: { appModel.featureFlags.verticalSlice1Enabled = $0 }
         )
     }
 
@@ -94,31 +59,6 @@ struct SettingsView: View {
                         VStack(alignment: .leading, spacing: 16) {
                             Text("Settings")
                                 .font(.largeTitle.weight(.black))
-
-                            Text("Make & Break")
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(.secondary)
-                                .padding(.top, 4)
-                            Toggle("Make & Break 1–20", isOn: verticalSliceBinding)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.85)
-                            VS1ToggleRow(
-                                title: "Make & Break loop V2 (recovery)",
-                                subtitle: "Uses the reopened #222 route: Make it → Gravity Split → Sum Sprint → Bond Blast.",
-                                isOn: makeBreakLoopV2Binding
-                            )
-                            VS1ToggleRow(
-                                title: "Bond Blast finale",
-                                subtitle: "Adds a free-match bonus round after all bonds for a number are found.",
-                                isOn: bondMatchBinding
-                            )
-                            VS1ToggleRow(
-                                title: "Gravity Split (beta)",
-                                subtitle: "Replace the Show-it step with a tilt-powered balance scale activity.",
-                                isOn: gravitySplitBinding
-                            )
-
-                            Divider()
 
                             Text("Room Quest")
                                 .font(.caption.weight(.semibold))
@@ -158,7 +98,6 @@ struct SettingsView: View {
                                 subtitle: "Listens for a clap to trigger celebrations (uses microphone).",
                                 isOn: soundReactionBinding
                             )
-                            Toggle("Test mode", isOn: testModeBinding)
                         }
                         .font(.title3.weight(.semibold))
                     }
@@ -221,11 +160,10 @@ struct SettingsView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(MatherTheme.cardSubtitle)
                             VStack(alignment: .leading, spacing: 8) {
-                                smokeStep("1. Enable Make & Break 1–20 (toggle above).")
-                                smokeStep("2. Tap Home → Play → Start Session.")
-                                smokeStep("3. If loop V2 is on, verify Make → Gravity Split → Sum Sprint → Bond Blast.")
-                                smokeStep("4. Confirm Session Complete screen appears.")
-                                smokeStep("5. Return here and tap Share latest export to verify JSONL.")
+                                smokeStep("1. Tap Home → Play → Start Session.")
+                                smokeStep("2. Verify Make → Gravity Split → Sum Sprint → Bond Blast.")
+                                smokeStep("3. Confirm Session Complete screen appears.")
+                                smokeStep("4. Return here and tap Share latest export to verify JSONL.")
                             }
                         }
                     }

--- a/Features/VerticalSlice1/RouteSupportViews.swift
+++ b/Features/VerticalSlice1/RouteSupportViews.swift
@@ -62,43 +62,17 @@ struct VS1SettingsPlaceholderView: View {
         )
     }
 
-    private var testModeBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.testModeEnabled },
-            set: { appModel.featureFlags.testModeEnabled = $0 }
-        )
-    }
-
-    private var verticalSliceBinding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.verticalSlice1Enabled },
-            set: { appModel.featureFlags.verticalSlice1Enabled = $0 }
-        )
-    }
-
-    private var makeBreakLoopV2Binding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.makeBreakLoopV2Enabled },
-            set: { appModel.featureFlags.makeBreakLoopV2Enabled = $0 }
-        )
-    }
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 VS1TitleBlock(
                     eyebrow: "Settings",
                     title: "Local controls",
-                    subtitle: "Feature flag, audio, and export helpers stay on-device for this alpha."
+                    subtitle: "Audio and export helpers stay on-device for this alpha."
                 )
 
                 VS1Card {
                     VStack(alignment: .leading, spacing: 12) {
-                        VS1ToggleRow(
-                            title: "Make & Break 1–20",
-                            subtitle: "Enable the Make & Break 1–20 activity for your child.",
-                            isOn: verticalSliceBinding
-                        )
                         VS1ToggleRow(
                             title: "Audio enabled",
                             subtitle: "Keep prompts and neutral feedback audible.",
@@ -108,16 +82,6 @@ struct VS1SettingsPlaceholderView: View {
                             title: "Haptics enabled",
                             subtitle: "Reserved for later implementation, kept as a visible setting.",
                             isOn: hapticsBinding
-                        )
-                        VS1ToggleRow(
-                            title: "Test mode",
-                            subtitle: "Deterministic ordering for repeatable pilot checks.",
-                            isOn: testModeBinding
-                        )
-                        VS1ToggleRow(
-                            title: "Make & Break loop V2",
-                            subtitle: "Use the issue #222 per-target route: Make it, Gravity Split, Sum Sprint, Bond Blast.",
-                            isOn: makeBreakLoopV2Binding
                         )
                     }
                 }

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -49,19 +49,20 @@ final class FeatureFlagService {
     }
 
     /// Gates the Bond Blast complement-match finale stage at the end of each VS1 session.
+    /// Defaults to true for shipped builds; tests can still pin it off explicitly.
     var vs1BondMatchEnabled: Bool {
         didSet { defaults.set(vs1BondMatchEnabled, forKey: Keys.vs1BondMatchEnabled) }
     }
 
     /// Replaces the Transfer (Show it) stepper stage with the tilt-powered balance activity.
-    /// Default false — parent opts in via Settings.
+    /// Defaults to true for shipped builds; tests can still pin it off explicitly.
     var vs1GravitySplitEnabled: Bool {
         didSet { defaults.set(vs1GravitySplitEnabled, forKey: Keys.vs1GravitySplitEnabled) }
     }
 
-    /// Enables the reopened issue #222 per-target loop:
+    /// Enables the shipped per-target loop:
     /// Make it -> Gravity Split -> Sum Sprint -> Bond Blast.
-    /// Default false until recovery QA signs off.
+    /// Defaults to true for shipped builds; tests can still pin it off explicitly.
     var makeBreakLoopV2Enabled: Bool {
         didSet { defaults.set(makeBreakLoopV2Enabled, forKey: Keys.makeBreakLoopV2Enabled) }
     }
@@ -137,14 +138,14 @@ final class FeatureFlagService {
         // "YES"/"NO"/"1"/"0" string values injected via -key value launch arguments,
         // which object(forKey:) as? Bool does not.
         defaults.register(defaults: [
-            Keys.verticalSlice1Enabled: false,
+            Keys.verticalSlice1Enabled: true,
             Keys.testModeEnabled: false,
             Keys.audioEnabled: true,
             Keys.hapticsEnabled: true,
             Keys.selectedThemeId: "classic",
-            Keys.vs1BondMatchEnabled: false,
-            Keys.vs1GravitySplitEnabled: false,
-            Keys.makeBreakLoopV2Enabled: false,
+            Keys.vs1BondMatchEnabled: true,
+            Keys.vs1GravitySplitEnabled: true,
+            Keys.makeBreakLoopV2Enabled: true,
             Keys.motionControlsEnabled: true,
             Keys.soundReactionEnabled: false,
             Keys.roomQuestSafetyAcknowledged: false,

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -35,9 +35,12 @@ struct FeatureFlagTests {
         #expect(flags.hapticsEnabled == true)
     }
 
-    @Test func makeBreakLoopV2DefaultsFalse() {
+    @Test func shippedVs1FlagsDefaultTrue() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
-        #expect(flags.makeBreakLoopV2Enabled == false)
+        #expect(flags.verticalSlice1Enabled)
+        #expect(flags.vs1BondMatchEnabled)
+        #expect(flags.vs1GravitySplitEnabled)
+        #expect(flags.makeBreakLoopV2Enabled)
     }
 
     @Test func makeBreakLoopV2PersistsAcrossInstances() {

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -175,6 +175,9 @@ struct ThemeTests {
     @Test func startSessionWithVehicleThemeIdActivatesVehicleTheme() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.selectedThemeId = "vehicle"
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -195,6 +198,9 @@ struct ThemeTests {
     @Test func startSessionWithClassicThemeIdActivatesClassicTheme() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.selectedThemeId = "classic"
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -215,6 +221,9 @@ struct ThemeTests {
     @Test func unknownThemeIdDefaultsToClassic() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.selectedThemeId = "unknown_theme_xyz"
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -232,6 +241,9 @@ struct ThemeTests {
     @Test func engineUsesInjectedThemeSessionStartFeedback() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         let engine = VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),
@@ -248,6 +260,9 @@ struct ThemeTests {
     @Test func engineUsesClassicThemeSessionStartFeedbackByDefault() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         let engine = VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),
@@ -263,6 +278,9 @@ struct ThemeTests {
     @Test func engineConcretePromptComesFromTheme() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         let engine = VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),
@@ -297,6 +315,9 @@ struct ThemeTests {
     @Test func engineConcreteFailureHintUsesThemeCounterNoun() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         let engine = VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),

--- a/Tests/MatherTests/TransferExactRebuildTests.swift
+++ b/Tests/MatherTests/TransferExactRebuildTests.swift
@@ -73,6 +73,9 @@ struct TransferExactRebuildTests {
     private func makeEngine() -> VerticalSliceEngine {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         return VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),

--- a/Tests/MatherTests/TransferIntentTests.swift
+++ b/Tests/MatherTests/TransferIntentTests.swift
@@ -46,6 +46,9 @@ struct TransferIntentTests {
     private func makeEngine() -> VerticalSliceEngine {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         return VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),

--- a/Tests/MatherTests/VehicleSpecTests.swift
+++ b/Tests/MatherTests/VehicleSpecTests.swift
@@ -96,6 +96,9 @@ struct VehicleSpecTests {
     @Test func engineStartsVehicleSessionWithCarTheme() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.selectedThemeId = "vehicle"
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -114,6 +117,9 @@ struct VehicleSpecTests {
     @Test func engineAdvancesVehicleThemeOnProblemTransition() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.selectedThemeId = "vehicle"
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -153,6 +159,9 @@ struct VehicleSpecTests {
     @Test func engineClassicThemeSessionHasNoProblemThemeRotation() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.selectedThemeId = "classic"
         let engine = VerticalSliceEngine(
             featureFlags: flags,

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -53,6 +53,9 @@ struct VerticalSliceEngineTests {
     func loopV2RoutesConcreteToGravitySplitToSumSprintToBondBlast() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.makeBreakLoopV2Enabled = true
 
         let engine = VerticalSliceEngine(
@@ -101,6 +104,9 @@ struct VerticalSliceEngineTests {
     func sessionRoutesThroughBondBlastThenWriteItThenTransfer() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.vs1BondMatchEnabled = true
 
         let engine = VerticalSliceEngine(
@@ -136,6 +142,9 @@ struct VerticalSliceEngineTests {
     func roomQuestRouteDoesNotForceTransferStageInVs1Engine() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -154,6 +163,9 @@ struct VerticalSliceEngineTests {
     func bondBlastStartsWhenConcreteStageClears() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -183,6 +195,9 @@ struct VerticalSliceEngineTests {
     func hapticsStageSuccessFiredOnConcreteStageClear() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.hapticsEnabled = true
         let haptics = HapticsService()
 
@@ -208,6 +223,9 @@ struct VerticalSliceEngineTests {
     func hapticsSuccessFiredOnProblemComplete() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.hapticsEnabled = true
         let haptics = HapticsService()
 
@@ -249,6 +267,9 @@ struct VerticalSliceEngineTests {
     func hapticsStageSuccessNotFiredWhenDisabled() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.hapticsEnabled = false
         let haptics = HapticsService()
 
@@ -272,6 +293,9 @@ struct VerticalSliceEngineTests {
     func hapticsFailureFiredOnWrongAnswer() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.hapticsEnabled = true
         let haptics = HapticsService()
 
@@ -295,6 +319,9 @@ struct VerticalSliceEngineTests {
     func equationAcceptsAlternativeCorrectDecomposition() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.hapticsEnabled = false
         let haptics = HapticsService()
 
@@ -338,6 +365,9 @@ struct VerticalSliceEngineTests {
     func hapticsFailureNotFiredWhenDisabled() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.hapticsEnabled = false
         let haptics = HapticsService()
 
@@ -359,6 +389,9 @@ struct VerticalSliceEngineTests {
     func concreteGroupsTrackWarmAndAccentSeparately() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -387,6 +420,9 @@ struct VerticalSliceEngineTests {
     func bondMatchStateInitialisedWhenEnteringBondMatchStage() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.vs1BondMatchEnabled = true
 
         // Use a 1-problem session so the first problem IS the last problem,
@@ -429,6 +465,9 @@ struct VerticalSliceEngineTests {
     func bondMatchCompletesSessionWhenAllPairsMatched() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.vs1BondMatchEnabled = true
 
         let engine = VerticalSliceEngine(
@@ -495,6 +534,9 @@ struct VerticalSliceEngineTests {
     func targetOneSkipsBlankPictorialBondBlastStage() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -520,6 +562,9 @@ struct VerticalSliceEngineTests {
     func targetOneSkipsBlankBondBlastFinaleInLoopV2() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.makeBreakLoopV2Enabled = true
 
         let engine = VerticalSliceEngine(
@@ -562,6 +607,9 @@ struct VerticalSliceEngineTests {
     func matchPairGracefullyIgnoresUnknownPairId() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.vs1BondMatchEnabled = true
 
         let engine = VerticalSliceEngine(
@@ -601,6 +649,9 @@ struct VerticalSliceEngineTests {
     func bondMatchNotFiredOnIntermediateProblems() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.vs1BondMatchEnabled = true
 
         let engine = VerticalSliceEngine(
@@ -657,6 +708,9 @@ struct VerticalSliceEngineTests {
     func gravitySplitStateInitialisedOnStageEntry() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.vs1GravitySplitEnabled = true
 
         let engine = VerticalSliceEngine(
@@ -679,6 +733,9 @@ struct VerticalSliceEngineTests {
     func gravitySplitAdjustByTapChangesCount() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.vs1GravitySplitEnabled = true
 
         let engine = VerticalSliceEngine(
@@ -703,6 +760,9 @@ struct VerticalSliceEngineTests {
     func gravitySplitTiltDoesNotAutoSolveStage() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.vs1GravitySplitEnabled = true
 
         let engine = VerticalSliceEngine(
@@ -729,6 +789,9 @@ struct VerticalSliceEngineTests {
     func gravitySplitStartsFromZeroAndUnsolved() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.vs1GravitySplitEnabled = true
 
         let engine = VerticalSliceEngine(
@@ -750,6 +813,9 @@ struct VerticalSliceEngineTests {
     func gravitySplitRequiresTapAdjustmentToLock() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.vs1GravitySplitEnabled = true
 
         let engine = VerticalSliceEngine(
@@ -778,6 +844,9 @@ struct VerticalSliceEngineTests {
     func gravitySplitAutoAdvancesWhenLocked() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.vs1GravitySplitEnabled = true
 
         let engine = VerticalSliceEngine(
@@ -803,6 +872,9 @@ struct VerticalSliceEngineTests {
     func concreteStageAcceptsCombinedWarmAndAccentTotal() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -829,6 +901,9 @@ struct VerticalSliceEngineTests {
     func makeBreakLoopV2RoutesConcreteToGravitySplitToSumSprintToBondBlast() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.makeBreakLoopV2Enabled = true
 
         let engine = VerticalSliceEngine(
@@ -865,6 +940,9 @@ struct VerticalSliceEngineTests {
     func makeBreakLoopV2CreatesMicroSumSprintBurstPerTarget() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.makeBreakLoopV2Enabled = true
 
         let engine = VerticalSliceEngine(
@@ -890,6 +968,9 @@ struct VerticalSliceEngineTests {
     func makeBreakLoopV2AdvancesToBondBlastAfterBurstCards() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1BondMatchEnabled = false
+        flags.vs1GravitySplitEnabled = false
         flags.makeBreakLoopV2Enabled = true
 
         let engine = VerticalSliceEngine(

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -128,6 +128,9 @@ final class CompactLayoutTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
+            "-feature.makeBreakLoopV2Enabled", "NO",
+            "-feature.vs1BondMatchEnabled", "NO",
+            "-feature.vs1GravitySplitEnabled", "NO",
             "-feature.roomQuestSafetyAcknowledged", "YES"
         ]
         app.launch()
@@ -140,7 +143,10 @@ final class CompactLayoutTests: XCTestCase {
         app.launchArguments = [
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
-            "-feature.testModeEnabled", "YES"
+            "-feature.testModeEnabled", "YES",
+            "-feature.makeBreakLoopV2Enabled", "NO",
+            "-feature.vs1BondMatchEnabled", "NO",
+            "-feature.vs1GravitySplitEnabled", "NO"
         ]
         app.launch()
         return app

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -302,7 +302,10 @@ final class ScreenshotTests: XCTestCase {
         app.launchArguments = [
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
-            "-feature.testModeEnabled", "YES"
+            "-feature.testModeEnabled", "YES",
+            "-feature.makeBreakLoopV2Enabled", "NO",
+            "-feature.vs1BondMatchEnabled", "NO",
+            "-feature.vs1GravitySplitEnabled", "NO"
         ]
         app.launch()
         return app
@@ -315,6 +318,9 @@ final class ScreenshotTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
+            "-feature.makeBreakLoopV2Enabled", "NO",
+            "-feature.vs1BondMatchEnabled", "NO",
+            "-feature.vs1GravitySplitEnabled", "NO",
         ]
         if let appearance {
             app.launchArguments += ["-uiTest.appearance", appearance.launchValue]
@@ -333,28 +339,14 @@ final class ScreenshotTests: XCTestCase {
             "-feature.soundReactionEnabled", "NO",
             "-feature.testModeEnabled", "YES",
             "-feature.makeBreakLoopV2Enabled", "YES",
+            "-feature.vs1BondMatchEnabled", "NO",
+            "-feature.vs1GravitySplitEnabled", "NO",
         ]
         if let appearance {
             app.launchArguments += ["-uiTest.appearance", appearance.launchValue]
         }
         app.launch()
         return app
-    }
-
-    /// Navigates to Settings, enables VS1, returns to Home.
-    private func enableVS1(_ app: XCUIApplication) {
-        let settingsButton = app.buttons["Settings"]
-        _ = settingsButton.waitForExistence(timeout: 5)
-        settingsButton.tap()
-        _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
-        let toggle = app.switches["Make & Break 1–20"]
-        if toggle.waitForExistence(timeout: 10), toggle.value as? String == "0" {
-            toggle.tap()
-        }
-        let homeButton = app.buttons["Home"]
-        _ = homeButton.waitForExistence(timeout: 5)
-        homeButton.tap()
-        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
     }
 
     /// Launches with VS1 pre-enabled and haptics on — use for tests that exercise success/failure feedback.
@@ -365,6 +357,9 @@ final class ScreenshotTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "YES",
             "-feature.testModeEnabled", "YES",
+            "-feature.makeBreakLoopV2Enabled", "NO",
+            "-feature.vs1BondMatchEnabled", "NO",
+            "-feature.vs1GravitySplitEnabled", "NO",
         ]
         if let appearance {
             app.launchArguments += ["-uiTest.appearance", appearance.launchValue]
@@ -380,6 +375,9 @@ final class ScreenshotTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
+            "-feature.makeBreakLoopV2Enabled", "NO",
+            "-feature.vs1BondMatchEnabled", "NO",
+            "-feature.vs1GravitySplitEnabled", "NO",
             "-uiTest.seedHistory", "\(count)"
         ]
         app.launch()
@@ -394,6 +392,9 @@ final class ScreenshotTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
+            "-feature.makeBreakLoopV2Enabled", "NO",
+            "-feature.vs1BondMatchEnabled", "NO",
+            "-feature.vs1GravitySplitEnabled", "NO",
             "-feature.selectedThemeId", "vehicle"
         ]
         if let appearance {


### PR DESCRIPTION
## Summary
- default shipped VS1 rollout flags on in `FeatureFlagService` and update default-value tests
- remove parent-facing rollout/test toggles from `SettingsView` and the legacy VS1 placeholder settings surface
- pin legacy-route unit/UI helpers off explicitly where tests still depend on the classic route

## Validation
- `git diff --check`
- python guard to ensure removed settings bindings are no longer referenced
- Remote `xcodebuild` validation on `ganesh-mba` is currently blocked from this runner (`ssh: connect to host mba port 22: No route to host`)

Closes #317.