### PR TITLE
Move Room Quest settings into setup flow

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -41,6 +41,7 @@ final class RoomQuestEngine {
     // MARK: - Dependencies
 
     private let featureFlags: FeatureFlagService
+    var settings: FeatureFlagService { featureFlags }
     private let telemetryWriter: TelemetryWriter
     private let speechService: SpeechService
     private let hapticsService: HapticsService

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -6,7 +6,6 @@ struct SettingsView: View {
     let summaries: [StoredSessionSummary]
 
     @State private var showingClearConfirmation = false
-    @State private var showingSafetyRules = false
 
     private var audioBinding: Binding<Bool> {
         Binding(
@@ -71,20 +70,7 @@ struct SettingsView: View {
 
                             Divider()
 
-                            Text("Room Quest")
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(.secondary)
-                            Button("Review Room Quest safety rules") {
-                                showingSafetyRules = true
-                            }
-                            .font(.subheadline.weight(.medium))
-                            .foregroundStyle(MatherTheme.accent)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.leading, 4)
-
-                            Divider()
-
-                            PlaceMatchThresholdSection(featureFlags: appModel.featureFlags)
+                            RoomQuestSettingsEntry(appModel: appModel)
 
                             Divider()
 
@@ -203,9 +189,6 @@ struct SettingsView: View {
                 .padding(24)
             }
         }
-        .sheet(isPresented: $showingSafetyRules) {
-            RoomSafetyRulesSheet()
-        }
         .alert("Clear all session data?", isPresented: $showingClearConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Clear", role: .destructive) {
@@ -218,171 +201,32 @@ struct SettingsView: View {
     }
 }
 
-// MARK: - Place matching threshold sliders
-
-private struct PlaceMatchThresholdSection: View {
-    @Bindable var featureFlags: FeatureFlagService
-
-    private let defaults = PlaceMatchThresholds.default
+private struct RoomQuestSettingsEntry: View {
+    let appModel: AppModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack {
-                Text("Place matching")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Button("Reset") { resetToDefaults() }
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(MatherTheme.accent)
-            }
-
-            Text("Tune how strictly the camera and GPS must agree that the child is at the right spot. Lower = stricter. Check the Xcode console for [PlaceMatch] lines to see live distances.")
-                .font(.caption)
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Room Quest")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text("Safety, camera setup, and place-matching tuning now live inside Room Quest setup.")
+                .font(.subheadline)
                 .foregroundStyle(MatherTheme.cardSubtitle)
                 .fixedSize(horizontal: false, vertical: true)
 
-            ThresholdSliderRow(
-                label: "Vision match",
-                unit: "",
-                value: $featureFlags.placeMatchVisionMatch,
-                range: 0.10...0.60,
-                step: 0.05,
-                defaultValue: Double(defaults.visionMatchDistance),
-                format: "%.2f",
-                hint: "Lower = more similar photos required. 0.25 rejects different rooms; 0.50 is lenient."
-            )
-
-            ThresholdSliderRow(
-                label: "Vision close",
-                unit: "",
-                value: $featureFlags.placeMatchVisionClose,
-                range: 0.20...1.00,
-                step: 0.05,
-                defaultValue: Double(defaults.visionCloseDistance),
-                format: "%.2f",
-                hint: "\"Almost there\" band. Should be above Vision match."
-            )
-
-            ThresholdSliderRow(
-                label: "GPS match",
-                unit: " m",
-                value: $featureFlags.placeMatchGPSMatch,
-                range: 3...20,
-                step: 1,
-                defaultValue: defaults.gpsMatchMetres,
-                format: "%.0f",
-                hint: "Metres. Outdoors: 8 m is reliable. Indoors: GPS is usually skipped by the accuracy cutoff."
-            )
-
-            ThresholdSliderRow(
-                label: "GPS close",
-                unit: " m",
-                value: $featureFlags.placeMatchGPSClose,
-                range: 10...50,
-                step: 2,
-                defaultValue: defaults.gpsCloseMetres,
-                format: "%.0f",
-                hint: "\"Almost there\" band for GPS. Should be above GPS match."
-            )
-
-            ThresholdSliderRow(
-                label: "GPS accuracy cutoff",
-                unit: " m",
-                value: $featureFlags.placeMatchGPSCutoff,
-                range: 3...20,
-                step: 1,
-                defaultValue: defaults.gpsAccuracyCutoff,
-                format: "%.0f",
-                hint: "Discard GPS fixes worse than this. 10 m blocks unreliable indoor readings."
-            )
-        }
-        .font(.subheadline)
-    }
-
-    private func resetToDefaults() {
-        featureFlags.placeMatchVisionMatch = Double(defaults.visionMatchDistance)
-        featureFlags.placeMatchVisionClose = Double(defaults.visionCloseDistance)
-        featureFlags.placeMatchGPSMatch    = defaults.gpsMatchMetres
-        featureFlags.placeMatchGPSClose    = defaults.gpsCloseMetres
-        featureFlags.placeMatchGPSCutoff   = defaults.gpsAccuracyCutoff
-    }
-}
-
-private struct ThresholdSliderRow: View {
-    let label: String
-    let unit: String
-    @Binding var value: Double
-    let range: ClosedRange<Double>
-    let step: Double
-    let defaultValue: Double
-    let format: String
-    let hint: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text(label)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(MatherTheme.ink)
-                Spacer()
-                Text(String(format: format, value) + unit)
-                    .font(.subheadline.weight(.black))
-                    .foregroundStyle(value == defaultValue ? MatherTheme.cardSubtitle : MatherTheme.accent)
-                    .monospacedDigit()
+            Button("Open Room Quest setup") {
+                appModel.engine.showRoomQuest()
             }
-            Slider(value: $value, in: range, step: step)
-                .tint(value == defaultValue ? MatherTheme.cardSubtitle : MatherTheme.accent)
-            Text(hint)
-                .font(.caption)
-                .foregroundStyle(MatherTheme.cardSubtitle)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .padding(.vertical, 2)
-    }
-}
-
-// MARK: - Room Quest safety rules sheet
-
-private struct RoomSafetyRulesSheet: View {
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
-                    Text("Before every Room Quest session, confirm:")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-
-                    CardSurface {
-                        VStack(alignment: .leading, spacing: 12) {
-                            Label("Safety checklist", systemImage: "checklist")
-                                .font(.headline.weight(.semibold))
-                            safetyItem("Both spot-cards in the same room as this iPad")
-                            safetyItem("Spots are away from stairs, windows, and balconies")
-                            safetyItem("Spots are away from the kitchen")
-                            safetyItem("A parent stays nearby during the room phase")
-                            safetyItem("Nothing in the activity rewards running or jumping")
-                        }
-                    }
-                }
-                .padding(24)
-            }
-            .background(MatherTheme.background.ignoresSafeArea())
-            .navigationTitle("Room Quest Safety")
-            .navigationBarTitleDisplayMode(.large)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { dismiss() }
-                }
-            }
-        }
-    }
-
-    private func safetyItem(_ text: String) -> some View {
-        Label(text, systemImage: "checkmark.circle.fill")
             .font(.subheadline.weight(.medium))
-            .foregroundStyle(MatherTheme.ink)
+            .foregroundStyle(MatherTheme.accent)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.leading, 4)
+            .accessibilityIdentifier("settings-roomquest-open")
+
+            Text(appModel.featureFlags.roomQuestSafetyAcknowledged ? "Safety checklist already acknowledged on this device." : "The one-time safety checklist appears when you open Room Quest.")
+                .font(.caption)
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
+        }
     }
 }

