### PR TITLE
feat: expand memory learn-more foundation

### DIFF
--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -811,31 +811,41 @@ struct MemoryView: View {
     }
 
     static func canOpenLearningDetails(for card: MemoryCard, deckSelection: DeckSelection, difficulty: MemoryDifficulty, showRoundComplete: Bool) -> Bool {
-        guard deckSelection == .birds else { return false }
+        guard supportsLearningDetails(for: deckSelection) else { return false }
         if card.isMatched { return true }
         guard !showRoundComplete else { return false }
         return difficulty.faceDown ? card.isSelected : true
     }
 
-    static func learningContent(for animal: MemoryAnimal, deckSelection: DeckSelection) -> MemoryLearningContent? {
-        guard deckSelection == .birds else { return nil }
+    static func supportsLearningDetails(for deckSelection: DeckSelection) -> Bool {
+        !deckSelection.animals.isEmpty
+    }
 
-        let summary = learningSummary(for: animal)
-        let sourceBadge = learningSourceBadge(for: deckSelection)
+    static func learningContent(for animal: MemoryAnimal, deckSelection: DeckSelection, description: MemoryCardDescription) -> MemoryLearningContent {
+        let sourceBadge = learningSourceBadge(for: deckSelection, source: description.source)
+        let factChips = description.factChips.map { MemoryFactCard(title: $0.title, value: $0.value) }
         return MemoryLearningContent(
             animal: animal,
-            title: animal.canonicalName,
-            shortDescription: summary,
-            factChips: animal.detailCards,
+            title: description.title,
+            shortDescription: description.shortDescription,
+            factChips: factChips,
             sourceBadge: sourceBadge,
-            readAloudText: learningReadAloudText(for: animal, summary: summary, sourceBadge: sourceBadge)
+            readAloudText: learningReadAloudText(for: description.title, summary: description.shortDescription, factChips: factChips, sourceBadge: sourceBadge)
         )
     }
 
     private func handleDoubleTap(_ card: MemoryCard) {
         guard Self.canOpenLearningDetails(for: card, deckSelection: deckSelection, difficulty: difficulty, showRoundComplete: showRoundComplete) else { return }
-        guard let content = Self.learningContent(for: animal(for: card), deckSelection: deckSelection) else { return }
-        learningContent = content
+        let selectedAnimal = animal(for: card)
+        learningContent = Self.learningContent(
+            for: selectedAnimal,
+            deckSelection: deckSelection,
+            description: appModel.memoryCardDescribeService.fallbackDescription(for: selectedAnimal)
+        )
+        Task { @MainActor in
+            let description = await appModel.memoryCardDescribeService.describe(selectedAnimal)
+            learningContent = Self.learningContent(for: selectedAnimal, deckSelection: deckSelection, description: description)
+        }
     }
 
     @ViewBuilder
@@ -1014,35 +1024,27 @@ struct MemoryView: View {
         return "memory-card-\(card.pairId)-\(kind)"
     }
 
-    private static func learningSourceBadge(for deckSelection: DeckSelection) -> String {
+    private static func learningSourceBadge(for deckSelection: DeckSelection, source: MemoryCardDescriptionSource) -> String {
+        let deckLabel: String
         switch deckSelection {
         case .birds:
-            return "Bird Guide"
+            deckLabel = "Bird Guide"
         case .domestic:
-            return "Animal Guide"
+            deckLabel = "Animal Guide"
         case .vehicles:
-            return "Vehicle Guide"
+            deckLabel = "Vehicle Guide"
+        }
+
+        switch source {
+        case .appleIntelligence:
+            return "Apple Intelligence + \(deckLabel)"
+        case .curatedFallback:
+            return deckLabel
         }
     }
 
-    private static func learningSummary(for animal: MemoryAnimal) -> String {
-        // Keep this isolated so a future describe/Apple Intelligence service can
-        // replace summary generation without reshaping the sheet UI state.
-        let home = animal.detailCards.first(where: { $0.title == "Home" })?.value
-        let colors = animal.detailCards.first(where: { $0.title == "Colors" })?.value
-
-        switch (home, colors) {
-        case let (home?, colors?):
-            return "A colorful bird from \(home.lowercased()), often seen in shades of \(colors)."
-        case let (home?, nil):
-            return "A bird that lives around \(home.lowercased())."
-        default:
-            return "A matching-card favorite with a few quick facts to explore."
-        }
-    }
-
-    private static func learningReadAloudText(for animal: MemoryAnimal, summary: String, sourceBadge: String) -> String {
-        let facts = animal.detailCards.map { "\($0.title): \($0.value)." }.joined(separator: " ")
-        return "\(animal.canonicalName). \(summary) Source: \(sourceBadge). \(facts)"
+    private static func learningReadAloudText(for title: String, summary: String, factChips: [MemoryFactCard], sourceBadge: String) -> String {
+        let facts = factChips.map { "\($0.title): \($0.value)." }.joined(separator: " ")
+        return "\(title). \(summary) Source: \(sourceBadge). \(facts)"
     }
 }

--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -117,7 +117,7 @@ final class MemoryCardDescribeService {
            let generated = try? await aiAdapter.shortDescription(for: animal),
            let sanitized = sanitizeGeneratedDescription(generated) {
             return MemoryCardDescription(
-                title: animal.name,
+                title: animal.canonicalName,
                 shortDescription: sanitized,
                 factChips: fallbackFactChips(for: animal),
                 source: .appleIntelligence
@@ -129,7 +129,7 @@ final class MemoryCardDescribeService {
 
     func fallbackDescription(for animal: MemoryAnimal) -> MemoryCardDescription {
         MemoryCardDescription(
-            title: animal.name,
+            title: animal.canonicalName,
             shortDescription: buildFallbackDescription(for: animal),
             factChips: fallbackFactChips(for: animal),
             source: .curatedFallback
@@ -142,21 +142,21 @@ final class MemoryCardDescribeService {
         switch metadata.deck {
         case .birds:
             if let habitat = metadata.habitat {
-                firstSentence = "\(animal.name) is a bird that lives in \(habitat.lowercased())."
+                firstSentence = "\(animal.canonicalName) is a bird that lives in \(habitat.lowercased())."
             } else {
-                firstSentence = "\(animal.name) is a colorful bird."
+                firstSentence = "\(animal.canonicalName) is a colorful bird."
             }
         case .domesticAnimals:
             if let habitat = metadata.habitat {
-                firstSentence = "\(animal.name) is a domestic animal you might find in \(habitat.lowercased())."
+                firstSentence = "\(animal.canonicalName) is a domestic animal you might find in \(habitat.lowercased())."
             } else {
-                firstSentence = "\(animal.name) is a friendly domestic animal."
+                firstSentence = "\(animal.canonicalName) is a friendly domestic animal."
             }
         case .vehicles:
             if let use = metadata.use {
-                firstSentence = "\(animal.name) is a vehicle that \(use.lowercased())."
+                firstSentence = "\(animal.canonicalName) is a vehicle that \(use.lowercased())."
             } else {
-                firstSentence = "\(animal.name) is a helpful vehicle."
+                firstSentence = "\(animal.canonicalName) is a helpful vehicle."
             }
         }
 

--- a/Tests/MatherTests/MemoryVarietyTests.swift
+++ b/Tests/MatherTests/MemoryVarietyTests.swift
@@ -46,14 +46,16 @@ struct MemoryVarietyTests {
         #expect(MemoryDeck.birds.allSatisfy { Set($0.detailCards.map(\.title)).isSuperset(of: ["Name", "Home", "Lifespan", "Weight", "Size", "Colors"]) })
     }
 
-    @MainActor @Test func learningDetailsAreOnlyAvailableForCompletedBirdRounds() {
+    @MainActor @Test func learningDetailsRespectRevealRulesAcrossDecks() {
         let bird = MemoryDeck.birds[0]
+        let domestic = MemoryDeck.domesticAnimals[0]
         let matchedBirdCard = MemoryCard(pairId: bird.id, content: .picture(bird), isMatched: true)
         let unmatchedBirdCard = MemoryCard(pairId: bird.id, content: .picture(bird), isMatched: false)
+        let revealedDomesticCard = MemoryCard(pairId: domestic.id, content: .picture(domestic), isSelected: true)
 
         #expect(MemoryView.canOpenLearningDetails(for: matchedBirdCard, deckSelection: .birds, difficulty: .medium, showRoundComplete: true))
         #expect(!MemoryView.canOpenLearningDetails(for: unmatchedBirdCard, deckSelection: .birds, difficulty: .hard, showRoundComplete: true))
-        #expect(!MemoryView.canOpenLearningDetails(for: matchedBirdCard, deckSelection: .domestic, difficulty: .medium, showRoundComplete: true))
+        #expect(MemoryView.canOpenLearningDetails(for: revealedDomesticCard, deckSelection: .domestic, difficulty: .hard, showRoundComplete: false))
         #expect(MemoryView.canOpenLearningDetails(for: matchedBirdCard, deckSelection: .birds, difficulty: .medium, showRoundComplete: false))
     }
 

--- a/Tests/MatherTests/MemoryViewTests.swift
+++ b/Tests/MatherTests/MemoryViewTests.swift
@@ -40,22 +40,31 @@ struct MemoryViewTests {
     }
 
     @MainActor
-    @Test func learningContentAndEligibilityFollowVisibleBirdRules() {
+    @Test func learningContentAndEligibilityFollowVisibleDeckRules() {
         let bird = MemoryDeck.birds[0]
-        let hiddenHardCard = MemoryCard(pairId: bird.id, content: .picture(bird))
-        let revealedHardCard = MemoryCard(pairId: bird.id, content: .picture(bird), isSelected: true)
-        let matchedBirdCard = MemoryCard(pairId: bird.id, content: .label(bird), isMatched: true)
+        let vehicle = MemoryDeck.vehicles[0]
+        let hiddenHardBirdCard = MemoryCard(pairId: bird.id, content: .picture(bird))
+        let revealedHardBirdCard = MemoryCard(pairId: bird.id, content: .picture(bird), isSelected: true)
+        let matchedVehicleCard = MemoryCard(pairId: vehicle.id, content: .label(vehicle), isMatched: true)
 
-        #expect(!MemoryView.canOpenLearningDetails(for: hiddenHardCard, deckSelection: .birds, difficulty: .hard, showRoundComplete: false))
-        #expect(MemoryView.canOpenLearningDetails(for: revealedHardCard, deckSelection: .birds, difficulty: .hard, showRoundComplete: false))
-        #expect(MemoryView.canOpenLearningDetails(for: matchedBirdCard, deckSelection: .birds, difficulty: .hard, showRoundComplete: true))
+        #expect(MemoryView.supportsLearningDetails(for: .birds))
+        #expect(MemoryView.supportsLearningDetails(for: .domestic))
+        #expect(MemoryView.supportsLearningDetails(for: .vehicles))
+        #expect(!MemoryView.canOpenLearningDetails(for: hiddenHardBirdCard, deckSelection: .birds, difficulty: .hard, showRoundComplete: false))
+        #expect(MemoryView.canOpenLearningDetails(for: revealedHardBirdCard, deckSelection: .birds, difficulty: .hard, showRoundComplete: false))
+        #expect(MemoryView.canOpenLearningDetails(for: matchedVehicleCard, deckSelection: .vehicles, difficulty: .hard, showRoundComplete: true))
 
-        let learningContent = MemoryView.learningContent(for: bird, deckSelection: .birds)
-        #expect(learningContent != nil)
-        #expect(learningContent?.title == bird.canonicalName)
-        #expect(learningContent?.sourceBadge == "Bird Guide")
-        #expect(learningContent?.factChips == bird.detailCards)
-        #expect(learningContent?.readAloudText.contains(bird.canonicalName) == true)
+        let vehicleDescription = MemoryCardDescription(
+            title: vehicle.canonicalName,
+            shortDescription: "A road vehicle for family trips.",
+            factChips: [MemoryFactChip(title: "Use", value: "family trips")],
+            source: .appleIntelligence
+        )
+        let learningContent = MemoryView.learningContent(for: vehicle, deckSelection: .vehicles, description: vehicleDescription)
+        #expect(learningContent.title == vehicle.canonicalName)
+        #expect(learningContent.sourceBadge == "Apple Intelligence + Vehicle Guide")
+        #expect(learningContent.factChips == [MemoryFactCard(title: "Use", value: "family trips")])
+        #expect(learningContent.readAloudText.contains(vehicle.canonicalName))
     }
 }
 


### PR DESCRIPTION
## Summary
- expand Memory Match learn-more eligibility beyond birds to any structured deck currently in the picker
- wire the existing `MemoryCardDescribeService` into the double-tap learn-more flow with curated fallback first and Apple-Intelligence upgrade support
- normalize learn-more titles/descriptions around `canonicalName` and cover the new behavior with focused tests

## Testing
- `git diff --check`
- remote `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'id=3A1BD382-28BD-4285-83B4-B6913DF496C4' -only-testing:MatherTests/MemoryViewTests -only-testing:MatherTests/MemoryVarietyTests` **blocked by an existing baseline build failure on fresh `main`** (`SessionSummaryView.swift` / `SettingsView.swift` / `SliceModels.swift`, unrelated to this change)
