### PR TITLE
Improve iPad responsiveness with adaptive layout widths and grids

### DIFF
--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -67,36 +67,38 @@ struct LabView: View {
     var body: some View {
         ZStack {
             MatherTheme.background.ignoresSafeArea()
-            ScrollView {
-                VStack(alignment: .leading, spacing: 20) {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Explorer Lab")
-                                .font(.system(size: 36, weight: .black, design: .rounded))
-                                .foregroundStyle(MatherTheme.ink)
-                            Text("Pick a game and discover maths")
-                                .font(.subheadline.weight(.medium))
-                                .foregroundStyle(MatherTheme.cardSubtitle)
+            GeometryReader { proxy in
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Explorer Lab")
+                                    .font(.system(size: 36, weight: .black, design: .rounded))
+                                    .foregroundStyle(MatherTheme.ink)
+                                Text("Pick a game and discover maths")
+                                    .font(.subheadline.weight(.medium))
+                                    .foregroundStyle(MatherTheme.cardSubtitle)
+                            }
+                            Spacer()
+                            Button {
+                                appModel.engine.showHome()
+                            } label: {
+                                Image(systemName: "house.fill")
+                                    .font(.title2.weight(.semibold))
+                                    .foregroundStyle(MatherTheme.accent)
+                                    .frame(width: 44, height: 44)
+                            }
+                            .accessibilityLabel("Home")
                         }
-                        Spacer()
-                        Button {
-                            appModel.engine.showHome()
-                        } label: {
-                            Image(systemName: "house.fill")
-                                .font(.title2.weight(.semibold))
-                                .foregroundStyle(MatherTheme.accent)
-                                .frame(width: 44, height: 44)
-                        }
-                        .accessibilityLabel("Home")
-                    }
 
-                    LazyVGrid(columns: [GridItem(.flexible(), spacing: 16), GridItem(.flexible(), spacing: 16)], spacing: 16) {
-                        ForEach(Array(tiles.enumerated()), id: \.offset) { _, tile in
-                            gameTileButton(tile)
+                        LazyVGrid(columns: ResponsiveLayout.labColumns(for: proxy.size.width), spacing: 16) {
+                            ForEach(Array(tiles.enumerated()), id: \.offset) { _, tile in
+                                gameTileButton(tile)
+                            }
                         }
                     }
+                    .padding(24)
                 }
-                .padding(24)
             }
         }
     }

--- a/Features/VerticalSlice1/ConcreteBuildView.swift
+++ b/Features/VerticalSlice1/ConcreteBuildView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ConcreteBuildView: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     let target: Int
     let warmCount: Int
     let accentCount: Int
@@ -48,7 +49,7 @@ struct ConcreteBuildView: View {
                             }
                     }
                 }
-                .frame(maxWidth: 400)
+                .frame(maxWidth: ResponsiveLayout.concreteGridMaxWidth(for: horizontalSizeClass))
                 .frame(maxWidth: .infinity)
 
 

--- a/Features/VerticalSlice1/RouteSupportViews.swift
+++ b/Features/VerticalSlice1/RouteSupportViews.swift
@@ -2,6 +2,7 @@ import Observation
 import SwiftUI
 
 struct VS1ParentSummaryPlaceholderView: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Bindable var appModel: AppModel
     let summaries: [StoredSessionSummary]
 
@@ -37,13 +38,14 @@ struct VS1ParentSummaryPlaceholderView: View {
                 }
             }
             .padding(24)
-            .frame(maxWidth: 760)
+            .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
             .frame(maxWidth: .infinity, alignment: .center)
         }
     }
 }
 
 struct VS1SettingsPlaceholderView: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Bindable var appModel: AppModel
     let summaries: [StoredSessionSummary]
     @State private var confirmClear = false
@@ -107,7 +109,7 @@ struct VS1SettingsPlaceholderView: View {
                 }
             }
             .padding(24)
-            .frame(maxWidth: 760)
+            .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
             .frame(maxWidth: .infinity, alignment: .center)
         }
         .confirmationDialog("Clear all session summaries?", isPresented: $confirmClear, titleVisibility: .visible) {

--- a/Features/VerticalSlice1/SessionConfigView.swift
+++ b/Features/VerticalSlice1/SessionConfigView.swift
@@ -13,6 +13,7 @@ private let themeOptions: [ThemeOption] = [
 ]
 
 struct SessionConfigView: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Bindable var appModel: AppModel
 
     var body: some View {
@@ -73,7 +74,7 @@ struct SessionConfigView: View {
                 }
                 .font(.headline.weight(.semibold))
             }
-            .frame(maxWidth: 760)
+            .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             .padding(24)
         }

--- a/Shared/ResponsiveLayout.swift
+++ b/Shared/ResponsiveLayout.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+@MainActor
+enum ResponsiveLayout {
+    static func contentMaxWidth(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        horizontalSizeClass == .regular ? 1_100 : 760
+    }
+
+    static func concreteGridMaxWidth(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        horizontalSizeClass == .regular ? 560 : 400
+    }
+
+    static func labColumns(for availableWidth: CGFloat) -> [GridItem] {
+        let minimumTileWidth: CGFloat = availableWidth >= 1_100 ? 260 : 220
+        return [GridItem(.adaptive(minimum: minimumTileWidth, maximum: 340), spacing: 16)]
+    }
+}


### PR DESCRIPTION
### Motivation
- Several primary screens were constrained by fixed width caps (for example `760` and `400`) which made the app look like a phone UI stretched on iPad instead of a native tablet layout.  
- The Explorer Lab used a hard-coded two-column grid which prevented showing more tiles on large widths and wasted horizontal space.  
- The Concrete (ten-frame) grid was capped too narrowly causing excessive centering and small layouts on regular-width devices.  

### Description
- Added a centralized helper `Shared/ResponsiveLayout.swift` with `contentMaxWidth(for:)`, `concreteGridMaxWidth(for:)`, and `labColumns(for:)` to express size-class and available-width rules.  
- Replaced fixed width caps in VS1 flows by reading the horizontal size class and applying `ResponsiveLayout.contentMaxWidth(for:)` in `Features/VerticalSlice1/SessionConfigView.swift` and `Features/VerticalSlice1/RouteSupportViews.swift`.  
- Updated `Features/VerticalSlice1/ConcreteBuildView.swift` to use `ResponsiveLayout.concreteGridMaxWidth(for:)` and added `@Environment(\.horizontalSizeClass)` so the counter grid can expand on iPad.  
- Converted `Features/Lab/LabView.swift` to use a `GeometryReader` and `ResponsiveLayout.labColumns(for:)` with an adaptive `LazyVGrid` so the Explorer Lab shows more tiles per row on larger widths.  

### Testing
- Attempted to run `xcodegen generate` in the environment but `xcodegen` is not installed so project generation could not be validated.  
- Attempted to run `xcodebuild -list -project Mather.xcodeproj` but `xcodebuild` is not available in this environment so no build/test was executed.  
- Changes were committed locally with the message `Improve iPad responsiveness across learning flows` and a PR was prepared with the accompanying changelog summary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a496e6bc8324ad7560531e8d9b36)