--- a/Features/RoomQuest/RoomSetupView.swift
+++ b/Features/RoomQuest/RoomSetupView.swift
@@ -5,6 +5,7 @@ import UIKit
 /// Displays the spot quantities and safety reminder; parent taps "Ready" when spots are placed.
 struct RoomSetupView: View {
     @Bindable var engine: RoomQuestEngine
+    @State private var showingConfiguration = false
 
     var body: some View {
         ScrollView {
@@ -17,6 +18,11 @@ struct RoomSetupView: View {
                         .foregroundStyle(MatherTheme.cardSubtitle)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
+
+                RoomQuestSetupConfigurationCard(
+                    featureFlags: engine.settings,
+                    showingConfiguration: $showingConfiguration
+                )
 
                 if let p = engine.problem {
                     HStack(spacing: 16) {
@@ -81,20 +87,6 @@ struct RoomSetupView: View {
                     }
                 }
 
-                CardSurface {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Label("Safety reminder", systemImage: "exclamationmark.triangle")
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MatherTheme.coral)
-                        Text("Place stations away from stairs, windows, balconies, and the kitchen.")
-                            .font(.subheadline)
-                            .foregroundStyle(MatherTheme.cardSubtitle)
-                        Text("Keep markers easy to see, but do not make the child walk while staring at the screen.")
-                            .font(.subheadline)
-                            .foregroundStyle(MatherTheme.cardSubtitle)
-                    }
-                }
-
                 Button("Ready, start Room Quest!") {
                     engine.markSetupComplete()
                 }
@@ -103,6 +95,9 @@ struct RoomSetupView: View {
                 .opacity(engine.allStationsRegistered ? 1 : 0.55)
             }
             .padding(24)
+        }
+        .sheet(isPresented: $showingConfiguration) {
+            RoomQuestConfigurationScreen(featureFlags: engine.settings)
         }
     }
 
@@ -215,5 +210,257 @@ struct RoomSetupView: View {
                     .foregroundStyle(MatherTheme.ink)
                 }
         }
