### PR TITLE
test: pin VS1 route assumptions explicitly

### DIFF
--- a/Tests/MatherTests/TransferExactRebuildTests.swift
+++ b/Tests/MatherTests/TransferExactRebuildTests.swift
@@ -73,6 +73,8 @@ struct TransferExactRebuildTests {
     private func makeEngine() -> VerticalSliceEngine {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
         return VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),

--- a/Tests/MatherTests/TransferIntentTests.swift
+++ b/Tests/MatherTests/TransferIntentTests.swift
@@ -46,6 +46,8 @@ struct TransferIntentTests {
     private func makeEngine() -> VerticalSliceEngine {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
         return VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),

--- a/Tests/MatherTests/VehicleSpecTests.swift
+++ b/Tests/MatherTests/VehicleSpecTests.swift
@@ -97,6 +97,8 @@ struct VehicleSpecTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.selectedThemeId = "vehicle"
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
         let engine = VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -102,6 +102,8 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1BondMatchEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -154,6 +156,7 @@ struct VerticalSliceEngineTests {
     func bondBlastStartsWhenConcreteStageClears() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -209,6 +212,8 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.hapticsEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
         let haptics = HapticsService()
 
         let engine = VerticalSliceEngine(
@@ -388,6 +393,8 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1BondMatchEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
 
         // Use a 1-problem session so the first problem IS the last problem,
         // ensuring showBondMatch = true when transfer completes.
@@ -430,6 +437,8 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1BondMatchEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -495,6 +504,7 @@ struct VerticalSliceEngineTests {
     func targetOneSkipsBlankPictorialBondBlastStage() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -563,6 +573,8 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1BondMatchEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -602,6 +614,8 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1BondMatchEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -658,6 +672,7 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1GravitySplitEnabled = true
+        flags.makeBreakLoopV2Enabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -680,6 +695,7 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1GravitySplitEnabled = true
+        flags.makeBreakLoopV2Enabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -704,6 +720,7 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1GravitySplitEnabled = true
+        flags.makeBreakLoopV2Enabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -730,6 +747,7 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1GravitySplitEnabled = true
+        flags.makeBreakLoopV2Enabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -751,6 +769,7 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1GravitySplitEnabled = true
+        flags.makeBreakLoopV2Enabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -779,6 +798,7 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.vs1GravitySplitEnabled = true
+        flags.makeBreakLoopV2Enabled = false
 
         let engine = VerticalSliceEngine(
             featureFlags: flags,


### PR DESCRIPTION
## Summary\n- pin legacy transfer and themed-problem tests to the non-loop-V2 route\n- pin gravity-split tests to legacy concrete → pictorial → abstract → gravity-split routing\n- keep loop-V2 coverage explicit so the suite no longer depends on feature-flag defaults\n\n## Validation\n- git diff --check\n- unable to run Swift/Xcode tests in this Linux environment (swift/xcodebuild unavailable)