### PR TITLE
test: fix remaining post-merge CI follow-ups

### DIFF
--- a/Tests/MatherTests/MemoryTextFitTests.swift
+++ b/Tests/MatherTests/MemoryTextFitTests.swift
@@ -26,7 +26,7 @@ struct MemoryTextFitTests {
     @Test func longestCurrentLabelsHaveFallbackHeadroom() {
         let labels = (MemoryDeck.domesticAnimals + MemoryDeck.birds + MemoryDeck.vehicles).map(\.name)
         let longestLabel = labels.max { $0.count < $1.count }
-        #expect(longestLabel == "Black Palm Cockatoo")
+        #expect(longestLabel == "Mitchell's Cockatoo")
         #expect(longestLabel?.count == 19)
         #expect(MemoryView.labelMinimumScaleFactor(for: .hard) <= 0.50)
     }

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -263,6 +263,8 @@ struct ThemeTests {
     @Test func engineConcretePromptComesFromTheme() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
         let engine = VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),

--- a/Tests/MatherTests/VehicleSpecTests.swift
+++ b/Tests/MatherTests/VehicleSpecTests.swift
@@ -117,6 +117,8 @@ struct VehicleSpecTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.selectedThemeId = "vehicle"
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
         let engine = VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -301,6 +301,8 @@ struct VerticalSliceEngineTests {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
         flags.hapticsEnabled = false
+        flags.makeBreakLoopV2Enabled = false
+        flags.vs1GravitySplitEnabled = false
         let haptics = HapticsService()
 
         let engine = VerticalSliceEngine(


### PR DESCRIPTION
Follow-up to #323 for the remaining narrow CI failures from run 24795240333.

Changes:
- update the stale longest-memory-label expectation to match current deck data
- pin the remaining route-sensitive engine tests to the legacy non-loop-v2 path they are asserting

Validation:
- git diff --check
- local toolchain validation blocked in this environment because `swift`/`xcodebuild` are unavailable