+    }
+}
+
+private struct RoomQuestSetupConfigurationCard: View {
+    @Bindable var featureFlags: FeatureFlagService
+    @Binding var showingConfiguration: Bool
+
+    var body: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Label("Room Quest setup & safety", systemImage: "slider.horizontal.3")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text("Review the checklist, choose camera fallback behavior, and tune place matching before the child starts moving.")
+                            .font(.subheadline)
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer()
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    setupSummaryRow(title: "Safety checklist", value: featureFlags.roomQuestSafetyAcknowledged ? "Reviewed" : "First run shows checklist")
+                    setupSummaryRow(title: "Marker scan", value: featureFlags.roomQuestMarkerSetupEnabled ? "On" : "Off")
+                    setupSummaryRow(title: "Saved place photo", value: featureFlags.roomQuestReferenceCaptureEnabled ? "On" : "Off")
+                }
+
+                Button("Open Room Quest setup & safety") {
+                    showingConfiguration = true
+                }
+                .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.18)))
+                .foregroundStyle(MatherTheme.accent)
+                .accessibilityIdentifier("roomquest-open-configuration")
+            }
+        }
+    }
+
+    private func setupSummaryRow(title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.ink)
+            Spacer()
+            Text(value)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+        }
+    }
+}
+
+private struct RoomQuestConfigurationScreen: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var featureFlags: FeatureFlagService
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 20) {
+                    CardSurface {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text("Room Quest setup & safety")
+                                .font(.title2.weight(.bold))
+                            Text("Keep this configuration close to setup so the parent can review it right before play.")
+                                .font(.subheadline)
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                        }
+                    }
+
+                    CardSurface {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Label("Camera setup", systemImage: "camera.badge.ellipsis")
+                                .font(.headline.weight(.semibold))
+                            Toggle("Use camera marker scans during setup", isOn: $featureFlags.roomQuestMarkerSetupEnabled)
+                                .accessibilityIdentifier("roomquest-config-marker-toggle")
+                            Toggle("Save a place photo after a successful scan", isOn: $featureFlags.roomQuestReferenceCaptureEnabled)
+                                .accessibilityIdentifier("roomquest-config-reference-toggle")
+                            Text("Turn both off if the room phase should run in same-place fallback mode only.")
+                                .font(.caption)
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+
+                    CardSurface {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Label("Safety checklist", systemImage: "checklist")
+                                .font(.headline.weight(.semibold))
+                            Text("Review this before every Room Quest session:")
+                                .font(.subheadline)
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                            RoomQuestSafetyChecklist()
+                        }
+                    }
+
+                    CardSurface {
+                        PlaceMatchThresholdSection(featureFlags: featureFlags)
+                    }
+                }
+                .padding(24)
+            }
+            .background(MatherTheme.background.ignoresSafeArea())
+            .navigationTitle("Room Quest Setup")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+private struct RoomQuestSafetyChecklist: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            safetyItem("Both spot-cards in the same room as this iPad")
+            safetyItem("Spots are away from stairs, windows, and balconies")
+            safetyItem("Spots are away from the kitchen")
+            safetyItem("A parent stays nearby during the room phase")
+            safetyItem("Nothing in the activity rewards running or jumping")
+            safetyItem("Keep markers easy to see, but do not make the child walk while staring at the screen")
+        }
+    }
+
+    private func safetyItem(_ text: String) -> some View {
+        Label(text, systemImage: "checkmark.circle.fill")
+            .font(.subheadline.weight(.medium))
+            .foregroundStyle(MatherTheme.ink)
+    }
+}
+
+private struct PlaceMatchThresholdSection: View {
+    @Bindable var featureFlags: FeatureFlagService
+
+    private let defaults = PlaceMatchThresholds.default
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Text("Place matching")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Reset") { resetToDefaults() }
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(MatherTheme.accent)
+            }
+
+            Text("Tune how strictly the camera and GPS must agree that the child is at the right spot. Lower = stricter. Check the Xcode console for [PlaceMatch] lines to see live distances.")
+                .font(.caption)
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ThresholdSliderRow(
+                label: "Vision match",
+                unit: "",
+                value: $featureFlags.placeMatchVisionMatch,
+                range: 0.10...0.60,
+                step: 0.05,
+                defaultValue: Double(defaults.visionMatchDistance),
+                format: "%.2f",
+                hint: "Lower = more similar photos required. 0.25 rejects different rooms, 0.50 is lenient."
+            )
+
+            ThresholdSliderRow(
+                label: "Vision close",
+                unit: "",
+                value: $featureFlags.placeMatchVisionClose,
+                range: 0.20...1.00,
+                step: 0.05,
+                defaultValue: Double(defaults.visionCloseDistance),
+                format: "%.2f",
+                hint: "\"Almost there\" band. Should be above Vision match."
+            )
+
+            ThresholdSliderRow(
+                label: "GPS match",
+                unit: " m",
+                value: $featureFlags.placeMatchGPSMatch,
+                range: 3...20,
+                step: 1,
+                defaultValue: defaults.gpsMatchMetres,
+                format: "%.0f",
+                hint: "Metres. Outdoors, 8 m is reliable. Indoors, GPS is usually skipped by the accuracy cutoff."
+            )
+
+            ThresholdSliderRow(
+                label: "GPS close",
+                unit: " m",
+                value: $featureFlags.placeMatchGPSClose,
+                range: 10...50,
+                step: 2,
+                defaultValue: defaults.gpsCloseMetres,
+                format: "%.0f",
+                hint: "\"Almost there\" band for GPS. Should be above GPS match."
+            )
+
+            ThresholdSliderRow(
+                label: "GPS accuracy cutoff",
+                unit: " m",
+                value: $featureFlags.placeMatchGPSCutoff,
+                range: 3...20,
+                step: 1,
+                defaultValue: defaults.gpsAccuracyCutoff,
+                format: "%.0f",
+                hint: "Discard GPS fixes worse than this. 10 m blocks unreliable indoor readings."
+            )
+        }
+        .font(.subheadline)
+    }
+
+    private func resetToDefaults() {
+        featureFlags.placeMatchVisionMatch = Double(defaults.visionMatchDistance)
+        featureFlags.placeMatchVisionClose = Double(defaults.visionCloseDistance)
+        featureFlags.placeMatchGPSMatch = defaults.gpsMatchMetres
+        featureFlags.placeMatchGPSClose = defaults.gpsCloseMetres
+        featureFlags.placeMatchGPSCutoff = defaults.gpsAccuracyCutoff
+    }
+}
+
+private struct ThresholdSliderRow: View {
+    let label: String
+    let unit: String
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    let step: Double
+    let defaultValue: Double
+    let format: String
+    let hint: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(label)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.ink)
+                Spacer()
+                Text(String(format: format, value) + unit)
+                    .font(.subheadline.weight(.black))
+                    .foregroundStyle(value == defaultValue ? MatherTheme.cardSubtitle : MatherTheme.accent)
+                    .monospacedDigit()
+            }
+            Slider(value: $value, in: range, step: step)
+                .tint(value == defaultValue ? MatherTheme.cardSubtitle : MatherTheme.accent)
+            Text(hint)
+                .font(.caption)
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 2)
     }
 }

