### PR TITLE
feat(layout): responsive iPad layout across all main screens

### DIFF
--- a/Features/ParentSummary/ParentSummaryView.swift
+++ b/Features/ParentSummary/ParentSummaryView.swift
@@ -5,6 +5,7 @@ struct ParentSummaryView: View {
     @Bindable var appModel: AppModel
     let summaries: [StoredSessionSummary]
     let profiles: [StoredKidProfile]
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
         let digest = appModel.telemetryWriter.digest(from: summaries)
@@ -43,7 +44,7 @@ struct ParentSummaryView: View {
                         }
                     } else {
                         LazyVGrid(
-                            columns: [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)],
+                            columns: ResponsiveLayout.statColumns(for: horizontalSizeClass),
                             spacing: 12
                         ) {
                             StatTile(
@@ -156,7 +157,9 @@ struct ParentSummaryView: View {
                         .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.7)))
                     }
                 }
-                .padding(24)
+                .padding(ResponsiveLayout.contentPadding(for: horizontalSizeClass))
+                .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
+                .frame(maxWidth: .infinity)
             }
         }
     }

--- a/Features/SumSprint/SumSprintDifficultyView.swift
+++ b/Features/SumSprint/SumSprintDifficultyView.swift
@@ -12,6 +12,7 @@ struct SumSprintDifficultyView: View {
 
     @State private var selectedDifficulty: SumSprintDifficulty? = nil
     @State private var hovered: SumSprintDifficulty? = nil
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
         ZStack {
@@ -19,16 +20,18 @@ struct SumSprintDifficultyView: View {
 
             VStack(spacing: 0) {
                 header
-                    .padding(.horizontal, 24)
+                    .padding(.horizontal, ResponsiveLayout.contentPadding(for: horizontalSizeClass))
                     .padding(.top, 24)
 
                 Spacer(minLength: 20)
 
                 difficultyCards
-                    .padding(.horizontal, 24)
+                    .padding(.horizontal, ResponsiveLayout.contentPadding(for: horizontalSizeClass))
 
                 Spacer()
             }
+            .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
+            .frame(maxWidth: .infinity)
         }
     }
 
@@ -59,9 +62,19 @@ struct SumSprintDifficultyView: View {
     // MARK: - Difficulty cards
 
     private var difficultyCards: some View {
-        VStack(spacing: 14) {
-            ForEach(SumSprintDifficulty.allCases, id: \.self) { diff in
-                difficultyCard(diff)
+        Group {
+            if ResponsiveLayout.isWide(horizontalSizeClass) {
+                HStack(alignment: .top, spacing: 14) {
+                    ForEach(SumSprintDifficulty.allCases, id: \.self) { diff in
+                        difficultyCard(diff)
+                    }
+                }
+            } else {
+                VStack(spacing: 14) {
+                    ForEach(SumSprintDifficulty.allCases, id: \.self) { diff in
+                        difficultyCard(diff)
+                    }
+                }
             }
         }
     }

--- a/Features/SumSprint/SumSprintSessionView.swift
+++ b/Features/SumSprint/SumSprintSessionView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SumSprintSessionView: View {
     @Bindable var appModel: AppModel
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     private var engine: SumSprintEngine { appModel.sumSprintEngine }
 
@@ -25,6 +26,8 @@ struct SumSprintSessionView: View {
                                 onSubmit: { engine.submitAnswer() }
                             )
                             .padding(.horizontal, 20)
+                            .frame(maxWidth: ResponsiveLayout.isWide(horizontalSizeClass) ? 700 : .infinity)
+                            .frame(maxWidth: .infinity)
                             .transition(.asymmetric(
                                 insertion: .move(edge: .trailing).combined(with: .opacity),
                                 removal: .move(edge: .leading).combined(with: .opacity)

--- a/Features/SumSprint/SumSprintSummaryView.swift
+++ b/Features/SumSprint/SumSprintSummaryView.swift
@@ -4,6 +4,7 @@ struct SumSprintSummaryView: View {
     let summary: SumSprintSessionSummary
     let onPlayAgain: () -> Void
     let onDone: () -> Void
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
         ZStack {
@@ -26,7 +27,9 @@ struct SumSprintSummaryView: View {
 
                     buttonStack
                 }
-                .padding(24)
+                .padding(ResponsiveLayout.contentPadding(for: horizontalSizeClass))
+                .frame(maxWidth: ResponsiveLayout.isWide(horizontalSizeClass) ? 900 : .infinity)
+                .frame(maxWidth: .infinity)
             }
         }
     }
@@ -133,8 +136,7 @@ struct SumSprintSummaryView: View {
                     .font(.headline.weight(.bold))
                     .foregroundStyle(MatherTheme.ink.opacity(0.7))
 
-                let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 2)
-                LazyVGrid(columns: columns, spacing: 8) {
+                LazyVGrid(columns: ResponsiveLayout.summaryFactColumns(for: horizontalSizeClass), spacing: 8) {
                     ForEach(summary.cards) { card in
                         factPill(card: card)
                     }

--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -49,7 +49,8 @@ struct BondMatchView: View {
 
     // MARK: - Constants
 
-    private let cardSize: CGFloat = 88
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    private var cardSize: CGFloat { ResponsiveLayout.isWide(horizontalSizeClass) ? 110 : 88 }
     private let cardSpacing: CGFloat = 12
 
     // MARK: - Tilt drift

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct HomeView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Bindable var appModel: AppModel
 
     var body: some View {
@@ -14,8 +15,15 @@ struct HomeView: View {
                         .foregroundStyle(MatherTheme.ink)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
-                    makeAndBreakCard
-                    labCard
+                    if ResponsiveLayout.isWide(horizontalSizeClass) {
+                        HStack(alignment: .top, spacing: 20) {
+                            makeAndBreakCard
+                            labCard
+                        }
+                    } else {
+                        makeAndBreakCard
+                        labCard
+                    }
 
                     HStack(spacing: 14) {
                         Button("Parent Summary") {
@@ -31,7 +39,9 @@ struct HomeView: View {
 
                     Spacer(minLength: 0)
                 }
-                .padding(24)
+                .padding(ResponsiveLayout.contentPadding(for: horizontalSizeClass))
+                .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
+                .frame(maxWidth: .infinity)
             }
         }
     }

--- a/Shared/ResponsiveLayout.swift
+++ b/Shared/ResponsiveLayout.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 @MainActor
 enum ResponsiveLayout {
+
+    // MARK: - Max widths
+
     static func contentMaxWidth(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
         horizontalSizeClass == .regular ? 1_100 : 760
     }
@@ -10,8 +13,32 @@ enum ResponsiveLayout {
         horizontalSizeClass == .regular ? 560 : 400
     }
 
+    // MARK: - Padding
+
+    static func contentPadding(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        horizontalSizeClass == .regular ? 48 : 24
+    }
+
+    // MARK: - Grid columns
+
     static func labColumns(for availableWidth: CGFloat) -> [GridItem] {
         let minimumTileWidth: CGFloat = availableWidth >= 1_100 ? 260 : 220
         return [GridItem(.adaptive(minimum: minimumTileWidth, maximum: 340), spacing: 16)]
+    }
+
+    static func statColumns(for horizontalSizeClass: UserInterfaceSizeClass?) -> [GridItem] {
+        let count = horizontalSizeClass == .regular ? 4 : 2
+        return Array(repeating: GridItem(.flexible(), spacing: 12), count: count)
+    }
+
+    static func summaryFactColumns(for horizontalSizeClass: UserInterfaceSizeClass?) -> [GridItem] {
+        let count = horizontalSizeClass == .regular ? 3 : 2
+        return Array(repeating: GridItem(.flexible(), spacing: 8), count: count)
+    }
+
+    // MARK: - Layout style
+
+    static func isWide(_ horizontalSizeClass: UserInterfaceSizeClass?) -> Bool {
+        horizontalSizeClass == .regular
     }
 }


### PR DESCRIPTION
## Summary

- **HomeView**: 2-column card grid on iPad, centered content with wider padding
- **ParentSummaryView**: 4-column stat tiles on iPad, centered max-width container
- **SumSprintDifficultyView**: 3 difficulty cards side-by-side on iPad
- **SumSprintSessionView**: flash card constrained to 700pt max and centered
- **SumSprintSummaryView**: 3-column facts grid on iPad, centered at 900pt max
- **BondMatchView**: card size scales 88→110pt on iPad
- **ResponsiveLayout**: adds `contentPadding`, `statColumns`, `summaryFactColumns`, `isWide` helpers

All screens now adapt to `@Environment(\.horizontalSizeClass)` so the app uses full iPad screen space without feeling stretched on iPhone.

## Test plan

- [ ] Run on iPhone 16 simulator — layout matches current state (no regressions)
- [ ] Run on iPad simulator — cards use wider grid, content centered within max-width containers
- [ ] SumSprint difficulty screen: 3 cards side-by-side on iPad
- [ ] SumSprint session: flash card centered with breathing room
- [ ] Parent Summary: 4-column stat grid on iPad
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)