### PR TITLE
[codex] Add Memory card ask follow-through

### DIFF
--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -656,6 +656,8 @@ struct MemoryView: View {
     @State private var deckSelection: DeckSelection = .domestic
     @State private var recentPairHistory: [String] = []
     @State private var learningContent: MemoryLearningContent? = nil
+    @State private var askSession: MemoryAskConversationSession? = nil
+    @State private var latestAskResponse: MemoryAskResponse? = nil
 
     enum DeckSelection: CaseIterable {
         case domestic, birds, vehicles, planets, fishes, countries, indiaStates
@@ -1134,6 +1136,8 @@ struct MemoryView: View {
     private func handleDoubleTap(_ card: MemoryCard) {
         guard Self.canOpenLearningDetails(for: card, deckSelection: deckSelection, difficulty: difficulty, showRoundComplete: showRoundComplete) else { return }
         let selectedAnimal = animal(for: card)
+        askSession = nil
+        latestAskResponse = nil
         learningContent = Self.learningContent(
             for: selectedAnimal,
             deckSelection: deckSelection,
@@ -1197,6 +1201,28 @@ struct MemoryView: View {
                     .buttonStyle(PrimaryActionButtonStyle())
                     .accessibilityIdentifier("memory-learning-read-aloud")
 
+                    MemoryAskConversationSection(
+                        session: askSession,
+                        latestResponse: latestAskResponse,
+                        startConversation: {
+                            Task { @MainActor in
+                                askSession = await MemoryAskConversationPolicy().startSession(for: animal)
+                                latestAskResponse = nil
+                            }
+                        },
+                        selectTurn: { turn in
+                            guard var session = askSession else { return }
+                            let response = session.respond(to: .suggestedTurn(id: turn.id))
+                            askSession = session
+                            latestAskResponse = response
+                            appModel.speechService.speakLearningDetails(response.spokenText, enabled: appModel.featureFlags.audioEnabled)
+                        },
+                        replayLatestAnswer: {
+                            guard let latestAskResponse else { return }
+                            appModel.speechService.speakLearningDetails(latestAskResponse.spokenText, enabled: appModel.featureFlags.audioEnabled)
+                        }
+                    )
+
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: ResponsiveLayout.memoryLearningFactMinimumWidth(for: horizontalSizeClass)), spacing: 10)], spacing: 10) {
                         ForEach(content.factChips, id: \.self) { fact in
                             VStack(alignment: .leading, spacing: 4) {
@@ -1225,7 +1251,11 @@ struct MemoryView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button("Done") { learningContent = nil }
+                    Button("Done") {
+                        learningContent = nil
+                        askSession = nil
+                        latestAskResponse = nil
+                    }
                         .accessibilityIdentifier("memory-learning-done")
                 }
             }
@@ -1238,6 +1268,8 @@ struct MemoryView: View {
         recentPairHistory = Self.updatedRecentPairHistory(previous: recentPairHistory, newRoundAnimals: roundAnimals, pairCount: totalPairs)
         cards = Self.buildCards(for: roundAnimals).shuffled()
         learningContent = nil
+        askSession = nil
+        latestAskResponse = nil
         firstSelected = nil
         matchedPairs = 0
         mismatchIds = []
@@ -1353,5 +1385,74 @@ struct MemoryView: View {
     private static func learningReadAloudText(for title: String, summary: String, factChips: [MemoryFactCard], sourceBadge: String) -> String {
         let facts = factChips.map { "\($0.title): \($0.value)." }.joined(separator: " ")
         return "\(title). \(summary) Source: \(sourceBadge). \(facts)"
+    }
+}
+
+private struct MemoryAskConversationSection: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let session: MemoryAskConversationSession?
+    let latestResponse: MemoryAskResponse?
+    let startConversation: () -> Void
+    let selectTurn: (MemoryAskSuggestedTurn) -> Void
+    let replayLatestAnswer: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let session {
+                Text("Ask about this card")
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+
+                VStack(spacing: 10) {
+                    ForEach(session.suggestedTurns) { turn in
+                        Button {
+                            selectTurn(turn)
+                        } label: {
+                            Label(turn.question, systemImage: "questionmark.circle.fill")
+                                .lineLimit(2)
+                                .minimumScaleFactor(0.78)
+                                .multilineTextAlignment(.center)
+                                .frame(maxWidth: .infinity, minHeight: 80)
+                        }
+                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(colorScheme == .dark ? 0.34 : 0.62)))
+                        .accessibilityIdentifier("memory-ask-suggested-turn-\(turn.id)")
+                    }
+                }
+
+                if let latestResponse {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text(latestResponse.spokenText)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.ink)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .accessibilityIdentifier("memory-ask-latest-answer")
+
+                        Button {
+                            replayLatestAnswer()
+                        } label: {
+                            Label("Replay answer", systemImage: "speaker.wave.2.fill")
+                                .font(.subheadline.weight(.bold))
+                                .frame(maxWidth: .infinity, minHeight: 52)
+                        }
+                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(colorScheme == .dark ? 0.28 : 0.52)))
+                        .accessibilityIdentifier("memory-ask-replay-answer")
+                    }
+                    .padding(12)
+                    .background(MatherTheme.background.opacity(colorScheme == .dark ? 0.45 : 1), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                }
+            } else {
+                Button {
+                    startConversation()
+                } label: {
+                    Label("Ask about this card", systemImage: "questionmark.bubble.fill")
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                        .frame(maxWidth: .infinity, minHeight: 80)
+                }
+                .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(colorScheme == .dark ? 0.34 : 0.62)))
+                .accessibilityIdentifier("memory-ask-about-this-card")
+            }
+        }
     }
 }

