### PR TITLE
chore: align make break telemetry fallback naming

### DIFF
--- a/Persistence/TelemetryWriter.swift
+++ b/Persistence/TelemetryWriter.swift
@@ -90,7 +90,7 @@ final class TelemetryWriter {
     func digest(from summaries: [StoredSessionSummary]) -> ParentDigest {
         guard !summaries.isEmpty else {
             return ParentDigest(
-                objectiveTitle: "Make & Break Numbers",
+                objectiveTitle: "Make & Break",
                 firstAttemptAccuracy: 0,
                 medianLatencyMs: 0,
                 problemsCompleted: 0,
@@ -116,7 +116,7 @@ final class TelemetryWriter {
         let transferCorrect = sorted.map(\.transferCorrectCount).reduce(0, +)
 
         return ParentDigest(
-            objectiveTitle: sorted.first?.objectiveTitle ?? "Make & Break Numbers",
+            objectiveTitle: sorted.first?.objectiveTitle ?? "Make & Break",
             firstAttemptAccuracy: accuracy,
             medianLatencyMs: median,
             problemsCompleted: completed,


### PR DESCRIPTION
## Summary
- align the fallback Make & Break objective title in telemetry digests
- remove the stale `Make & Break Numbers` label from the empty/history fallback path
- keep the Make & Break V2 rollout flag posture unchanged

## Validation
- `git diff --check`

Closes part of #351
Refs #222
Refs #349
