### PR TITLE
Enable clap reaction by default and keep it persistent

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Mather listens for claps to celebrate with you! Enable in Settings → Clap reaction.</string>
+	<string>Mather listens for claps to celebrate with you. You can turn Clap reaction off any time in Settings.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Room Quest uses the camera to scan station markers and unlock playful AR moments for kids.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -106,7 +106,7 @@ struct SettingsView: View {
                             )
                             VS1ToggleRow(
                                 title: "Clap reaction (mic)",
-                                subtitle: "Listens for a clap to trigger celebrations (uses microphone).",
+                                subtitle: "On by default. Listens for a clap to trigger celebrations when microphone access is available.",
                                 isOn: soundReactionBinding
                             )
                         }

--- a/Services/SoundDetectionService.swift
+++ b/Services/SoundDetectionService.swift
@@ -9,7 +9,7 @@ import Observation
 ///
 /// **Privacy**: Audio data is never stored or transmitted — the tap computes
 /// only an RMS scalar. The service is started only when
-/// `featureFlags.soundReactionEnabled` is true (default: false), and stops
+/// `featureFlags.soundReactionEnabled` is true (default: true), and stops
 /// immediately when BondMatchView disappears.
 ///
 /// Requires `NSMicrophoneUsageDescription` in Info.plist.

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -71,7 +71,7 @@ final class FeatureFlagService {
     }
 
     /// Enables AVAudioEngine clap detection in Bond Blast.
-    /// Defaults to false — requires NSMicrophoneUsageDescription permission.
+    /// Defaults to true and persists as a parent preference.
     var soundReactionEnabled: Bool {
         didSet { defaults.set(soundReactionEnabled, forKey: Keys.soundReactionEnabled) }
     }
@@ -144,7 +144,7 @@ final class FeatureFlagService {
             Keys.vs1GravitySplitEnabled: true,
             Keys.makeBreakLoopV2Enabled: true,
             Keys.motionControlsEnabled: true,
-            Keys.soundReactionEnabled: false,
+            Keys.soundReactionEnabled: true,
             Keys.roomQuestSafetyAcknowledged: false,
             Keys.roomQuestMarkerSetupEnabled: true,
             Keys.roomQuestReferenceCaptureEnabled: true,

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -41,6 +41,7 @@ struct FeatureFlagTests {
         #expect(flags.vs1BondMatchEnabled)
         #expect(flags.vs1GravitySplitEnabled)
         #expect(flags.makeBreakLoopV2Enabled)
+        #expect(flags.soundReactionEnabled)
     }
 
     @Test func makeBreakLoopV2PersistsAcrossInstances() {
@@ -50,5 +51,14 @@ struct FeatureFlagTests {
 
         let flags2 = FeatureFlagService(defaults: defaults)
         #expect(flags2.makeBreakLoopV2Enabled)
+    }
+
+    @Test func soundReactionPreferencePersistsAcrossInstances() {
+        let defaults = UserDefaults(suiteName: #function)!
+        let flags1 = FeatureFlagService(defaults: defaults)
+        flags1.soundReactionEnabled = false
+
+        let flags2 = FeatureFlagService(defaults: defaults)
+        #expect(!flags2.soundReactionEnabled)
     }
 }


### PR DESCRIPTION
## Summary
- default Bond Blast clap reaction to on for new installs
- keep the existing Settings toggle as the persistent parent preference
- update clap-related copy/comments to match the new default while preserving graceful no-permission behavior
- add focused feature-flag coverage for the new default and persisted opt-out

## Testing
- Not run in this Linux subagent
- Attempted remote Xcode verification on ganesh-mba, but SSH was unreachable from this environment (`No route to host`)
- Graceful no-permission behavior remains unchanged in `SoundDetectionService.startListening()` and existing sound-detection tests were left intact