### PR TITLE
Adapt Parent Summary for wide and compact layouts

### DIFF
--- a/Features/ParentSummary/ParentSummaryView.swift
+++ b/Features/ParentSummary/ParentSummaryView.swift
@@ -73,79 +73,27 @@ struct ParentSummaryView: View {
                             )
                         }
 
-                        CardSurface {
-                            VStack(alignment: .leading, spacing: 10) {
-                                Text("Profile overview")
-                                    .font(.title3.weight(.bold))
-                                ForEach(profiles, id: \.id) { profile in
-                                    let count = summaries.filter { $0.profileId == profile.id }.count
-                                    HStack {
-                                        Text("\(profile.emoji) \(profile.name)")
-                                        Spacer()
-                                        Text("\(count) sessions")
-                                            .foregroundStyle(MatherTheme.cardSubtitle)
-                                    }
-                                }
+                        if ResponsiveLayout.isWide(horizontalSizeClass) {
+                            LazyVGrid(
+                                columns: ResponsiveLayout.parentSummarySupportingColumns(for: horizontalSizeClass),
+                                alignment: .leading,
+                                spacing: 16
+                            ) {
+                                profileOverviewCard(summaries: summaries)
+                                nextTargetCard(digest: digest)
                             }
-                        }
-
-                        CardSurface {
-                            VStack(alignment: .leading, spacing: 10) {
-                                Text("Recent sessions")
-                                    .font(.title3.weight(.bold))
-                                Text(historyCaption(totalCount: summaries.count, visibleCount: recentSummaries.count))
-                                    .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(MatherTheme.cardSubtitle)
-                                ForEach(Array(recentSummaries.enumerated()), id: \.element.sessionId) { index, summary in
-                                    HStack {
-                                        VStack(alignment: .leading, spacing: 4) {
-                                            Text("Session \(index + 1)")
-                                                .font(.caption.weight(.bold))
-                                                .foregroundStyle(MatherTheme.accent)
-                                            if let profile = profiles.first(where: { $0.id == summary.profileId }) {
-                                                Text("\(profile.emoji) \(profile.name)")
-                                                    .font(.caption)
-                                                    .foregroundStyle(MatherTheme.cardSubtitle)
-                                            }
-                                            Text(summary.startedAt.formatted(date: .abbreviated, time: .shortened))
-                                                .font(.subheadline.weight(.semibold))
-                                            Text("\(summary.problemsCompleted) problems · \(Int(summary.firstAttemptAccuracy * 100))% first try")
-                                                .font(.caption)
-                                                .foregroundStyle(MatherTheme.cardSubtitle)
-                                        }
-                                        Spacer()
-                                        if summary.sessionId == summaries.first?.sessionId {
-                                            Text("Latest")
-                                                .font(.caption.weight(.bold))
-                                                .foregroundStyle(MatherTheme.accent)
-                                                .padding(.horizontal, 8)
-                                                .padding(.vertical, 4)
-                                                .background(MatherTheme.accent.opacity(0.12))
-                                                .clipShape(Capsule())
-                                        }
-                                    }
-                                    .padding(10)
-                                    .background(summary.sessionId == summaries.first?.sessionId ? MatherTheme.warm.opacity(0.2) : Color.secondary.opacity(0.06))
-                                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                                    .accessibilityElement(children: .combine)
-                                    .accessibilityIdentifier("parent-summary-session-\(index)")
-                                }
-                            }
-                        }
-
-                        CardSurface {
-                            HStack(alignment: .top, spacing: 12) {
-                                Image(systemName: "lightbulb.fill")
-                                    .foregroundStyle(MatherTheme.warm)
-                                    .font(.title3)
-                                Text(digest.nextTargetHint)
-                                    .font(.subheadline.weight(.medium))
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
+                            recentSessionsCard(summaries: summaries, recentSummaries: recentSummaries)
+                        } else {
+                            profileOverviewCard(summaries: summaries)
+                            recentSessionsCard(summaries: summaries, recentSummaries: recentSummaries)
+                            nextTargetCard(digest: digest)
                         }
                     }
 
-                    HStack(spacing: 16) {
+                    LazyVGrid(
+                        columns: ResponsiveLayout.parentActionColumns(for: horizontalSizeClass),
+                        spacing: 16
+                    ) {
                         Button("Settings") {
                             appModel.engine.showSettings()
                         }
@@ -176,6 +124,83 @@ struct ParentSummaryView: View {
             return "\(totalCount) saved locally"
         }
         return "Showing latest \(visibleCount) of \(totalCount) saved locally"
+    }
+
+    private func profileOverviewCard(summaries: [StoredSessionSummary]) -> some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Profile overview")
+                    .font(.title3.weight(.bold))
+                ForEach(profiles, id: \.id) { profile in
+                    let count = summaries.filter { $0.profileId == profile.id }.count
+                    HStack {
+                        Text("\(profile.emoji) \(profile.name)")
+                        Spacer()
+                        Text("\(count) sessions")
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                    }
+                }
+            }
+        }
+    }
+
+    private func nextTargetCard(digest: ParentDigest) -> some View {
+        CardSurface {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "lightbulb.fill")
+                    .foregroundStyle(MatherTheme.warm)
+                    .font(.title3)
+                Text(digest.nextTargetHint)
+                    .font(.subheadline.weight(.medium))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func recentSessionsCard(summaries: [StoredSessionSummary], recentSummaries: [StoredSessionSummary]) -> some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Recent sessions")
+                    .font(.title3.weight(.bold))
+                Text(historyCaption(totalCount: summaries.count, visibleCount: recentSummaries.count))
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                ForEach(Array(recentSummaries.enumerated()), id: \.element.sessionId) { index, summary in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Session \(index + 1)")
+                                .font(.caption.weight(.bold))
+                                .foregroundStyle(MatherTheme.accent)
+                            if let profile = profiles.first(where: { $0.id == summary.profileId }) {
+                                Text("\(profile.emoji) \(profile.name)")
+                                    .font(.caption)
+                                    .foregroundStyle(MatherTheme.cardSubtitle)
+                            }
+                            Text(summary.startedAt.formatted(date: .abbreviated, time: .shortened))
+                                .font(.subheadline.weight(.semibold))
+                            Text("\(summary.problemsCompleted) problems · \(Int(summary.firstAttemptAccuracy * 100))% first try")
+                                .font(.caption)
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                        }
+                        Spacer()
+                        if summary.sessionId == summaries.first?.sessionId {
+                            Text("Latest")
+                                .font(.caption.weight(.bold))
+                                .foregroundStyle(MatherTheme.accent)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(MatherTheme.accent.opacity(0.12))
+                                .clipShape(Capsule())
+                        }
+                    }
+                    .padding(10)
+                    .background(summary.sessionId == summaries.first?.sessionId ? MatherTheme.warm.opacity(0.2) : Color.secondary.opacity(0.06))
+                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .accessibilityElement(children: .combine)
+                    .accessibilityIdentifier("parent-summary-session-\(index)")
+                }
+            }
+        }
     }
 }
 

