### PR TITLE
Improve adaptive child session shells

### DIFF
--- a/Features/RoomQuest/RoomSetupView.swift
+++ b/Features/RoomQuest/RoomSetupView.swift
@@ -4,6 +4,7 @@ import UIKit
 /// Parent setup screen shown before the room phase begins.
 /// Displays the spot quantities and safety reminder; parent taps "Ready" when spots are placed.
 struct RoomSetupView: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Bindable var engine: RoomQuestEngine
     @State private var showingConfiguration = false
 
@@ -25,7 +26,7 @@ struct RoomSetupView: View {
                 )
 
                 if let p = engine.problem {
-                    HStack(spacing: 16) {
+                    LazyVGrid(columns: ResponsiveLayout.roomQuestStationColumns(for: horizontalSizeClass), spacing: 16) {
                         ForEach(engine.stations) { station in
                             stationCard(for: station)
                         }
@@ -94,7 +95,9 @@ struct RoomSetupView: View {
                 .disabled(!engine.allStationsRegistered)
                 .opacity(engine.allStationsRegistered ? 1 : 0.55)
             }
-            .padding(24)
+            .padding(ResponsiveLayout.contentPadding(for: horizontalSizeClass))
+            .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
+            .frame(maxWidth: .infinity)
         }
         .sheet(isPresented: $showingConfiguration) {
             RoomQuestConfigurationScreen(featureFlags: engine.settings)

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SliceSessionView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Bindable var appModel: AppModel
     @State private var celebrationScale: CGFloat = 0.3
 
@@ -18,7 +19,8 @@ struct SliceSessionView: View {
 
             VStack(spacing: 0) {
                 header
-                    .padding(.horizontal, 20)
+                    .frame(maxWidth: ResponsiveLayout.childSessionMaxWidth(for: horizontalSizeClass))
+                    .padding(.horizontal, ResponsiveLayout.contentPadding(for: horizontalSizeClass))
                     .padding(.top, 20)
 
                 ScrollView {
@@ -31,9 +33,11 @@ struct SliceSessionView: View {
                             CardSurface { Text("No problem loaded.") }
                         }
                     }
-                    .padding(.horizontal, 20)
+                    .frame(maxWidth: ResponsiveLayout.childSessionMaxWidth(for: horizontalSizeClass))
+                    .padding(.horizontal, ResponsiveLayout.contentPadding(for: horizontalSizeClass))
                     .padding(.top, 12)
                     .padding(.bottom, 20)
+                    .frame(maxWidth: .infinity)
                 }
             }
 
@@ -352,7 +356,8 @@ struct SliceSessionView: View {
                 appModel.engine.submitCurrentStage()
             }
             .buttonStyle(PrimaryActionButtonStyle())
-            .padding(.horizontal, 20)
+            .frame(maxWidth: ResponsiveLayout.childSessionMaxWidth(for: horizontalSizeClass))
+            .padding(.horizontal, ResponsiveLayout.contentPadding(for: horizontalSizeClass))
             .padding(.top, 12)
             .padding(.bottom, 8)
         }

--- a/Shared/ResponsiveLayout.swift
+++ b/Shared/ResponsiveLayout.swift
@@ -13,6 +13,10 @@ enum ResponsiveLayout {
         horizontalSizeClass == .regular ? 560 : 400
     }
 
+    static func childSessionMaxWidth(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        horizontalSizeClass == .regular ? 940 : CGFloat.infinity
+    }
+
     // MARK: - Padding
 
     static func contentPadding(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
@@ -45,6 +49,16 @@ enum ResponsiveLayout {
         let minimum = horizontalSizeClass == .regular ? 140.0 : 110.0
         let maximum = horizontalSizeClass == .regular ? 180.0 : 160.0
         return [GridItem(.adaptive(minimum: minimum, maximum: maximum), spacing: 16)]
+    }
+
+    static func roomQuestStationMinimumWidth(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        horizontalSizeClass == .regular ? 240 : 170
+    }
+
+    static func roomQuestStationColumns(for horizontalSizeClass: UserInterfaceSizeClass?) -> [GridItem] {
+        let minimum = roomQuestStationMinimumWidth(for: horizontalSizeClass)
+        let maximum: CGFloat = horizontalSizeClass == .regular ? 320 : CGFloat.infinity
+        return [GridItem(.adaptive(minimum: minimum, maximum: maximum), spacing: 16, alignment: .top)]
     }
 
     static func profilePickerMaxWidth(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {

--- a/Tests/MatherTests/ResponsiveLayoutTests.swift
+++ b/Tests/MatherTests/ResponsiveLayoutTests.swift
@@ -23,4 +23,13 @@ struct ResponsiveLayoutTests {
         #expect(ResponsiveLayout.isWide(.regular))
         #expect(!ResponsiveLayout.isWide(.compact))
     }
+
+    @MainActor @Test func childShellsUseAdaptiveWidthRules() {
+        #expect(ResponsiveLayout.childSessionMaxWidth(for: .regular) == 940)
+        #expect(ResponsiveLayout.childSessionMaxWidth(for: .compact) == CGFloat.infinity)
+        #expect(ResponsiveLayout.roomQuestStationMinimumWidth(for: .compact) == 170)
+        #expect(ResponsiveLayout.roomQuestStationMinimumWidth(for: .regular) == 240)
+        #expect(ResponsiveLayout.roomQuestStationColumns(for: .compact).count == 1)
+        #expect(ResponsiveLayout.roomQuestStationColumns(for: .regular).count == 1)
+    }
 }


### PR DESCRIPTION
## Summary
- adds shared responsive helpers for child session max width and Room Quest station grids
- constrains the VS1 child session shell on regular-width layouts while keeping compact width full-bleed
- converts Room Quest setup station cards from a fixed `HStack` to an adaptive grid with responsive padding/max width
- adds layout-helper coverage in `ResponsiveLayoutTests`

## Validation
- Attempted: `xcodebuild test -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.3.1' -only-testing:MatherTests/ResponsiveLayoutTests`
- Result: blocked by Swift frontend crash while type-checking existing `Features/ParentSummary/SettingsView.swift` in the `profilesCard` body.
- Control check: the same targeted command also fails from a clean `origin/main` archive with the same SwiftCompile/frontend crash, so this is not introduced by this PR.

## Notes
This is the next small #354 adaptive shell slice after PR #373 landed iPhone/iPad UI Review coverage.