### PR TITLE
feat: add a tiny sum-match round before Bond Blast

### DIFF
--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -273,42 +273,60 @@ struct BondMatchState: Equatable {
 
 // MARK: - Embedded Sum Sprint models
 
+enum SumSprintBurstCardContent: Equatable {
+    case prompt(String)
+    case sum(Int)
+
+    var displayText: String {
+        switch self {
+        case .prompt(let value):
+            return value
+        case .sum(let value):
+            return String(value)
+        }
+    }
+}
+
 struct SumSprintBurstCard: Identifiable, Equatable {
     let id: UUID
-    let prompt: String
-    let answer: Int
-    var typedAnswer: String = ""
-    var isCorrect: Bool = false
+    let pairId: UUID
+    let content: SumSprintBurstCardContent
+    var isMatched: Bool = false
+    var isSelected: Bool = false
 }
 
 struct SumSprintBurstState: Equatable {
     let target: Int
     var cards: [SumSprintBurstCard]
-    var currentCardIndex: Int = 0
+    var selectedCardID: UUID? = nil
 
-    var currentCard: SumSprintBurstCard? {
-        guard cards.indices.contains(currentCardIndex) else { return nil }
-        return cards[currentCardIndex]
+    var totalPairs: Int {
+        Set(cards.map(\.pairId)).count
+    }
+
+    var matchedPairs: Int {
+        Set(cards.filter { $0.isMatched }.map(\.pairId)).count
     }
 
     var isComplete: Bool {
-        currentCardIndex >= cards.count
+        matchedPairs == totalPairs && totalPairs > 0
     }
 
     var progressLabel: String {
-        guard !cards.isEmpty else { return "0 / 0" }
-        return "\(min(currentCardIndex + 1, cards.count)) / \(cards.count)"
+        "\(matchedPairs) / \(totalPairs)"
     }
 
     static func make(for problem: SliceProblem) -> SumSprintBurstState {
-        let cards = makeFacts(for: problem).map { fact in
-            SumSprintBurstCard(
-                id: UUID(),
-                prompt: "\(fact.0) + \(fact.1)",
-                answer: fact.0 + fact.1
-            )
+        let cards = makeFacts(for: problem).flatMap { fact -> [SumSprintBurstCard] in
+            let pairId = UUID()
+            let prompt = "\(fact.0) + \(fact.1)"
+            let sum = fact.0 + fact.1
+            return [
+                SumSprintBurstCard(id: UUID(), pairId: pairId, content: .prompt(prompt)),
+                SumSprintBurstCard(id: UUID(), pairId: pairId, content: .sum(sum))
+            ]
         }
-        return SumSprintBurstState(target: problem.target, cards: cards)
+        return SumSprintBurstState(target: problem.target, cards: cards.shuffled())
     }
 
     private static func makeFacts(for problem: SliceProblem) -> [(Int, Int)] {

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -100,7 +100,7 @@ final class VerticalSliceEngine {
     }
 
     var concreteCount: Int { concreteWarmCount + concreteAccentCount }
-    var sumSprintStageCardCount: Int { sumSprintBurstState?.cards.count ?? 0 }
+    var sumSprintStageCardCount: Int { sumSprintBurstState?.totalPairs ?? 0 }
 
     func showSettings() { route = .settings }
     func showHome() { route = .home }
@@ -296,70 +296,66 @@ final class VerticalSliceEngine {
         speechService.speak(promptForCurrentStage(), enabled: featureFlags.audioEnabled)
     }
 
-    func appendSumSprintDigit(_ digit: Int) {
+    func selectSumSprintCard(id: UUID) {
         guard currentStage == .sumSprint, var state = sumSprintBurstState,
-              state.cards.indices.contains(state.currentCardIndex) else { return }
-        let current = state.cards[state.currentCardIndex].typedAnswer
-        guard current.count < 2 else { return }
-        state.cards[state.currentCardIndex].typedAnswer = current + String(digit)
-        sumSprintBurstState = state
-    }
+              let tappedIndex = state.cards.firstIndex(where: { $0.id == id }),
+              !state.cards[tappedIndex].isMatched else { return }
 
-    func deleteSumSprintDigit() {
-        guard currentStage == .sumSprint, var state = sumSprintBurstState,
-              state.cards.indices.contains(state.currentCardIndex) else { return }
-        let current = state.cards[state.currentCardIndex].typedAnswer
-        guard !current.isEmpty else { return }
-        state.cards[state.currentCardIndex].typedAnswer = String(current.dropLast())
-        sumSprintBurstState = state
-    }
+        recordInteraction(action: "sum_sprint_select", value: tappedIndex)
 
-    func submitSumSprintCard() {
-        guard currentStage == .sumSprint, var state = sumSprintBurstState,
-              state.cards.indices.contains(state.currentCardIndex) else { return }
-        guard let entered = Int(state.cards[state.currentCardIndex].typedAnswer) else { return }
-        let card = state.cards[state.currentCardIndex]
-        let isCorrect = entered == card.answer
-        recordInteraction(action: "sum_sprint_submit", value: entered)
+        if let selectedID = state.selectedCardID,
+           let selectedIndex = state.cards.firstIndex(where: { $0.id == selectedID }) {
+            guard selectedIndex != tappedIndex else {
+                state.cards[tappedIndex].isSelected = false
+                state.selectedCardID = nil
+                sumSprintBurstState = state
+                return
+            }
 
-        if isCorrect {
-            state.cards[state.currentCardIndex].isCorrect = true
-            try? telemetryWriter.append(
-                SliceEvent(type: .sumSprintCardAnswered, payload: [
-                    "problem_id": currentProblem?.id.uuidString ?? "",
-                    "card_index": String(state.currentCardIndex),
-                    "prompt": card.prompt,
-                    "correct": "true"
-                ])
-            )
-            state.currentCardIndex += 1
-            sumSprintBurstState = state
-            if state.isComplete, let problem = currentProblem {
-                completeStage(successMessage: successMessage(for: .sumSprint, problem: problem))
-            } else {
-                if let nextCard = state.currentCard {
-                    try? telemetryWriter.append(
-                        SliceEvent(type: .sumSprintCardShown, payload: [
-                            "problem_id": currentProblem?.id.uuidString ?? "",
-                            "card_index": String(state.currentCardIndex),
-                            "prompt": nextCard.prompt
-                        ])
-                    )
+            let selectedCard = state.cards[selectedIndex]
+            let tappedCard = state.cards[tappedIndex]
+            let isMatch = selectedCard.pairId == tappedCard.pairId
+                && selectedCard.content != tappedCard.content
+
+            state.cards[selectedIndex].isSelected = false
+            state.cards[tappedIndex].isSelected = false
+            state.selectedCardID = nil
+
+            if isMatch {
+                state.cards[selectedIndex].isMatched = true
+                state.cards[tappedIndex].isMatched = true
+                sumSprintBurstState = state
+                try? telemetryWriter.append(
+                    SliceEvent(type: .sumSprintCardAnswered, payload: [
+                        "problem_id": currentProblem?.id.uuidString ?? "",
+                        "pair_id": selectedCard.pairId.uuidString,
+                        "correct": "true"
+                    ])
+                )
+                if state.isComplete, let problem = currentProblem {
+                    completeStage(successMessage: successMessage(for: .sumSprint, problem: problem))
+                } else {
+                    feedbackMessage = promptForCurrentStage()
                 }
-                feedbackMessage = promptForCurrentStage()
+            } else {
+                sumSprintBurstState = state
+                try? telemetryWriter.append(
+                    SliceEvent(type: .sumSprintCardAnswered, payload: [
+                        "problem_id": currentProblem?.id.uuidString ?? "",
+                        "pair_id": selectedCard.pairId.uuidString,
+                        "correct": "false"
+                    ])
+                )
+                feedbackMessage = "Try again. Match the sum sentence with its total before Bond Blast."
+                speechService.speak(feedbackMessage, enabled: featureFlags.audioEnabled)
+                hapticsService.failure(enabled: featureFlags.hapticsEnabled)
             }
         } else {
-            try? telemetryWriter.append(
-                SliceEvent(type: .sumSprintCardAnswered, payload: [
-                    "problem_id": currentProblem?.id.uuidString ?? "",
-                    "card_index": String(state.currentCardIndex),
-                    "prompt": card.prompt,
-                    "correct": "false"
-                ])
-            )
-            feedbackMessage = "Try again. Solve this one before Bond Blast."
-            speechService.speak(feedbackMessage, enabled: featureFlags.audioEnabled)
-            hapticsService.failure(enabled: featureFlags.hapticsEnabled)
+            for index in state.cards.indices {
+                state.cards[index].isSelected = index == tappedIndex
+            }
+            state.selectedCardID = id
+            sumSprintBurstState = state
         }
     }
 
@@ -534,15 +530,13 @@ final class VerticalSliceEngine {
                         "card_count": String(burst.cards.count)
                     ])
                 )
-                if let card = burst.currentCard {
-                    try? telemetryWriter.append(
-                        SliceEvent(type: .sumSprintCardShown, payload: [
-                            "problem_id": problem.id.uuidString,
-                            "card_index": "0",
-                            "prompt": card.prompt
-                        ])
-                    )
-                }
+                try? telemetryWriter.append(
+                    SliceEvent(type: .sumSprintCardShown, payload: [
+                        "problem_id": problem.id.uuidString,
+                        "card_count": String(burst.cards.count),
+                        "pair_count": String(burst.totalPairs)
+                    ])
+                )
             }
         case .bondMatch:
             if let problem = currentProblem {
@@ -741,10 +735,10 @@ final class VerticalSliceEngine {
         case .pictorial, .bondMatch:
             return "Bond Blast! Match the pairs that make \(currentProblem.target)!"
         case .sumSprint:
-            if let card = sumSprintBurstState?.currentCard {
-                return "Quick Sum Sprint. Solve \(card.prompt), then finish with Bond Blast."
+            if let burst = sumSprintBurstState {
+                return "Quick Sum Sprint. Match each sum sentence to its total: \(burst.progressLabel) pairs found."
             }
-            return "Quick Sum Sprint! Solve a tiny burst, then finish with Bond Blast."
+            return "Quick Sum Sprint! Match each sum sentence to its total, then finish with Bond Blast."
         case .abstract:
             return activeTheme.abstractPrompt()
         case .transfer:

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -148,36 +148,35 @@ struct SliceSessionView: View {
                 CardSurface { Text("Loading Balance...") }
             }
         case .sumSprint:
-            if let burst = appModel.engine.sumSprintBurstState,
-               let card = burst.currentCard {
+            if let burst = appModel.engine.sumSprintBurstState {
                 CardSurface {
                     VStack(alignment: .leading, spacing: 16) {
                         Text("Sum Sprint")
                             .font(.title.weight(.black))
-                        Text("Card \(burst.progressLabel)")
+                        Text("Matches \(burst.progressLabel)")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.secondary)
-                        Text(card.prompt)
-                            .font(.system(size: 40, weight: .black, design: .rounded))
-                        Text(card.typedAnswer.isEmpty ? "?" : card.typedAnswer)
-                            .font(.system(size: 34, weight: .bold, design: .rounded))
-                            .foregroundStyle(MatherTheme.accent)
-                        VStack(spacing: 12) {
-                            ForEach([[1,2,3],[4,5,6],[7,8,9]], id: \.self) { row in
-                                HStack(spacing: 12) {
-                                    ForEach(row, id: \.self) { digit in
-                                        Button(String(digit)) { appModel.engine.appendSumSprintDigit(digit) }
-                                            .buttonStyle(PrimaryActionButtonStyle())
-                                    }
+                        Text("Tap a sum sentence, then tap its total.")
+                            .font(.headline)
+                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), spacing: 12)], spacing: 12) {
+                            ForEach(burst.cards) { card in
+                                Button {
+                                    appModel.engine.selectSumSprintCard(id: card.id)
+                                } label: {
+                                    Text(card.content.displayText)
+                                        .font(.system(size: 26, weight: .black, design: .rounded))
+                                        .foregroundStyle(cardForeground(for: card))
+                                        .frame(maxWidth: .infinity, minHeight: 88)
+                                        .padding(.horizontal, 12)
+                                        .background(cardBackground(for: card))
+                                        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                                        .overlay {
+                                            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                                                .stroke(cardBorder(for: card), lineWidth: card.isSelected ? 4 : 2)
+                                        }
                                 }
-                            }
-                            HStack(spacing: 12) {
-                                Button("⌫") { appModel.engine.deleteSumSprintDigit() }
-                                    .buttonStyle(PrimaryActionButtonStyle())
-                                Button("0") { appModel.engine.appendSumSprintDigit(0) }
-                                    .buttonStyle(PrimaryActionButtonStyle())
-                                Button("Go") { appModel.engine.submitSumSprintCard() }
-                                    .buttonStyle(PrimaryActionButtonStyle())
+                                .buttonStyle(.plain)
+                                .disabled(card.isMatched)
                             }
                         }
                     }
@@ -218,6 +217,26 @@ struct SliceSessionView: View {
         case .done:
             CardSurface { Text("Moving to the next problem...") }
         }
+    }
+
+    private func cardBackground(for card: SumSprintBurstCard) -> some ShapeStyle {
+        if card.isMatched {
+            return AnyShapeStyle(MatherTheme.mint.opacity(0.22))
+        }
+        if card.isSelected {
+            return AnyShapeStyle(MatherTheme.accent.opacity(0.18))
+        }
+        return AnyShapeStyle(MatherTheme.panel)
+    }
+
+    private func cardBorder(for card: SumSprintBurstCard) -> Color {
+        if card.isMatched { return MatherTheme.mint }
+        if card.isSelected { return MatherTheme.accent }
+        return MatherTheme.accent.opacity(0.18)
+    }
+
+    private func cardForeground(for card: SumSprintBurstCard) -> Color {
+        card.isMatched ? MatherTheme.mint : .primary
     }
 
     private var header: some View {

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -221,7 +221,7 @@ struct SliceSessionView: View {
 
     private func cardBackground(for card: SumSprintBurstCard) -> some ShapeStyle {
         if card.isMatched {
-            return AnyShapeStyle(MatherTheme.mint.opacity(0.22))
+            return AnyShapeStyle(MatherTheme.softBlue.opacity(0.22))
         }
         if card.isSelected {
             return AnyShapeStyle(MatherTheme.accent.opacity(0.18))
@@ -230,13 +230,13 @@ struct SliceSessionView: View {
     }
 
     private func cardBorder(for card: SumSprintBurstCard) -> Color {
-        if card.isMatched { return MatherTheme.mint }
+        if card.isMatched { return MatherTheme.softBlue }
         if card.isSelected { return MatherTheme.accent }
         return MatherTheme.accent.opacity(0.18)
     }
 
     private func cardForeground(for card: SumSprintBurstCard) -> Color {
-        card.isMatched ? MatherTheme.mint : .primary
+        card.isMatched ? MatherTheme.softBlue : .primary
     }
 
     private var header: some View {

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -31,11 +31,13 @@ struct VerticalSliceEngineTests {
     }
 
     private func completeSumSprintBurst(_ engine: VerticalSliceEngine) {
-        while let card = engine.sumSprintBurstState?.currentCard {
-            for digit in String(card.answer) {
-                engine.appendSumSprintDigit(Int(String(digit))!)
-            }
-            engine.submitSumSprintCard()
+        guard let cards = engine.sumSprintBurstState?.cards else { return }
+        let pairIDs = Array(Set(cards.map(\.pairId)))
+        for pairID in pairIDs {
+            guard let pairCards = engine.sumSprintBurstState?.cards.filter({ $0.pairId == pairID }),
+                  pairCards.count == 2 else { continue }
+            engine.selectSumSprintCard(id: pairCards[0].id)
+            engine.selectSumSprintCard(id: pairCards[1].id)
         }
     }
 
@@ -77,8 +79,8 @@ struct VerticalSliceEngineTests {
         // Wait for the durable next-stage outcome instead of the transient lock bit.
         await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
         #expect(engine.currentStage == .sumSprint)
-        #expect((engine.sumSprintBurstState?.cards.count ?? 0) >= 1)
-        #expect((engine.sumSprintBurstState?.cards.count ?? 0) <= 3)
+        #expect((engine.sumSprintBurstState?.totalPairs ?? 0) >= 1)
+        #expect((engine.sumSprintBurstState?.totalPairs ?? 0) <= 3)
 
         completeSumSprintBurst(engine)
         await waitFor("bond blast after sum sprint") { engine.currentStage == .bondMatch }
@@ -553,14 +555,17 @@ struct VerticalSliceEngineTests {
         engine.adjustGravitySplitByTap(delta: 1, side: .left)
         await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
 
-        while engine.currentStage == .sumSprint, let card = engine.sumSprintBurstState?.currentCard {
-            for digit in String(card.answer).compactMap(\.wholeNumberValue) {
-                engine.appendSumSprintDigit(digit)
-            }
-            engine.submitSumSprintCard()
+        while engine.currentStage == .sumSprint,
+              let nextPair = engine.sumSprintBurstState?.cards
+                .filter({ !$0.isMatched })
+                .reduce(into: [UUID: [SumSprintBurstCard]]()) { partial, card in partial[card.pairId, default: []].append(card) }
+                .values
+                .first(where: { $0.count == 2 }) {
+            engine.selectSumSprintCard(id: nextPair[0].id)
+            engine.selectSumSprintCard(id: nextPair[1].id)
             if engine.currentStage == .sumSprint {
-                await waitFor("advance sum sprint card") {
-                    engine.sumSprintBurstState?.currentCard?.id != card.id || engine.currentStage != .sumSprint
+                await waitFor("advance sum sprint pair") {
+                    (engine.sumSprintBurstState?.matchedPairs ?? 0) > 0 || engine.currentStage != .sumSprint
                 }
             }
         }
@@ -568,6 +573,22 @@ struct VerticalSliceEngineTests {
         await waitFor("session summary after target-1 loop") { engine.route == .sessionSummary }
         #expect(engine.currentStage == .done)
         #expect(engine.bondMatchState == nil)
+    }
+
+    @Test
+    func sumSprintRequiresMatchingExpressionWithResult() {
+        let state = SumSprintBurstState.make(for: SliceProblem(target: 6, decompositionA: 2, decompositionB: 4))
+        #expect(state.cards.count == state.totalPairs * 2)
+
+        let grouped = Dictionary(grouping: state.cards, by: \.pairId)
+        let firstPair = grouped.values.first(where: { $0.count == 2 })!
+        let contents = Set(firstPair.map { card -> String in
+            switch card.content {
+            case .prompt(let value): return "p:\(value)"
+            case .sum(let value): return "s:\(value)"
+            }
+        })
+        #expect(contents.count == 2)
     }
 
     @Test
@@ -904,8 +925,8 @@ struct VerticalSliceEngineTests {
         await waitFor("gravity split after concrete") { engine.currentStage == .gravitySplit }
         lockGravitySplit(engine, problem: problem)
         await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
-        #expect((engine.sumSprintBurstState?.cards.count ?? 0) >= 1)
-        #expect((engine.sumSprintBurstState?.cards.count ?? 0) <= 3)
+        #expect((engine.sumSprintBurstState?.totalPairs ?? 0) >= 1)
+        #expect((engine.sumSprintBurstState?.totalPairs ?? 0) <= 3)
     }
 
     @Test

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -555,20 +555,8 @@ struct VerticalSliceEngineTests {
         engine.adjustGravitySplitByTap(delta: 1, side: .left)
         await waitFor("sum sprint after gravity split") { engine.currentStage == .sumSprint }
 
-        while engine.currentStage == .sumSprint,
-              let nextPair = engine.sumSprintBurstState?.cards
-                .filter({ !$0.isMatched })
-                .reduce(into: [UUID: [SumSprintBurstCard]]()) { partial, card in partial[card.pairId, default: []].append(card) }
-                .values
-                .first(where: { $0.count == 2 }) {
-            engine.selectSumSprintCard(id: nextPair[0].id)
-            engine.selectSumSprintCard(id: nextPair[1].id)
-            if engine.currentStage == .sumSprint {
-                await waitFor("advance sum sprint pair") {
-                    (engine.sumSprintBurstState?.matchedPairs ?? 0) > 0 || engine.currentStage != .sumSprint
-                }
-            }
-        }
+        completeSumSprintBurst(engine)
+        await waitFor("sum sprint completes") { engine.currentStage != .sumSprint }
 
         await waitFor("session summary after target-1 loop") { engine.route == .sessionSummary }
         #expect(engine.currentStage == .done)


### PR DESCRIPTION
## Summary
- turn the embedded Sum Sprint step in the Make & Break v2 loop into a tiny memory-match round
- match each summation sentence with its total before advancing into Bond Blast
- cover the new pair-generation / loop expectations with focused vertical-slice tests

## Testing
- Remote `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4.1' -only-testing:MatherTests/VerticalSliceEngineTests`
  - blocked by a pre-existing baseline iOS build failure in `SessionSummaryView.swift`, `SettingsView.swift`, `SliceModels.swift`
- Remote `xcodebuild build -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4.1'`
  - baseline `origin/main` also fails in the same compile area, so this lane is carrying forward a known validation blocker rather than introducing a clean green build

Closes #355