--- a/Tests/MatherUITests/RoomQuestUITests.swift
+++ b/Tests/MatherUITests/RoomQuestUITests.swift
@@ -5,8 +5,8 @@ import XCTest
 /// These tests focus on stable companion-slice checkpoints:
 /// - Safety acknowledgement screen renders and can be accepted
 /// - Setup screen shows station cards and saved fallback state
-/// - Hunt entry reaches the first spot with the expected scan/pause affordances
-/// - Settings can still review the Room Quest safety rules
+/// - Setup owns the dedicated Room Quest configuration surface
+/// - Global settings keeps only a minimal Room Quest entry back into setup
 @MainActor
 final class RoomQuestUITests: XCTestCase {
 
@@ -18,12 +18,10 @@ final class RoomQuestUITests: XCTestCase {
 
         openRoomQuest(app)
 
-        // Safety ack screen
         XCTAssertTrue(app.staticTexts["Before you start"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Safety checklist"].waitForExistence(timeout: 3))
         snapshot(app, "RoomQuest-SafetyAck")
 
-        // Accept — transitions to Setup
         app.buttons["I understand — let's go"].tap()
         XCTAssertTrue(app.staticTexts["Set up the room"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.buttons["Scan station marker"].waitForExistence(timeout: 5))
@@ -33,7 +31,6 @@ final class RoomQuestUITests: XCTestCase {
     // MARK: - Setup screen
 
     func testRoomQuestSetupScreenShowsSpotCards() {
-        // Pre-acknowledge safety so we land directly on Setup.
         let app = launchWithRoomQuestAndSafetyAck()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
@@ -43,8 +40,30 @@ final class RoomQuestUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Red Rocket"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.staticTexts["Blue Bubble"].waitForExistence(timeout: 3))
         XCTAssertTrue(app.staticTexts["Setup progress"].waitForExistence(timeout: 3))
-        XCTAssertTrue(app.staticTexts["Safety reminder"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["Room Quest setup & safety"].waitForExistence(timeout: 3))
         snapshot(app, "RoomQuest-SetupView")
+    }
+
+    func testRoomQuestSetupOwnsConfigurationSheet() {
+        let app = launchWithRoomQuestAndSafetyAck()
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
+
+        openRoomQuest(app)
+        XCTAssertTrue(app.staticTexts["Set up the room"].waitForExistence(timeout: 5))
+
+        let configButton = app.buttons["roomquest-open-configuration"]
+        XCTAssertTrue(configButton.waitForExistence(timeout: 5))
+        configButton.tap()
+
+        XCTAssertTrue(app.navigationBars["Room Quest Setup"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.switches["roomquest-config-marker-toggle"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.switches["roomquest-config-reference-toggle"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Safety checklist"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["Place matching"].waitForExistence(timeout: 3))
+        snapshot(app, "RoomQuest-SetupConfiguration")
+
+        app.buttons["Done"].tap()
+        XCTAssertTrue(app.staticTexts["Set up the room"].waitForExistence(timeout: 5))
     }
 
     // MARK: - Spot prompt screens
@@ -137,31 +156,27 @@ final class RoomQuestUITests: XCTestCase {
         XCTAssertTrue(app.buttons["room-pause-button"].waitForExistence(timeout: 5))
     }
 
-    // MARK: - Settings safety rules review
+    // MARK: - Global settings handoff
 
-    func testSettingsSafetyRulesReviewButtonAppearsWhenEnabled() {
+    func testSettingsKeepsMinimalRoomQuestEntryThatReturnsToSetup() {
         let app = launchWithRoomQuestEnabled()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
         app.buttons["Settings"].tap()
-        _ = app.staticTexts["Settings"].waitForExistence(timeout: 5)
+        XCTAssertTrue(app.staticTexts["Settings"].waitForExistence(timeout: 5))
 
-        let reviewButton = app.buttons["Review Room Quest safety rules"]
-        XCTAssertTrue(reviewButton.waitForExistence(timeout: 5))
-        snapshot(app, "Settings-RoomQuestSafetyLink")
+        let openButton = app.buttons["settings-roomquest-open"]
+        XCTAssertTrue(openButton.waitForExistence(timeout: 5))
+        XCTAssertFalse(app.staticTexts["Place matching"].exists)
+        snapshot(app, "Settings-RoomQuestEntry")
 
-        reviewButton.tap()
-        XCTAssertTrue(app.staticTexts["Room Quest Safety"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.staticTexts["Safety checklist"].waitForExistence(timeout: 3))
-        snapshot(app, "Settings-SafetyRulesSheet")
-
-        app.buttons["Done"].tap()
-        _ = app.staticTexts["Settings"].waitForExistence(timeout: 3)
+        openButton.tap()
+        XCTAssertTrue(app.staticTexts["Before you start"].waitForExistence(timeout: 5) ||
+                      app.staticTexts["Set up the room"].waitForExistence(timeout: 5))
     }
 
     // MARK: - Helpers
 
-    /// Navigates from Home → Explorer Lab → Room Quest.
     private func openRoomQuest(_ app: XCUIApplication) {
         app.buttons["ExplorerLab"].tap()
         _ = app.staticTexts["Explorer Lab"].waitForExistence(timeout: 5)
@@ -246,8 +261,6 @@ final class RoomQuestUITests: XCTestCase {
         launch()
     }
 
-    /// Launches with safety already acknowledged —
-    /// skips the one-time SafetyAckView so tests land directly on Setup.
     private func launchWithRoomQuestAndSafetyAck() -> XCUIApplication {
         continueAfterFailure = false
         let app = XCUIApplication()


### PR DESCRIPTION
## Summary
- remove Room Quest-specific controls from the crowded global parent settings surface
- move Room Quest setup and safety controls into the dedicated Room Quest setup flow
- keep a minimal top-level entry point into Room Quest from settings and cover the new flow in UI tests

## Testing
- git diff --check
- targeted Room Quest UI test updates only (no Xcode run available from this host)