### PR TITLE
test(memory): fix bird fact text expectation

### DIFF
--- a/Tests/MatherTests/MemoryTextFitTests.swift
+++ b/Tests/MatherTests/MemoryTextFitTests.swift
@@ -46,8 +46,8 @@ struct MemoryTextFitTests {
             .flatMap(\.detailCards)
             .map(\.value)
             .max { $0.count < $1.count }
-        #expect(longestBirdFact == "Central and South American forests")
-        #expect(longestBirdFact?.count == 34)
+        #expect(longestBirdFact == "Woodland streams in Africa and Asia")
+        #expect(longestBirdFact?.count == 35)
         #expect(MemoryView.detailMinimumScaleFactor(for: .hard) >= 0.62)
     }
 }


### PR DESCRIPTION
## Summary
- update the fallback bird fact text-fit expectation to match the actual longest clue string
- keep the bird fact-card feature unchanged

## Testing
- not run locally here
- relies on CI after PR creation
