### PR TITLE
fix: avoid reusing visible sum sprint screenshot pairs

### DIFF
--- a/.github/workflows/ios-ui-review-main.yml
+++ b/.github/workflows/ios-ui-review-main.yml
@@ -1,6 +1,7 @@
 name: iOS UI Review (main)
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -505,6 +505,7 @@ final class ScreenshotTests: XCTestCase {
     private func completeVisibleSumSprintPairs(in app: XCUIApplication, target: Int, expectedPairs: Int) {
         let promptPrefix = "sumsprint-prompt-"
         let sumPrefix = "sumsprint-sum-"
+        var usedPromptTokens = Set<String>()
 
         for pairIndex in 0..<expectedPairs {
             let promptButtons = app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", promptPrefix))
@@ -515,13 +516,15 @@ final class ScreenshotTests: XCTestCase {
                 let button = promptButtons.element(boundBy: index)
                 let identifier = button.identifier
                 guard identifier.hasPrefix(promptPrefix), button.waitForExistence(timeout: 1), button.isHittable else { continue }
-                promptToken = String(identifier.dropFirst(promptPrefix.count))
+                let candidateToken = String(identifier.dropFirst(promptPrefix.count))
+                guard !usedPromptTokens.contains(candidateToken) else { continue }
+                promptToken = candidateToken
                 selectedPrompt = button
                 break
             }
 
             guard let promptButton = selectedPrompt else {
-                XCTFail("Expected a hittable Sum Sprint prompt for target \(target) pair \(pairIndex + 1)")
+                XCTFail("Expected a new hittable Sum Sprint prompt for target \(target) pair \(pairIndex + 1); already used \(usedPromptTokens)")
                 return
             }
             promptButton.tap()
@@ -541,6 +544,7 @@ final class ScreenshotTests: XCTestCase {
                 return
             }
             sumButton.tap()
+            usedPromptTokens.insert(promptToken)
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid reusing the same visible Sum Sprint pair twice during screenshot tapping
- keep the fix as a narrow follow-up on top of current `main`
- publish the prepared branch so the remaining blocker is hosted validation, not local branch recovery

## Context
This is the prepared follow-up for issue #222 after the merged `iOS UI Review (main)` run exposed repeated Sum Sprint pair taps on `main`.

## Validation status
- local branch prepared and published from commit `a19188a360c55bfbabace01783e986866db68bbb`
- **not yet runtime-validated on Apple-capable UI review**
- next required step is the targeted validation path documented in:
  - `scripts/mather_validate_sumsprint_fix_next_steps.sh`
  - issue #222 handoff comments / artifacts

## Why draft
This should stay draft until the iOS UI Review lane or equivalent runtime-capable pass confirms the repeated-pair failure is cleared.

Closes #222