--- a/Tests/MatherTests/MemoryAskConversationPolicyTests.swift
+++ b/Tests/MatherTests/MemoryAskConversationPolicyTests.swift
@@ -86,6 +86,20 @@ struct MemoryAskConversationPolicyTests {
     }
 
     @MainActor
+    @Test func suggestedTurnSelectionReturnsOnlyTheChosenCardAnswer() async {
+        var session = await MemoryAskConversationPolicy().startSession(for: MemoryDeck.planets[4])
+        let jupiterSizeTurn = session.suggestedTurns.first { $0.id == "size" }!
+
+        let response = session.respond(to: .suggestedTurn(id: jupiterSizeTurn.id))
+
+        #expect(response.kind == .answer)
+        #expect(response.spokenText == jupiterSizeTurn.answer)
+        #expect(response.spokenText.localizedCaseInsensitiveContains("Jupiter"))
+        #expect(response.spokenText.localizedCaseInsensitiveContains("139,820 km"))
+        #expect(session.selectedTurnIDs == ["size"])
+    }
+
+    @MainActor
     @Test func policyDoesNotPermitUnrestrictedChatOrMicrophoneInput() {
         #expect(MemoryAskConversationPolicy.allowsMicrophoneInput == false)
         #expect(MemoryAskConversationPolicy.allowsFreeformTextInput == false)

--- a/wiki/Specs/Memory-Ask-About-This-Card.md
+++ b/wiki/Specs/Memory-Ask-About-This-Card.md
@@ -1,7 +1,7 @@
 # Spec: Memory Ask About This Card
 
 **Issue**: #380  
-**Status**: draft  
+**Status**: UI slice implemented
 **Author**: Codex  
 **Date**: 2026-04-27
 
@@ -17,20 +17,20 @@ Memory Match should let a child ask a few safe, card-grounded questions from the
 
 ## Acceptance Criteria
 
-- [ ] The child can only choose from app-provided suggested turns for the visible Memory card.
-- [ ] Jupiter and other planet cards have deterministic fallback turns for order/type, size, and a special fact when metadata exists.
-- [ ] If Apple Intelligence or a future suggested-turn provider is unavailable, empty, or unsafe, the app uses curated metadata fallback.
-- [ ] Off-card or unsupported requests receive a short refusal that redirects the child to card questions.
-- [ ] The app stores only lightweight session state such as `cardId` and selected turn IDs; it does not retain a conversation transcript.
-- [ ] The child flow has no freeform text input, no microphone input, and no unrestricted generated chat.
-- [ ] Spoken answers use `SpeechService` read-aloud behavior and respect the existing parent audio toggle for in-session prompts.
+- [x] The child can only choose from app-provided suggested turns for the visible Memory card.
+- [x] Jupiter and other planet cards have deterministic fallback turns for order/type, size, and a special fact when metadata exists.
+- [x] If Apple Intelligence or a future suggested-turn provider is unavailable, empty, or unsafe, the app uses curated metadata fallback.
+- [x] Off-card or unsupported requests receive a short refusal that redirects the child to card questions.
+- [x] The app stores only lightweight session state such as `cardId` and selected turn IDs; it does not retain a conversation transcript.
+- [x] The child flow has no freeform text input, no microphone input, and no unrestricted generated chat.
+- [x] Spoken answers use `SpeechService` read-aloud behavior and respect the existing parent audio toggle for in-session prompts.
 
 ## Design
 
 ### SwiftUI Views
 
 - `MemoryView.learningSheet(for:)`: adds an "Ask about this card" entry point below existing Learn content.
-- `MemoryAskConversationView`: shows 2-3 large suggested-question buttons and a replay button for the latest spoken answer. Buttons must meet the 80 pt touch target guidance.
+- `MemoryAskConversationSection`: shows 2-3 large suggested-question buttons and a replay button for the latest spoken answer. Buttons must meet the 80 pt touch target guidance.
 - No keyboard, dictation button, chat transcript, or microphone affordance appears in the child flow.
 
 ### Data Model
@@ -63,7 +63,6 @@ Flag name: `FeatureFlags.memoryCardAppleIntelligenceEnabled` gates any future Ap
 
 ## Open Questions
 
-- [ ] Should the first UI slice ship the conversation view immediately, or keep this as tested policy scaffolding until the next Memory UI issue?
 - [ ] Should parent settings expose a separate Ask toggle, or is the existing Learn/Apple Intelligence flag enough for the first implementation?
 - [ ] What telemetry event names should be used if aggregate turn-selection analytics are added?
 


### PR DESCRIPTION
## What changed

- Adds an "Ask about this card" entry point inside the Memory Learn sheet.
- Starts a bounded `MemoryAskConversationPolicy` session from the visible card and renders only app-provided suggested question buttons.
- Speaks selected answers through the existing `SpeechService` read-aloud path and offers replay for the latest answer.
- Clears Ask session state when changing Learn cards, closing the sheet, or dealing a new round.
- Updates the #380 spec status and adds focused Jupiter suggested-turn follow-through coverage.

## Safety posture

This does not add freeform text input, microphone input, speech recognition, unrestricted chat, network calls, or transcript persistence. The UI uses the existing deterministic fallback session scaffold when no provider is available.

## Validation

- `git diff --check` passed.
- Not run: `xcodegen generate` and `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO` because this Linux worker has no `xcodegen` or `xcodebuild` installed.