### PR TITLE
Guard memory card AI descriptions

### DIFF
--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -69,15 +69,35 @@ struct MemoryCardDescription: Equatable {
     let source: MemoryCardDescriptionSource
 }
 
+struct MemoryCardAIPrompt: Equatable {
+    static let maxGeneratedCharacters = 220
+    static let maxGeneratedSentences = 2
+
+    let systemInstruction: String
+    let userPrompt: String
+
+    static func childSafePrompt(for animal: MemoryAnimal) -> MemoryCardAIPrompt {
+        let facts = animal.detailCards
+            .prefix(5)
+            .map { "\($0.title): \($0.value)" }
+            .joined(separator: "; ")
+        let deckName = animal.metadata.deck.displayName
+        return MemoryCardAIPrompt(
+            systemInstruction: "Write for a child age 5 to 8. Be factual, warm, and concise. Use no more than two short sentences. Do not ask questions, invent facts, mention AI, or include unsafe instructions.",
+            userPrompt: "Explain this Memory Match card in simple words. Deck: \(deckName). Card: \(animal.canonicalName). Known facts: \(facts)."
+        )
+    }
+}
+
 @MainActor
 protocol MemoryCardAIAdapter {
     var isAvailable: Bool { get }
-    func shortDescription(for animal: MemoryAnimal) async throws -> String?
+    func shortDescription(for animal: MemoryAnimal, prompt: MemoryCardAIPrompt) async throws -> String?
 }
 
 private struct NullMemoryCardAIAdapter: MemoryCardAIAdapter {
     var isAvailable: Bool { false }
-    func shortDescription(for animal: MemoryAnimal) async throws -> String? { nil }
+    func shortDescription(for animal: MemoryAnimal, prompt: MemoryCardAIPrompt) async throws -> String? { nil }
 }
 
 #if canImport(FoundationModels)
@@ -89,11 +109,13 @@ private struct FoundationModelsMemoryCardAIAdapter: MemoryCardAIAdapter {
         return false
     }
 
-    func shortDescription(for animal: MemoryAnimal) async throws -> String? {
+    func shortDescription(for animal: MemoryAnimal, prompt: MemoryCardAIPrompt) async throws -> String? {
         guard isAvailable else { return nil }
-        // Intentionally guarded and fallback-first for Slice A. A future slice can
-        // replace this stub with a live Foundation Models request without changing
-        // the service API or the curated fallback path.
+        _ = prompt
+        // Intentionally guarded and fallback-first until the FoundationModels API
+        // is enabled for this app target. The prompt and sanitizer are production
+        // boundaries: short, factual, child-safe copy in; deterministic fallback out
+        // whenever the platform model is unavailable or returns unsuitable text.
         return nil
     }
 }
