### PR TITLE
[codex] Add child-safe Memory Ask card scaffold

### DIFF
--- a/Features/Memory/MemoryAskConversationPolicy.swift
+++ b/Features/Memory/MemoryAskConversationPolicy.swift
@@ -107,7 +107,10 @@ final class MemoryAskConversationPolicy {
             animal.metadata.category,
             animal.metadata.kind
         ] + animal.detailCards.flatMap { [$0.title, $0.value] }
-        let cardWords = Set(Self.words(in: cardText.joined(separator: " ")).filter { $0.count > 2 })
+        let genericWords: Set<String> = ["about", "card", "current", "question", "tell", "this", "turn"]
+        let cardWords = Set(Self.words(in: cardText.joined(separator: " ")).filter { word in
+            word.count > 2 && !genericWords.contains(word)
+        })
 
         var seenIDs = Set<String>()
         var sanitizedTurns: [MemoryAskSuggestedTurn] = []

--- a/Features/Memory/MemoryAskConversationPolicy.swift
+++ b/Features/Memory/MemoryAskConversationPolicy.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+enum MemoryAskConversationSource: Equatable {
+    case appleIntelligenceSuggested
+    case deterministicFallback
+}
+
+enum MemoryAskInputMode: Equatable {
+    case suggestedTurnSelection
+}
+
+struct MemoryAskSuggestedTurn: Identifiable, Equatable {
+    let id: String
+    let question: String
+    let answer: String
+}
+
+struct MemoryAskResponse: Equatable {
+    enum Kind: Equatable {
+        case answer
+        case refusal
+    }
+
+    let kind: Kind
+    let spokenText: String
+}
+
+enum MemoryAskTurnRequest: Equatable {
+    case suggestedTurn(id: String)
+    case unsupportedTopic
+}
+
+struct MemoryAskConversationSession: Equatable {
+    let cardId: String
+    let source: MemoryAskConversationSource
+    let suggestedTurns: [MemoryAskSuggestedTurn]
+    private(set) var selectedTurnIDs: [String] = []
+
+    mutating func respond(to request: MemoryAskTurnRequest) -> MemoryAskResponse {
+        switch request {
+        case let .suggestedTurn(id):
+            guard let turn = suggestedTurns.first(where: { $0.id == id }) else {
+                return Self.offScopeResponse
+            }
+            selectedTurnIDs.append(id)
+            return MemoryAskResponse(kind: .answer, spokenText: turn.answer)
+        case .unsupportedTopic:
+            return Self.offScopeResponse
+        }
+    }
+
+    private static var offScopeResponse: MemoryAskResponse {
+        MemoryAskResponse(
+            kind: .refusal,
+            spokenText: "I can only talk about this card. Pick one of the card questions."
+        )
+    }
+}
+
+@MainActor
+protocol MemoryAskConversationTurnProvider {
+    var isAvailable: Bool { get }
+    func suggestedTurns(for animal: MemoryAnimal) async throws -> [MemoryAskSuggestedTurn]
+}
+
+private struct NullMemoryAskConversationTurnProvider: MemoryAskConversationTurnProvider {
+    var isAvailable: Bool { false }
+    func suggestedTurns(for animal: MemoryAnimal) async throws -> [MemoryAskSuggestedTurn] { [] }
+}
+
+@MainActor
+final class MemoryAskConversationPolicy {
+    static let allowsMicrophoneInput = false
+    static let allowsFreeformTextInput = false
+    static let supportedInputModes: [MemoryAskInputMode] = [.suggestedTurnSelection]
+
+    private let provider: any MemoryAskConversationTurnProvider
+
+    init(provider: (any MemoryAskConversationTurnProvider)? = nil) {
+        self.provider = provider ?? NullMemoryAskConversationTurnProvider()
+    }
+
+    func startSession(for animal: MemoryAnimal) async -> MemoryAskConversationSession {
+        if provider.isAvailable,
+           let generatedTurns = try? await provider.suggestedTurns(for: animal) {
+            let safeTurns = sanitize(generatedTurns, for: animal)
+            if !safeTurns.isEmpty {
+                return MemoryAskConversationSession(
+                    cardId: animal.id,
+                    source: .appleIntelligenceSuggested,
+                    suggestedTurns: safeTurns
+                )
+            }
+        }
+
+        return MemoryAskConversationSession(
+            cardId: animal.id,
+            source: .deterministicFallback,
+            suggestedTurns: Self.fallbackTurns(for: animal)
+        )
+    }
+
+    private func sanitize(_ turns: [MemoryAskSuggestedTurn], for animal: MemoryAnimal) -> [MemoryAskSuggestedTurn] {
+        let cardWords = Set(
+            ([animal.canonicalName, animal.name, animal.metadata.category, animal.metadata.kind] + animal.detailCards.flatMap { [$0.title, $0.value] })
+                .flatMap { $0.lowercased().split { !$0.isLetter && !$0.isNumber } }
+                .map(String.init)
+                .filter { $0.count > 2 }
+        )
+
+        var seenIDs = Set<String>()
+        return turns.compactMap { turn in
+            let cleanQuestion = Self.clean(turn.question)
+            let cleanAnswer = Self.clean(turn.answer)
+            guard !turn.id.isEmpty,
+                  seenIDs.insert(turn.id).inserted,
+                  !cleanQuestion.isEmpty,
+                  !cleanAnswer.isEmpty,
+                  cleanQuestion.count <= 90,
+                  cleanAnswer.count <= 220 else { return nil }
+
+            let turnWords = Set((cleanQuestion + " " + cleanAnswer).lowercased().split { !$0.isLetter && !$0.isNumber }.map(String.init))
+            guard !cardWords.isDisjoint(with: turnWords) else { return nil }
+            return MemoryAskSuggestedTurn(id: turn.id, question: cleanQuestion, answer: cleanAnswer)
+        }
+        .prefix(3)
+        .map { $0 }
+    }
+
+    private static func fallbackTurns(for animal: MemoryAnimal) -> [MemoryAskSuggestedTurn] {
+        var turns: [MemoryAskSuggestedTurn] = []
+        let name = animal.canonicalName
+        let metadata = animal.metadata
+
+        if metadata.deck == .planets,
+           let order = animal.detailCards.first(where: { $0.title == "Order" })?.value,
+           let type = animal.detailCards.first(where: { $0.title == "Type" })?.value {
+            turns.append(MemoryAskSuggestedTurn(
+                id: "planet-place",
+                question: "Where is \(name)?",
+                answer: "\(name) is the \(order.lowercased()) planet. It is a \(type.lowercased())."
+            ))
+        } else if let home = metadata.habitat {
+            turns.append(MemoryAskSuggestedTurn(
+                id: "home",
+                question: "Where does \(name) belong?",
+                answer: "\(name) belongs in \(home.lowercased())."
+            ))
+        }
+
+        if let size = metadata.size {
+            turns.append(MemoryAskSuggestedTurn(
+                id: "size",
+                question: "How big is \(name)?",
+                answer: "\(name) can be about \(size.lowercased())."
+            ))
+        }
+
+        if metadata.deck == .planets,
+           let funFact = animal.detailCards.first(where: { $0.title == "Fun Fact" })?.value {
+            turns.append(MemoryAskSuggestedTurn(
+                id: "fun-fact",
+                question: "What is special about \(name)?",
+                answer: "\(name) is special because \(funFact.lowercased())."
+            ))
+        }
+
+        if let colors = metadata.colors {
+            turns.append(MemoryAskSuggestedTurn(
+                id: "colors",
+                question: "What colors can I see?",
+                answer: "Look for \(colors.lowercased()) on \(name)."
+            ))
+        }
+
+        if metadata.deck != .planets, let movement = metadata.movement {
+            turns.append(MemoryAskSuggestedTurn(
+                id: "movement",
+                question: "How does \(name) move?",
+                answer: "\(name) \(movement.lowercased())."
+            ))
+        }
+
+        return Array(turns.prefix(3))
+    }
+
+    private static func clean(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Features/Memory/MemoryAskConversationPolicy.swift
+++ b/Features/Memory/MemoryAskConversationPolicy.swift
@@ -107,7 +107,11 @@ final class MemoryAskConversationPolicy {
             animal.metadata.category,
             animal.metadata.kind
         ] + animal.detailCards.flatMap { [$0.title, $0.value] }
-        let genericWords: Set<String> = ["about", "card", "current", "question", "tell", "this", "turn"]
+        let genericWords: Set<String> = [
+            "about", "and", "are", "because", "but", "can", "card", "current", "for", "from",
+            "has", "have", "how", "into", "its", "not", "one", "our", "question", "that", "the",
+            "their", "them", "this", "turn", "tell", "was", "what", "when", "where", "who", "why", "with"
+        ]
         let cardWords = Set(Self.words(in: cardText.joined(separator: " ")).filter { word in
             word.count > 2 && !genericWords.contains(word)
         })

--- a/Features/Memory/MemoryAskConversationPolicy.swift
+++ b/Features/Memory/MemoryAskConversationPolicy.swift
@@ -101,15 +101,16 @@ final class MemoryAskConversationPolicy {
     }
 
     private func sanitize(_ turns: [MemoryAskSuggestedTurn], for animal: MemoryAnimal) -> [MemoryAskSuggestedTurn] {
-        let cardWords = Set(
-            ([animal.canonicalName, animal.name, animal.metadata.category, animal.metadata.kind] + animal.detailCards.flatMap { [$0.title, $0.value] })
-                .flatMap { $0.lowercased().split { !$0.isLetter && !$0.isNumber } }
-                .map(String.init)
-                .filter { $0.count > 2 }
-        )
+        let cardText: [String] = [
+            animal.canonicalName,
+            animal.name,
+            animal.metadata.category,
+            animal.metadata.kind
+        ] + animal.detailCards.flatMap { [$0.title, $0.value] }
+        let cardWords = Set(Self.words(in: cardText.joined(separator: " ")).filter { $0.count > 2 })
 
         var seenIDs = Set<String>()
-        return turns.compactMap { turn in
+        let sanitizedTurns: [MemoryAskSuggestedTurn] = turns.compactMap { turn -> MemoryAskSuggestedTurn? in
             let cleanQuestion = Self.clean(turn.question)
             let cleanAnswer = Self.clean(turn.answer)
             guard !turn.id.isEmpty,
@@ -119,12 +120,12 @@ final class MemoryAskConversationPolicy {
                   cleanQuestion.count <= 90,
                   cleanAnswer.count <= 220 else { return nil }
 
-            let turnWords = Set((cleanQuestion + " " + cleanAnswer).lowercased().split { !$0.isLetter && !$0.isNumber }.map(String.init))
+            let turnWords = Set(Self.words(in: cleanQuestion + " " + cleanAnswer))
             guard !cardWords.isDisjoint(with: turnWords) else { return nil }
             return MemoryAskSuggestedTurn(id: turn.id, question: cleanQuestion, answer: cleanAnswer)
         }
-        .prefix(3)
-        .map { $0 }
+
+        return Array(sanitizedTurns.prefix(3))
     }
 
     private static func fallbackTurns(for animal: MemoryAnimal) -> [MemoryAskSuggestedTurn] {
@@ -189,5 +190,11 @@ final class MemoryAskConversationPolicy {
             .replacingOccurrences(of: "\n", with: " ")
             .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func words(in text: String) -> [String] {
+        text.lowercased()
+            .split { !$0.isLetter && !$0.isNumber }
+            .map(String.init)
     }
 }

--- a/Features/Memory/MemoryAskConversationPolicy.swift
+++ b/Features/Memory/MemoryAskConversationPolicy.swift
@@ -110,7 +110,8 @@ final class MemoryAskConversationPolicy {
         let cardWords = Set(Self.words(in: cardText.joined(separator: " ")).filter { $0.count > 2 })
 
         var seenIDs = Set<String>()
-        let sanitizedTurns: [MemoryAskSuggestedTurn] = turns.compactMap { turn -> MemoryAskSuggestedTurn? in
+        var sanitizedTurns: [MemoryAskSuggestedTurn] = []
+        for turn in turns {
             let cleanQuestion = Self.clean(turn.question)
             let cleanAnswer = Self.clean(turn.answer)
             guard !turn.id.isEmpty,
@@ -118,14 +119,15 @@ final class MemoryAskConversationPolicy {
                   !cleanQuestion.isEmpty,
                   !cleanAnswer.isEmpty,
                   cleanQuestion.count <= 90,
-                  cleanAnswer.count <= 220 else { return nil }
+                  cleanAnswer.count <= 220 else { continue }
 
             let turnWords = Set(Self.words(in: cleanQuestion + " " + cleanAnswer))
-            guard !cardWords.isDisjoint(with: turnWords) else { return nil }
-            return MemoryAskSuggestedTurn(id: turn.id, question: cleanQuestion, answer: cleanAnswer)
-        }
+            guard !cardWords.isDisjoint(with: turnWords) else { continue }
 
-        return Array(sanitizedTurns.prefix(3))
+            sanitizedTurns.append(MemoryAskSuggestedTurn(id: turn.id, question: cleanQuestion, answer: cleanAnswer))
+            if sanitizedTurns.count == 3 { break }
+        }
+        return sanitizedTurns
     }
 
     private static func fallbackTurns(for animal: MemoryAnimal) -> [MemoryAskSuggestedTurn] {

--- a/Tests/MatherTests/MemoryAskConversationPolicyTests.swift
+++ b/Tests/MatherTests/MemoryAskConversationPolicyTests.swift
@@ -1,0 +1,94 @@
+import Testing
+@testable import Mather
+
+@Suite("MemoryAskConversationPolicy")
+struct MemoryAskConversationPolicyTests {
+    private struct StubTurnProvider: MemoryAskConversationTurnProvider {
+        let isAvailable: Bool
+        let turns: [MemoryAskSuggestedTurn]
+
+        func suggestedTurns(for animal: MemoryAnimal) async throws -> [MemoryAskSuggestedTurn] {
+            turns
+        }
+    }
+
+    @MainActor
+    @Test func jupiterGetsSuggestedCardTurns() async {
+        let jupiter = MemoryDeck.planets.first { $0.canonicalName == "Jupiter" }!
+        let session = await MemoryAskConversationPolicy().startSession(for: jupiter)
+
+        #expect(session.cardId == "planet-jupiter")
+        #expect(session.source == .deterministicFallback)
+        #expect(session.suggestedTurns.map(\.question) == [
+            "Where is Jupiter?",
+            "How big is Jupiter?",
+            "What is special about Jupiter?"
+        ])
+        let spokenAnswers = session.suggestedTurns.map(\.answer).joined(separator: " ")
+        #expect(spokenAnswers.localizedCaseInsensitiveContains("139,820 km"))
+        #expect(spokenAnswers.localizedCaseInsensitiveContains("biggest planet"))
+    }
+
+    @MainActor
+    @Test func unavailableProviderUsesDeterministicFallback() async {
+        let provider = StubTurnProvider(
+            isAvailable: false,
+            turns: [
+                MemoryAskSuggestedTurn(id: "generated", question: "Generated?", answer: "Generated answer.")
+            ]
+        )
+        let session = await MemoryAskConversationPolicy(provider: provider).startSession(for: MemoryDeck.planets[4])
+
+        #expect(session.source == .deterministicFallback)
+        #expect(session.suggestedTurns.map(\.id).contains("generated") == false)
+        #expect(session.suggestedTurns.count == 3)
+    }
+
+    @MainActor
+    @Test func availableProviderCanSupplyBoundedSuggestedTurnsOnly() async {
+        let provider = StubTurnProvider(
+            isAvailable: true,
+            turns: [
+                MemoryAskSuggestedTurn(id: "spot", question: "What spot is on Jupiter?", answer: "Jupiter has a storm called the Great Red Spot."),
+                MemoryAskSuggestedTurn(id: "off-card", question: "Tell me about bedtime", answer: "This is not about the current card.")
+            ]
+        )
+        let session = await MemoryAskConversationPolicy(provider: provider).startSession(for: MemoryDeck.planets[4])
+
+        #expect(session.source == .appleIntelligenceSuggested)
+        #expect(session.suggestedTurns == [
+            MemoryAskSuggestedTurn(id: "spot", question: "What spot is on Jupiter?", answer: "Jupiter has a storm called the Great Red Spot.")
+        ])
+    }
+
+    @MainActor
+    @Test func offScopeRequestGetsCardOnlyRefusal() async {
+        var session = await MemoryAskConversationPolicy().startSession(for: MemoryDeck.planets[4])
+
+        let response = session.respond(to: .unsupportedTopic)
+
+        #expect(response.kind == .refusal)
+        #expect(response.spokenText == "I can only talk about this card. Pick one of the card questions.")
+        #expect(session.selectedTurnIDs.isEmpty)
+    }
+
+    @MainActor
+    @Test func sessionRetainsOnlySelectedTurnIDsNotTranscriptText() async {
+        var session = await MemoryAskConversationPolicy().startSession(for: MemoryDeck.planets[4])
+        let firstTurn = session.suggestedTurns[0]
+
+        let response = session.respond(to: .suggestedTurn(id: firstTurn.id))
+
+        #expect(response.kind == .answer)
+        #expect(session.selectedTurnIDs == [firstTurn.id])
+        #expect(String(describing: session.selectedTurnIDs).contains(firstTurn.answer) == false)
+        #expect(Mirror(reflecting: session).children.map { $0.label ?? "" }.contains("transcript") == false)
+    }
+
+    @MainActor
+    @Test func policyDoesNotPermitUnrestrictedChatOrMicrophoneInput() {
+        #expect(MemoryAskConversationPolicy.allowsMicrophoneInput == false)
+        #expect(MemoryAskConversationPolicy.allowsFreeformTextInput == false)
+        #expect(MemoryAskConversationPolicy.supportedInputModes == [.suggestedTurnSelection])
+    }
+}

--- a/wiki/Specs/Memory-Ask-About-This-Card.md
+++ b/wiki/Specs/Memory-Ask-About-This-Card.md
@@ -1,0 +1,73 @@
+# Spec: Memory Ask About This Card
+
+**Issue**: #380  
+**Status**: draft  
+**Author**: Codex  
+**Date**: 2026-04-27
+
+## Overview
+
+Memory Match should let a child ask a few safe, card-grounded questions from the Learn sheet, such as asking about Jupiter's size, color, place in the solar system, or special fact. The interaction is not an open chat box. The app presents bounded suggested turns, speaks the chosen answer, and falls back to deterministic card metadata whenever Apple Intelligence or future on-device generation is unavailable.
+
+## User Stories
+
+- As a child, I want to tap "Ask about this card" and choose a spoken question so I can learn a little more without needing to read or type.
+- As a parent, I want the feature to stay grounded in the current card and avoid unrestricted conversation, microphone input, or retained transcripts.
+- As a developer, I want the generated path to be replaceable while deterministic fallback behavior remains stable and testable.
+
+## Acceptance Criteria
+
+- [ ] The child can only choose from app-provided suggested turns for the visible Memory card.
+- [ ] Jupiter and other planet cards have deterministic fallback turns for order/type, size, and a special fact when metadata exists.
+- [ ] If Apple Intelligence or a future suggested-turn provider is unavailable, empty, or unsafe, the app uses curated metadata fallback.
+- [ ] Off-card or unsupported requests receive a short refusal that redirects the child to card questions.
+- [ ] The app stores only lightweight session state such as `cardId` and selected turn IDs; it does not retain a conversation transcript.
+- [ ] The child flow has no freeform text input, no microphone input, and no unrestricted generated chat.
+- [ ] Spoken answers use `SpeechService` read-aloud behavior and respect the existing parent audio toggle for in-session prompts.
+
+## Design
+
+### SwiftUI Views
+
+- `MemoryView.learningSheet(for:)`: adds an "Ask about this card" entry point below existing Learn content.
+- `MemoryAskConversationView`: shows 2-3 large suggested-question buttons and a replay button for the latest spoken answer. Buttons must meet the 80 pt touch target guidance.
+- No keyboard, dictation button, chat transcript, or microphone affordance appears in the child flow.
+
+### Data Model
+
+- `MemoryAskConversationPolicy`: starts a session from a `MemoryAnimal`, chooses safe suggested turns, and falls back to deterministic metadata.
+- `MemoryAskConversationSession`: stores `cardId`, `source`, `suggestedTurns`, and selected turn IDs only.
+- `MemoryAskSuggestedTurn`: bounded `question` and `answer` strings generated from metadata or a safe provider.
+- `MemoryAskConversationTurnProvider`: future adapter boundary for Apple Intelligence suggested turns. It supplies candidate turns only; it does not accept child-authored prompts.
+
+### Navigation
+
+The feature starts from a visible Memory Learn card. Closing the sheet returns to the current Memory round. Starting a new round clears the session.
+
+### State Management
+
+The session is local to the Learn sheet. `MemoryAskConversationPolicy` owns no persistence. If telemetry is later added, it may record aggregate events such as `ask_card_turn_selected` with card ID and turn ID, but not the spoken answer or any transcript text.
+
+## Feature Flag
+
+Flag name: `FeatureFlags.memoryCardAppleIntelligenceEnabled` gates any future Apple Intelligence suggested-turn provider. Deterministic fallback remains available when the Learn sheet is available.
+
+## Out of Scope
+
+- Speech recognition, dictation, microphone-driven questions, or live voice conversation.
+- Freeform text entry by the child.
+- Unrestricted chat completion or multi-turn generated conversation.
+- Persisted conversation transcripts.
+- Cloud AI providers or network calls.
+- Fact expansion beyond the current card's curated metadata unless separately specified and sourced.
+
+## Open Questions
+
+- [ ] Should the first UI slice ship the conversation view immediately, or keep this as tested policy scaffolding until the next Memory UI issue?
+- [ ] Should parent settings expose a separate Ask toggle, or is the existing Learn/Apple Intelligence flag enough for the first implementation?
+- [ ] What telemetry event names should be used if aggregate turn-selection analytics are added?
+
+## References
+
+- Related triage: [TestFlight-Feedback-Triage-349-368-372](TestFlight-Feedback-Triage-349-368-372.md)
+- Related implementation baseline: `MemoryCardDescribeService` in `Services/SpeechService.swift`

--- a/wiki/Specs/README.md
+++ b/wiki/Specs/README.md
@@ -19,6 +19,7 @@ Specifications for features in Mather. Each spec is linked to a GitHub issue lab
 | [VS1-Complement-Match-Finale](VS1-Complement-Match-Finale.md) | [#137](https://github.com/ganesh47/mather/issues/137) | draft |
 | [Sum-Sprint](Sum-Sprint.md) | [#179](https://github.com/ganesh47/mather/issues/179) | draft |
 | [Room-Quest-Reference-Capture](Room-Quest-Reference-Capture.md) | [#182](https://github.com/ganesh47/mather/issues/182) | draft |
+| [Memory-Ask-About-This-Card](Memory-Ask-About-This-Card.md) | [#380](https://github.com/ganesh47/mather/issues/380) | draft |
 | [Sum-Sprint](Sum-Sprint.md) | [#179](https://github.com/ganesh47/mather/issues/179) | draft |
 
 ---


### PR DESCRIPTION
## What changed

- Added `MemoryAskConversationPolicy` and session models for a child-safe, card-grounded Ask About This Card flow.
- Added deterministic Jupiter/card fallback behavior plus an adapter boundary for future Apple Intelligence suggested turns.
- Added Swift Testing coverage for Jupiter suggested turns, unavailable-provider fallback, off-scope refusal, no transcript retention, and no unrestricted chat or microphone input.
- Added `wiki/Specs/Memory-Ask-About-This-Card.md` and linked it from the specs index.

## Safety posture

This is scaffolding only. It does not add unrestricted conversational AI, microphone input, speech recognition, freeform text entry, cloud calls, or transcript persistence.

## Validation

- `git diff --check` passed.
- Not run: `xcodegen generate` / `xcodebuild test`. This worker is Linux and has no `xcodegen`, `swift`, or `xcodebuild` available, so Xcode validation must run in CI or a macOS dev environment.