### PR TITLE
fix: remove stale make & break to-ten intro framing

### DIFF
--- a/Domain/ClassicTheme.swift
+++ b/Domain/ClassicTheme.swift
@@ -37,7 +37,7 @@ struct ClassicTheme: SliceTheme {
     }
 
     func sessionIntroPhrase() -> String {
-        "Let's make and break numbers to ten."
+        "Let's make and break numbers in different ways."
     }
 
     func sessionEndPhrase() -> String {

--- a/Domain/VehicleSpec.swift
+++ b/Domain/VehicleSpec.swift
@@ -46,7 +46,7 @@ extension VehicleSpec {
             case .done:       return "Problem complete."
             }
         },
-        sessionIntroFn: { "Let's park and split cars to ten." },
+        sessionIntroFn: { "Let's park and split cars in different ways." },
         sessionEndFn: { "Session complete. Great parking!" },
         sessionStartFeedbackFn: { "Park the cars in the garage." }
     )
@@ -71,7 +71,7 @@ extension VehicleSpec {
             case .done:       return "Problem complete."
             }
         },
-        sessionIntroFn: { "Let's load and split trucks to ten." },
+        sessionIntroFn: { "Let's load and split trucks in different ways." },
         sessionEndFn: { "Session complete. Great hauling!" },
         sessionStartFeedbackFn: { "Load the trucks at the depot." }
     )
@@ -96,7 +96,7 @@ extension VehicleSpec {
             case .done:       return "Problem complete."
             }
         },
-        sessionIntroFn: { "Let's deliver vans to ten." },
+        sessionIntroFn: { "Let's deliver vans in different ways." },
         sessionEndFn: { "Session complete. All delivered!" },
         sessionStartFeedbackFn: { "Send the vans to the warehouse." }
     )
@@ -121,7 +121,7 @@ extension VehicleSpec {
             case .done:       return "Problem complete."
             }
         },
-        sessionIntroFn: { "Let's fill buses to ten." },
+        sessionIntroFn: { "Let's fill buses in different ways." },
         sessionEndFn: { "Session complete. Everyone on board!" },
         sessionStartFeedbackFn: { "Fill the buses with passengers." }
     )
@@ -146,7 +146,7 @@ extension VehicleSpec {
             case .done:       return "Problem complete."
             }
         },
-        sessionIntroFn: { "Let's line up bulldozers to ten." },
+        sessionIntroFn: { "Let's line up bulldozers in different ways." },
         sessionEndFn: { "Session complete. Great work on the site!" },
         sessionStartFeedbackFn: { "Line up the bulldozers on the site." }
     )
@@ -171,7 +171,7 @@ extension VehicleSpec {
             case .done:       return "Problem complete."
             }
         },
-        sessionIntroFn: { "Let's land helicopters to ten." },
+        sessionIntroFn: { "Let's land helicopters in different ways." },
         sessionEndFn: { "Session complete. Great landing!" },
         sessionStartFeedbackFn: { "Land the helicopters on the pad." }
     )
@@ -196,7 +196,7 @@ extension VehicleSpec {
             case .done:       return "Problem complete."
             }
         },
-        sessionIntroFn: { "Let's park planes to ten." },
+        sessionIntroFn: { "Let's park planes in different ways." },
         sessionEndFn: { "Session complete. Safe travels!" },
         sessionStartFeedbackFn: { "Park the planes at the gate." }
     )

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -72,7 +72,7 @@ struct ThemeTests {
 
     @Test func classicThemeSessionPhrases() {
         let theme = ClassicTheme()
-        #expect(theme.sessionIntroPhrase() == "Let's make and break numbers to ten.")
+        #expect(theme.sessionIntroPhrase() == "Let's make and break numbers in different ways.")
         #expect(!theme.sessionEndPhrase().isEmpty)
         #expect(!theme.sessionStartFeedback().isEmpty)
     }


### PR DESCRIPTION
## Summary
- remove stale child-facing `to ten` session-intro wording from the live theme path
- keep the replacement wording numerically neutral until the actual reachable 1–20 session configuration is proven
- update the matching theme test expectation

## Why
PR #338 fixed rollout-gate truth, but issue #222 still had live session-intro strings anchoring the product to the old `to ten` framing.

This RX1 slice fixes that real runtime surface-truth problem **without** overclaiming unrevalidated 1–20 behavior.

## Validation
- inspected runtime path: `VerticalSliceEngine -> activeTheme.sessionIntroPhrase()`
- updated the matching theme test expectation
- CI is green on this PR:
  - `Build & Test`
  - `Analyze Actions Workflows`
  - `Dependency Review`
  - `CodeQL`

## Issue
- relates to #222
- this is a narrow surface-truth slice, not full #222 closeout