@@ -113,8 +135,9 @@ final class MemoryCardDescribeService {
     }
 
     func describe(_ animal: MemoryAnimal) async -> MemoryCardDescription {
+        let prompt = MemoryCardAIPrompt.childSafePrompt(for: animal)
         if appleIntelligenceEnabled(), aiAdapter.isAvailable,
-           let generated = try? await aiAdapter.shortDescription(for: animal),
+           let generated = try? await aiAdapter.shortDescription(for: animal, prompt: prompt),
            let sanitized = sanitizeGeneratedDescription(generated) {
             return MemoryCardDescription(
                 title: animal.canonicalName,
@@ -219,7 +242,41 @@ final class MemoryCardDescribeService {
             .replacingOccurrences(of: "\n", with: " ")
             .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        return collapsed.isEmpty ? nil : collapsed
+        guard !collapsed.isEmpty else { return nil }
+        guard isGeneratedDescriptionAllowed(collapsed) else { return nil }
+
+        let sentences = collapsed
+            .split(whereSeparator: { ".!?".contains($0) })
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let limitedSentences = Array(sentences.prefix(MemoryCardAIPrompt.maxGeneratedSentences))
+        let sentenceLimited = limitedSentences.isEmpty ? collapsed : limitedSentences.joined(separator: ". ") + "."
+        guard sentenceLimited.count <= MemoryCardAIPrompt.maxGeneratedCharacters else {
+            let endIndex = sentenceLimited.index(sentenceLimited.startIndex, offsetBy: MemoryCardAIPrompt.maxGeneratedCharacters)
+            let clipped = String(sentenceLimited[..<endIndex])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: ",;:-"))
+            return clipped.isEmpty ? nil : clipped + "…"
+        }
+        return sentenceLimited
+    }
+
+    private func isGeneratedDescriptionAllowed(_ text: String) -> Bool {
+        let lowercased = text.lowercased()
+        let disallowedFragments = [
+            "as an ai",
+            "language model",
+            "i cannot",
+            "i can't",
+            "ask an adult",
+            "click here",
+            "http://",
+            "https://",
+            "scary",
+            "violent",
+            "weapon"
+        ]
+        return !disallowedFragments.contains { lowercased.contains($0) }
     }
 
     private static func makeDefaultAIAdapter() -> any MemoryCardAIAdapter {

--- a/Tests/MatherTests/MemoryViewTests.swift
+++ b/Tests/MatherTests/MemoryViewTests.swift
@@ -121,7 +121,7 @@ struct MemoryCardDescribeServiceTests {
         let isAvailable: Bool
         let response: String?
 
-        func shortDescription(for animal: MemoryAnimal) async throws -> String? {
+        func shortDescription(for animal: MemoryAnimal, prompt: MemoryCardAIPrompt) async throws -> String? {
             response
         }
     }
@@ -168,4 +168,44 @@ struct MemoryCardDescribeServiceTests {
         #expect(description.shortDescription == "A rocket zooms high and can reach space.")
         #expect(description.factChips.count == 4)
     }
+
+    @Test func appleIntelligencePromptStaysChildSafeAndFactBound() {
+        let prompt = MemoryCardAIPrompt.childSafePrompt(for: MemoryDeck.planets.first { $0.id == "planet-earth" }!)
+
+        #expect(prompt.systemInstruction.localizedCaseInsensitiveContains("child age 5 to 8"))
+        #expect(prompt.systemInstruction.localizedCaseInsensitiveContains("two short sentences"))
+        #expect(prompt.systemInstruction.localizedCaseInsensitiveContains("Do not ask questions"))
+        #expect(prompt.userPrompt.contains("Earth"))
+        #expect(prompt.userPrompt.contains("Order: 3rd from the Sun"))
+        #expect(prompt.userPrompt.contains("Fun Fact: It has one moon"))
+    }
+
+    @MainActor @Test func generatedDescriptionsAreSanitizedBeforeUse() async {
+        let service = MemoryCardDescribeService(
+            appleIntelligenceEnabled: { true },
+            aiAdapter: StubAIAdapter(
+                isAvailable: true,
+                response: "  Earth is our home planet.  It has blue oceans and white clouds. Extra sentence should not be read.  "
+            )
+        )
+
+        let description = await service.describe(MemoryDeck.planets.first { $0.id == "planet-earth" }!)
+
+        #expect(description.source == .appleIntelligence)
+        #expect(description.shortDescription == "Earth is our home planet. It has blue oceans and white clouds.")
+    }
+
+    @MainActor @Test func unsafeGeneratedDescriptionsFallBackToCuratedCopy() async {
+        let service = MemoryCardDescribeService(
+            appleIntelligenceEnabled: { true },
+            aiAdapter: StubAIAdapter(isAvailable: true, response: "As an AI language model, click here to learn about rockets.")
+        )
+
+        let description = await service.describe(MemoryDeck.vehicles.first { $0.id == "rocket" }!)
+
+        #expect(description.source == .curatedFallback)
+        #expect(description.shortDescription.localizedCaseInsensitiveContains("vehicle"))
+        #expect(description.shortDescription.localizedCaseInsensitiveContains("space"))
+    }
+
 }


### PR DESCRIPTION
## Summary
- add a child-safe prompt contract for Memory card Apple Intelligence descriptions
- pass the prompt through the private AI adapter seam while keeping fallback-first behavior
- strengthen generated-description sanitization with sentence/length limits and unsafe-fragment fallback
- add focused tests for prompt content, sanitized AI copy, and deterministic fallback on unsafe generated text

## Validation
- git diff --check ✅
- targeted remote xcodebuild test: blocked by existing fresh-main build failure in unrelated files (SessionSummaryView.swift / SettingsView.swift / SliceModels.swift); failure reproduced while only running MatherTests/MemoryCardDescribeServiceTests on iPhone 16 OS 18.3.1

Refs #353
Refs #352