### PR TITLE
Add grouped number representation for high targets

### DIFF
--- a/Domain/GroupedNumberRepresentation.swift
+++ b/Domain/GroupedNumberRepresentation.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Place-value representation for VS1 targets and build counts.
+///
+/// This model derives only from numeric truth already owned by the problem or
+/// current build state. It is intentionally bounded to summary units so high
+/// targets never require hundreds of loose counters in SwiftUI.
+struct GroupedNumberRepresentation: Equatable {
+    enum Band: Equatable {
+        case zero
+        case ones
+        case teenTenFrames
+        case tensOnes
+        case hundredsTensOnes
+        case thousand
+    }
+
+    enum UnitKind: String, Equatable {
+        case thousand
+        case hundred
+        case ten
+        case tenFrame
+        case one
+    }
+
+    struct UnitGroup: Equatable, Identifiable {
+        var id: UnitKind { kind }
+        let kind: UnitKind
+        let count: Int
+        let valuePerUnit: Int
+
+        var totalValue: Int { count * valuePerUnit }
+
+        var label: String {
+            switch kind {
+            case .thousand:
+                return count == 1 ? "1 thousand" : "\(count) thousands"
+            case .hundred:
+                return count == 1 ? "1 hundred" : "\(count) hundreds"
+            case .ten:
+                return count == 1 ? "1 ten" : "\(count) tens"
+            case .tenFrame:
+                return count == 1 ? "1 ten-frame" : "\(count) ten-frames"
+            case .one:
+                return count == 1 ? "1 one" : "\(count) ones"
+            }
+        }
+    }
+
+    let value: Int
+    let band: Band
+    let groups: [UnitGroup]
+    /// Teen values still live visually in two ten-frame slots without creating
+    /// one loose cell per value above 10.
+    let tenFrameSlots: Int
+
+    init(_ rawValue: Int) {
+        value = min(max(rawValue, 0), 1000)
+
+        switch value {
+        case 0:
+            band = .zero
+            groups = []
+            tenFrameSlots = 0
+        case 1...10:
+            band = .ones
+            groups = [UnitGroup(kind: .one, count: value, valuePerUnit: 1)]
+            tenFrameSlots = 1
+        case 11...20:
+            band = .teenTenFrames
+            let ones = value - 10
+            groups = [
+                UnitGroup(kind: .tenFrame, count: 1, valuePerUnit: 10),
+                UnitGroup(kind: .one, count: ones, valuePerUnit: 1)
+            ].filter { $0.count > 0 }
+            tenFrameSlots = 2
+        case 21...100:
+            band = .tensOnes
+            groups = Self.placeValueGroups(value: value, includeHundreds: false)
+            tenFrameSlots = 0
+        case 101...999:
+            band = .hundredsTensOnes
+            groups = Self.placeValueGroups(value: value, includeHundreds: true)
+            tenFrameSlots = 0
+        default:
+            band = .thousand
+            groups = [UnitGroup(kind: .thousand, count: 1, valuePerUnit: 1000)]
+            tenFrameSlots = 0
+        }
+    }
+
+    var accessibilityText: String {
+        guard !groups.isEmpty else { return "0" }
+        return groups.map(\.label).joined(separator: ", ")
+    }
+
+    var suggestedSteps: [Int] {
+        switch band {
+        case .zero, .ones, .teenTenFrames:
+            return [1]
+        case .tensOnes:
+            return [10, 1]
+        case .hundredsTensOnes, .thousand:
+            return [100, 10, 1]
+        }
+    }
+
+    private static func placeValueGroups(value: Int, includeHundreds: Bool) -> [UnitGroup] {
+        let hundreds = includeHundreds ? value / 100 : 0
+        let tens = includeHundreds ? (value % 100) / 10 : value / 10
+        let ones = value % 10
+
+        return [
+            UnitGroup(kind: .hundred, count: hundreds, valuePerUnit: 100),
+            UnitGroup(kind: .ten, count: tens, valuePerUnit: 10),
+            UnitGroup(kind: .one, count: ones, valuePerUnit: 1)
+        ].filter { $0.count > 0 }
+    }
+}

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -300,17 +300,45 @@ struct BondMatchState: Equatable {
     let target: Int
     /// Canonical pair list ordered by ascending left value.
     var pairs: [ComplementPair]
+    static let highTargetPairLimit = 10
 
     var matchCount: Int { pairs.filter(\.isMatched).count }
     var isComplete: Bool { pairs.allSatisfy(\.isMatched) }
 
     /// Generate all unique complement pairs (a, b) where a ≤ b and a + b == target.
     /// Excludes (0, target) — zero is not a meaningful addend in this context.
+    /// For targets above 20, returns a small deterministic sample of exact pairs
+    /// so Bond Blast never creates hundreds of cards.
     static func makePairs(for target: Int) -> [ComplementPair] {
         guard target >= 2 else { return [] }
-        return (1...(target - 1))
+        if target <= 20 {
+            return allPairLeftValues(for: target)
+                .map { a in ComplementPair(left: a, right: target - a) }
+        }
+
+        let midpoint = target / 2
+        let candidateLeftValues = [
+            1,
+            2,
+            5,
+            10,
+            max(1, target / 10),
+            max(1, target / 4),
+            max(1, target / 3),
+            max(1, midpoint - 10),
+            max(1, midpoint - 1),
+            midpoint
+        ]
+
+        return Array(Set(candidateLeftValues))
             .filter { $0 <= target - $0 }
+            .sorted()
+            .prefix(highTargetPairLimit)
             .map { a in ComplementPair(left: a, right: target - a) }
+    }
+
+    private static func allPairLeftValues(for target: Int) -> [Int] {
+        (1...(target - 1)).filter { $0 <= target - $0 }
     }
 }
 

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -197,6 +197,10 @@ final class VerticalSliceEngine {
 
     func adjustConcrete(by delta: Int, side: ConcreteGroup) {
         guard let currentProblem else { return }
+        guard currentProblem.target <= 20 else {
+            setConcreteTotal(concreteCount + delta)
+            return
+        }
         switch side {
         case .warm:
             let maxWarm = min(10, max(currentProblem.target - concreteAccentCount, 0))
@@ -834,6 +838,15 @@ final class VerticalSliceEngine {
     private func setConcreteTotal(_ total: Int) {
         let maxTotal = currentProblem?.target ?? 10
         let clamped = min(max(total, 0), maxTotal)
+        if maxTotal > 20 {
+            concreteWarmCount = clamped
+            concreteAccentCount = 0
+            recordInteraction(action: "place", value: concreteCount)
+            #if targetEnvironment(simulator)
+            print("[Mather][concrete] warm=\(concreteWarmCount) accent=\(concreteAccentCount) total=\(concreteCount)")
+            #endif
+            return
+        }
         concreteWarmCount = min(clamped, 10)
         concreteAccentCount = max(clamped - concreteWarmCount, 0)
         recordInteraction(action: "place", value: concreteCount)

--- a/Features/VerticalSlice1/ConcreteBuildView.swift
+++ b/Features/VerticalSlice1/ConcreteBuildView.swift
@@ -13,6 +13,10 @@ struct ConcreteBuildView: View {
     // We keep 5 columns so the child still sees familiar subitizing-friendly rows,
     // but expand the surface to 4 rows when needed.
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 10), count: 5)
+    private var currentCount: Int { warmCount + accentCount }
+    private var representation: GroupedNumberRepresentation {
+        GroupedNumberRepresentation(target)
+    }
 
     var body: some View {
         CardSurface {
@@ -26,31 +30,11 @@ struct ConcreteBuildView: View {
                         .foregroundStyle(MatherTheme.accent)
                 }
 
-                // Color.clear with aspectRatio is the reliable SwiftUI idiom for
-                // square grid cells — it constrains height = width without fighting
-                // the grid's flexible column width calculation.
-                // Cells are capped at 72pt so on wide screens (iPad) they don't grow
-                // to 130pt+ — "bigger circles" feedback and scrolling are eliminated.
-                LazyVGrid(columns: columns, spacing: 10) {
-                    ForEach(0..<min(max(target, 1), 20), id: \.self) { index in
-                        counterCell(index: index)
-                            .frame(maxWidth: 72, maxHeight: 72)
-                            .accessibilityIdentifier("counter-cell-\(index)")
-                            .accessibilityLabel("Counter \(index + 1)")
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                guard let tap = Self.tapAction(
-                                    for: index,
-                                    target: target,
-                                    warmCount: warmCount,
-                                    accentCount: accentCount
-                                ) else { return }
-                                onAdjust(tap.delta, tap.group)
-                            }
-                    }
+                if target <= 20 {
+                    tapCounterGrid
+                } else {
+                    groupedBuildControls
                 }
-                .frame(maxWidth: ResponsiveLayout.concreteGridMaxWidth(for: horizontalSizeClass))
-                .frame(maxWidth: .infinity)
 
 
                 // Number-bond display: live A + B = target as circles are tapped.
@@ -84,6 +68,70 @@ struct ConcreteBuildView: View {
                 .buttonStyle(PrimaryActionButtonStyle())
             }
         }
+    }
+
+    private var tapCounterGrid: some View {
+        LazyVGrid(columns: columns, spacing: 10) {
+            ForEach(0..<min(max(target, 1), 20), id: \.self) { index in
+                counterCell(index: index)
+                    .frame(maxWidth: 72, maxHeight: 72)
+                    .accessibilityIdentifier("counter-cell-\(index)")
+                    .accessibilityLabel("Counter \(index + 1)")
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        guard let tap = Self.tapAction(
+                            for: index,
+                            target: target,
+                            warmCount: warmCount,
+                            accentCount: accentCount
+                        ) else { return }
+                        onAdjust(tap.delta, tap.group)
+                    }
+            }
+        }
+        .frame(maxWidth: ResponsiveLayout.concreteGridMaxWidth(for: horizontalSizeClass))
+        .frame(maxWidth: .infinity)
+    }
+
+    private var groupedBuildControls: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                GroupedNumberView(value: currentCount, fill: MatherTheme.warm)
+                    .accessibilityIdentifier("concrete-current-grouped-representation")
+                Image(systemName: "arrow.right")
+                    .font(.title3.weight(.black))
+                    .foregroundStyle(.secondary)
+                GroupedNumberView(value: target, fill: MatherTheme.accent)
+                    .accessibilityIdentifier("concrete-target-grouped-representation")
+            }
+            .frame(maxWidth: .infinity)
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 96), spacing: 10)], spacing: 10) {
+                ForEach(representation.suggestedSteps, id: \.self) { step in
+                    groupedStepButton(step: -step)
+                    groupedStepButton(step: step)
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    private func groupedStepButton(step: Int) -> some View {
+        let canApply = step < 0 ? currentCount > 0 : currentCount < target
+        let clampedStep = step < 0 ? max(step, -currentCount) : min(step, target - currentCount)
+
+        return Button {
+            onAdjust(clampedStep, .warm)
+        } label: {
+            Label("\(step > 0 ? "+" : "-")\(abs(step))", systemImage: step > 0 ? "plus.circle.fill" : "minus.circle.fill")
+                .font(.headline.weight(.black))
+                .frame(minWidth: 88, minHeight: 80)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(canApply ? MatherTheme.warm : MatherTheme.warm.opacity(0.28))
+        .disabled(!canApply)
+        .accessibilityLabel(step > 0 ? "Add \(step)" : "Remove \(abs(step))")
+        .accessibilityIdentifier("concrete-step-\(step > 0 ? "plus" : "minus")-\(abs(step))")
     }
 
     nonisolated static func tapAction(

--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -199,34 +199,39 @@ struct GravitySplitView: View {
 
     private func panView(count: Int, fill: Color, side: String) -> some View {
         VStack(spacing: 6) {
-            // Counter dots in the pan (up to target, max display 10)
-            let display = min(state.target, 20)
-            LazyVGrid(
-                columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 5),
-                spacing: 4
-            ) {
-                ForEach(0..<display, id: \.self) { idx in
-                    Circle()
-                        .fill(idx < count ? fill : fill.opacity(0.15))
-                        .overlay(
-                            Circle()
-                                .strokeBorder(fill.opacity(idx < count ? 0.3 : 0.4), lineWidth: 1.5)
-                        )
-                        .shadow(color: idx < count ? fill.opacity(0.3) : .clear, radius: 3, y: 1)
-                        .aspectRatio(1, contentMode: .fit)
-                        .accessibilityIdentifier("gravity-\(side)-dot-\(idx)")
+            if state.target <= 20 {
+                let display = min(state.target, 20)
+                LazyVGrid(
+                    columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 5),
+                    spacing: 4
+                ) {
+                    ForEach(0..<display, id: \.self) { idx in
+                        Circle()
+                            .fill(idx < count ? fill : fill.opacity(0.15))
+                            .overlay(
+                                Circle()
+                                    .strokeBorder(fill.opacity(idx < count ? 0.3 : 0.4), lineWidth: 1.5)
+                            )
+                            .shadow(color: idx < count ? fill.opacity(0.3) : .clear, radius: 3, y: 1)
+                            .aspectRatio(1, contentMode: .fit)
+                            .accessibilityIdentifier("gravity-\(side)-dot-\(idx)")
+                    }
                 }
+            } else {
+                GroupedNumberView(value: count, fill: fill)
+                    .frame(minHeight: 74)
+                    .accessibilityIdentifier("gravity-\(side)-grouped-representation")
             }
-            .padding(8)
-            .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(fill.opacity(0.10))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .strokeBorder(fill.opacity(0.22), lineWidth: 1.5)
-                    )
-            )
         }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(fill.opacity(0.10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .strokeBorder(fill.opacity(0.22), lineWidth: 1.5)
+                )
+        )
         .frame(maxWidth: .infinity)
     }
 
@@ -239,7 +244,8 @@ struct GravitySplitView: View {
                 fill: MatherTheme.warm,
                 side: "left",
                 canDecrement: state.leftCount > 0 && !state.isLocked,
-                canIncrement: state.leftCount < state.decompositionA && !state.isLocked
+                canIncrement: state.leftCount < state.decompositionA && !state.isLocked,
+                steps: gravitySteps
             ) { delta in
                 onTap(delta, .left)
             }
@@ -249,11 +255,16 @@ struct GravitySplitView: View {
                 fill: MatherTheme.accent,
                 side: "right",
                 canDecrement: state.rightCount > 0 && !state.isLocked,
-                canIncrement: state.rightCount < state.decompositionB && !state.isLocked
+                canIncrement: state.rightCount < state.decompositionB && !state.isLocked,
+                steps: gravitySteps
             ) { delta in
                 onTap(delta, .right)
             }
         }
+    }
+
+    private var gravitySteps: [Int] {
+        state.target <= 20 ? [1] : GroupedNumberRepresentation(state.target).suggestedSteps
     }
 
     private func panControlButtons(
@@ -262,39 +273,20 @@ struct GravitySplitView: View {
         side: String,
         canDecrement: Bool,
         canIncrement: Bool,
+        steps: [Int],
         action: @escaping (Int) -> Void
     ) -> some View {
-        HStack(spacing: 8) {
-            Button {
-                action(-1)
-            } label: {
-                Image(systemName: "minus.circle.fill")
-                    .font(.title.weight(.bold))
-                    .frame(minWidth: 48, minHeight: 48)
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(canDecrement ? fill : fill.opacity(0.3))
-            .disabled(!canDecrement)
-            .accessibilityLabel("Remove from \(label.lowercased()) pan")
-            .accessibilityIdentifier("gravity-\(side)-minus")
-
+        VStack(spacing: 8) {
             Text(label)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(fill)
                 .frame(minWidth: 38)
-
-            Button {
-                action(1)
-            } label: {
-                Image(systemName: "plus.circle.fill")
-                    .font(.title.weight(.bold))
-                    .frame(minWidth: 48, minHeight: 48)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: state.target <= 20 ? 48 : 82), spacing: 6)], spacing: 6) {
+                ForEach(steps, id: \.self) { step in
+                    gravityStepButton(step: -step, fill: fill, side: side, isEnabled: canDecrement, action: action)
+                    gravityStepButton(step: step, fill: fill, side: side, isEnabled: canIncrement, action: action)
+                }
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(canIncrement ? fill : fill.opacity(0.3))
-            .disabled(!canIncrement)
-            .accessibilityLabel("Add to \(label.lowercased()) pan")
-            .accessibilityIdentifier("gravity-\(side)-plus")
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
@@ -303,6 +295,29 @@ struct GravitySplitView: View {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(fill.opacity(0.08))
         )
+    }
+
+    private func gravityStepButton(
+        step: Int,
+        fill: Color,
+        side: String,
+        isEnabled: Bool,
+        action: @escaping (Int) -> Void
+    ) -> some View {
+        Button {
+            action(step)
+        } label: {
+            Label("\(step > 0 ? "+" : "-")\(abs(step))", systemImage: step > 0 ? "plus.circle.fill" : "minus.circle.fill")
+                .font(.subheadline.weight(.black))
+                .minimumScaleFactor(0.7)
+                .lineLimit(1)
+                .frame(minWidth: state.target <= 20 ? 48 : 80, minHeight: state.target <= 20 ? 48 : 80)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isEnabled ? fill : fill.opacity(0.3))
+        .disabled(!isEnabled)
+        .accessibilityLabel(step > 0 ? "Add \(step)" : "Remove \(abs(step))")
+        .accessibilityIdentifier("gravity-\(side)-\(step > 0 ? "plus" : "minus")-\(abs(step))")
     }
 
     // MARK: - Instruction

--- a/Features/VerticalSlice1/GroupedNumberView.swift
+++ b/Features/VerticalSlice1/GroupedNumberView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct GroupedNumberView: View {
+    let representation: GroupedNumberRepresentation
+    let fill: Color
+
+    init(value: Int, fill: Color) {
+        self.representation = GroupedNumberRepresentation(value)
+        self.fill = fill
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if representation.groups.isEmpty {
+                unitToken(text: "0", symbol: "circle")
+            } else {
+                ForEach(representation.groups) { group in
+                    unitToken(text: groupText(for: group), symbol: symbol(for: group.kind))
+                }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(representation.accessibilityText)
+    }
+
+    private func unitToken(text: String, symbol: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: symbol)
+                .font(.caption.weight(.black))
+            Text(text)
+                .font(.system(size: 17, weight: .black, design: .rounded))
+                .minimumScaleFactor(0.7)
+                .lineLimit(1)
+        }
+        .foregroundStyle(fill)
+        .frame(minHeight: 44)
+        .padding(.horizontal, 10)
+        .background(fill.opacity(0.11), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(fill.opacity(0.26), lineWidth: 1.5)
+        )
+    }
+
+    private func groupText(for group: GroupedNumberRepresentation.UnitGroup) -> String {
+        switch group.kind {
+        case .thousand:
+            return "1000"
+        case .hundred:
+            return "\(group.count)x100"
+        case .ten, .tenFrame:
+            return "\(group.count)x10"
+        case .one:
+            return "\(group.count)"
+        }
+    }
+
+    private func symbol(for kind: GroupedNumberRepresentation.UnitKind) -> String {
+        switch kind {
+        case .thousand:
+            return "cube.fill"
+        case .hundred:
+            return "square.grid.3x3.fill"
+        case .ten, .tenFrame:
+            return "rectangle.grid.1x2.fill"
+        case .one:
+            return "circle.fill"
+        }
+    }
+}

--- a/Tests/MatherTests/BondMatchViewTests.swift
+++ b/Tests/MatherTests/BondMatchViewTests.swift
@@ -52,4 +52,21 @@ struct BondMatchViewTests {
         )
         #expect(wrongDrop == .mismatch(4))
     }
+
+    @Test func lowTargetsKeepAllUniquePairs() {
+        let pairs = BondMatchState.makePairs(for: 20)
+
+        #expect(pairs.count == 10)
+        #expect(pairs.map(\.left) == Array(1...10))
+        #expect(pairs.allSatisfy { $0.left + $0.right == 20 })
+    }
+
+    @Test func highTargetsUseSmallExactPairSample() {
+        let pairs = BondMatchState.makePairs(for: 1000)
+
+        #expect(pairs.count <= BondMatchState.highTargetPairLimit)
+        #expect(!pairs.isEmpty)
+        #expect(pairs.allSatisfy { $0.left <= $0.right })
+        #expect(pairs.allSatisfy { $0.left + $0.right == 1000 })
+    }
 }

