### PR TITLE
Add kid profiles with per-profile session storage and SwiftData telemetry

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -5,6 +5,7 @@ import SwiftData
 @MainActor
 @Observable
 final class AppModel {
+    let profileStore: KidProfileStore
     let featureFlags: FeatureFlagService
     let speechService: SpeechService
     let telemetryWriter: TelemetryWriter
@@ -20,10 +21,11 @@ final class AppModel {
     let sumSprintEngine: SumSprintEngine
 
     init(modelContext: ModelContext) {
+        let profileStore = KidProfileStore(modelContext: modelContext)
         let featureFlags = FeatureFlagService()
         let speechService = SpeechService()
-        let telemetryWriter = TelemetryWriter()
-        let historyStore = SessionHistoryStore(modelContext: modelContext)
+        let telemetryWriter = TelemetryWriter(modelContext: modelContext, activeProfileIdProvider: { profileStore.activeProfileId })
+        let historyStore = SessionHistoryStore(modelContext: modelContext, activeProfileIdProvider: { profileStore.activeProfileId })
         let roomQuestStationStore = RoomQuestStationStore(modelContext: modelContext)
         let hapticsService = HapticsService()
         let motionService = MotionService()
@@ -31,6 +33,7 @@ final class AppModel {
         let roomQuestScanner = RoomQuestLiveScanner()
 
         self.featureFlags = featureFlags
+        self.profileStore = profileStore
         self.speechService = speechService
         self.telemetryWriter = telemetryWriter
         self.historyStore = historyStore
@@ -79,7 +82,7 @@ final class AppModel {
             }
         }
 
-        let factStore = FactRecordStore(modelContext: modelContext)
+        let factStore = FactRecordStore(modelContext: modelContext, activeProfileIdProvider: { profileStore.activeProfileId })
         let sumSprintEngine = SumSprintEngine(
             featureFlags: featureFlags,
             telemetryWriter: telemetryWriter,

--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -8,7 +8,13 @@ struct MatherApp: App {
 
     init() {
         do {
-            container = try ModelContainer(for: StoredSessionSummary.self, StoredRoomQuestStationReference.self, StoredFactRecord.self)
+            container = try ModelContainer(
+                for: StoredSessionSummary.self,
+                StoredRoomQuestStationReference.self,
+                StoredFactRecord.self,
+                StoredKidProfile.self,
+                StoredTelemetryEvent.self
+            )
             let appModel = AppModel(modelContext: container.mainContext)
             Self.seedSessionHistoryIfRequested(using: appModel)
             _appModel = State(initialValue: appModel)
@@ -45,7 +51,7 @@ private extension MatherApp {
               arguments.indices.contains(flagIndex + 1),
               let requestedCount = Int(arguments[flagIndex + 1]) else { return }
 
-        appModel.historyStore.clearAll()
+        appModel.historyStore.clearAllProfiles()
 
         for index in 0..<max(requestedCount, 0) {
             let startedAt = Date.now.addingTimeInterval(TimeInterval(-index * 3_600))
@@ -60,7 +66,7 @@ private extension MatherApp {
                 transferCorrectCount: 2 + (index % 2),
                 medianLatencyMs: 90_000 + (index * 15_000),
                 nextTargetHint: "UI test seeded session history.",
-                exportFileName: "session-\(sessionId).jsonl"
+                exportFileName: "swiftdata://session/\(sessionId)"
             )
             appModel.historyStore.save(draft)
         }

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -5,6 +5,11 @@ import SwiftUI
 struct RootView: View {
     @Bindable var appModel: AppModel
     @Query(sort: \StoredSessionSummary.startedAt, order: .reverse) private var sessionSummaries: [StoredSessionSummary]
+    @Query(sort: \StoredKidProfile.createdAt) private var kidProfiles: [StoredKidProfile]
+
+    private var activeProfileSummaries: [StoredSessionSummary] {
+        sessionSummaries.filter { $0.profileId == appModel.profileStore.activeProfileId }
+    }
 
     var body: some View {
         NavigationStack {
@@ -19,9 +24,9 @@ struct RootView: View {
                 case .sessionSummary:
                     SessionSummaryView(appModel: appModel)
                 case .parentSummary:
-                    ParentSummaryView(appModel: appModel, summaries: sessionSummaries)
+                    ParentSummaryView(appModel: appModel, summaries: sessionSummaries, profiles: kidProfiles)
                 case .settings:
-                    SettingsView(appModel: appModel, summaries: sessionSummaries)
+                    SettingsView(appModel: appModel, summaries: activeProfileSummaries)
                 case .roomQuest:
                     RoomSessionView(engine: appModel.roomQuestEngine, vsEngine: appModel.engine)
                         .sheet(item: Binding(

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -162,6 +162,38 @@ struct SessionSummaryDraft: Equatable {
     var exportFileName: String
 }
 
+@Model
+final class StoredKidProfile {
+    @Attribute(.unique) var id: String
+    var name: String
+    var emoji: String
+    var createdAt: Date
+
+    init(id: String = UUID().uuidString, name: String, emoji: String, createdAt: Date = .now) {
+        self.id = id
+        self.name = name
+        self.emoji = emoji
+        self.createdAt = createdAt
+    }
+}
+
+@Model
+final class StoredTelemetryEvent {
+    var sessionId: String
+    var profileId: String
+    var typeRawValue: String
+    var timestamp: Date
+    var encodedEvent: String
+
+    init(sessionId: String, profileId: String, event: SliceEvent, encodedEvent: String) {
+        self.sessionId = sessionId
+        self.profileId = profileId
+        self.typeRawValue = event.type.rawValue
+        self.timestamp = event.timestamp
+        self.encodedEvent = encodedEvent
+    }
+}
+
 // MARK: - Gravity Split models
 
 /// State for the Gravity Split balance stage — held by `VerticalSliceEngine`.
@@ -465,7 +497,9 @@ final class StoredRoomQuestStationReference {
 
 @Model
 final class StoredFactRecord {
-    @Attribute(.unique) var factKey: String  // "\(addendA)+\(addendB)"
+    @Attribute(.unique) var uniqueKey: String
+    var profileId: String
+    var factKey: String  // "\(addendA)+\(addendB)"
     var addendA: Int
     var addendB: Int
     var boxRawValue: Int
@@ -473,7 +507,9 @@ final class StoredFactRecord {
     var correctStreak: Int
     var lastSeenAt: Date?
 
-    init(factKey: String, addendA: Int, addendB: Int) {
+    init(profileId: String, factKey: String, addendA: Int, addendB: Int) {
+        self.uniqueKey = "\(profileId)|\(factKey)"
+        self.profileId = profileId
         self.factKey = factKey
         self.addendA = addendA
         self.addendB = addendB
@@ -496,8 +532,9 @@ final class StoredSessionSummary {
     var medianLatencyMs: Int
     var nextTargetHint: String
     var exportFileName: String
+    var profileId: String
 
-    init(from draft: SessionSummaryDraft) {
+    init(from draft: SessionSummaryDraft, profileId: String) {
         sessionId = draft.sessionId
         startedAt = draft.startedAt
         endedAt = draft.endedAt
@@ -508,5 +545,6 @@ final class StoredSessionSummary {
         medianLatencyMs = draft.medianLatencyMs
         nextTargetHint = draft.nextTargetHint
         exportFileName = draft.exportFileName
+        self.profileId = profileId
     }
 }

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -99,10 +99,6 @@ final class VerticalSliceEngine {
         return "\(min(currentProblemIndex + 1, problems.count)) / \(problems.count)"
     }
 
-    var exportArtifact: ExportArtifact? {
-        telemetryWriter.currentExport
-    }
-
     var concreteCount: Int { concreteWarmCount + concreteAccentCount }
     var sumSprintStageCardCount: Int { sumSprintBurstState?.cards.count ?? 0 }
 
@@ -598,7 +594,7 @@ final class VerticalSliceEngine {
     private func endSession() {
         currentSession.endedAt = .now
         let digest = buildDigest()
-        let export = try? telemetryWriter.finishSession(session: currentSession, digest: digest, themeId: featureFlags.selectedThemeId)
+        try? telemetryWriter.finishSession(session: currentSession, digest: digest, themeId: featureFlags.selectedThemeId)
         let summary = SessionSummaryDraft(
             sessionId: currentSession.sessionId.uuidString,
             startedAt: currentSession.startedAt,
@@ -609,7 +605,7 @@ final class VerticalSliceEngine {
             transferCorrectCount: digest.transferCorrectCount,
             medianLatencyMs: digest.medianLatencyMs,
             nextTargetHint: digest.nextTargetHint,
-            exportFileName: export?.fileName ?? "session-\(currentSession.sessionId.uuidString).jsonl"
+            exportFileName: "swiftdata://session/\(currentSession.sessionId.uuidString)"
         )
         saveSummary(summary)
         completedSummary = summary

--- a/Features/ParentSummary/ParentSummaryView.swift
+++ b/Features/ParentSummary/ParentSummaryView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct ParentSummaryView: View {
     @Bindable var appModel: AppModel
     let summaries: [StoredSessionSummary]
+    let profiles: [StoredKidProfile]
 
     var body: some View {
         let digest = appModel.telemetryWriter.digest(from: summaries)
@@ -73,6 +74,22 @@ struct ParentSummaryView: View {
 
                         CardSurface {
                             VStack(alignment: .leading, spacing: 10) {
+                                Text("Profile overview")
+                                    .font(.title3.weight(.bold))
+                                ForEach(profiles, id: \.id) { profile in
+                                    let count = summaries.filter { $0.profileId == profile.id }.count
+                                    HStack {
+                                        Text("\(profile.emoji) \(profile.name)")
+                                        Spacer()
+                                        Text("\(count) sessions")
+                                            .foregroundStyle(MatherTheme.cardSubtitle)
+                                    }
+                                }
+                            }
+                        }
+
+                        CardSurface {
+                            VStack(alignment: .leading, spacing: 10) {
                                 Text("Recent sessions")
                                     .font(.title3.weight(.bold))
                                 Text(historyCaption(totalCount: summaries.count, visibleCount: recentSummaries.count))
@@ -84,6 +101,11 @@ struct ParentSummaryView: View {
                                             Text("Session \(index + 1)")
                                                 .font(.caption.weight(.bold))
                                                 .foregroundStyle(MatherTheme.accent)
+                                            if let profile = profiles.first(where: { $0.id == summary.profileId }) {
+                                                Text("\(profile.emoji) \(profile.name)")
+                                                    .font(.caption)
+                                                    .foregroundStyle(MatherTheme.cardSubtitle)
+                                            }
                                             Text(summary.startedAt.formatted(date: .abbreviated, time: .shortened))
                                                 .font(.subheadline.weight(.semibold))
                                             Text("\(summary.problemsCompleted) problems · \(Int(summary.firstAttemptAccuracy * 100))% first try")

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -6,6 +6,8 @@ struct SettingsView: View {
     let summaries: [StoredSessionSummary]
 
     @State private var showingClearConfirmation = false
+    @State private var newProfileName = ""
+    @State private var newProfileEmoji = KidProfileStore.emojiChoices[0]
 
     private var audioBinding: Binding<Bool> {
         Binding(
@@ -39,14 +41,6 @@ struct SettingsView: View {
         Label(text, systemImage: "checkmark.circle")
             .font(.subheadline)
             .foregroundStyle(.primary)
-    }
-
-    private var latestExportURL: URL? {
-        if let current = appModel.telemetryWriter.currentExport?.url {
-            return current
-        }
-        guard let latest = summaries.first else { return nil }
-        return appModel.telemetryWriter.exportURL(fileName: latest.exportFileName)
     }
 
     var body: some View {
@@ -101,18 +95,37 @@ struct SettingsView: View {
 
                     CardSurface {
                         VStack(alignment: .leading, spacing: 14) {
-                            Text("Export and review")
+                            Text("Kid profiles")
                                 .font(.title2.weight(.bold))
-                            Text(latestExportURL == nil ? "Run a session to create the first JSONL export." : "The most recent session export is ready to share from this device.")
+                            Text("Each profile keeps session data separate. Parent summary combines all profiles.")
                                 .foregroundStyle(MatherTheme.cardSubtitle)
 
-                            if let latestExportURL, FileManager.default.fileExists(atPath: latestExportURL.path) {
-                                ShareLink(item: latestExportURL) {
-                                    Text("Share latest export")
-                                        .frame(maxWidth: .infinity)
+                            Picker("Active profile", selection: Binding(
+                                get: { appModel.profileStore.activeProfileId },
+                                set: { appModel.profileStore.setActiveProfile(id: $0) }
+                            )) {
+                                ForEach(appModel.profileStore.profiles, id: \.id) { profile in
+                                    Text("\(profile.emoji) \(profile.name)")
+                                        .tag(profile.id)
                                 }
-                                .buttonStyle(PrimaryActionButtonStyle())
                             }
+
+                            HStack {
+                                TextField("New profile name", text: $newProfileName)
+                                    .textFieldStyle(.roundedBorder)
+                                Picker("Emoji", selection: $newProfileEmoji) {
+                                    ForEach(KidProfileStore.emojiChoices, id: \.self) { emoji in
+                                        Text(emoji).tag(emoji)
+                                    }
+                                }
+                                .pickerStyle(.menu)
+                            }
+
+                            Button("Add profile") {
+                                appModel.profileStore.addProfile(name: newProfileName, emoji: newProfileEmoji)
+                                newProfileName = ""
+                            }
+                            .buttonStyle(PrimaryActionButtonStyle())
                         }
                     }
 
@@ -134,7 +147,7 @@ struct SettingsView: View {
                                             .foregroundStyle(MatherTheme.cardSubtitle)
                                     }
                                     Spacer()
-                                    Text(summary.exportFileName)
+                                    Text(summary.exportFileName.replacingOccurrences(of: "swiftdata://session/", with: "Session ID "))
                                         .font(.caption)
                                         .foregroundStyle(MatherTheme.cardSubtitle)
                                 }
@@ -160,7 +173,7 @@ struct SettingsView: View {
                                 smokeStep("1. Tap Home → Play → Start Session.")
                                 smokeStep("2. Verify Make → Gravity Split → Sum Sprint → Bond Blast.")
                                 smokeStep("3. Confirm Session Complete screen appears.")
-                                smokeStep("4. Return here and tap Share latest export to verify JSONL.")
+                                smokeStep("4. Confirm events are writing to the on-device SwiftData telemetry store.")
                             }
                         }
                     }
@@ -193,10 +206,10 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) {}
             Button("Clear", role: .destructive) {
                 appModel.historyStore.clearAll()
-                appModel.telemetryWriter.clearExports()
+                appModel.telemetryWriter.clearEventsForActiveProfile()
             }
         } message: {
-            Text("This removes saved summaries and local JSONL exports.")
+            Text("This removes saved summaries and telemetry events for the active kid profile.")
         }
     }
 }

--- a/Persistence/FactRecordStore.swift
+++ b/Persistence/FactRecordStore.swift
@@ -6,21 +6,31 @@ import SwiftData
 @Observable
 final class FactRecordStore {
     private let modelContext: ModelContext
+    private let activeProfileIdProvider: () -> String
 
-    init(modelContext: ModelContext) {
+    init(modelContext: ModelContext, activeProfileIdProvider: @escaping () -> String) {
         self.modelContext = modelContext
+        self.activeProfileIdProvider = activeProfileIdProvider
+    }
+
+    convenience init(modelContext: ModelContext) {
+        self.init(modelContext: modelContext, activeProfileIdProvider: { "default-profile" })
     }
 
     // MARK: - Fetch
 
     func fetchAll() -> [StoredFactRecord] {
-        let descriptor = FetchDescriptor<StoredFactRecord>()
+        let profileId = activeProfileIdProvider()
+        let descriptor = FetchDescriptor<StoredFactRecord>(
+            predicate: #Predicate { $0.profileId == profileId }
+        )
         return (try? modelContext.fetch(descriptor)) ?? []
     }
 
     func record(forKey key: String) -> StoredFactRecord? {
+        let profileId = activeProfileIdProvider()
         var descriptor = FetchDescriptor<StoredFactRecord>(
-            predicate: #Predicate { $0.factKey == key }
+            predicate: #Predicate { $0.factKey == key && $0.profileId == profileId }
         )
         descriptor.fetchLimit = 1
         return try? modelContext.fetch(descriptor).first
@@ -35,7 +45,7 @@ final class FactRecordStore {
         } else {
             let parts = factKey.split(separator: "+").compactMap { Int($0) }
             guard parts.count == 2 else { return }
-            let new = StoredFactRecord(factKey: factKey, addendA: parts[0], addendB: parts[1])
+            let new = StoredFactRecord(profileId: activeProfileIdProvider(), factKey: factKey, addendA: parts[0], addendB: parts[1])
             update(new)
             modelContext.insert(new)
         }

--- a/Persistence/KidProfileStore.swift
+++ b/Persistence/KidProfileStore.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Observation
+import SwiftData
+
+@MainActor
+@Observable
+final class KidProfileStore {
+    static let emojiChoices = ["🦊", "🐼", "🐨", "🦖", "🦁", "🐳", "🦄", "🐸", "🐯", "🐙"]
+
+    private let modelContext: ModelContext
+    private let defaults: UserDefaults
+    private let activeProfileDefaultsKey = "activeKidProfileId"
+
+    private(set) var activeProfileId: String = ""
+
+    init(modelContext: ModelContext, defaults: UserDefaults = .standard) {
+        self.modelContext = modelContext
+        self.defaults = defaults
+        bootstrapDefaultProfileIfNeeded()
+    }
+
+    var profiles: [StoredKidProfile] {
+        let descriptor = FetchDescriptor<StoredKidProfile>(sortBy: [SortDescriptor(\StoredKidProfile.createdAt)])
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
+    var activeProfile: StoredKidProfile? {
+        profiles.first(where: { $0.id == activeProfileId })
+    }
+
+    func addProfile(name: String, emoji: String) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+        let cleanEmoji = emoji.isEmpty ? Self.emojiChoices[0] : emoji
+        let profile = StoredKidProfile(name: trimmedName, emoji: cleanEmoji)
+        modelContext.insert(profile)
+        try? modelContext.save()
+        setActiveProfile(id: profile.id)
+    }
+
+    func setActiveProfile(id: String) {
+        guard profiles.contains(where: { $0.id == id }) else { return }
+        activeProfileId = id
+        defaults.set(id, forKey: activeProfileDefaultsKey)
+    }
+
+    private func bootstrapDefaultProfileIfNeeded() {
+        if profiles.isEmpty {
+            let defaultProfile = StoredKidProfile(name: "Kiddo", emoji: "🦊")
+            modelContext.insert(defaultProfile)
+            try? modelContext.save()
+        }
+
+        let savedProfileId = defaults.string(forKey: activeProfileDefaultsKey)
+        if let savedProfileId, profiles.contains(where: { $0.id == savedProfileId }) {
+            activeProfileId = savedProfileId
+            return
+        }
+
+        if let first = profiles.first {
+            setActiveProfile(id: first.id)
+        }
+    }
+}

--- a/Persistence/SessionHistoryStore.swift
+++ b/Persistence/SessionHistoryStore.swift
@@ -6,17 +6,48 @@ import SwiftData
 @Observable
 final class SessionHistoryStore {
     private let modelContext: ModelContext
+    private let activeProfileIdProvider: () -> String
 
-    init(modelContext: ModelContext) {
+    init(modelContext: ModelContext, activeProfileIdProvider: @escaping () -> String) {
         self.modelContext = modelContext
+        self.activeProfileIdProvider = activeProfileIdProvider
+    }
+
+    convenience init(modelContext: ModelContext) {
+        self.init(modelContext: modelContext, activeProfileIdProvider: { "default-profile" })
     }
 
     func save(_ draft: SessionSummaryDraft) {
-        modelContext.insert(StoredSessionSummary(from: draft))
+        modelContext.insert(StoredSessionSummary(from: draft, profileId: activeProfileIdProvider()))
         try? modelContext.save()
     }
 
+    func summariesForActiveProfile() -> [StoredSessionSummary] {
+        let profileId = activeProfileIdProvider()
+        let descriptor = FetchDescriptor<StoredSessionSummary>(
+            predicate: #Predicate { $0.profileId == profileId },
+            sortBy: [SortDescriptor(\StoredSessionSummary.startedAt, order: .reverse)]
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
+    func allSummaries() -> [StoredSessionSummary] {
+        let descriptor = FetchDescriptor<StoredSessionSummary>(sortBy: [SortDescriptor(\StoredSessionSummary.startedAt, order: .reverse)])
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
     func clearAll() {
+        let descriptor = FetchDescriptor<StoredSessionSummary>(
+            predicate: #Predicate { $0.profileId == activeProfileIdProvider() }
+        )
+        guard let sessions = try? modelContext.fetch(descriptor) else { return }
+        for session in sessions {
+            modelContext.delete(session)
+        }
+        try? modelContext.save()
+    }
+
+    func clearAllProfiles() {
         let descriptor = FetchDescriptor<StoredSessionSummary>()
         guard let sessions = try? modelContext.fetch(descriptor) else { return }
         for session in sessions {

--- a/Persistence/SessionHistoryStore.swift
+++ b/Persistence/SessionHistoryStore.swift
@@ -37,8 +37,9 @@ final class SessionHistoryStore {
     }
 
     func clearAll() {
+        let profileId = activeProfileIdProvider()
         let descriptor = FetchDescriptor<StoredSessionSummary>(
-            predicate: #Predicate { $0.profileId == activeProfileIdProvider() }
+            predicate: #Predicate { $0.profileId == profileId }
         )
         guard let sessions = try? modelContext.fetch(descriptor) else { return }
         for session in sessions {

--- a/Persistence/TelemetryWriter.swift
+++ b/Persistence/TelemetryWriter.swift
@@ -1,36 +1,32 @@
 import Foundation
-
-struct ExportArtifact: Equatable {
-    let url: URL
-    let fileName: String
-}
+import SwiftData
 
 @MainActor
 final class TelemetryWriter {
     static let schemaVersion = 1
 
     private let encoder: JSONEncoder
-    private let fileManager: FileManager
-    private let documentsDirectory: URL
-    private(set) var currentExport: ExportArtifact?
+    private let modelContext: ModelContext
+    private let activeProfileIdProvider: () -> String
 
-    init(fileManager: FileManager = .default) {
-        self.fileManager = fileManager
+    private(set) var currentSessionId: String?
+
+    convenience init() {
+        let schema = Schema([StoredTelemetryEvent.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: config)
+        self.init(modelContext: ModelContext(container), activeProfileIdProvider: { "default-profile" })
+    }
+
+    init(modelContext: ModelContext, activeProfileIdProvider: @escaping () -> String) {
+        self.modelContext = modelContext
+        self.activeProfileIdProvider = activeProfileIdProvider
         encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
-        documentsDirectory = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
     }
 
     func beginSession(sessionId: UUID, featureFlags: FeatureFlagService) throws {
-        let fileName = "session-\(sessionId.uuidString).jsonl"
-        let exportDirectory = exportsDirectory()
-        if !fileManager.fileExists(atPath: exportDirectory.path) {
-            try fileManager.createDirectory(at: exportDirectory, withIntermediateDirectories: true)
-        }
-
-        let fileURL = exportDirectory.appendingPathComponent(fileName)
-        fileManager.createFile(atPath: fileURL.path, contents: nil)
-        currentExport = ExportArtifact(url: fileURL, fileName: fileName)
+        currentSessionId = sessionId.uuidString
 
         try append(
             SliceEvent(
@@ -46,21 +42,23 @@ final class TelemetryWriter {
     }
 
     func append(_ event: SliceEvent) throws {
-        guard let currentExport else { return }
+        guard let currentSessionId else { return }
         let data = try encoder.encode(event)
-        guard let line = String(data: data, encoding: .utf8)?.appending("\n").data(using: .utf8) else {
+        guard let encodedEvent = String(data: data, encoding: .utf8) else {
             throw CocoaError(.fileWriteUnknown)
         }
 
-        if let handle = try? FileHandle(forWritingTo: currentExport.url) {
-            try handle.seekToEnd()
-            try handle.write(contentsOf: line)
-            try handle.close()
-        }
+        let row = StoredTelemetryEvent(
+            sessionId: currentSessionId,
+            profileId: activeProfileIdProvider(),
+            event: event,
+            encodedEvent: encodedEvent
+        )
+        modelContext.insert(row)
+        try modelContext.save()
     }
 
-    @discardableResult
-    func finishSession(session: SliceSession, digest: ParentDigest, themeId: String = "classic") throws -> ExportArtifact? {
+    func finishSession(session: SliceSession, digest: ParentDigest, themeId: String = "classic") throws {
         try append(
             SliceEvent(
                 type: .sessionEnd,
@@ -74,33 +72,19 @@ final class TelemetryWriter {
                 ]
             )
         )
-        try verifyReadableJSONL()
-        return currentExport
     }
 
-    func verifyReadableJSONL() throws {
-        guard let currentExport else { return }
-        let content = try String(contentsOf: currentExport.url, encoding: .utf8)
-        for line in content.split(separator: "\n") {
-            _ = try JSONDecoder().decode(SliceEvent.self, from: Data(line.utf8))
+    func clearEventsForActiveProfile() {
+        let profileId = activeProfileIdProvider()
+        let descriptor = FetchDescriptor<StoredTelemetryEvent>(
+            predicate: #Predicate { $0.profileId == profileId }
+        )
+        guard let events = try? modelContext.fetch(descriptor) else { return }
+        for event in events {
+            modelContext.delete(event)
         }
-    }
-
-    func exportsDirectory() -> URL {
-        documentsDirectory.appendingPathComponent("SessionExports", isDirectory: true)
-    }
-
-    func exportURL(fileName: String) -> URL {
-        exportsDirectory().appendingPathComponent(fileName)
-    }
-
-    func clearExports() {
-        let directory = exportsDirectory()
-        guard let urls = try? fileManager.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) else { return }
-        for url in urls {
-            try? fileManager.removeItem(at: url)
-        }
-        currentExport = nil
+        try? modelContext.save()
+        currentSessionId = nil
     }
 
     func digest(from summaries: [StoredSessionSummary]) -> ParentDigest {

--- a/Tests/MatherTests/SessionHistoryTests.swift
+++ b/Tests/MatherTests/SessionHistoryTests.swift
@@ -7,11 +7,11 @@ import Testing
 
 @MainActor
 private func makeInMemoryStore() throws -> (SessionHistoryStore, ModelContext) {
-    let schema = Schema([StoredSessionSummary.self])
+    let schema = Schema([StoredSessionSummary.self, StoredTelemetryEvent.self])
     let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
     let container = try ModelContainer(for: schema, configurations: config)
     let context = ModelContext(container)
-    return (SessionHistoryStore(modelContext: context), context)
+    return (SessionHistoryStore(modelContext: context, activeProfileIdProvider: { "test-profile" }), context)
 }
 
 private func makeDraft(
@@ -32,7 +32,7 @@ private func makeDraft(
         transferCorrectCount: transferCorrect,
         medianLatencyMs: medianLatencyMs,
         nextTargetHint: "Keep going.",
-        exportFileName: "session-\(sessionId).jsonl"
+        exportFileName: "swiftdata://session/\(sessionId)"
     )
 }
 
@@ -82,7 +82,11 @@ struct SessionHistoryStoreTests {
 struct TelemetryWriterDigestTests {
     @Test
     func digestReturnsDefaultsForEmptyHistory() {
-        let digest = TelemetryWriter().digest(from: [])
+        let schema = Schema([StoredTelemetryEvent.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: config)
+        let writer = TelemetryWriter(modelContext: ModelContext(container), activeProfileIdProvider: { "test-profile" })
+        let digest = writer.digest(from: [])
 
         #expect(digest.problemsCompleted == 0)
         #expect(digest.firstAttemptAccuracy == 0)
@@ -97,7 +101,10 @@ struct TelemetryWriterDigestTests {
         store.save(makeDraft(problemsCompleted: 6, accuracy: 0.5, transferCorrect: 2, medianLatencyMs: 2000))
 
         let summaries = try context.fetch(FetchDescriptor<StoredSessionSummary>())
-        let digest = TelemetryWriter().digest(from: summaries)
+        let schema = Schema([StoredTelemetryEvent.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: config)
+        let digest = TelemetryWriter(modelContext: ModelContext(container), activeProfileIdProvider: { "test-profile" }).digest(from: summaries)
 
         #expect(digest.problemsCompleted == 10)
         #expect(digest.transferCorrectCount == 6)
@@ -113,7 +120,10 @@ struct TelemetryWriterDigestTests {
         store.save(makeDraft(medianLatencyMs: 3000))
 
         let summaries = try context.fetch(FetchDescriptor<StoredSessionSummary>())
-        let digest = TelemetryWriter().digest(from: summaries)
+        let schema = Schema([StoredTelemetryEvent.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: config)
+        let digest = TelemetryWriter(modelContext: ModelContext(container), activeProfileIdProvider: { "test-profile" }).digest(from: summaries)
 
         #expect(digest.medianLatencyMs == 2000)
     }
@@ -124,7 +134,10 @@ struct TelemetryWriterDigestTests {
         store.save(makeDraft(accuracy: 0.9))
 
         let summaries = try context.fetch(FetchDescriptor<StoredSessionSummary>())
-        let digest = TelemetryWriter().digest(from: summaries)
+        let schema = Schema([StoredTelemetryEvent.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: config)
+        let digest = TelemetryWriter(modelContext: ModelContext(container), activeProfileIdProvider: { "test-profile" }).digest(from: summaries)
 
         // High accuracy (>= 0.7) should give a "keep going" hint, not a "repeat" hint
         #expect(!digest.nextTargetHint.contains("Repeat"))
@@ -136,7 +149,10 @@ struct TelemetryWriterDigestTests {
         store.save(makeDraft(accuracy: 0.4))
 
         let summaries = try context.fetch(FetchDescriptor<StoredSessionSummary>())
-        let digest = TelemetryWriter().digest(from: summaries)
+        let schema = Schema([StoredTelemetryEvent.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: config)
+        let digest = TelemetryWriter(modelContext: ModelContext(container), activeProfileIdProvider: { "test-profile" }).digest(from: summaries)
 
         #expect(digest.nextTargetHint.contains("Repeat"))
     }
@@ -150,7 +166,10 @@ struct TelemetryWriterDigestTests {
         store.save(makeDraft(problemsCompleted: 9, accuracy: 0.0))
 
         let summaries = try context.fetch(FetchDescriptor<StoredSessionSummary>())
-        let digest = TelemetryWriter().digest(from: summaries)
+        let schema = Schema([StoredTelemetryEvent.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: config)
+        let digest = TelemetryWriter(modelContext: ModelContext(container), activeProfileIdProvider: { "test-profile" }).digest(from: summaries)
 
         // Session-average would give (1.0 + 0.0) / 2 = 0.50 — wrong.
         // Problem-weighted: (1 × 1.0 + 9 × 0.0) / 10 = 0.10 — correct.
@@ -165,7 +184,10 @@ struct TelemetryWriterDigestTests {
         store.save(makeDraft(problemsCompleted: 0, accuracy: 0.0))
 
         let summaries = try context.fetch(FetchDescriptor<StoredSessionSummary>())
-        let digest = TelemetryWriter().digest(from: summaries)
+        let schema = Schema([StoredTelemetryEvent.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: schema, configurations: config)
+        let digest = TelemetryWriter(modelContext: ModelContext(container), activeProfileIdProvider: { "test-profile" }).digest(from: summaries)
 
         #expect(digest.firstAttemptAccuracy == 0)  // divide-by-zero guard
         #expect(digest.problemsCompleted == 0)


### PR DESCRIPTION
### Motivation

- Introduce per-kid profiles (name + emoji) so session history and telemetry are stored per profile while a parent view can aggregate across profiles.
- Replace the file-based JSONL telemetry exporter with an on-device SwiftData-backed store so events can be queried and partitioned by profile.

### Description

- Add `@Model` types `StoredKidProfile` and `StoredTelemetryEvent` and add `profileId` to `StoredSessionSummary`, and convert `StoredFactRecord` to include a profile-scoped unique key (`uniqueKey`).
- New `KidProfileStore` provides profile creation, bootstrapping, active-profile persistence, and a small emoji palette used by the UI.
- Rework persistence APIs to be active-profile aware by adding an `activeProfileIdProvider` dependency to `SessionHistoryStore`, `FactRecordStore`, and `TelemetryWriter`, and add profile-scoped fetch/clear helpers (`summariesForActiveProfile`, `clearEventsForActiveProfile`, etc.).
- Replace JSONL file writes with SwiftData rows in `TelemetryWriter.append(_:)` and `finishSession`, and update `VerticalSliceEngine` to save a `swiftdata://session/<id>` URI into `SessionSummaryDraft` as the export identifier.
- Wire the new stores into the app in `AppModel` and register the new models in the `ModelContainer` in `MatherApp`; update UI so `SettingsView` can switch/create profiles and `ParentSummaryView` shows aggregated cross-profile digest and per-profile counts.
- Update `Tests/MatherTests/SessionHistoryTests.swift` to account for the new models and initialization shape and to use `swiftdata://session/...` export identifiers.

### Testing

- Updated unit tests: `Tests/MatherTests/SessionHistoryTests.swift` was modified to initialize SwiftData in-memory schemas including `StoredTelemetryEvent` and to use the new `SessionHistoryStore` constructor; these tests were not executed in this environment.
- Attempted to run `xcodegen generate` but the `xcodegen` binary is not available in the environment so project generation could not be validated.
- Attempted to run `xcodebuild -list -project Mather.xcodeproj` but `xcodebuild` is not available in the environment so the full test suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9a88defe883248ec2fb6480ce1064)