### PR TITLE
Give iPad UI screenshot review more time

### DIFF
--- a/.github/workflows/ios-ui-review-main.yml
+++ b/.github/workflows/ios-ui-review-main.yml
@@ -104,7 +104,11 @@ jobs:
           exit 1
 
       - name: Run UI screenshot tests
-        timeout-minutes: 15
+        # The iPad matrix leg runs the same artifact-producing screenshots on a
+        # slower simulator and can exceed 15 minutes after the Issue #222 loop
+        # coverage. Keep the step bounded, but give it enough room to finish and
+        # upload review artifacts instead of being killed mid-run.
+        timeout-minutes: 25
         run: |
           mkdir -p ci-videos
           SIM_ID="${SIM_DESTINATION#id=}"


### PR DESCRIPTION
## Summary
- raise the UI screenshot test step timeout from 15 to 25 minutes
- document why the iPad matrix leg needs extra room after Issue #222 screenshot coverage

## Evidence
- main run 24983035872 timed out in the iPad `Run UI screenshot tests` step after 15 minutes
- the log showed prior screenshot tests passing and no assertion failure before timeout
- `git diff --check` ✅

Fixes the main-validation blocker from PR #376/#377.