### PR TITLE
Make Sum Sprint adapt on wide layouts

### DIFF
--- a/Features/SumSprint/SumSprintSessionView.swift
+++ b/Features/SumSprint/SumSprintSessionView.swift
@@ -12,8 +12,10 @@ struct SumSprintSessionView: View {
 
             VStack(spacing: 0) {
                 header
-                    .padding(.horizontal, 20)
+                    .padding(.horizontal, ResponsiveLayout.contentPadding(for: horizontalSizeClass))
                     .padding(.top, 12)
+                    .frame(maxWidth: ResponsiveLayout.sumSprintSessionMaxWidth(for: horizontalSizeClass))
+                    .frame(maxWidth: .infinity)
 
                 ScrollView {
                     VStack(spacing: 20) {
@@ -26,7 +28,7 @@ struct SumSprintSessionView: View {
                                 onSubmit: { engine.submitAnswer() }
                             )
                             .padding(.horizontal, 20)
-                            .frame(maxWidth: ResponsiveLayout.isWide(horizontalSizeClass) ? 700 : .infinity)
+                            .frame(maxWidth: ResponsiveLayout.sumSprintSessionMaxWidth(for: horizontalSizeClass))
                             .frame(maxWidth: .infinity)
                             .transition(.asymmetric(
                                 insertion: .move(edge: .trailing).combined(with: .opacity),
@@ -35,6 +37,8 @@ struct SumSprintSessionView: View {
                             .id(engine.currentCardIndex)
                         }
                     }
+                    .frame(maxWidth: ResponsiveLayout.sumSprintSessionMaxWidth(for: horizontalSizeClass))
+                    .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)
                 }
             }
@@ -46,7 +50,7 @@ struct SumSprintSessionView: View {
                         Spacer()
                         countdownRing
                             .padding(.top, 12)
-                            .padding(.trailing, 20)
+                            .padding(.trailing, ResponsiveLayout.contentPadding(for: horizontalSizeClass))
                     }
                     Spacer()
                 }

--- a/Features/SumSprint/SumSprintSummaryView.swift
+++ b/Features/SumSprint/SumSprintSummaryView.swift
@@ -19,17 +19,35 @@ struct SumSprintSummaryView: View {
                 VStack(spacing: 28) {
                     Spacer(minLength: 20)
 
-                    celebrationBlock
-
-                    statsRow
-
-                    factsPracticedGrid
-
-                    buttonStack
+                    summaryContent
                 }
                 .padding(ResponsiveLayout.contentPadding(for: horizontalSizeClass))
-                .frame(maxWidth: ResponsiveLayout.isWide(horizontalSizeClass) ? 900 : .infinity)
+                .frame(maxWidth: ResponsiveLayout.sumSprintSummaryMaxWidth(for: horizontalSizeClass))
                 .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var summaryContent: some View {
+        if ResponsiveLayout.isWide(horizontalSizeClass) {
+            HStack(alignment: .top, spacing: 24) {
+                celebrationBlock
+                    .frame(maxWidth: 340)
+
+                VStack(spacing: 20) {
+                    statsRow
+                    factsPracticedGrid
+                    buttonStack
+                }
+                .frame(maxWidth: .infinity)
+            }
+        } else {
+            VStack(spacing: 28) {
+                celebrationBlock
+                statsRow
+                factsPracticedGrid
+                buttonStack
             }
         }
     }
@@ -136,7 +154,7 @@ struct SumSprintSummaryView: View {
                     .font(.headline.weight(.bold))
                     .foregroundStyle(MatherTheme.ink.opacity(0.7))
 
-                LazyVGrid(columns: ResponsiveLayout.summaryFactColumns(for: horizontalSizeClass), spacing: 8) {
+                LazyVGrid(columns: ResponsiveLayout.sumSprintSummaryFactColumns(for: horizontalSizeClass), spacing: 8) {
                     ForEach(summary.cards) { card in
                         factPill(card: card)
                     }
@@ -178,13 +196,27 @@ struct SumSprintSummaryView: View {
 
     // MARK: - Buttons
 
+    @ViewBuilder
     private var buttonStack: some View {
-        VStack(spacing: 12) {
-            Button("Play again") { onPlayAgain() }
-                .buttonStyle(PrimaryActionButtonStyle())
-
-            Button("Done") { onDone() }
-                .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.55)))
+        if ResponsiveLayout.isWide(horizontalSizeClass) {
+            HStack(spacing: 12) {
+                summaryButtons
+            }
+            .frame(maxWidth: .infinity)
+        } else {
+            VStack(spacing: 12) {
+                summaryButtons
+            }
+            .frame(maxWidth: .infinity)
         }
+    }
+
+    @ViewBuilder
+    private var summaryButtons: some View {
+        Button("Play again") { onPlayAgain() }
+            .buttonStyle(PrimaryActionButtonStyle())
+
+        Button("Done") { onDone() }
+            .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.55)))
     }
 }

