### PR TITLE
fix: invert Compass Angles yaw sign

### DIFF
--- a/Services/MotionService.swift
+++ b/Services/MotionService.swift
@@ -98,6 +98,16 @@ final class MotionService {
         }
     }
 
+    /// Convert CoreMotion's reference-relative attitude yaw to the app's
+    /// child-facing body-turn convention: positive means the child turned right.
+    ///
+    /// `CMAttitude.yaw` increases in the opposite direction from the Compass
+    /// Angles UI/copy contract, so keep the sign flip at the sensor boundary
+    /// instead of mirroring individual game views.
+    nonisolated static func bodyRelativeYawDegrees(fromCoreMotionYawRadians yaw: Double) -> Double {
+        -(yaw * 180 / .pi)
+    }
+
     // MARK: - Private helpers
 
     private func applyMotion(_ motion: CMDeviceMotion) {
@@ -116,7 +126,7 @@ final class MotionService {
         if let ref = referenceAttitude {
             let current = motion.attitude.copy() as! CMAttitude
             current.multiply(byInverseOf: ref)
-            relativeYaw = current.yaw * 180 / .pi
+            relativeYaw = Self.bodyRelativeYawDegrees(fromCoreMotionYawRadians: current.yaw)
         }
     }
 

--- a/Tests/MatherTests/MotionServiceTests.swift
+++ b/Tests/MatherTests/MotionServiceTests.swift
@@ -69,6 +69,17 @@ struct MotionServiceTests {
         #expect(!service.shakeDetected)
     }
 
+    // MARK: - Compass Angles relative yaw convention
+
+    @Test
+    func coreMotionYawIsInvertedToBodyRelativeRightPositiveDegrees() {
+        let rightTurn = MotionService.bodyRelativeYawDegrees(fromCoreMotionYawRadians: -.pi / 2)
+        let leftTurn = MotionService.bodyRelativeYawDegrees(fromCoreMotionYawRadians: .pi / 2)
+
+        #expect(abs(rightTurn - 90) < 0.01)
+        #expect(abs(leftTurn - (-90)) < 0.01)
+    }
+
     // MARK: - stopUpdates resets state
 
     @Test


### PR DESCRIPTION
## Summary
- invert CoreMotion reference-relative yaw at the MotionService boundary so Compass Angles keeps the app contract `positive = child turned right`
- add a focused unit test for the CoreMotion-yaw-to-body-relative sign convention

Fixes #368.

## Validation
- `git diff --check`
- Attempted on `ganesh-mba`: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:MatherTests/MotionServiceTests`
  - Blocked by an unrelated Swift frontend crash while type-checking `Features/ParentSummary/SettingsView.swift`; no failure reached the changed MotionService test.
