### PR TITLE
Add deterministic number story prompts

### DIFF
--- a/Domain/NumberStoryGenerator.swift
+++ b/Domain/NumberStoryGenerator.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+enum NumberStoryGenerator {
+    static func prompt(for problem: SliceProblem, themeId: String) -> NumberStoryPrompt {
+        let pack = pack(for: problem.target, themeId: themeId)
+        return pack.prompt(for: problem)
+    }
+
+    private static func pack(for target: Int, themeId: String) -> NumberStoryPack {
+        let normalizedTheme = themeId.lowercased()
+
+        let preferred: NumberStoryTemplateID
+        switch normalizedTheme {
+        case "vehicle", "vehicles", "vehicle_garage":
+            preferred = .vehicleGarage
+        case "garden", "garden_seed_shop":
+            preferred = .gardenSeedShop
+        case "festival", "festival_prep":
+            preferred = .festivalPrep
+        case "space", "space_cargo":
+            preferred = .spaceCargo
+        default:
+            preferred = classicTemplate(for: target)
+        }
+
+        if let pack = packs[preferred], pack.supports(target) {
+            return pack
+        }
+
+        return packs[.spaceCargo] ?? NumberStoryPack.spaceCargo
+    }
+
+    private static func classicTemplate(for target: Int) -> NumberStoryTemplateID {
+        switch target {
+        case 1...10:
+            return .gardenSeedShop
+        case 11...20:
+            return .spaceCargo
+        case 21...100:
+            return .festivalPrep
+        default:
+            return .spaceCargo
+        }
+    }
+
+    private static let packs: [NumberStoryTemplateID: NumberStoryPack] = [
+        .spaceCargo: .spaceCargo,
+        .vehicleGarage: .vehicleGarage,
+        .gardenSeedShop: .gardenSeedShop,
+        .festivalPrep: .festivalPrep,
+    ]
+}
+
+private struct NumberStoryPack {
+    let id: NumberStoryTemplateID
+    let title: String
+    let supportedRange: ClosedRange<Int>
+    let setting: String
+    let action: String
+    let objectNoun: String
+    let leftContainer: String
+    let rightContainer: String
+    let successVerb: String
+
+    func supports(_ target: Int) -> Bool {
+        supportedRange.contains(target)
+    }
+
+    func prompt(for problem: SliceProblem) -> NumberStoryPrompt {
+        let target = problem.target
+        let leftPart = problem.decompositionA
+        let rightPart = problem.decompositionB
+        let noun = objectNoun
+        let hint = NumberStoryRepresentationHint.forTarget(target)
+
+        return NumberStoryPrompt(
+            id: "\(id.rawValue)-\(target)-\(leftPart)-\(rightPart)",
+            templateID: id,
+            title: title,
+            spokenIntro: "\(setting) needs \(target) \(noun). \(action) \(leftPart) in \(leftContainer) and \(rightPart) in \(rightContainer).",
+            reminder: "Remember: \(target) \(noun).",
+            successLine: "Yes: \(leftPart) and \(rightPart) \(successVerb) \(target) \(noun).",
+            target: target,
+            leftPart: leftPart,
+            rightPart: rightPart,
+            objectNoun: noun,
+            leftContainer: leftContainer,
+            rightContainer: rightContainer,
+            representationHint: hint
+        )
+    }
+
+    static let spaceCargo = NumberStoryPack(
+        id: .spaceCargo,
+        title: "Space Cargo",
+        supportedRange: 1...1_000,
+        setting: "The rocket",
+        action: "Load",
+        objectNoun: "star bolts",
+        leftContainer: "the silver bay",
+        rightContainer: "the blue bay",
+        successVerb: "make"
+    )
+
+    static let vehicleGarage = NumberStoryPack(
+        id: .vehicleGarage,
+        title: "Vehicle Garage",
+        supportedRange: 1...1_000,
+        setting: "The garage",
+        action: "Park",
+        objectNoun: "wheels",
+        leftContainer: "the red lift",
+        rightContainer: "the blue lift",
+        successVerb: "make"
+    )
+
+    static let gardenSeedShop = NumberStoryPack(
+        id: .gardenSeedShop,
+        title: "Seed Shop",
+        supportedRange: 1...100,
+        setting: "The garden",
+        action: "Plant",
+        objectNoun: "seeds",
+        leftContainer: "the sunny bed",
+        rightContainer: "the shady bed",
+        successVerb: "grow into"
+    )
+
+    static let festivalPrep = NumberStoryPack(
+        id: .festivalPrep,
+        title: "Festival Prep",
+        supportedRange: 1...1_000,
+        setting: "The festival",
+        action: "Place",
+        objectNoun: "lanterns",
+        leftContainer: "the stage tray",
+        rightContainer: "the gate tray",
+        successVerb: "make"
+    )
+}
+
+private extension NumberStoryRepresentationHint {
+    static func forTarget(_ target: Int) -> NumberStoryRepresentationHint {
+        switch target {
+        case 1...10:
+            return .singles
+        case 11...20:
+            return .tenFrames
+        case 21...100:
+            return .tensAndOnes
+        case 1_000:
+            return .thousandBlock
+        default:
+            return .hundredsTensOnes
+        }
+    }
+}

