### PR TITLE
fix: stop Bond Blast drag from auto-matching

### DIFF
--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 /// Bond Blast — the sensor-powered complement-match finale stage for VS1.
 ///
 /// Displays all complement pairs for the session target (e.g. for 7:
-/// 1+6, 2+5, 3+4). The child can drag or tap a left card, then drop or tap on
-/// the matching right card to lock the pair. All pairs locked = stage done.
+/// 1+6, 2+5, 3+4). The child can tap a left card, then tap the matching
+/// right card to lock the pair. Dragging a left card previews the target lane,
+/// but correctness is only confirmed against the actual right-slot landing row.
 ///
 /// **Sensor integration** (both ambient — tap-only path always works):
 /// - Tilt drift: unselected left cards float ±6 pt with device attitude.
@@ -46,6 +47,12 @@ struct BondMatchView: View {
     @State private var shuffledRightValues: [Int] = []
     /// Right-value that is currently wobbling after a mismatch.
     @State private var mismatchedRightValue: Int? = nil
+
+    enum DragReleaseResolution: Equatable {
+        case cancel
+        case match(UUID)
+        case mismatch(Int)
+    }
 
     // MARK: - Constants
 
@@ -223,13 +230,24 @@ struct BondMatchView: View {
                 }
                 .onEnded { value in
                     guard !isMatched else { return }
-                    let horizontalTravel = value.translation.width
-                    if horizontalTravel > 90 {
+                    let resolution = Self.dragReleaseResolution(
+                        pair: pair,
+                        translation: value.translation,
+                        state: state,
+                        shuffledRightValues: shuffledRightValues,
+                        cardSize: cardSize,
+                        cardSpacing: cardSpacing
+                    )
+                    switch resolution {
+                    case .cancel:
+                        break
+                    case .match(let id):
                         onNearTarget()
-                        onMatch(pair.id)
+                        onMatch(id)
                         withAnimation(.spring(response: 0.2)) { selectedPairId = nil }
-                    } else if abs(horizontalTravel) > 40 {
+                    case .mismatch(let rightValue):
                         onMismatch()
+                        triggerMismatch(for: rightValue)
                     }
                 }
         )
@@ -301,6 +319,31 @@ struct BondMatchView: View {
     ) -> Int? {
         let isMatched = state.pairs.first(where: { $0.right == rightValue })?.isMatched == true
         return (selectedPairId != nil || isMatched) ? rightValue : nil
+    }
+
+    nonisolated static func dragReleaseResolution(
+        pair: ComplementPair,
+        translation: CGSize,
+        state: BondMatchState,
+        shuffledRightValues: [Int],
+        cardSize: CGFloat,
+        cardSpacing: CGFloat
+    ) -> DragReleaseResolution {
+        let horizontalTravel = translation.width
+        guard horizontalTravel > 90 else {
+            return .cancel
+        }
+
+        guard let sourceRow = state.pairs.firstIndex(where: { $0.id == pair.id }), !shuffledRightValues.isEmpty else {
+            return .cancel
+        }
+
+        let rowStride = cardSize + cardSpacing
+        let rowOffset = Int((translation.height / rowStride).rounded())
+        let targetRow = min(max(sourceRow + rowOffset, 0), shuffledRightValues.count - 1)
+        let droppedValue = shuffledRightValues[targetRow]
+
+        return droppedValue == pair.right ? .match(pair.id) : .mismatch(droppedValue)
     }
 
     @ViewBuilder

--- a/Tests/MatherTests/BondMatchViewTests.swift
+++ b/Tests/MatherTests/BondMatchViewTests.swift
@@ -22,4 +22,34 @@ struct BondMatchViewTests {
         let right = state.pairs[0].right
         #expect(BondMatchView.visibleRightValue(selectedPairId: nil, rightValue: right, state: state) == right)
     }
+
+
+    @Test func dragReleaseResolutionOnlyMatchesWhenDroppedOnCorrectRow() {
+        let state = BondMatchState(target: 6, pairs: BondMatchState.makePairs(for: 6))
+        let pair = state.pairs[0] // 1 + 5
+        let correct = BondMatchView.dragReleaseResolution(
+            pair: pair,
+            translation: CGSize(width: 120, height: 0),
+            state: state,
+            shuffledRightValues: state.pairs.map(\.right),
+            cardSize: 88,
+            cardSpacing: 12
+        )
+        #expect(correct == .match(pair.id))
+    }
+
+    @Test func dragReleaseResolutionDoesNotAutoMatchWrongLandingRow() {
+        let state = BondMatchState(target: 6, pairs: BondMatchState.makePairs(for: 6))
+        let pair = state.pairs[0] // wants 5
+        let shuffled = [4, 5, 3]
+        let wrongDrop = BondMatchView.dragReleaseResolution(
+            pair: pair,
+            translation: CGSize(width: 120, height: 0),
+            state: state,
+            shuffledRightValues: shuffled,
+            cardSize: 88,
+            cardSpacing: 12
+        )
+        #expect(wrongDrop == .mismatch(4))
+    }
 }


### PR DESCRIPTION
## Summary
- stop Bond Blast from treating any long rightward drag as a correct match
- resolve drag releases against the actual landed right-slot row before calling match
- add regression tests covering correct-row match vs wrong-row mismatch

## Why
A regression introduced in `c734eba2` made `BondMatchView` call `onMatch(pair.id)` whenever a drag moved more than 90pt to the right, without checking which right card the child landed on.

## Validation
- CI via GitHub Actions on this PR
- local host cannot run xcodebuild