### PR TITLE
fix(ui-test): bypass profile picker in screenshot tests

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -26,6 +26,10 @@ final class AppModel {
     private var pendingGameAction: (() -> Void)?
 
     func pickProfileThenRun(_ action: @escaping () -> Void) {
+        if featureFlags.skipProfilePicker {
+            action()
+            return
+        }
         pendingGameAction = action
         showingProfilePicker = true
     }

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -24,6 +24,7 @@ final class FeatureFlagService {
         static let roomQuestMarkerSetupEnabled = "feature.roomQuestMarkerSetupEnabled"
         static let roomQuestReferenceCaptureEnabled = "feature.roomQuestReferenceCaptureEnabled"
         static let memoryCardAppleIntelligenceEnabled = "feature.memoryCardAppleIntelligenceEnabled"
+        static let skipProfilePicker = "feature.skipProfilePicker"
     }
 
     var verticalSlice1Enabled: Bool {
@@ -98,6 +99,12 @@ final class FeatureFlagService {
         didSet { defaults.set(memoryCardAppleIntelligenceEnabled, forKey: Keys.memoryCardAppleIntelligenceEnabled) }
     }
 
+    /// Bypasses the profile picker sheet and runs game actions immediately.
+    /// Injected via `-feature.skipProfilePicker YES` in UI tests.
+    var skipProfilePicker: Bool {
+        didSet { defaults.set(skipProfilePicker, forKey: Keys.skipProfilePicker) }
+    }
+
     // MARK: - Place-matching thresholds
 
     /// GPS match radius in metres. Default 8 m. Tighter = harder to get false match indoors.
@@ -155,6 +162,7 @@ final class FeatureFlagService {
             Keys.roomQuestMarkerSetupEnabled: true,
             Keys.roomQuestReferenceCaptureEnabled: true,
             Keys.memoryCardAppleIntelligenceEnabled: true,
+            Keys.skipProfilePicker: false,
             Keys.placeMatchGPSMatch:    PlaceMatchThresholds.default.gpsMatchMetres,
             Keys.placeMatchGPSClose:    PlaceMatchThresholds.default.gpsCloseMetres,
             Keys.placeMatchGPSCutoff:   PlaceMatchThresholds.default.gpsAccuracyCutoff,
@@ -175,6 +183,7 @@ final class FeatureFlagService {
         roomQuestMarkerSetupEnabled = defaults.bool(forKey: Keys.roomQuestMarkerSetupEnabled)
         roomQuestReferenceCaptureEnabled = defaults.bool(forKey: Keys.roomQuestReferenceCaptureEnabled)
         memoryCardAppleIntelligenceEnabled = defaults.bool(forKey: Keys.memoryCardAppleIntelligenceEnabled)
+        skipProfilePicker = defaults.bool(forKey: Keys.skipProfilePicker)
         placeMatchGPSMatch   = defaults.double(forKey: Keys.placeMatchGPSMatch)
         placeMatchGPSClose   = defaults.double(forKey: Keys.placeMatchGPSClose)
         placeMatchGPSCutoff  = defaults.double(forKey: Keys.placeMatchGPSCutoff)

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -351,6 +351,7 @@ final class ScreenshotTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
+            "-feature.skipProfilePicker", "YES",
         ]
         if let appearance {
             launchArguments += ["-uiTest.appearance", appearance.launchValue]
@@ -366,6 +367,7 @@ final class ScreenshotTests: XCTestCase {
             "-feature.soundReactionEnabled", "NO",
             "-feature.testModeEnabled", "YES",
             "-feature.makeBreakLoopV2Enabled", "YES",
+            "-feature.skipProfilePicker", "YES",
         ]
         if let appearance {
             launchArguments += ["-uiTest.appearance", appearance.launchValue]
@@ -379,6 +381,7 @@ final class ScreenshotTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "YES",
             "-feature.testModeEnabled", "YES",
+            "-feature.skipProfilePicker", "YES",
         ]
         if let appearance {
             launchArguments += ["-uiTest.appearance", appearance.launchValue]


### PR DESCRIPTION
## Summary

- Adds `feature.skipProfilePicker` launch argument to `FeatureFlagService`
- When `YES`, `AppModel.pickProfileThenRun` calls the action immediately without showing the profile picker sheet
- All screenshot test launchers that tap "Play" now pass `-feature.skipProfilePicker YES`

## Why it broke

PR #344 introduced the profile picker sheet before every game. When tests tap "Play" on the home screen, the sheet now intercepts the tap — so the tests that wait for "Session setup" to appear immediately all time out.

## Test plan

- [ ] `iOS UI Review (main)` passes after merge
- [ ] Profile picker still appears for normal (non-test) app usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)