### PR TITLE
feat(profiles): kid profiles with per-child SwiftData scoping

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -18,6 +18,21 @@ final class AppModel {
     let roomQuestEngine: RoomQuestEngine
     let factStore: FactRecordStore
     let sumSprintEngine: SumSprintEngine
+    let profileStore: KidProfileStore
+
+    var activeProfile: StoredKidProfile? {
+        didSet {
+            historyStore.activeProfileId = activeProfile?.id
+            factStore.activeProfileId = activeProfile?.id
+            if let id = activeProfile?.id {
+                UserDefaults.standard.set(id.uuidString, forKey: "lastProfileId")
+            }
+        }
+    }
+
+    func selectProfile(_ profile: StoredKidProfile) {
+        activeProfile = profile
+    }
 
     init(modelContext: ModelContext) {
         let featureFlags = FeatureFlagService()
@@ -29,6 +44,7 @@ final class AppModel {
         let motionService = MotionService()
         let soundDetectionService = SoundDetectionService()
         let roomQuestScanner = RoomQuestLiveScanner()
+        let profileStore = KidProfileStore(modelContext: modelContext)
 
         self.featureFlags = featureFlags
         self.speechService = speechService
@@ -39,6 +55,7 @@ final class AppModel {
         self.motionService = motionService
         self.soundDetectionService = soundDetectionService
         self.roomQuestScanner = roomQuestScanner
+        self.profileStore = profileStore
         roomQuestScanner.featureFlags = featureFlags
 
         let vsEngine = VerticalSliceEngine(

--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -8,7 +8,12 @@ struct MatherApp: App {
 
     init() {
         do {
-            container = try ModelContainer(for: StoredSessionSummary.self, StoredRoomQuestStationReference.self, StoredFactRecord.self)
+            container = try ModelContainer(
+                for: StoredSessionSummary.self,
+                     StoredRoomQuestStationReference.self,
+                     StoredFactRecord.self,
+                     StoredKidProfile.self
+            )
             let appModel = AppModel(modelContext: container.mainContext)
             Self.seedSessionHistoryIfRequested(using: appModel)
             _appModel = State(initialValue: appModel)
@@ -22,11 +27,19 @@ struct MatherApp: App {
             RootView(appModel: appModel)
                 .modelContainer(container)
                 .preferredColorScheme(Self.preferredColorSchemeForUITests())
+                .task { restoreLastProfile() }
         }
     }
 }
 
 private extension MatherApp {
+    func restoreLastProfile() {
+        guard let idString = UserDefaults.standard.string(forKey: "lastProfileId"),
+              let id = UUID(uuidString: idString),
+              let profile = appModel.profileStore.profile(withId: id) else { return }
+        appModel.activeProfile = profile
+    }
+
     static func preferredColorSchemeForUITests() -> ColorScheme? {
         let arguments = ProcessInfo.processInfo.arguments
         guard let flagIndex = arguments.firstIndex(of: "-uiTest.appearance"),

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -6,6 +6,13 @@ struct RootView: View {
     @Bindable var appModel: AppModel
     @Query(sort: \StoredSessionSummary.startedAt, order: .reverse) private var sessionSummaries: [StoredSessionSummary]
 
+    private var showingProfilePicker: Binding<Bool> {
+        Binding(
+            get: { appModel.activeProfile == nil },
+            set: { if !$0 { /* dismissal only allowed once a profile is selected */ } }
+        )
+    }
+
     var body: some View {
         NavigationStack {
             Group {
@@ -71,5 +78,8 @@ struct RootView: View {
             .navigationBarTitleDisplayMode(.inline)
         }
         .background(MatherTheme.background.ignoresSafeArea())
+        .sheet(isPresented: showingProfilePicker) {
+            ProfilePickerView(appModel: appModel)
+        }
     }
 }

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -160,6 +160,7 @@ struct SessionSummaryDraft: Equatable {
     var medianLatencyMs: Int
     var nextTargetHint: String
     var exportFileName: String
+    var profileId: UUID? = nil
 }
 
 // MARK: - Gravity Split models
@@ -464,16 +465,32 @@ final class StoredRoomQuestStationReference {
 }
 
 @Model
+final class StoredKidProfile {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var emoji: String
+    var createdAt: Date
+
+    init(name: String, emoji: String) {
+        self.id = UUID()
+        self.name = name
+        self.emoji = emoji
+        self.createdAt = .now
+    }
+}
+
+@Model
 final class StoredFactRecord {
-    @Attribute(.unique) var factKey: String  // "\(addendA)+\(addendB)"
+    @Attribute(.unique) var factKey: String  // profile-scoped: "\(profileId.uuidString):\(a)+\(b)" or legacy "\(a)+\(b)"
     var addendA: Int
     var addendB: Int
     var boxRawValue: Int
     var sessionsSinceLastSeen: Int
     var correctStreak: Int
     var lastSeenAt: Date?
+    var profileId: UUID?
 
-    init(factKey: String, addendA: Int, addendB: Int) {
+    init(factKey: String, addendA: Int, addendB: Int, profileId: UUID? = nil) {
         self.factKey = factKey
         self.addendA = addendA
         self.addendB = addendB
@@ -481,6 +498,7 @@ final class StoredFactRecord {
         self.sessionsSinceLastSeen = 0
         self.correctStreak = 0
         self.lastSeenAt = nil
+        self.profileId = profileId
     }
 }
 
@@ -496,6 +514,7 @@ final class StoredSessionSummary {
     var medianLatencyMs: Int
     var nextTargetHint: String
     var exportFileName: String
+    var profileId: UUID?
 
     init(from draft: SessionSummaryDraft) {
         sessionId = draft.sessionId
@@ -508,5 +527,6 @@ final class StoredSessionSummary {
         medianLatencyMs = draft.medianLatencyMs
         nextTargetHint = draft.nextTargetHint
         exportFileName = draft.exportFileName
+        profileId = draft.profileId
     }
 }

--- a/Features/ParentSummary/ParentSummaryView.swift
+++ b/Features/ParentSummary/ParentSummaryView.swift
@@ -6,8 +6,9 @@ struct ParentSummaryView: View {
     let summaries: [StoredSessionSummary]
 
     var body: some View {
-        let digest = appModel.telemetryWriter.digest(from: summaries)
-        let recentSummaries = Array(summaries.prefix(5))
+        let filtered = summaries.filter { $0.profileId == appModel.activeProfile?.id }
+        let digest = appModel.telemetryWriter.digest(from: filtered)
+        let recentSummaries = Array(filtered.prefix(5))
 
         ZStack {
             MatherTheme.background.ignoresSafeArea()
@@ -15,6 +16,15 @@ struct ParentSummaryView: View {
                 VStack(spacing: 16) {
                     CardSurface {
                         VStack(alignment: .leading, spacing: 8) {
+                            if let profile = appModel.activeProfile {
+                                HStack(spacing: 8) {
+                                    Text(profile.emoji)
+                                        .font(.title2)
+                                    Text(profile.name)
+                                        .font(.title2.weight(.black))
+                                        .foregroundStyle(MatherTheme.ink)
+                                }
+                            }
                             Text("Parent Summary")
                                 .font(.largeTitle.weight(.black))
                             Text(digest.objectiveTitle)
@@ -23,7 +33,7 @@ struct ParentSummaryView: View {
                         }
                     }
 
-                    if summaries.isEmpty {
+                    if filtered.isEmpty {
                         CardSurface {
                             VStack(spacing: 12) {
                                 Image(systemName: "chart.bar.xaxis")
@@ -75,7 +85,7 @@ struct ParentSummaryView: View {
                             VStack(alignment: .leading, spacing: 10) {
                                 Text("Recent sessions")
                                     .font(.title3.weight(.bold))
-                                Text(historyCaption(totalCount: summaries.count, visibleCount: recentSummaries.count))
+                                Text(historyCaption(totalCount: filtered.count, visibleCount: recentSummaries.count))
                                     .font(.subheadline.weight(.medium))
                                     .foregroundStyle(MatherTheme.cardSubtitle)
                                 ForEach(Array(recentSummaries.enumerated()), id: \.element.sessionId) { index, summary in
@@ -91,7 +101,7 @@ struct ParentSummaryView: View {
                                                 .foregroundStyle(MatherTheme.cardSubtitle)
                                         }
                                         Spacer()
-                                        if summary.sessionId == summaries.first?.sessionId {
+                                        if summary.sessionId == filtered.first?.sessionId {
                                             Text("Latest")
                                                 .font(.caption.weight(.bold))
                                                 .foregroundStyle(MatherTheme.accent)
@@ -102,7 +112,7 @@ struct ParentSummaryView: View {
                                         }
                                     }
                                     .padding(10)
-                                    .background(summary.sessionId == summaries.first?.sessionId ? MatherTheme.warm.opacity(0.2) : Color.secondary.opacity(0.06))
+                                    .background(summary.sessionId == filtered.first?.sessionId ? MatherTheme.warm.opacity(0.2) : Color.secondary.opacity(0.06))
                                     .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                                     .accessibilityElement(children: .combine)
                                     .accessibilityIdentifier("parent-summary-session-\(index)")
@@ -123,6 +133,12 @@ struct ParentSummaryView: View {
                     }
 
                     HStack(spacing: 16) {
+                        Button("Switch Profile") {
+                            appModel.activeProfile = nil
+                            appModel.engine.showHome()
+                        }
+                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.accent.opacity(0.18)))
+
                         Button("Settings") {
                             appModel.engine.showSettings()
                         }

--- a/Features/Profile/ProfilePickerView.swift
+++ b/Features/Profile/ProfilePickerView.swift
@@ -1,0 +1,214 @@
+import SwiftData
+import SwiftUI
+
+struct ProfilePickerView: View {
+    @Bindable var appModel: AppModel
+    @Query(sort: \StoredKidProfile.createdAt) private var profiles: [StoredKidProfile]
+    @State private var showingCreation = false
+    @State private var newName = ""
+    @State private var selectedEmoji = "🦊"
+
+    private var hasProfiles: Bool { !profiles.isEmpty }
+
+    var body: some View {
+        ZStack {
+            MatherTheme.background.ignoresSafeArea()
+            VStack(spacing: 0) {
+                headerSection
+                ScrollView {
+                    VStack(spacing: 20) {
+                        if hasProfiles {
+                            profileGrid
+                        }
+                        addKidSection
+                    }
+                    .padding(24)
+                }
+            }
+        }
+        .interactiveDismissDisabled(true)
+    }
+
+    // MARK: - Header
+
+    private var headerSection: some View {
+        VStack(spacing: 6) {
+            Text("Who's playing?")
+                .font(.system(size: 34, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+            Text("Pick a profile to get started")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+        .padding(.bottom, 20)
+        .padding(.horizontal, 24)
+    }
+
+    // MARK: - Profile grid
+
+    private var profileGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.flexible(), spacing: 16), GridItem(.flexible(), spacing: 16)],
+            spacing: 16
+        ) {
+            ForEach(profiles) { profile in
+                ProfileTile(profile: profile) {
+                    appModel.selectProfile(profile)
+                }
+            }
+        }
+    }
+
+    // MARK: - Add kid
+
+    private var addKidSection: some View {
+        VStack(spacing: 16) {
+            if showingCreation {
+                creationForm
+            } else {
+                Button {
+                    showingCreation = true
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.title2)
+                            .foregroundStyle(MatherTheme.accent)
+                        Text(hasProfiles ? "Add another kid" : "Create a profile")
+                            .font(.headline.weight(.bold))
+                            .foregroundStyle(MatherTheme.ink)
+                        Spacer()
+                    }
+                    .padding(20)
+                    .background(MatherTheme.card)
+                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: - Creation form
+
+    private var creationForm: some View {
+        VStack(spacing: 20) {
+            Text("New profile")
+                .font(.title3.weight(.bold))
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            emojiPicker
+
+            TextField("Name", text: $newName)
+                .font(.title3.weight(.semibold))
+                .textFieldStyle(.plain)
+                .padding(16)
+                .background(MatherTheme.background)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .strokeBorder(MatherTheme.accent.opacity(0.3), lineWidth: 1.5)
+                )
+                .autocorrectionDisabled()
+                .onChange(of: newName) { _, value in
+                    if value.count > 20 { newName = String(value.prefix(20)) }
+                }
+
+            HStack(spacing: 12) {
+                if hasProfiles {
+                    Button("Cancel") {
+                        showingCreation = false
+                        newName = ""
+                        selectedEmoji = "🦊"
+                    }
+                    .buttonStyle(SecondaryTileButtonStyle(fill: Color.secondary.opacity(0.15)))
+                }
+
+                Button("Start playing!") {
+                    guard !newName.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+                    let profile = appModel.profileStore.insert(
+                        name: newName.trimmingCharacters(in: .whitespaces),
+                        emoji: selectedEmoji
+                    )
+                    appModel.selectProfile(profile)
+                }
+                .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.accent.opacity(0.85)))
+                .disabled(newName.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+        .padding(20)
+        .background(MatherTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+
+    // MARK: - Emoji picker
+
+    private var emojiPicker: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Pick a picture")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 6), spacing: 8) {
+                ForEach(ProfilePickerView.kidEmojis, id: \.self) { emoji in
+                    Button {
+                        selectedEmoji = emoji
+                    } label: {
+                        Text(emoji)
+                            .font(.system(size: 30))
+                            .frame(width: 48, height: 48)
+                            .background(selectedEmoji == emoji ? MatherTheme.accent.opacity(0.2) : Color.clear)
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .strokeBorder(
+                                        selectedEmoji == emoji ? MatherTheme.accent : Color.clear,
+                                        lineWidth: 2
+                                    )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    static let kidEmojis: [String] = [
+        "🦊", "🐶", "🐱", "🐼", "🐨", "🦁",
+        "🐸", "🐧", "🦋", "🦄", "🐢", "🐬",
+        "🦖", "🐙", "🦀", "🐝", "🦔", "🐿️",
+        "🚀", "⭐️", "🌈", "🎈", "🏆", "🎨",
+        "⚽️", "🏀", "🎸", "🎯", "🍎", "🍦",
+    ]
+}
+
+// MARK: - Profile tile
+
+private struct ProfileTile: View {
+    let profile: StoredKidProfile
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(spacing: 10) {
+                Text(profile.emoji)
+                    .font(.system(size: 52))
+                    .frame(width: 80, height: 80)
+                    .background(MatherTheme.accent.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+
+                Text(profile.name)
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(MatherTheme.ink)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 20)
+            .background(MatherTheme.card)
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Play as \(profile.name)")
+    }
+}

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -9,10 +9,34 @@ struct HomeView: View {
             MatherTheme.background.ignoresSafeArea()
             ScrollView {
                 VStack(spacing: 20) {
-                    Text("Mather")
-                        .font(.system(size: 48, weight: .black, design: .rounded))
-                        .foregroundStyle(MatherTheme.ink)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    HStack(alignment: .firstTextBaseline) {
+                        Text("Mather")
+                            .font(.system(size: 48, weight: .black, design: .rounded))
+                            .foregroundStyle(MatherTheme.ink)
+                        Spacer()
+                        if let profile = appModel.activeProfile {
+                            Button {
+                                appModel.activeProfile = nil
+                            } label: {
+                                HStack(spacing: 6) {
+                                    Text(profile.emoji)
+                                        .font(.title3)
+                                    Text(profile.name)
+                                        .font(.subheadline.weight(.semibold))
+                                        .foregroundStyle(MatherTheme.ink)
+                                    Image(systemName: "chevron.down")
+                                        .font(.caption.weight(.bold))
+                                        .foregroundStyle(.secondary)
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 8)
+                                .background(MatherTheme.card)
+                                .clipShape(Capsule())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Switch profile, currently \(profile.name)")
+                        }
+                    }
 
                     makeAndBreakCard
                     labCard

--- a/Persistence/FactRecordStore.swift
+++ b/Persistence/FactRecordStore.swift
@@ -6,6 +6,7 @@ import SwiftData
 @Observable
 final class FactRecordStore {
     private let modelContext: ModelContext
+    var activeProfileId: UUID?
 
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
@@ -15,10 +16,15 @@ final class FactRecordStore {
 
     func fetchAll() -> [StoredFactRecord] {
         let descriptor = FetchDescriptor<StoredFactRecord>()
-        return (try? modelContext.fetch(descriptor)) ?? []
+        let all = (try? modelContext.fetch(descriptor)) ?? []
+        guard let profileId = activeProfileId else {
+            return all.filter { $0.profileId == nil }
+        }
+        return all.filter { $0.profileId == profileId }
     }
 
-    func record(forKey key: String) -> StoredFactRecord? {
+    func record(forKey rawKey: String) -> StoredFactRecord? {
+        let key = storedKey(rawKey)
         var descriptor = FetchDescriptor<StoredFactRecord>(
             predicate: #Predicate { $0.factKey == key }
         )
@@ -28,14 +34,18 @@ final class FactRecordStore {
 
     // MARK: - Upsert
 
-    /// Updates an existing record or creates one if it doesn't exist.
-    func upsert(factKey: String, update: (StoredFactRecord) -> Void) {
-        if let existing = record(forKey: factKey) {
+    func upsert(factKey rawKey: String, update: (StoredFactRecord) -> Void) {
+        if let existing = record(forKey: rawKey) {
             update(existing)
         } else {
-            let parts = factKey.split(separator: "+").compactMap { Int($0) }
+            let parts = rawKey.split(separator: "+").compactMap { Int($0) }
             guard parts.count == 2 else { return }
-            let new = StoredFactRecord(factKey: factKey, addendA: parts[0], addendB: parts[1])
+            let new = StoredFactRecord(
+                factKey: storedKey(rawKey),
+                addendA: parts[0],
+                addendB: parts[1],
+                profileId: activeProfileId
+            )
             update(new)
             modelContext.insert(new)
         }
@@ -44,13 +54,19 @@ final class FactRecordStore {
 
     // MARK: - Session bookkeeping
 
-    /// Called at the end of each session.
-    /// Increments sessionsSinceLastSeen for all records that were NOT seen this session.
-    func incrementSessionCounts(excludingKeys seenKeys: Set<String>) {
+    func incrementSessionCounts(excludingKeys seenRawKeys: Set<String>) {
+        let seenStoredKeys = Set(seenRawKeys.map { storedKey($0) })
         let all = fetchAll()
-        for record in all where !seenKeys.contains(record.factKey) {
+        for record in all where !seenStoredKeys.contains(record.factKey) {
             record.sessionsSinceLastSeen += 1
         }
         try? modelContext.save()
+    }
+
+    // MARK: - Private
+
+    private func storedKey(_ rawKey: String) -> String {
+        guard let profileId = activeProfileId else { return rawKey }
+        return "\(profileId.uuidString):\(rawKey)"
     }
 }

--- a/Persistence/KidProfileStore.swift
+++ b/Persistence/KidProfileStore.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Observation
+import SwiftData
+
+@MainActor
+@Observable
+final class KidProfileStore {
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    func fetchAll() -> [StoredKidProfile] {
+        let descriptor = FetchDescriptor<StoredKidProfile>(
+            sortBy: [SortDescriptor(\.createdAt)]
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
+    @discardableResult
+    func insert(name: String, emoji: String) -> StoredKidProfile {
+        let profile = StoredKidProfile(name: name, emoji: emoji)
+        modelContext.insert(profile)
+        try? modelContext.save()
+        return profile
+    }
+
+    func delete(_ profile: StoredKidProfile) {
+        modelContext.delete(profile)
+        try? modelContext.save()
+    }
+
+    func profile(withId id: UUID) -> StoredKidProfile? {
+        var descriptor = FetchDescriptor<StoredKidProfile>(
+            predicate: #Predicate { $0.id == id }
+        )
+        descriptor.fetchLimit = 1
+        return try? modelContext.fetch(descriptor).first
+    }
+}

--- a/Persistence/SessionHistoryStore.swift
+++ b/Persistence/SessionHistoryStore.swift
@@ -6,13 +6,16 @@ import SwiftData
 @Observable
 final class SessionHistoryStore {
     private let modelContext: ModelContext
+    var activeProfileId: UUID?
 
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
     }
 
     func save(_ draft: SessionSummaryDraft) {
-        modelContext.insert(StoredSessionSummary(from: draft))
+        var stamped = draft
+        stamped.profileId = activeProfileId
+        modelContext.insert(StoredSessionSummary(from: stamped))
         try? modelContext.save()
     }
 

--- a/Tests/MatherTests/SessionHistoryTests.swift
+++ b/Tests/MatherTests/SessionHistoryTests.swift
@@ -7,7 +7,7 @@ import Testing
 
 @MainActor
 private func makeInMemoryStore() throws -> (SessionHistoryStore, ModelContext) {
-    let schema = Schema([StoredSessionSummary.self])
+    let schema = Schema([StoredSessionSummary.self, StoredKidProfile.self])
     let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
     let container = try ModelContainer(for: schema, configurations: config)
     let context = ModelContext(container)
@@ -73,6 +73,19 @@ struct SessionHistoryStoreTests {
 
         let fetched = try context.fetch(FetchDescriptor<StoredSessionSummary>())
         #expect(fetched.count == 2)
+    }
+
+    @Test
+    func saveStampsProfileId() throws {
+        let (store, context) = try makeInMemoryStore()
+        let profileId = UUID()
+        store.activeProfileId = profileId
+
+        store.save(makeDraft(sessionId: "profile-test"))
+
+        let fetched = try context.fetch(FetchDescriptor<StoredSessionSummary>())
+        #expect(fetched.count == 1)
+        #expect(fetched[0].profileId == profileId)
     }
 }
 

--- a/Tests/MatherTests/SumSprintEngineTests.swift
+++ b/Tests/MatherTests/SumSprintEngineTests.swift
@@ -13,7 +13,7 @@ struct SumSprintEngineTests {
         flags.audioEnabled = false
         flags.hapticsEnabled = false
 
-        let schema = Schema([StoredFactRecord.self])
+        let schema = Schema([StoredFactRecord.self, StoredKidProfile.self])
         let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
         let container = try ModelContainer(for: schema, configurations: config)
         let store = FactRecordStore(modelContext: ModelContext(container))


### PR DESCRIPTION
## Summary

- Introduces `StoredKidProfile` (name + emoji) as a new SwiftData model
- Parents are prompted to pick or create a profile before any session — profile picker sheet is non-dismissable until a profile is selected
- All `StoredSessionSummary` and `StoredFactRecord` writes are stamped with `profileId`; reads are scoped to the active profile
- Spaced-repetition fact keys use a `"UUID:a+b"` composite to preserve the existing unique constraint without a custom DDL migration
- Last-used profile ID persisted in UserDefaults — auto-restored on relaunch so parents don't re-pick every time
- Profile badge in HomeView lets parents switch profiles; Parent Summary header shows active child's name/emoji and only their sessions
- Migration is lightweight (new model + optional nullable fields) — SwiftData migrates automatically; existing sessions stay with `profileId = nil`

## Test plan

- [ ] `xcodebuild test` passes all existing tests + new `saveStampsProfileId` test
- [ ] Fresh install: profile picker appears, create profile → home shown, session saved with correct `profileId`
- [ ] Switch profile via badge in HomeView → picker shown → select different profile → Parent Summary filters correctly
- [ ] Relaunch app → last profile auto-selected, picker not shown
- [ ] Upgrade path: build over existing SwiftData store → picker shown → legacy sessions (nil profileId) not shown in any profile's Parent Summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)