### PR TITLE
test(memory): fix fallback bird label expectation

### DIFF
--- a/Tests/MatherTests/MemoryTextFitTests.swift
+++ b/Tests/MatherTests/MemoryTextFitTests.swift
@@ -26,8 +26,8 @@ struct MemoryTextFitTests {
     @Test func birdLabelsStayWithinReasonableFallbackRange() {
         let labels = (MemoryDeck.domesticAnimals + MemoryDeck.birds + MemoryDeck.vehicles).map(\.name)
         let longestLabel = labels.max { $0.count < $1.count }
-        #expect(longestLabel == "Crested Bird 17")
-        #expect(longestLabel?.count == 15)
+        #expect(longestLabel == "Pink Cockatoo 34")
+        #expect(longestLabel?.count == 16)
         #expect(MemoryView.labelMinimumScaleFactor(for: .hard) >= 0.58)
     }
 }


### PR DESCRIPTION
## Summary\n- fix the post-merge Memory text-fit test expectation for the extracted bird-sheet fallback release\n- update the longest fallback bird label assertion to match the current deck data\n\n## Testing\n- not run locally here\n- intended to restore green CI on main so the follow-up release can be tagged\n