### PR TITLE
[codex] Fix Compass Angles yaw direction

### DIFF
--- a/Services/MotionService.swift
+++ b/Services/MotionService.swift
@@ -98,6 +98,12 @@ final class MotionService {
         }
     }
 
+    /// Convert CoreMotion relative yaw into Mather's body-relative convention:
+    /// positive degrees means the child turned right, negative means left.
+    nonisolated static func bodyRelativeYawDegrees(fromCoreMotionDeltaYawRadians yaw: Double) -> Double {
+        -yaw * 180 / .pi
+    }
+
     // MARK: - Private helpers
 
     private func applyMotion(_ motion: CMDeviceMotion) {
@@ -116,7 +122,7 @@ final class MotionService {
         if let ref = referenceAttitude {
             let current = motion.attitude.copy() as! CMAttitude
             current.multiply(byInverseOf: ref)
-            relativeYaw = current.yaw * 180 / .pi
+            relativeYaw = Self.bodyRelativeYawDegrees(fromCoreMotionDeltaYawRadians: current.yaw)
         }
     }
 

--- a/Tests/MatherTests/MotionServiceTests.swift
+++ b/Tests/MatherTests/MotionServiceTests.swift
@@ -34,6 +34,20 @@ struct MotionServiceTests {
         #expect(service.tiltRoll  == -0.5)
     }
 
+    // MARK: - Relative yaw conversion
+
+    @Test
+    func coreMotionNegativeYawMapsToRightTurn() {
+        let degrees = MotionService.bodyRelativeYawDegrees(fromCoreMotionDeltaYawRadians: -.pi / 2)
+        #expect(abs(degrees - 90) < 0.01)
+    }
+
+    @Test
+    func coreMotionPositiveYawMapsToLeftTurn() {
+        let degrees = MotionService.bodyRelativeYawDegrees(fromCoreMotionDeltaYawRadians: .pi / 2)
+        #expect(abs(degrees - (-90)) < 0.01)
+    }
+
     // MARK: - Shake detection
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #368.

- Add a named `MotionService.bodyRelativeYawDegrees(fromCoreMotionDeltaYawRadians:)` conversion helper for CoreMotion delta yaw.
- Invert the CoreMotion yaw sign at the `MotionService` boundary so Mather's existing contract stays true: positive `relativeYaw` means turned right, negative means turned left.
- Add regression tests for the physical sign mapping: CoreMotion `-pi/2` -> `+90` right turn, CoreMotion `+pi/2` -> `-90` left turn.

## Root Cause

Compass Angles labels and targets already treat positive degrees as right turns and negative degrees as left turns. `MotionService.relativeYaw` documents the same body-relative convention, but `applyMotion` was assigning CoreMotion's raw relative yaw sign directly, which inverted left/right readings in the child-facing flow.

## Validation

- `git diff --check` passes.
- Attempted targeted test command:
  `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO -only-testing:MatherTests/MotionServiceTests`
- Blocked locally because this worker environment does not have `xcodebuild` installed (`/bin/bash: xcodebuild: command not found`).