--- a/Domain/NumberStoryModels.swift
+++ b/Domain/NumberStoryModels.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum NumberStoryTemplateID: String, Codable, CaseIterable, Identifiable {
+    case spaceCargo = "space_cargo"
+    case vehicleGarage = "vehicle_garage"
+    case gardenSeedShop = "garden_seed_shop"
+    case festivalPrep = "festival_prep"
+
+    var id: String { rawValue }
+}
+
+enum NumberStoryRepresentationHint: String, Codable {
+    case singles
+    case tenFrames
+    case tensAndOnes
+    case hundredsTensOnes
+    case thousandBlock
+}
+
+struct NumberStoryPrompt: Identifiable, Codable, Equatable {
+    let id: String
+    let templateID: NumberStoryTemplateID
+    let title: String
+    let spokenIntro: String
+    let reminder: String
+    let successLine: String
+    let target: Int
+    let leftPart: Int
+    let rightPart: Int
+    let objectNoun: String
+    let leftContainer: String
+    let rightContainer: String
+    let representationHint: NumberStoryRepresentationHint
+}

--- a/Tests/MatherTests/NumberStoryGeneratorTests.swift
+++ b/Tests/MatherTests/NumberStoryGeneratorTests.swift
@@ -1,0 +1,138 @@
+import Testing
+@testable import Mather
+
+struct NumberStoryGeneratorTests {
+    @Test
+    func generatedPromptsCarryExactProblemNumbers() {
+        let cases = [
+            SliceProblem(target: 6, decompositionA: 2, decompositionB: 4),
+            SliceProblem(target: 10, decompositionA: 7, decompositionB: 3),
+            SliceProblem(target: 14, decompositionA: 8, decompositionB: 6),
+            SliceProblem(target: 20, decompositionA: 12, decompositionB: 8),
+            SliceProblem(target: 37, decompositionA: 20, decompositionB: 17),
+            SliceProblem(target: 100, decompositionA: 60, decompositionB: 40),
+            SliceProblem(target: 250, decompositionA: 100, decompositionB: 150),
+            SliceProblem(target: 1_000, decompositionA: 400, decompositionB: 600),
+        ]
+
+        for problem in cases {
+            let prompt = NumberStoryGenerator.prompt(for: problem, themeId: "space")
+
+            #expect(prompt.target == problem.target)
+            #expect(prompt.leftPart == problem.decompositionA)
+            #expect(prompt.rightPart == problem.decompositionB)
+            #expect(prompt.spokenIntro.contains("\(problem.target)"))
+            #expect(prompt.spokenIntro.contains("\(problem.decompositionA)"))
+            #expect(prompt.spokenIntro.contains("\(problem.decompositionB)"))
+            #expect(prompt.reminder.contains("\(problem.target)"))
+            #expect(prompt.successLine.contains("\(problem.target)"))
+            #expect(prompt.successLine.contains("\(problem.decompositionA)"))
+            #expect(prompt.successLine.contains("\(problem.decompositionB)"))
+        }
+    }
+
+    @Test
+    func promptGenerationIsDeterministicForSameProblemAndTheme() {
+        let problem = SliceProblem(target: 37, decompositionA: 20, decompositionB: 17)
+
+        let first = NumberStoryGenerator.prompt(for: problem, themeId: "classic")
+        let second = NumberStoryGenerator.prompt(for: problem, themeId: "classic")
+
+        #expect(first == second)
+    }
+
+    @Test
+    func classicAndVehicleThemesUseDifferentCuratedPacks() {
+        let problem = SliceProblem(target: 20, decompositionA: 12, decompositionB: 8)
+
+        let classic = NumberStoryGenerator.prompt(for: problem, themeId: "classic")
+        let vehicle = NumberStoryGenerator.prompt(for: problem, themeId: "vehicle")
+
+        #expect(classic.templateID != vehicle.templateID)
+        #expect(vehicle.templateID == .vehicleGarage)
+        #expect(vehicle.title == "Vehicle Garage")
+        #expect(vehicle.objectNoun == "wheels")
+        #expect(classic.target == vehicle.target)
+        #expect(classic.leftPart == vehicle.leftPart)
+        #expect(classic.rightPart == vehicle.rightPart)
+    }
+
+    @Test
+    func curatedPacksCoverRequiredFamiliesAndBands() {
+        let small = SliceProblem(target: 6, decompositionA: 2, decompositionB: 4)
+        let hundred = SliceProblem(target: 100, decompositionA: 60, decompositionB: 40)
+        let large = SliceProblem(target: 250, decompositionA: 100, decompositionB: 150)
+
+        #expect(NumberStoryGenerator.prompt(for: small, themeId: "space").templateID == .spaceCargo)
+        #expect(NumberStoryGenerator.prompt(for: small, themeId: "vehicle").templateID == .vehicleGarage)
+        #expect(NumberStoryGenerator.prompt(for: small, themeId: "garden").templateID == .gardenSeedShop)
+        #expect(NumberStoryGenerator.prompt(for: hundred, themeId: "festival").templateID == .festivalPrep)
+        #expect(NumberStoryGenerator.prompt(for: large, themeId: "garden").templateID == .spaceCargo)
+    }
+
+    @Test
+    func promptTextAvoidsBannedPressureAndDangerLanguage() {
+        let bannedTerms = [
+            "timer",
+            "hurry",
+            "fast",
+            "race",
+            "lose",
+            "lost",
+            "wrong",
+            "shame",
+            "scary",
+            "danger",
+            "rescue",
+            "punish",
+            "punishment",
+            "emergency",
+            "before it is too late",
+        ]
+        let problems = [
+            SliceProblem(target: 6, decompositionA: 2, decompositionB: 4),
+            SliceProblem(target: 10, decompositionA: 7, decompositionB: 3),
+            SliceProblem(target: 14, decompositionA: 8, decompositionB: 6),
+            SliceProblem(target: 20, decompositionA: 12, decompositionB: 8),
+            SliceProblem(target: 37, decompositionA: 20, decompositionB: 17),
+            SliceProblem(target: 100, decompositionA: 60, decompositionB: 40),
+            SliceProblem(target: 250, decompositionA: 100, decompositionB: 150),
+            SliceProblem(target: 1_000, decompositionA: 400, decompositionB: 600),
+        ]
+        let themeIds = ["classic", "space", "vehicle", "garden", "festival"]
+
+        for problem in problems {
+            for themeId in themeIds {
+                let prompt = NumberStoryGenerator.prompt(for: problem, themeId: themeId)
+                let text = prompt.searchableText.lowercased()
+
+                for term in bannedTerms {
+                    #expect(!text.contains(term))
+                }
+            }
+        }
+    }
+
+    @Test
+    func representationHintsFollowNumberBands() {
+        #expect(NumberStoryGenerator.prompt(for: SliceProblem(target: 6, decompositionA: 2, decompositionB: 4), themeId: "space").representationHint == .singles)
+        #expect(NumberStoryGenerator.prompt(for: SliceProblem(target: 14, decompositionA: 8, decompositionB: 6), themeId: "space").representationHint == .tenFrames)
+        #expect(NumberStoryGenerator.prompt(for: SliceProblem(target: 37, decompositionA: 20, decompositionB: 17), themeId: "space").representationHint == .tensAndOnes)
+        #expect(NumberStoryGenerator.prompt(for: SliceProblem(target: 250, decompositionA: 100, decompositionB: 150), themeId: "space").representationHint == .hundredsTensOnes)
+        #expect(NumberStoryGenerator.prompt(for: SliceProblem(target: 1_000, decompositionA: 400, decompositionB: 600), themeId: "space").representationHint == .thousandBlock)
+    }
+}
+
+private extension NumberStoryPrompt {
+    var searchableText: String {
+        [
+            title,
+            spokenIntro,
+            reminder,
+            successLine,
+            objectNoun,
+            leftContainer,
+            rightContainer,
+        ].joined(separator: " ")
+    }
+}

