### PR TITLE
test(memory): mark learning-details test MainActor-safe

### DIFF
--- a/Tests/MatherTests/MemoryVarietyTests.swift
+++ b/Tests/MatherTests/MemoryVarietyTests.swift
@@ -46,7 +46,7 @@ struct MemoryVarietyTests {
         #expect(MemoryDeck.birds.allSatisfy { Set($0.detailCards.map(\.title)).isSuperset(of: ["Name", "Home", "Lifespan", "Weight", "Size", "Colors"]) })
     }
 
-    @Test func learningDetailsAreOnlyAvailableForCompletedBirdRounds() {
+    @MainActor @Test func learningDetailsAreOnlyAvailableForCompletedBirdRounds() {
         let bird = MemoryDeck.birds[0]
         let matchedBirdCard = MemoryCard(pairId: bird.id, content: .picture(bird), isMatched: true)
         let unmatchedBirdCard = MemoryCard(pairId: bird.id, content: .picture(bird), isMatched: false)


### PR DESCRIPTION
## Why
`main` is currently red because `MemoryVarietyTests` calls `MemoryView.canOpenLearningDetails(...)` from a nonisolated test even though that API is main-actor isolated. This breaks both `CI` and `iOS UI Review (main)`, and in turn blocks the open PR backlog.

## What changed
- mark `learningDetailsAreOnlyAvailableForCompletedBirdRounds` as `@MainActor`

## Impact
- restores baseline compatibility with the main-actor isolated API under test
- unblocks PR #332 once checks are green

## Notes
I attempted remote Mac validation, but the configured `ganesh-mba` host was unreachable from this environment at the moment (`No route to host`), so validation is currently delegated to GitHub Actions.