--- a/Shared/ResponsiveLayout.swift
+++ b/Shared/ResponsiveLayout.swift
@@ -17,6 +17,14 @@ enum ResponsiveLayout {
         horizontalSizeClass == .regular ? 940 : CGFloat.infinity
     }
 
+    static func sumSprintSessionMaxWidth(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        horizontalSizeClass == .regular ? 820 : CGFloat.infinity
+    }
+
+    static func sumSprintSummaryMaxWidth(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        horizontalSizeClass == .regular ? 980 : CGFloat.infinity
+    }
+
     // MARK: - Padding
 
     static func contentPadding(for horizontalSizeClass: UserInterfaceSizeClass?) -> CGFloat {
@@ -38,6 +46,10 @@ enum ResponsiveLayout {
     static func summaryFactColumns(for horizontalSizeClass: UserInterfaceSizeClass?) -> [GridItem] {
         let count = horizontalSizeClass == .regular ? 3 : 2
         return Array(repeating: GridItem(.flexible(), spacing: 8), count: count)
+    }
+
+    static func sumSprintSummaryFactColumns(for horizontalSizeClass: UserInterfaceSizeClass?) -> [GridItem] {
+        Array(repeating: GridItem(.flexible(), spacing: 8), count: 2)
     }
 
     static func settingsColumns(for horizontalSizeClass: UserInterfaceSizeClass?) -> [GridItem] {

--- a/Tests/MatherTests/ResponsiveLayoutTests.swift
+++ b/Tests/MatherTests/ResponsiveLayoutTests.swift
@@ -32,4 +32,13 @@ struct ResponsiveLayoutTests {
         #expect(ResponsiveLayout.roomQuestStationColumns(for: .compact).count == 1)
         #expect(ResponsiveLayout.roomQuestStationColumns(for: .regular).count == 1)
     }
+
+    @MainActor @Test func sumSprintUsesDedicatedRegularWidthCaps() {
+        #expect(ResponsiveLayout.sumSprintSessionMaxWidth(for: .compact) == CGFloat.infinity)
+        #expect(ResponsiveLayout.sumSprintSessionMaxWidth(for: .regular) == 820)
+        #expect(ResponsiveLayout.sumSprintSummaryMaxWidth(for: .compact) == CGFloat.infinity)
+        #expect(ResponsiveLayout.sumSprintSummaryMaxWidth(for: .regular) == 980)
+        #expect(ResponsiveLayout.sumSprintSummaryFactColumns(for: .compact).count == 2)
+        #expect(ResponsiveLayout.sumSprintSummaryFactColumns(for: .regular).count == 2)
+    }
 }


### PR DESCRIPTION
## Summary
- add dedicated Sum Sprint regular-width layout caps to `ResponsiveLayout`
- widen the live Sum Sprint session shell on regular-width devices while keeping compact layouts full-width
- split the Sum Sprint summary into a regular-width celebration rail plus details/actions column, with compact layouts unchanged as a stacked flow
- add focused `ResponsiveLayoutTests` coverage for the new Sum Sprint rules

## Validation
- `git diff --check` ✅
- attempted remote targeted test on `ganesh@ganeshs-macbook-air.tailb4aad7.ts.net`:
  - `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 16,OS=18.3.1" -only-testing:MatherTests/ResponsiveLayoutTests CODE_SIGNING_ALLOWED=NO`
  - blocked by existing Swift frontend crash while type-checking `Features/ParentSummary/SettingsView.swift` / `profilesCard`, matching the known local validation blocker documented on #354 / PR #374; not introduced by this Sum Sprint slice.

## Scope notes
- This is intentionally separate from PR #381, which is scoped to Memory board/sheet adaptivity.
- Does not touch planned lanes #352/#368/#379/#380/#349.

Closes part of #354.