--- a/Tests/MatherTests/GroupedNumberRepresentationTests.swift
+++ b/Tests/MatherTests/GroupedNumberRepresentationTests.swift
@@ -1,0 +1,67 @@
+import Testing
+@testable import Mather
+
+struct GroupedNumberRepresentationTests {
+    @Test func value8UsesOnesBand() {
+        let representation = GroupedNumberRepresentation(8)
+
+        #expect(representation.band == .ones)
+        #expect(representation.groups.map(\.kind) == [.one])
+        #expect(representation.groups.map(\.count) == [8])
+        #expect(representation.accessibilityText == "8 ones")
+    }
+
+    @Test func value14UsesTeenTenFramesBand() {
+        let representation = GroupedNumberRepresentation(14)
+
+        #expect(representation.band == .teenTenFrames)
+        #expect(representation.tenFrameSlots == 2)
+        #expect(representation.groups.map(\.kind) == [.tenFrame, .one])
+        #expect(representation.groups.map(\.count) == [1, 4])
+        #expect(representation.accessibilityText == "1 ten-frame, 4 ones")
+    }
+
+    @Test func value37UsesTensAndOnesBand() {
+        let representation = GroupedNumberRepresentation(37)
+
+        #expect(representation.band == .tensOnes)
+        #expect(representation.groups.map(\.kind) == [.ten, .one])
+        #expect(representation.groups.map(\.count) == [3, 7])
+        #expect(representation.suggestedSteps == [10, 1])
+    }
+
+    @Test func value100UsesTenTensWithoutHundredsBand() {
+        let representation = GroupedNumberRepresentation(100)
+
+        #expect(representation.band == .tensOnes)
+        #expect(representation.groups.map(\.kind) == [.ten])
+        #expect(representation.groups.map(\.count) == [10])
+        #expect(representation.accessibilityText == "10 tens")
+    }
+
+    @Test func value250UsesHundredsTensAndOnesBand() {
+        let representation = GroupedNumberRepresentation(250)
+
+        #expect(representation.band == .hundredsTensOnes)
+        #expect(representation.groups.map(\.kind) == [.hundred, .ten])
+        #expect(representation.groups.map(\.count) == [2, 5])
+        #expect(representation.suggestedSteps == [100, 10, 1])
+    }
+
+    @Test func value999UsesHundredsTensAndOnesBand() {
+        let representation = GroupedNumberRepresentation(999)
+
+        #expect(representation.band == .hundredsTensOnes)
+        #expect(representation.groups.map(\.kind) == [.hundred, .ten, .one])
+        #expect(representation.groups.map(\.count) == [9, 9, 9])
+    }
+
+    @Test func value1000UsesSingleThousandUnit() {
+        let representation = GroupedNumberRepresentation(1000)
+
+        #expect(representation.band == .thousand)
+        #expect(representation.groups.map(\.kind) == [.thousand])
+        #expect(representation.groups.map(\.count) == [1])
+        #expect(representation.accessibilityText == "1 thousand")
+    }
+}


### PR DESCRIPTION
## Summary
- add `GroupedNumberRepresentation` for 1...10, 11...20, 21...100, 101...999, and 1000
- render high targets as grouped tokens instead of loose counter grids in Concrete Build and Gravity Split
- add large stepped touch controls for high targets while preserving <=20 tap-counter flow
- cap Bond Blast high-target pair samples so high caps do not create hundreds of cards
- add grouped representation and high-target Bond tests

## Validation
- `git diff --check` passed
- Swift/Xcode tests not run locally: Linux worker has no `swift`, `xcodebuild`, or `xcodegen` on PATH
- CI will provide device/build validation

Issue #400 Lane B. Builds on merged #404.