--- a/wiki/Specs/Make-Break-Number-Story-Thread.md
+++ b/wiki/Specs/Make-Break-Number-Story-Thread.md
@@ -79,6 +79,8 @@ Acceptance:
 
 **Goal:** Every `SliceProblem` has a deterministic story prompt whose numbers exactly match the problem.
 
+**Implementation status:** Landed in Lane C / `feat/issue-400-c-story-prompts` as deterministic story-domain code only. Story Anchor UI/routing and AI variation remain in later milestones.
+
 Add:
 
 - `Domain/NumberStoryModels.swift`
@@ -86,7 +88,8 @@ Add:
   - `NumberStoryTemplateID`
 - `Domain/NumberStoryGenerator.swift`
   - `static func prompt(for problem: SliceProblem, themeId: String) -> NumberStoryPrompt`
-  - Curated templates for classic/vehicle themes.
+  - Curated packs for Space Cargo, Vehicle Garage, Garden Seed Shop, and Festival Prep.
+  - Number-band representation hints for singles, ten-frames, tens/ones, hundreds/tens/ones, and 1000 blocks.
 
 Rules:
 
@@ -95,13 +98,15 @@ Rules:
 - `prompt.rightPart == problem.decompositionB`.
 - Spoken intro is short, concrete, and reading-light.
 - No generated text in this milestone.
