### PR TITLE
[codex] Add fish memory asset plan

### DIFF
--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -300,6 +300,17 @@ enum MemoryDeck {
         imagePlan("planet-neptune", asset: "MemoryPlanetNeptune", prompt: "Neptune planet disk, deep blue with subtle storm/cloud texture", notes: "deeper blue than Uranus; avoid over-saturated fantasy art")
     ]
 
+    static let fishImageAssetPlan: [MemoryImageAssetPlan] = [
+        imagePlan("fish-clownfish", asset: "MemoryFishClownfish", prompt: "clownfish with orange body and white bands near coral or sea anemone", notes: "white bands and orange body must be readable; crop out busy reef clutter"),
+        imagePlan("fish-goldfish", asset: "MemoryFishGoldfish", prompt: "goldfish side view with rounded body and flowing tail on a clean water background", notes: "orange or gold body should distinguish it from clownfish; avoid bowl-only compositions"),
+        imagePlan("fish-betta", asset: "MemoryFishBetta", prompt: "betta fish with large flowing fins, side view, clean aquatic background", notes: "flowing fins are the recognition cue; keep fin edges visible in square crop"),
+        imagePlan("fish-angelfish", asset: "MemoryFishAngelfish", prompt: "angelfish with tall triangular fins, side view, simple reef or water background", notes: "tall dorsal and anal fins must stay inside crop; avoid confusing with generic reef fish"),
+        imagePlan("fish-catfish", asset: "MemoryFishCatfish", prompt: "catfish with visible whisker-like barbels, side or three-quarter view", notes: "barbels must be clear at card size; prefer uncluttered river or aquarium background"),
+        imagePlan("fish-swordtail", asset: "MemoryFishSwordtail", prompt: "swordtail fish side view with long sword-shaped lower tail extension", notes: "tail sword is required for recognition; avoid crops that trim the tail"),
+        imagePlan("fish-tuna", asset: "MemoryFishTuna", prompt: "tuna fish with streamlined silver and blue body, side view in open water", notes: "sleek torpedo shape should read clearly; avoid fishing/deck scenes"),
+        imagePlan("fish-seahorse", asset: "MemoryFishSeahorse", prompt: "seahorse upright profile with curled tail, clean sea grass or water background", notes: "upright posture and curled tail must be visible; keep subject large in square crop")
+    ]
+
     static let planets: [MemoryAnimal] = [
         planet("planet-mercury", prompt: "☿", name: "Mercury", order: "1st from the Sun", type: "rocky planet", size: "4,879 km wide", colors: "gray", funFact: "A year lasts 88 days"),
         planet("planet-venus", prompt: "♀", name: "Venus", order: "2nd from the Sun", type: "rocky planet", size: "12,104 km wide", colors: "pale yellow", funFact: "It spins very slowly"),

--- a/Tests/MatherTests/MemoryViewTests.swift
+++ b/Tests/MatherTests/MemoryViewTests.swift
@@ -53,6 +53,22 @@ struct MemoryViewTests {
         #expect(MemoryDeck.planets.allSatisfy { $0.imageAssetName == nil })
     }
 
+    @Test func issue379FishImageAssetPlanCoversFishesWithoutPrematureImports() {
+        let fishIds = MemoryDeck.fishes.map(\.id)
+        let plan = MemoryDeck.fishImageAssetPlan
+        let plannedAssets = plan.map(\.assetName)
+
+        #expect(plan.map(\.cardId) == fishIds)
+        #expect(Set(plannedAssets).count == plannedAssets.count)
+        #expect(plannedAssets.allSatisfy { $0.hasPrefix("MemoryFish") })
+        #expect(plan.allSatisfy { !$0.searchPrompt.isEmpty && !$0.styleNotes.isEmpty })
+        #expect(plan.allSatisfy { plan in
+            if case .needsVettedSource = plan.status { return true }
+            return false
+        })
+        #expect(MemoryDeck.fishes.allSatisfy { $0.imageAssetName == nil })
+    }
+
     @Test func deckSelectionExposesVehiclesDeck() {
         #expect(MemoryView.DeckSelection.allCases.contains(.vehicles))
         #expect(MemoryView.DeckSelection.vehicles.menuLabel == "Vehicles")

--- a/wiki/Specs/Issue-379-Fishes-Asset-Plan.md
+++ b/wiki/Specs/Issue-379-Fishes-Asset-Plan.md
@@ -1,0 +1,41 @@
+# Issue 379 - Fishes Image Asset Plan
+
+This is the safe pre-import plan for upgrading the `fishes` Memory Match deck to image-backed cards. It intentionally does **not** import images yet; every fish image still needs a vetted source, license/reuse check, and provenance note before the deck can reference `.asset(...)`.
+
+## Asset naming
+
+Fish assets should use `MemoryFish<Name>`:
+
+- `MemoryFishClownfish`
+- `MemoryFishGoldfish`
+- `MemoryFishBetta`
+- `MemoryFishAngelfish`
+- `MemoryFishCatfish`
+- `MemoryFishSwordtail`
+- `MemoryFishTuna`
+- `MemoryFishSeahorse`
+
+The same planned names are captured in `MemoryDeck.fishImageAssetPlan` so tests can guard coverage before asset import.
+
+## Source rules before import
+
+1. Use public-domain, CC0, project-owned, or generated-and-approved assets only.
+2. Record provenance next to imported images before switching cards from `.text(...)` to `.asset(...)`.
+3. Prefer uncluttered side/profile views where each fish's recognition cue is visible at card size.
+4. Avoid watermarks, aquarium labels, visible people, fishing/deck scenes, brand marks, and images where the animal is tiny or ambiguous.
+
+## Import checklist
+
+For each planned asset:
+
+- source URL / creator / license recorded
+- reuse is compatible with the app/repo
+- square crop exported and checked at Memory card size
+- image added under `App/Assets.xcassets/<assetName>.imageset`
+- matching card switched to `.asset(assetName)`
+- tests updated from plan coverage to actual asset reference coverage
+
+## Current status
+
+- Fishes: 8/8 cards have planned asset names and sourcing prompts.
+- No unvetted images were imported in this slice.


### PR DESCRIPTION
## Summary

- Add `MemoryDeck.fishImageAssetPlan` with planned `MemoryFish...` asset names for all eight fish cards.
- Add a focused MemoryView test that keeps fish cards on text placeholders until vetted sources are available.
- Document the Issue #379 fish image asset provenance/import checklist without importing unverified images.

## Validation

- `git diff --check`
- `python3` structural validation confirming the fish asset plan covers all 8 fish IDs with unique `MemoryFish...` names
- Attempted `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' -only-testing:MatherTests/MemoryViewTests CODE_SIGNING_ALLOWED=NO`, but this worker environment does not have `xcodebuild` installed.