### PR TITLE
fix: restore and validate make & break loop V2 rollout gate

### DIFF
--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -30,6 +30,13 @@ struct SettingsView: View {
         )
     }
 
+    private var makeBreakLoopV2Binding: Binding<Bool> {
+        Binding(
+            get: { appModel.featureFlags.makeBreakLoopV2Enabled },
+            set: { appModel.featureFlags.makeBreakLoopV2Enabled = $0 }
+        )
+    }
+
     private var soundReactionBinding: Binding<Bool> {
         Binding(
             get: { appModel.featureFlags.soundReactionEnabled },
@@ -57,10 +64,16 @@ struct SettingsView: View {
                                 .font(.caption.weight(.semibold))
                                 .foregroundStyle(.secondary)
                                 .padding(.top, 4)
-                            Text("Make & Break, Bond Blast, Gravity Split, and the current loop ship on by default.")
+                            Text("Use the rollout toggle below to keep the reopened 4-stage loop behind parent/QA control until validation is complete.")
                                 .font(.subheadline)
                                 .foregroundStyle(MatherTheme.cardSubtitle)
                                 .fixedSize(horizontal: false, vertical: true)
+
+                            VS1ToggleRow(
+                                title: "Make & Break loop v2",
+                                subtitle: "Turns on the repeated Make it → Gravity Split → Sum Sprint → Bond Blast route for each target.",
+                                isOn: makeBreakLoopV2Binding
+                            )
 
                             Divider()
 

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -72,6 +72,7 @@ struct SettingsView: View {
                             VS1ToggleRow(
                                 title: "Make & Break loop v2",
                                 subtitle: "Turns on the repeated Make it → Gravity Split → Sum Sprint → Bond Blast route for each target.",
+                                accessibilityIdentifier: "settings-loop-v2-toggle",
                                 isOn: makeBreakLoopV2Binding
                             )
 

--- a/Features/VerticalSlice1/VS1SharedUI.swift
+++ b/Features/VerticalSlice1/VS1SharedUI.swift
@@ -119,6 +119,7 @@ struct VS1SecondaryButton: View {
 struct VS1ToggleRow: View {
     let title: String
     let subtitle: String
+    var accessibilityIdentifier: String? = nil
     @Binding var isOn: Bool
 
     var body: some View {
@@ -131,6 +132,7 @@ struct VS1ToggleRow: View {
                     .foregroundStyle(.secondary)
             }
         }
+        .accessibilityIdentifier(accessibilityIdentifier ?? "")
         .tint(MatherTheme.accent)
         .padding(.vertical, 10)
     }

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -142,7 +142,7 @@ final class FeatureFlagService {
             Keys.selectedThemeId: "classic",
             Keys.vs1BondMatchEnabled: true,
             Keys.vs1GravitySplitEnabled: true,
-            Keys.makeBreakLoopV2Enabled: true,
+            Keys.makeBreakLoopV2Enabled: false,
             Keys.motionControlsEnabled: true,
             Keys.soundReactionEnabled: true,
             Keys.roomQuestSafetyAcknowledged: false,

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -35,12 +35,12 @@ struct FeatureFlagTests {
         #expect(flags.hapticsEnabled == true)
     }
 
-    @Test func stableFeatureRolloutDefaultsAreEnabled() {
+    @Test func stableFeatureRolloutDefaultsMatchRecoveryPolicy() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         #expect(flags.verticalSlice1Enabled)
         #expect(flags.vs1BondMatchEnabled)
         #expect(flags.vs1GravitySplitEnabled)
-        #expect(flags.makeBreakLoopV2Enabled)
+        #expect(flags.makeBreakLoopV2Enabled == false)
         #expect(flags.soundReactionEnabled)
     }
 

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -203,6 +203,7 @@ final class ScreenshotTests: XCTestCase {
         // Navigate to Settings and capture the pilot runbook
         app.buttons["Settings"].tap()
         _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
+        _ = app.switches["settings-loop-v2-toggle"].waitForExistence(timeout: 5)
         _ = app.staticTexts["Pilot smoke test"].waitForExistence(timeout: 5)
         snapshot(app, "iPhone-Settings-PilotRunbook")
         app.buttons["Home"].tap()

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -55,11 +55,26 @@ final class ScreenshotTests: XCTestCase {
 
         app.buttons["Settings"].tap()
         _ = app.staticTexts["Settings"].waitForExistence(timeout: 3)
+        let rolloutToggle = app.switches["settings-loop-v2-toggle"]
+        XCTAssertTrue(rolloutToggle.waitForExistence(timeout: 5))
+        XCTAssertEqual(rolloutToggle.value as? String, "0")
         snapshot(app, "Settings-DefaultRolloutState")
 
         app.buttons["Home"].tap()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 3)
         snapshot(app, "Home-DefaultRolloutState")
+    }
+
+    func testScreenshot_Settings_LoopV2EnabledViaLaunchArgument() {
+        let app = launchWithLoopV2()
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
+
+        app.buttons["Settings"].tap()
+        _ = app.staticTexts["Settings"].waitForExistence(timeout: 3)
+        let rolloutToggle = app.switches["settings-loop-v2-toggle"]
+        XCTAssertTrue(rolloutToggle.waitForExistence(timeout: 5))
+        XCTAssertEqual(rolloutToggle.value as? String, "1")
+        snapshot(app, "Settings-LoopV2EnabledViaLaunchArgument")
     }
 
     // MARK: - Session Config screen


### PR DESCRIPTION
## Summary
Reopen Queue 2 / PR2 for #222 on top of current `main` by restoring and validating the Make & Break loop V2 rollout gate.

## What changed
- default `makeBreakLoopV2Enabled` back to off
- expose the loop V2 gate in Settings
- add UI/screenshot validation for gate visibility
- add UI/screenshot validation for default-off and launch-forced-on states

## Why
Current `main` already contains much of the route scaffold for #222.
The real mismatch here was rollout truth: recovery notes said loop V2 should remain gated until QA/release signoff, but code had drifted to default-on and the gate was not clearly surfaced in Settings.

## Validation
- feature-flag unit test aligned with recovery policy
- screenshot/UI tests now cover gate visibility and both default/forced states
- GitHub CI `Build & Test` passed on this PR
- CodeQL / dependency review checks passed on this PR

## Scope note
This is a Queue 2 rollout/validation recovery slice only. It does **not** claim full #222 closeout.

## Issue
- Closes part of #222