+- Theme selection is deterministic. Vehicle theme maps to Vehicle Garage; classic uses curated non-vehicle packs by target band; explicit pack IDs can request Space, Garden, or Festival.
 
 Tests:
 
 - `Tests/MatherTests/NumberStoryGeneratorTests.swift`
-  - Story numbers match `SliceProblem` for representative targets 6, 10, 14, 20.
+  - Story numbers match `SliceProblem` for representative targets 6, 10, 14, 20, 37, 100, 250, and 1000.
   - Generated story contains the exact target and both parts.
   - Deterministic output is stable for the same problem/theme.
+  - Prompt language avoids timer, pressure, shame, danger, punishment, scarcity panic, and rescue-in-danger terms.
 
 Acceptance:
 

--- a/wiki/Specs/Make-Break-Number-Storyline-Packs.md
+++ b/wiki/Specs/Make-Break-Number-Storyline-Packs.md
@@ -1,0 +1,412 @@
+# Secondary Research: Make & Break Number Storyline Packs
+
+**Issue:** #400
+**Status:** Proposed storyline catalogue
+**Date:** 2026-04-27
+
+## Purpose
+This is the second-pass research and curation layer for **Make & Break: Number Story Quest**. The goal is to turn the gameplay idea into a reusable set of storylines that help children remember the target number, understand its decomposition, and scale from small numbers to large parent-selected caps up to 1000.
+
+The storyline layer must serve the math. It should never become a long plot, a distracting cartoon wrapper, or a generated-AI free-for-all.
+
+## Research synthesis
+
+### Why story belongs here
+Story contexts are useful in early math when they make number relationships concrete and meaningful. They help children connect quantities to everyday situations and word-problem structure. For Mather, this means the story should encode the target number and two parts, then hand off quickly to concrete manipulation.
+
+This fits existing Mather research:
+- CPA first: story introduces a concrete scenario, the child manipulates objects, then symbols appear.
+- Play-based learning: math should be the play, not an interruption.
+- No mandatory reading: story is spoken first and visually represented.
+- Short sessions: story beats must be tiny.
+
+### Large numbers need concrete grouping
+For 10 and 20, individual objects are still manageable. For 100 and 1000, individual counters become noise. The storyline should shift from loose objects to grouped bundles:
+
+- ones: single items
+- tens: crates, baskets, rods, shelves, teams, rows
+- hundreds: pallets, rooms, big boxes, fields, pages
+- thousand: a festival storehouse, rocket cargo bay, library archive, kingdom treasury
+
+This aligns with Montessori-style place-value materials: units, tens, hundreds, thousands are concrete objects with different visual forms.
+
+## Storyline design rules
+
+### Non-negotiables
+1. Story must include the exact target number.
+2. If it includes parts, it must include the exact decomposition from `SliceProblem`.
+3. The story must be one action, not an episode.
+4. The child should know what object is being counted.
+5. The visual representation must preserve quantity structure.
+6. No scary, competitive, shame, danger, punishment, or scarcity pressure.
+7. No timer language.
+8. Apple Intelligence may vary wording, but cannot change math truth.
+
+### Word limits
+- Target ≤ 20: 12–22 spoken words
+- Target 30–100: 16–28 spoken words
+- Target 110–1000: 18–35 spoken words
+
+### Story grammar
+Use this deterministic grammar:
+
+```text
+[Character/team] needs [target] [objects] for [purpose].
+Put [leftPart] in/on [leftContainer] and [rightPart] in/on [rightContainer].
+```
+
+Optional simplified version for younger children:
+
+```text
+We need [target] [objects]. [leftPart] here, [rightPart] there.
+```
+
+## Number-band mapping
+
+| Band | Math focus | Story representation | Example object grouping |
+| --- | --- | --- | --- |
+| 1–10 | subitizing, make-ten, part-part-whole | single familiar objects | apples, cars, stars, fish |
+| 11–20 | teen numbers, two ten-frames | two trays / two rows | moon berries in two baskets |
+| 21–100 | tens + ones, counting by tens | crates, shelves, rows, teams | 4 crates of 10 + 7 loose |
+| 101–999 | hundreds/tens/ones | pallets, big boxes, pages, rooms | 2 hundred boxes + 5 ten crates + 3 singles |
+| 1000 | thousand as a concrete unit | one giant cube/storehouse plus subgroups | one thousand-cube cargo block |
+
+## Recommended storyline families
+
+### 1. Rocket Picnic / Space Cargo
+**Best for:** 1–1000
+**Objects:** moon berries, star bolts, rover batteries, oxygen leaves, comet stickers
+**Containers:** rocket trays, cargo crates, moon baskets, docking bays
+**Why it works:** Space supports both small fantasy objects and big cargo bundles. It scales naturally to 1000.
+
+Example small:
+> We need 14 moon berries for the rocket picnic. Put 8 in the warm basket and 6 in the blue basket.
+
+Example large:
+> The rocket needs 240 star bolts. Load 100 in the silver crate and 140 in the blue crate.
+
+Large-number visual metaphor:
+- 10 = a small tray
+- 100 = a cargo crate
+- 1000 = a full rocket cargo block
+
+### 2. Animal Rescue / Habitat Helpers
+**Best for:** 1–100
+**Objects:** fish, bird seeds, turtle snacks, leaf bundles, animal badges
+**Containers:** ponds, nests, barns, habitats
+**Why it works:** Links well to existing Memory animal/fish decks and child-friendly categories.
+
+Example:
+> The pond team needs 37 fish snacks. Put 20 by the lily pads and 17 by the rocks.
+
+Guardrail:
+Avoid “rescue in danger” framing. Use care/help language, not emergency pressure.
+
+### 3. Vehicle Garage / Delivery Depot
+**Best for:** 1–1000
+**Objects:** cars, wheels, packages, fuel stars, road cones
+**Containers:** parking bays, garages, delivery shelves, crates
+**Why it works:** The repo already has a Vehicle theme and research supports structured parking frames.
+
+Example:
+> The garage needs 20 wheels. Park 12 by the red lift and 8 by the blue lift.
+
+Large-number visual metaphor:
+- 10 = one parking row
+- 100 = one delivery pallet
+- 1000 = one full depot wall
+
+### 4. Garden / Seed Shop
+**Best for:** 1–100
+**Objects:** seeds, flowers, carrots, magic beans, watering drops
+**Containers:** garden beds, seed trays, baskets
+**Why it works:** Naturally supports grouping rows of 10 and calm non-competitive play.
+
+Example:
+> The garden needs 58 seeds. Plant 30 in the sunny bed and 28 in the shady bed.
+
+### 5. Library / Story Archive
+**Best for:** 10–1000
+**Objects:** books, pages, stickers, story cards
+**Containers:** shelves, boxes, rooms, archive carts
+**Why it works:** Excellent for large numbers because shelves/boxes/pages can represent tens and hundreds.
+
+Example:
+> The library has 250 story cards. Place 100 on the top shelf and 150 on the lower shelf.
+
+### 6. Festival / Celebration Prep
+**Best for:** 1–1000
+**Objects:** lanterns, beads, flags, sweets, flower petals
+**Containers:** trays, garlands, crates, booths
+**Why it works:** Joyful, culturally flexible, and naturally about collecting/preparing quantities.
+
+Example:
+> The festival needs 100 lanterns. Hang 60 near the stage and 40 near the gate.
+
+Guardrail:
+Avoid religious specificity unless explicitly provided as a theme pack.
+
+### 7. Ocean Lab / Aquarium
+**Best for:** 1–100
+**Objects:** fish, shells, bubbles, coral beads, sea stars
+**Containers:** tanks, tide pools, reef zones
+**Why it works:** Connects to fish feedback/future deck work; strong visual identity.
+
+Example:
+> The reef needs 27 bubbles. Send 10 to the coral cave and 17 to the turtle tunnel.
+
+### 8. Castle Workshop / Builder Guild
+**Best for:** 10–1000
+**Objects:** blocks, bricks, gems, flags, bridge stones
+**Containers:** towers, wagons, storehouses
+**Why it works:** Building naturally maps to CPA and grouped place-value representations.
+
+Example:
+> The castle needs 340 bricks. Stack 200 by the tower and 140 by the bridge.
+
+## Curation matrix
+
+| Story family | 1–10 | 11–20 | 21–100 | 101–1000 | Best first slice? |
+| --- | --- | --- | --- | --- | --- |
+| Rocket Picnic / Space Cargo | Yes | Yes | Yes | Yes | Yes |
+| Vehicle Garage / Delivery Depot | Yes | Yes | Yes | Yes | Yes |
+| Garden / Seed Shop | Yes | Yes | Yes | Maybe | Yes |
+| Festival Prep | Yes | Yes | Yes | Yes | Yes |
+| Animal Habitat Helpers | Yes | Yes | Yes | No | Later |
+| Library / Story Archive | Maybe | Yes | Yes | Yes | Later |
+| Ocean Lab / Aquarium | Yes | Yes | Yes | No | Later |
+| Castle Workshop | Maybe | Yes | Yes | Yes | Later |
+
+Recommended first shipped set:
+1. Space Cargo
+2. Vehicle Garage
+3. Garden Seed Shop
+4. Festival Prep
+
+These cover fantasy, existing vehicle theme, calm nature, and celebration.
+
+## Example prompts by target
+
+### Target 8: `3 + 5`
+Family: Garden
+- Title: “Seed Tray”
+- Spoken intro: “We need 8 magic seeds. Plant 3 in the sunny bed and 5 in the shady bed.”
+- Reminder: “Remember: 8 seeds.”
+- Success: “Yes — 3 and 5 grow into 8 seeds.”
+- Retell check: “How many seeds did the garden need?”
+
+### Target 14: `8 + 6`
+Family: Space
+- Title: “Rocket Picnic”
+- Spoken intro: “We need 14 moon berries. Put 8 in the warm basket and 6 in the blue basket.”
+- Reminder: “Remember: 14 moon berries.”
+- Success: “Yes — 8 and 6 make the 14-berry picnic.”
+- Sum Story Match cards: `8 + 6`, `14`, `moon berries`
+
+### Target 37: `20 + 17`
+Family: Ocean
+- Title: “Reef Bubbles”
+- Spoken intro: “The reef needs 37 bubbles. Send 20 to the coral cave and 17 to the turtle tunnel.”
+- Reminder: “Remember: 37 reef bubbles.”
+- Representation: two ten-bundles plus 17 as one ten-bundle and seven singles.
+
+### Target 100: `60 + 40`
+Family: Festival
+- Title: “Lantern Night”
+- Spoken intro: “The festival needs 100 lanterns. Hang 60 near the stage and 40 near the gate.”
+- Reminder: “Remember: 100 lanterns.”
+- Representation: ten bundles of 10 lanterns; split as 6 bundles and 4 bundles.
+
+### Target 250: `100 + 150`
+Family: Library
+- Title: “Story Archive”
+- Spoken intro: “The library has 250 story cards. Place 100 on the top shelf and 150 on the lower shelf.”
+- Reminder: “Remember: 250 story cards.”
+- Representation: 2 hundred boxes + 5 ten packs; split by shelves.
+
+### Target 1000: `400 + 600`
+Family: Space Cargo
+- Title: “Rocket Storehouse”
+- Spoken intro: “The rocket needs 1000 star bolts. Load 400 in the silver bay and 600 in the blue bay.”
+- Reminder: “Remember: 1000 star bolts.”
+- Representation: ten hundred-crates; split as 4 crates and 6 crates.
+
+## Storyline data model proposal
+
+```swift
+struct NumberStoryPack: Identifiable, Codable, Equatable {
+    let id: String
+    let displayName: String
+    let supportedRange: ClosedRange<Int>
+    let objectNouns: [String]
+    let containerPairs: [(left: String, right: String)]
+    let purposeTemplates: [String]
+    let representationHint: StoryRepresentationHint
+}
+
+enum StoryRepresentationHint: String, Codable {
+    case singles
+    case tenFrames
+    case tensAndOnes
+    case hundredsTensOnes
+}
+
+struct NumberStoryPrompt: Identifiable, Codable, Equatable {
+    let id: UUID
+    let packId: String
+    let title: String
+    let target: Int
+    let leftPart: Int
+    let rightPart: Int
+    let objectNoun: String
+    let leftContainer: String
+    let rightContainer: String
+    let spokenIntro: String
+    let reminder: String
+    let success: String
+    let representationHint: StoryRepresentationHint
+}
+```
+
+## Apple Intelligence prompt contract
+
+Apple Intelligence can rewrite within a strict envelope. It should receive structured numbers and a selected pack, then return only story copy.
+
+### Request
+```json
+{
+  "target": 37,
+  "leftPart": 20,
+  "rightPart": 17,
+  "pack": "ocean_lab",
+  "objectNoun": "bubbles",
+  "leftContainer": "coral cave",
+  "rightContainer": "turtle tunnel",
+  "maxWords": 24,
+  "readingLevel": "spoken-preschool"
+}
+```
+
+### Required validation
+Reject generated output unless:
+- it contains the target number exactly once or clearly once
+- it contains both parts if parts are requested
+- it contains no additional numbers except the provided ones
+- it is under the word limit
+- it contains no negative/fear/punishment language
+- it has no external factual claims that require verification
+
+### Fallback
+Always keep deterministic curated templates. AI is an enhancer, not a dependency.
+
+## Interaction placement
+
+### Before the problem
+Story Anchor card:
+- big target number
+- story object illustration
+- spoken intro
+- “I remember” / “Let’s make it” button
+
+### During Make It
+- small persistent reminder pill: “14 moon berries”
+- no long story text
+
+### During Gravity Split
+- containers named from story: warm basket / blue basket, coral cave / turtle tunnel
+
+### During Sum Story Match
+Cards can be:
+- expression: `8 + 6`
+- total: `14`
+- story icon/card: `moon berries`
+
+### After problem
+Optional retell check:
+- “How many moon berries did we need?”
+- three choices: target, near-lower, near-higher
+- no penalty; if wrong, replay reminder
+
+## Anti-patterns
+
+Do not ship:
+- “The dragon is angry unless you solve 14.”
+- “Hurry before the rocket leaves.”
+- “You lost 6 berries.”
+- Long multi-step stories requiring memory beyond the number.
+- AI-generated factual science explanations inside Make & Break.
+- Showing 1000 individual objects.
+
+## Recommended execution split
+
+### Slice B1 — deterministic story packs
+- Add `NumberStoryPack` and curated packs for Space, Vehicle, Garden, Festival.
+- Generate story prompt from `SliceProblem`.
+- Unit tests for exact number consistency and no extra numbers.
+
+### Slice B2 — Story Anchor UI
+- Add Story Anchor pre-stage/card.
+- Speak intro before Make It.
+- Add persistent reminder pill.
+
+### Slice B3 — grouped representation design
+- Implement representation hints for `10`, `20`, `30...100`, `101...1000`.
+- Do not overload current counter grid.
+
+### Slice B4 — story-aware stage vocabulary
+- Rename containers and prompts in Gravity Split / Sum Sprint from generic terms to story terms.
+- Keep fallback generic copy.
+
+### Slice D1 — AI variation adapter
+- Add bounded `NumberStoryAIAdapter`.
+- Validate output strictly.
+- Prove fallback behavior.
+
+## Recommended issue update
+Add this storyline pack artifact to #400 and make Slice B explicitly about deterministic curated story packs before AI.
+
+
+## Addendum from secondary synthesis
+
+### Additional candidate packs
+
+#### Train Ticket Station
+**Best for:** 20–1000
+**Objects:** tickets, seats, cargo tags
+**Containers:** platform A / platform B, front train / back train
+**Why it works:** strong for tens/hundreds grouping through ticket books, seat rows, and cargo crates.
+
+Example:
+> The train needs 37 tickets. Load 30 on platform A and 7 on platform B.
+
+#### Robot Workshop
+**Best for:** 20–1000
+**Objects:** bolts, chips, buttons
+**Containers:** build tray / repair tray
+**Why it works:** maps naturally to base-ten blocks and large-number guided mode.
+
+Example:
+> The robot workshop needs 250 bolts. Put 200 on the build tray and 50 on the repair tray.
+
+#### Treasure Shelves
+**Best for:** 1–1000
+**Objects:** gems, stickers, tokens
+**Containers:** gold shelf / blue shelf
+**Why it works:** highly motivating, but must avoid pirate/threat/stealing language.
+
+Example:
+> The treasure shelf needs 1000 gems. Put 600 on the gold shelf and 400 on the blue shelf.
+
+### Decomposition bias by band
+
+| Target band | Preferred early splits | Avoid early |
+| --- | --- | --- |
+| 1–10 | nonzero pairs, make-5, make-10, doubles/near-doubles | too many zero splits |
+| 11–20 | 10+n, 8+6, 9+5, near-ten pairs | arbitrary teen splits before two-ten-frame model is clear |
+| 30–100 | tens+ones, friendly tens, multiples of 10 | noisy splits like 43+29 before place value is explicit |
+| 101–200 | 100+n, clean tens | ones-heavy split without grouped representation |
+| 210–500 | 100s + 10s, multiples of 50/100 | unstructured arbitrary decomposition |
+| 510–1000 | hundreds splits such as 600+400 | showing 1000 individual items |
+
+### Product rule
+The parent-selected cap is a ceiling, not a demand that every problem be near the ceiling. For high caps, ramp deliberately and label the experience as guided/older-kid mode.


### PR DESCRIPTION
## Summary
- Add deterministic `NumberStoryPrompt` domain models and curated pack selection for Space Cargo, Vehicle Garage, Garden Seed Shop, and Festival Prep.
- Generate story copy only from `SliceProblem.target`, `decompositionA`, and `decompositionB`, with representation hints through 1000.
- Add unit coverage for representative targets, deterministic stability, theme variation, and banned pressure/danger language.
- Commit the storyline pack spec artifact and update the story thread M1 notes.

## Validation
- `git diff --check`
- `git diff --cached --check`

Swift/Xcode validation was not run locally because this host is Linux and has no `xcodegen`, `xcodebuild`, or `swift` executable available.

## Stacking note
This PR targets `feat/issue-400-target-cap-1000` as requested. That branch had been deleted on GitHub after PR #404 merged, so it was restored at its original head commit `d4a52e36e69805992069c6103e840e49515aa4f4` before opening this draft PR.