### PR TITLE
Expand parent target cap model

### DIFF
--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -61,7 +61,7 @@ private extension MatherApp {
                 sessionId: sessionId,
                 startedAt: startedAt,
                 endedAt: startedAt.addingTimeInterval(300),
-                objectiveTitle: "Make & Break 1–20",
+                objectiveTitle: "Make & Break",
                 problemsCompleted: 4 + index,
                 firstAttemptAccuracy: index == 0 ? 0.75 : 0.5,
                 transferCorrectCount: 2 + (index % 2),

--- a/Domain/ProblemGenerator.swift
+++ b/Domain/ProblemGenerator.swift
@@ -30,7 +30,7 @@ enum ProblemGenerator {
     static func generateProblems(config: SliceConfig) -> [SliceProblem] {
         let tuples: [(Int, Int, Int)]
         if config.deterministicMode {
-            tuples = deterministicSeed.filter { config.targetRange.contains($0.0) }
+            tuples = deterministicTuples(in: config.targetRange, count: max(config.maxProblems, 6))
         } else {
             tuples = randomTuples(in: config.targetRange, count: max(config.maxProblems, 6))
         }
@@ -43,6 +43,44 @@ enum ProblemGenerator {
                 difficultyTier: difficultyTier(for: tuple.0, index: index)
             )
         }
+    }
+
+    private static func deterministicTuples(in range: ClosedRange<Int>, count: Int) -> [(Int, Int, Int)] {
+        let fixture = deterministicSeed.filter { range.contains($0.0) }
+        guard range.upperBound > 20 else { return fixture }
+
+        var tuples: [(Int, Int, Int)] = []
+        var usedTargets = Set<Int>()
+
+        func appendTarget(_ target: Int) {
+            guard range.contains(target), !usedTargets.contains(target) else { return }
+            usedTargets.insert(target)
+
+            if let seeded = deterministicSeed.first(where: { $0.0 == target }) {
+                tuples.append(seeded)
+            } else {
+                let decomposition = deterministicDecomposition(for: target, index: tuples.count)
+                tuples.append((target, decomposition.0, decomposition.1))
+            }
+        }
+
+        appendTarget(fixture.first?.0 ?? range.lowerBound)
+        appendTarget(fixture.dropFirst().first?.0 ?? min(range.lowerBound + 1, range.upperBound))
+
+        let highTargets = [
+            max(21, range.upperBound / 2),
+            range.upperBound,
+            max(21, (range.upperBound * 3) / 4),
+            max(21, range.upperBound / 3),
+        ]
+        highTargets.forEach(appendTarget)
+        fixture.dropFirst(2).forEach { appendTarget($0.0) }
+
+        for target in range where tuples.count < count {
+            appendTarget(target)
+        }
+
+        return tuples
     }
 
     private static func randomTuples(in range: ClosedRange<Int>, count: Int) -> [(Int, Int, Int)] {
@@ -94,6 +132,15 @@ enum ProblemGenerator {
         }
 
         return Bool.random() ? basePair : (basePair.1, basePair.0)
+    }
+
+    private static func deterministicDecomposition(for target: Int, index: Int) -> (Int, Int) {
+        guard target > 0 else { return (0, 0) }
+        guard target > 1 else { return (1, 0) }
+
+        let offset = index % 4
+        let left = min(max((target / 2) - offset, 1), target - 1)
+        return (left, target - left)
     }
 
     private static func difficultyTier(for target: Int, index: Int) -> Int {

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -54,20 +54,65 @@ enum SliceEventType: String, Codable {
     case sumSprintCompleted = "sum_sprint_completed"
 }
 
+enum ParentTargetCap {
+    static let minimum = 10
+    static let maximum = 1_000
+    static let step = 10
+    static let quickPicks = [10, 20, 50, 100, 1_000]
+
+    static func normalize(_ value: Int) -> Int {
+        let clamped = min(max(value, minimum), maximum)
+        return (clamped / step) * step
+    }
+
+    static func displayLabel(for value: Int) -> String {
+        "Up to \(normalize(value))"
+    }
+}
+
 struct SliceConfig: Codable, Equatable {
-    private static let allowedTargets = 1...20
+    private static let allowedTargets = 1...1_000
 
     var maxProblems: Int = 6
-    var minTarget: Int = allowedTargets.lowerBound
-    var maxTarget: Int = allowedTargets.upperBound
+    var minTarget: Int = allowedTargets.lowerBound {
+        didSet { minTarget = Self.clampTarget(minTarget) }
+    }
+    var maxTarget: Int = 20 {
+        didSet { maxTarget = Self.clampTarget(maxTarget) }
+    }
     var showTransfer: Bool = true
     var audioEnabled: Bool = true
     var deterministicMode: Bool = true
 
+    init(
+        maxProblems: Int = 6,
+        minTarget: Int = allowedTargets.lowerBound,
+        maxTarget: Int = 20,
+        showTransfer: Bool = true,
+        audioEnabled: Bool = true,
+        deterministicMode: Bool = true
+    ) {
+        self.maxProblems = maxProblems
+        self.minTarget = Self.clampTarget(minTarget)
+        self.maxTarget = Self.clampTarget(maxTarget)
+        self.showTransfer = showTransfer
+        self.audioEnabled = audioEnabled
+        self.deterministicMode = deterministicMode
+    }
+
+    var parentTargetCap: Int {
+        get { ParentTargetCap.normalize(maxTarget) }
+        set { maxTarget = ParentTargetCap.normalize(newValue) }
+    }
+
     var targetRange: ClosedRange<Int> {
-        let lower = min(max(minTarget, Self.allowedTargets.lowerBound), Self.allowedTargets.upperBound)
-        let upper = min(max(maxTarget, Self.allowedTargets.lowerBound), Self.allowedTargets.upperBound)
+        let lower = Self.clampTarget(minTarget)
+        let upper = Self.clampTarget(maxTarget)
         return min(lower, upper)...max(lower, upper)
+    }
+
+    private static func clampTarget(_ value: Int) -> Int {
+        min(max(value, allowedTargets.lowerBound), allowedTargets.upperBound)
     }
 }
 

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -621,7 +621,7 @@ final class VerticalSliceEngine {
         let accuracy = completed == 0 ? 0 : Double(firstTryCount) / Double(completed)
 
         return ParentDigest(
-            objectiveTitle: "Make & Break 1–20",
+            objectiveTitle: "Make & Break up to \(config.parentTargetCap)",
             firstAttemptAccuracy: accuracy,
             medianLatencyMs: median,
             problemsCompleted: completed,
@@ -641,7 +641,7 @@ final class VerticalSliceEngine {
             return "Your child found the reverse (equation → counters) harder. Try this at home: write '3 + 4 =' on paper and ask them to show it with grapes or blocks."
         }
         if accuracy < 0.5 {
-            return "The concept is still new. Keep sessions short, use physical objects at home (up to 20 buttons or pebbles), and don't rush to the written equation."
+            return "The concept is still new. Keep sessions short, use a small set of physical objects at home, and don't rush to the written equation."
         }
         if accuracy < 0.7 {
             return "Repeat the same range with spoken prompts. At home, practise splitting groups of 4–12 objects into two parts and counting each."
@@ -649,7 +649,7 @@ final class VerticalSliceEngine {
         if accuracy < 0.9 {
             return "Solid progress! Try increasing to 7–8 problems next session when they seem relaxed."
         }
-        return "Excellent mastery. Try the full 1–20 range or introduce writing the equation on paper first before using the app."
+        return "Excellent mastery. Try a slightly larger target cap or introduce writing the equation on paper first before using the app."
     }
 
     private func logProblemPresented() {

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -79,7 +79,7 @@ struct HomeView: View {
                             Text("Make & Break")
                                 .font(.title3.weight(.black))
                                 .foregroundStyle(.white)
-                            Text("1–20")
+                            Text("Targets")
                                 .font(.system(size: 36, weight: .black, design: .rounded))
                                 .foregroundStyle(.white)
                         }
@@ -141,7 +141,7 @@ struct HomeView: View {
     private var lockedActivityCard: some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 14) {
-                Text("Make & Break 1–20")
+                Text("Make & Break")
                     .font(.title2.weight(.bold))
                 Text("Enable the activity in Settings before handing the iPad to your child.")
                     .font(.headline)

--- a/Features/VerticalSlice1/SessionConfigView.swift
+++ b/Features/VerticalSlice1/SessionConfigView.swift
@@ -61,10 +61,22 @@ struct SessionConfigView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(MatherTheme.ink.opacity(0.6))
 
-                            HStack(spacing: 12) {
-                                targetCapButton(maxTarget: 10)
-                                targetCapButton(maxTarget: 20)
+                            LazyVGrid(columns: [GridItem(.adaptive(minimum: 96), spacing: 12)], spacing: 12) {
+                                ForEach(ParentTargetCap.quickPicks, id: \.self) { maxTarget in
+                                    targetCapButton(maxTarget: maxTarget)
+                                }
                             }
+
+                            Stepper(
+                                value: targetCapBinding,
+                                in: ParentTargetCap.minimum...ParentTargetCap.maximum,
+                                step: ParentTargetCap.step
+                            ) {
+                                Text(ParentTargetCap.displayLabel(for: appModel.engine.config.parentTargetCap))
+                                    .font(.headline.weight(.semibold))
+                                    .accessibilityIdentifier("target-cap-current-value")
+                            }
+                            .accessibilityIdentifier("target-cap-stepper")
                         }
 
                         Toggle("Speak prompts", isOn: Binding(
@@ -95,16 +107,24 @@ struct SessionConfigView: View {
         }
     }
 
+    private var targetCapBinding: Binding<Int> {
+        Binding(
+            get: { appModel.engine.config.parentTargetCap },
+            set: { appModel.engine.updateConfig(minTarget: 1, maxTarget: ParentTargetCap.normalize($0)) }
+        )
+    }
+
     private func targetCapButton(maxTarget: Int) -> some View {
-        let isSelected = appModel.engine.config.targetRange.upperBound == maxTarget
+        let normalizedTarget = ParentTargetCap.normalize(maxTarget)
+        let isSelected = appModel.engine.config.parentTargetCap == normalizedTarget
         return Button {
-            appModel.engine.updateConfig(minTarget: 1, maxTarget: maxTarget)
+            appModel.engine.updateConfig(minTarget: 1, maxTarget: normalizedTarget)
         } label: {
             VStack(spacing: 6) {
                 Text("Up to")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(MatherTheme.ink.opacity(0.55))
-                Text("\(maxTarget)")
+                Text("\(normalizedTarget)")
                     .font(.title2.weight(.black))
                     .foregroundStyle(isSelected ? MatherTheme.warm : MatherTheme.ink)
             }
@@ -120,8 +140,8 @@ struct SessionConfigView: View {
             )
         }
         .buttonStyle(.plain)
-        .accessibilityIdentifier("target-cap-up-to-\(maxTarget)")
-        .accessibilityLabel("Target numbers up to \(maxTarget)")
+        .accessibilityIdentifier("target-cap-up-to-\(normalizedTarget)")
+        .accessibilityLabel("Target numbers up to \(normalizedTarget)")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 

--- a/Tests/MatherTests/ProblemGeneratorTests.swift
+++ b/Tests/MatherTests/ProblemGeneratorTests.swift
@@ -22,6 +22,41 @@ struct ProblemGeneratorTests {
         #expect(config.targetRange == 1...20)
     }
 
+    @Test
+    func maxTargetClampsToOneThousand() {
+        var config = SliceConfig(maxTarget: 1_200)
+
+        #expect(config.maxTarget == 1_000)
+        #expect(config.targetRange == 1...1_000)
+
+        config.maxTarget = 2_000
+
+        #expect(config.maxTarget == 1_000)
+        #expect(config.targetRange == 1...1_000)
+    }
+
+    @Test
+    func parentTargetCapsNormalizeToMultiplesOfTen() {
+        var config = SliceConfig(maxTarget: 57)
+
+        #expect(config.maxTarget == 57)
+        #expect(config.parentTargetCap == 50)
+
+        config.parentTargetCap = 96
+
+        #expect(config.maxTarget == 90)
+        #expect(config.parentTargetCap == 90)
+
+        config.parentTargetCap = 9
+
+        #expect(config.maxTarget == 10)
+        #expect(config.parentTargetCap == 10)
+
+        config.parentTargetCap = 1_200
+
+        #expect(config.maxTarget == 1_000)
+        #expect(config.parentTargetCap == 1_000)
+    }
 
     @Test
     func deterministicGenerationRespectsParentFacingTargetCap() {
@@ -35,6 +70,18 @@ struct ProblemGeneratorTests {
     }
 
     @Test
+    func deterministicGenerationRespectsExpandedParentFacingTargetCap() {
+        let config = SliceConfig(maxProblems: 8, minTarget: 1, maxTarget: 50, showTransfer: true, audioEnabled: true, deterministicMode: true)
+
+        let problems = ProblemGenerator.generateProblems(config: config)
+
+        #expect(problems.count == 8)
+        #expect(problems.allSatisfy { (1...50).contains($0.target) })
+        #expect(problems.contains { $0.target > 20 })
+        #expect(problems.allSatisfy { $0.decompositionA + $0.decompositionB == $0.target })
+    }
+
+    @Test
     func randomGenerationRespectsUpToTenCap() {
         let config = SliceConfig(maxProblems: 12, minTarget: 1, maxTarget: 10, showTransfer: true, audioEnabled: true, deterministicMode: false)
 
@@ -42,6 +89,17 @@ struct ProblemGeneratorTests {
 
         #expect(problems.count == 12)
         #expect(problems.allSatisfy { (1...10).contains($0.target) })
+        #expect(problems.allSatisfy { $0.decompositionA + $0.decompositionB == $0.target })
+    }
+
+    @Test
+    func randomGenerationRespectsExpandedParentFacingTargetCap() {
+        let config = SliceConfig(maxProblems: 12, minTarget: 1, maxTarget: 100, showTransfer: true, audioEnabled: true, deterministicMode: false)
+
+        let problems = ProblemGenerator.generateProblems(config: config)
+
+        #expect(problems.count == 12)
+        #expect(problems.allSatisfy { (1...100).contains($0.target) })
         #expect(problems.allSatisfy { $0.decompositionA + $0.decompositionB == $0.target })
     }
 

--- a/Tests/MatherTests/SessionHistoryTests.swift
+++ b/Tests/MatherTests/SessionHistoryTests.swift
@@ -26,7 +26,7 @@ private func makeDraft(
         sessionId: sessionId,
         startedAt: startedAt,
         endedAt: startedAt.addingTimeInterval(300),
-        objectiveTitle: "Make & Break 1–20",
+        objectiveTitle: "Make & Break",
         problemsCompleted: problemsCompleted,
         firstAttemptAccuracy: accuracy,
         transferCorrectCount: transferCorrect,


### PR DESCRIPTION
## Summary
- Expand SliceConfig target clamping to 1...1000 while preserving minTarget lower bound and target-1 internal scenarios.
- Add parent target cap normalization/quick-pick model for 10-step caps from 10...1000.
- Update VS1 parent config UI with quick picks, stepped cap control, and stable accessibility identifiers.
- Extend generator tests for 1000 clamp, parent cap normalization, and generation above 20 while preserving existing 10/20 behavior.

Refs #400

## Validation
- git diff --check

Swift/Xcode tests were not run in this Linux worktree because xcodebuild, xcodegen, and swift are not available on PATH.