### PR TITLE
fix(ui-test): both Sum Sprint answers for target 4 in loop-v2 screenshot test

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -311,7 +311,8 @@ final class ScreenshotTests: XCTestCase {
             concreteCellIndex: 3,
             leftPanCount: 1,
             rightPanCount: 3,
-            sumSprintAnswers: ["4"],
+            // Target 4 with decomposition (1,3) yields two Sum Sprint cards: "1+3" and "3+1"
+            sumSprintAnswers: ["4", "4"],
             bondPairs: [(1, 3), (2, 2)],
             snapshotPrefix: "Issue222-Target4",
             skipInitialConcreteSnapshot: true


### PR DESCRIPTION
## Summary

- Target 4 with decomposition `(1,3)` generates two Sum Sprint burst cards: `"1+3"` and `"3+1"` (both sum to 4)
- `testScreenshot_Issue222LoopV2_AcrossFourTargetsIncludingTwelve` was only supplying one answer `["4"]`, leaving the second card unanswered and Bond Blast never appearing
- Fix: pass `["4", "4"]` to supply both answers

## Root cause

`SumSprintBurstState.makeFacts` appends a `second` fact `(max(1, target-1), min(1, target))` for any `target >= 4`. For target 4 this is `(3, 1)` which is distinct from the primary `(1, 3)`, giving two unique cards. The PR #340 test was written with only one answer.

## Test plan

- [ ] `iOS UI Review (main)` passes with this fix
- [ ] All other `Build & Test` checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)