--- a/Shared/ResponsiveLayout.swift
+++ b/Shared/ResponsiveLayout.swift
@@ -48,6 +48,16 @@ enum ResponsiveLayout {
         return Array(repeating: GridItem(.flexible(), spacing: 8), count: count)
     }
 
+    static func parentSummarySupportingColumns(for horizontalSizeClass: UserInterfaceSizeClass?) -> [GridItem] {
+        let count = horizontalSizeClass == .regular ? 2 : 1
+        return Array(repeating: GridItem(.flexible(), spacing: 16, alignment: .top), count: count)
+    }
+
+    static func parentActionColumns(for horizontalSizeClass: UserInterfaceSizeClass?) -> [GridItem] {
+        let count = horizontalSizeClass == .regular ? 2 : 1
+        return Array(repeating: GridItem(.flexible(), spacing: 16), count: count)
+    }
+
     static func sumSprintSummaryFactColumns(for horizontalSizeClass: UserInterfaceSizeClass?) -> [GridItem] {
         Array(repeating: GridItem(.flexible(), spacing: 8), count: 2)
     }

--- a/Tests/MatherTests/ResponsiveLayoutTests.swift
+++ b/Tests/MatherTests/ResponsiveLayoutTests.swift
@@ -24,6 +24,13 @@ struct ResponsiveLayoutTests {
         #expect(!ResponsiveLayout.isWide(.compact))
     }
 
+    @MainActor @Test func parentSummaryUsesRegularWidthSupportingAndActionColumns() {
+        #expect(ResponsiveLayout.parentSummarySupportingColumns(for: .compact).count == 1)
+        #expect(ResponsiveLayout.parentSummarySupportingColumns(for: .regular).count == 2)
+        #expect(ResponsiveLayout.parentActionColumns(for: .compact).count == 1)
+        #expect(ResponsiveLayout.parentActionColumns(for: .regular).count == 2)
+    }
+
     @MainActor @Test func childShellsUseAdaptiveWidthRules() {
         #expect(ResponsiveLayout.childSessionMaxWidth(for: .regular) == 940)
         #expect(ResponsiveLayout.childSessionMaxWidth(for: .compact) == CGFloat.infinity)


### PR DESCRIPTION
## Summary
- add reusable `ResponsiveLayout` helpers for Parent Summary supporting cards and parent action rows
- let Parent Summary place the profile overview and next-target card side by side on regular-width devices while preserving the existing compact reading order
- stack Parent Summary footer actions on compact screens and keep them side by side on regular-width devices
- add focused `ResponsiveLayoutTests` coverage for the new parent layout rules

## Validation
- `git diff --check` ✅
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' -only-testing:MatherTests/ResponsiveLayoutTests CODE_SIGNING_ALLOWED=NO` blocked: `xcodebuild` is not installed in this Linux worker
- `swift --version` blocked: `swift` is not installed in this Linux worker
- `xcodegen --version` blocked: `xcodegen` is not installed in this Linux worker

Advances #354 parent surface adaptive follow-through without touching the already-merged Memory (#381) or Sum Sprint (#382) slices.