### PR TITLE
Make Make & Break loop built in

### DIFF
--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -31,13 +31,6 @@ struct SettingsView: View {
         )
     }
 
-    private var makeBreakLoopV2Binding: Binding<Bool> {
-        Binding(
-            get: { appModel.featureFlags.makeBreakLoopV2Enabled },
-            set: { appModel.featureFlags.makeBreakLoopV2Enabled = $0 }
-        )
-    }
-
     private var soundReactionBinding: Binding<Bool> {
         Binding(
             get: { appModel.featureFlags.soundReactionEnabled },
@@ -110,17 +103,10 @@ struct SettingsView: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .padding(.top, 4)
-                Text("Use the rollout toggle below to keep the reopened 4-stage loop behind parent/QA control until validation is complete.")
+                Text("The repeated Make it → Gravity Split → Sum Sprint → Bond Blast route is now built in for every target.")
                     .font(.subheadline)
                     .foregroundStyle(MatherTheme.cardSubtitle)
                     .fixedSize(horizontal: false, vertical: true)
-
-                VS1ToggleRow(
-                    title: "Make & Break loop v2",
-                    subtitle: "Turns on the repeated Make it → Gravity Split → Sum Sprint → Bond Blast route for each target.",
-                    accessibilityIdentifier: "settings-loop-v2-toggle",
-                    isOn: makeBreakLoopV2Binding
-                )
 
                 Divider()
 

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -60,8 +60,8 @@ final class FeatureFlagService {
         didSet { defaults.set(vs1GravitySplitEnabled, forKey: Keys.vs1GravitySplitEnabled) }
     }
 
-    /// Enables the issue #222 per-target loop:
-    /// Make it -> Gravity Split -> Sum Sprint -> Bond Blast.
+    /// Controls the issue #222 per-target loop for explicit test/rollback coverage.
+    /// Default is built-in/on; Settings no longer exposes this as a parent rollout toggle.
     var makeBreakLoopV2Enabled: Bool {
         didSet { defaults.set(makeBreakLoopV2Enabled, forKey: Keys.makeBreakLoopV2Enabled) }
     }
@@ -141,6 +141,11 @@ final class FeatureFlagService {
 
     private let defaults: UserDefaults
 
+    private static func hasLaunchArgumentOverride(for key: String) -> Bool {
+        ProcessInfo.processInfo.arguments.contains(key) ||
+            ProcessInfo.processInfo.arguments.contains("-\(key)")
+    }
+
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         // Register fallback defaults so bool(forKey:) returns the correct value
@@ -155,7 +160,7 @@ final class FeatureFlagService {
             Keys.selectedThemeId: "classic",
             Keys.vs1BondMatchEnabled: true,
             Keys.vs1GravitySplitEnabled: true,
-            Keys.makeBreakLoopV2Enabled: false,
+            Keys.makeBreakLoopV2Enabled: true,
             Keys.motionControlsEnabled: true,
             Keys.soundReactionEnabled: true,
             Keys.roomQuestSafetyAcknowledged: false,
@@ -176,6 +181,10 @@ final class FeatureFlagService {
         selectedThemeId = defaults.string(forKey: Keys.selectedThemeId) ?? "classic"
         vs1BondMatchEnabled = defaults.bool(forKey: Keys.vs1BondMatchEnabled)
         vs1GravitySplitEnabled = defaults.bool(forKey: Keys.vs1GravitySplitEnabled)
+        if defaults === UserDefaults.standard, !Self.hasLaunchArgumentOverride(for: Keys.makeBreakLoopV2Enabled) {
+            // Graduate issue #222: ignore any stale parent-toggle value from pre-cutover builds.
+            defaults.set(true, forKey: Keys.makeBreakLoopV2Enabled)
+        }
         makeBreakLoopV2Enabled = defaults.bool(forKey: Keys.makeBreakLoopV2Enabled)
         motionControlsEnabled = defaults.bool(forKey: Keys.motionControlsEnabled)
         soundReactionEnabled = defaults.bool(forKey: Keys.soundReactionEnabled)

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -35,22 +35,22 @@ struct FeatureFlagTests {
         #expect(flags.hapticsEnabled == true)
     }
 
-    @Test func stableFeatureRolloutDefaultsMatchRecoveryPolicy() {
+    @Test func stableFeatureRolloutDefaultsMatchGraduatedPolicy() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         #expect(flags.verticalSlice1Enabled)
         #expect(flags.vs1BondMatchEnabled)
         #expect(flags.vs1GravitySplitEnabled)
-        #expect(flags.makeBreakLoopV2Enabled == false)
+        #expect(flags.makeBreakLoopV2Enabled)
         #expect(flags.soundReactionEnabled)
     }
 
-    @Test func makeBreakLoopV2PersistsAcrossInstances() {
+    @Test func makeBreakLoopV2CanBeDisabledExplicitlyForLegacyCoverage() {
         let defaults = UserDefaults(suiteName: #function)!
         let flags1 = FeatureFlagService(defaults: defaults)
-        flags1.makeBreakLoopV2Enabled = true
+        flags1.makeBreakLoopV2Enabled = false
 
         let flags2 = FeatureFlagService(defaults: defaults)
-        #expect(flags2.makeBreakLoopV2Enabled)
+        #expect(!flags2.makeBreakLoopV2Enabled)
     }
 
     @Test func soundReactionPreferencePersistsAcrossInstances() {

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -49,32 +49,19 @@ final class ScreenshotTests: XCTestCase {
 
     // MARK: - Settings screen
 
-    func testScreenshot_Settings_DefaultRolloutState() {
+    func testScreenshot_Settings_MakeBreakLoopBuiltIn() {
         let app = launch()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
         app.buttons["Settings"].tap()
         _ = app.staticTexts["Settings"].waitForExistence(timeout: 3)
-        let rolloutToggle = app.switches["settings-loop-v2-toggle"]
-        XCTAssertTrue(rolloutToggle.waitForExistence(timeout: 5))
-        XCTAssertEqual(rolloutToggle.value as? String, "0")
-        snapshot(app, "Settings-DefaultRolloutState")
+        XCTAssertFalse(app.switches["settings-loop-v2-toggle"].exists)
+        XCTAssertTrue(app.staticTexts["The repeated Make it → Gravity Split → Sum Sprint → Bond Blast route is now built in for every target."].waitForExistence(timeout: 5))
+        snapshot(app, "Settings-MakeBreakLoopBuiltIn")
 
         app.buttons["Home"].tap()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 3)
-        snapshot(app, "Home-DefaultRolloutState")
-    }
-
-    func testScreenshot_Settings_LoopV2EnabledViaLaunchArgument() {
-        let app = launchWithLoopV2()
-        _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
-
-        app.buttons["Settings"].tap()
-        _ = app.staticTexts["Settings"].waitForExistence(timeout: 3)
-        let rolloutToggle = app.switches["settings-loop-v2-toggle"]
-        XCTAssertTrue(rolloutToggle.waitForExistence(timeout: 5))
-        XCTAssertEqual(rolloutToggle.value as? String, "1")
-        snapshot(app, "Settings-LoopV2EnabledViaLaunchArgument")
+        snapshot(app, "Home-MakeBreakLoopBuiltIn")
     }
 
     // MARK: - Session Config screen
@@ -116,7 +103,7 @@ final class ScreenshotTests: XCTestCase {
     /// Exercises the failure-then-success path so the screen recording captures
     /// both the failure feedback banner and the celebration state.
     func testScreenshot_ConcreteBuild_FailureThenSuccess() {
-        let app = launchWithVS1AndHaptics()
+        let app = launchWithLegacyVS1AndHaptics()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
 
         let playButton = app.buttons["Play"]
@@ -211,14 +198,14 @@ final class ScreenshotTests: XCTestCase {
     /// Verifies the full session flow renders without crash and screenshots the
     /// pilot runbook in Settings — covers the M8 smoke-test acceptance criterion.
     func testScreenshot_PilotRunbook() {
-        let app = launchWithVS1()
+        let app = launchWithLegacyVS1()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
         snapshot(app, "iPhone-Home")
 
         // Navigate to Settings and capture the pilot runbook
         app.buttons["Settings"].tap()
         _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
-        _ = app.switches["settings-loop-v2-toggle"].waitForExistence(timeout: 5)
+        XCTAssertFalse(app.switches["settings-loop-v2-toggle"].exists)
         _ = app.staticTexts["Pilot smoke test"].waitForExistence(timeout: 5)
         snapshot(app, "iPhone-Settings-PilotRunbook")
         app.buttons["Home"].tap()
@@ -366,7 +353,6 @@ final class ScreenshotTests: XCTestCase {
             "-feature.motionControlsEnabled", "NO",
             "-feature.soundReactionEnabled", "NO",
             "-feature.testModeEnabled", "YES",
-            "-feature.makeBreakLoopV2Enabled", "YES",
             "-feature.skipProfilePicker", "YES",
         ]
         if let appearance {
@@ -375,11 +361,26 @@ final class ScreenshotTests: XCTestCase {
         return launchApp(with: launchArguments)
     }
 
-    /// Launches with VS1 pre-enabled and haptics on — use for tests that exercise success/failure feedback.
-    private func launchWithVS1AndHaptics(appearance: UIAppearanceMode? = nil) -> XCUIApplication {
+    private func launchWithLegacyVS1(appearance: UIAppearanceMode? = nil) -> XCUIApplication {
+        var launchArguments = [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.makeBreakLoopV2Enabled", "NO",
+            "-feature.testModeEnabled", "YES",
+            "-feature.skipProfilePicker", "YES",
+        ]
+        if let appearance {
+            launchArguments += ["-uiTest.appearance", appearance.launchValue]
+        }
+        return launchApp(with: launchArguments)
+    }
+
+    /// Launches the explicit legacy route with haptics on — use for tests that exercise success/failure feedback.
+    private func launchWithLegacyVS1AndHaptics(appearance: UIAppearanceMode? = nil) -> XCUIApplication {
         var launchArguments = [
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "YES",
+            "-feature.makeBreakLoopV2Enabled", "NO",
             "-feature.testModeEnabled", "YES",
             "-feature.skipProfilePicker", "YES",
         ]

--- a/wiki/Specs/Issue-222-Closeout-Checklist.md
+++ b/wiki/Specs/Issue-222-Closeout-Checklist.md
@@ -38,7 +38,7 @@
 | Sum Sprint appears in every loop in short form | Done in repo | `Domain/VerticalSliceEngine.swift`, `Domain/SliceModels.swift`, `Tests/MatherTests/VerticalSliceEngineTests.swift` | No pacing evidence across at least 5 loops |
 | Bond Blast appears in every loop as short capstone | Done in repo | `Domain/SliceStateMachine.swift`, `Domain/VerticalSliceEngine.swift`, `Tests/MatherTests/VerticalSliceEngineTests.swift` | No pacing evidence from a longer session run |
 | Session pacing still feels good | Missing closeout evidence | existing smoke-test checklist in `Features/ParentSummary/SettingsView.swift` | No measured session-duration or pilot note in repo |
-| Rollout remains gated until QA signoff | Done in repo | `makeBreakLoopV2Enabled` defaults to off in `Shared/FeatureFlags.swift`; settings expose the gate in `Features/ParentSummary/SettingsView.swift` | No explicit rollout recommendation note yet |
+| Make & Break loop graduated/default-on | Done in repo | `makeBreakLoopV2Enabled` now defaults on in `Shared/FeatureFlags.swift`, stale standard defaults are migrated on, and `Features/ParentSummary/SettingsView.swift` no longer exposes a parent-visible rollout toggle. Legacy route coverage remains available through explicit test/launch overrides. | Fresh device/Xcode proof should still be attached by the validation lane. |
 | Honest re-close backed by release-truth evidence | Missing | none beyond source/test audit and prior issue comments | Need a concise validation note with CI result, simulator/device evidence, pacing signoff, and close recommendation |
 
 ## Missing Artifacts Blocking Honest Close

--- a/wiki/Specs/Issue-349-Validation-Note.md
+++ b/wiki/Specs/Issue-349-Validation-Note.md
@@ -1,0 +1,26 @@
+# Issue #349 validation note — Make & Break de-gating
+
+Environment: Linux 6.8.0-110-generic. Xcode/iOS Simulator are not available in this worker, so native Swift/Xcode test execution was not possible here.
+
+Commands run:
+
+```text
+xcodebuild -version
+# /bin/bash: xcodebuild: command not found
+
+swift --version
+# /bin/bash: swift: command not found
+
+grep -RIn --exclude-dir=.git "settings-loop-v2-toggle" Features Shared Domain Tests wiki docs
+# Tests/MatherUITests/ScreenshotTests.swift:58: asserts the toggle is absent
+# Tests/MatherUITests/ScreenshotTests.swift:208: asserts the toggle is absent
+
+grep -RIn --exclude-dir=.git "Keys.makeBreakLoopV2Enabled: true" Shared/FeatureFlags.swift
+# Shared/FeatureFlags.swift:163: default is registered true
+
+grep -RIn --exclude-dir=.git "feature.makeBreakLoopV2Enabled\", \"NO" Tests/MatherUITests Tests/MatherTests
+# Tests/MatherUITests/ScreenshotTests.swift:368 and :383 keep explicit legacy launch coverage
+
+git diff --check
+# passed with no whitespace errors
+```


### PR DESCRIPTION
## Summary
- graduate Make & Break loop v2 to default/built-in behavior and migrate stale standard defaults on
- remove the parent-visible Settings rollout toggle and replace it with built-in route copy
- keep explicit legacy coverage through launch/test overrides and update screenshots/unit expectations
- add a local validation note for this Linux worker

Closes #349

## Validation
- `git diff --check`
- grep sanity for removed Settings toggle / default-on flag / explicit legacy overrides
- Not run: Swift/Xcode tests (xcodebuild and swift are not installed in this Linux worker; recorded in `wiki/Specs/Issue-349-Validation-Note.md`)
