### PR TITLE
Integrate Number Story representation and prompts

### DIFF
--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -61,7 +61,7 @@ private extension MatherApp {
                 sessionId: sessionId,
                 startedAt: startedAt,
                 endedAt: startedAt.addingTimeInterval(300),
-                objectiveTitle: "Make & Break 1–20",
+                objectiveTitle: "Make & Break",
                 problemsCompleted: 4 + index,
                 firstAttemptAccuracy: index == 0 ? 0.75 : 0.5,
                 transferCorrectCount: 2 + (index % 2),

--- a/Domain/GroupedNumberRepresentation.swift
+++ b/Domain/GroupedNumberRepresentation.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Place-value representation for VS1 targets and build counts.
+///
+/// This model derives only from numeric truth already owned by the problem or
+/// current build state. It is intentionally bounded to summary units so high
+/// targets never require hundreds of loose counters in SwiftUI.
+struct GroupedNumberRepresentation: Equatable {
+    enum Band: Equatable {
+        case zero
+        case ones
+        case teenTenFrames
+        case tensOnes
+        case hundredsTensOnes
+        case thousand
+    }
+
+    enum UnitKind: String, Equatable {
+        case thousand
+        case hundred
+        case ten
+        case tenFrame
+        case one
+    }
+
+    struct UnitGroup: Equatable, Identifiable {
+        var id: UnitKind { kind }
+        let kind: UnitKind
+        let count: Int
+        let valuePerUnit: Int
+
+        var totalValue: Int { count * valuePerUnit }
+
+        var label: String {
+            switch kind {
+            case .thousand:
+                return count == 1 ? "1 thousand" : "\(count) thousands"
+            case .hundred:
+                return count == 1 ? "1 hundred" : "\(count) hundreds"
+            case .ten:
+                return count == 1 ? "1 ten" : "\(count) tens"
+            case .tenFrame:
+                return count == 1 ? "1 ten-frame" : "\(count) ten-frames"
+            case .one:
+                return count == 1 ? "1 one" : "\(count) ones"
+            }
+        }
+    }
+
+    let value: Int
+    let band: Band
+    let groups: [UnitGroup]
+    /// Teen values still live visually in two ten-frame slots without creating
+    /// one loose cell per value above 10.
+    let tenFrameSlots: Int
+
+    init(_ rawValue: Int) {
+        value = min(max(rawValue, 0), 1000)
+
+        switch value {
+        case 0:
+            band = .zero
+            groups = []
+            tenFrameSlots = 0
+        case 1...10:
+            band = .ones
+            groups = [UnitGroup(kind: .one, count: value, valuePerUnit: 1)]
+            tenFrameSlots = 1
+        case 11...20:
+            band = .teenTenFrames
+            let ones = value - 10
+            groups = [
+                UnitGroup(kind: .tenFrame, count: 1, valuePerUnit: 10),
+                UnitGroup(kind: .one, count: ones, valuePerUnit: 1)
+            ].filter { $0.count > 0 }
+            tenFrameSlots = 2
+        case 21...100:
+            band = .tensOnes
+            groups = Self.placeValueGroups(value: value, includeHundreds: false)
+            tenFrameSlots = 0
+        case 101...999:
+            band = .hundredsTensOnes
+            groups = Self.placeValueGroups(value: value, includeHundreds: true)
+            tenFrameSlots = 0
+        default:
+            band = .thousand
+            groups = [UnitGroup(kind: .thousand, count: 1, valuePerUnit: 1000)]
+            tenFrameSlots = 0
+        }
+    }
+
+    var accessibilityText: String {
+        guard !groups.isEmpty else { return "0" }
+        return groups.map(\.label).joined(separator: ", ")
+    }
+
+    var suggestedSteps: [Int] {
+        switch band {
+        case .zero, .ones, .teenTenFrames:
+            return [1]
+        case .tensOnes:
+            return [10, 1]
+        case .hundredsTensOnes, .thousand:
+            return [100, 10, 1]
+        }
+    }
+
+    private static func placeValueGroups(value: Int, includeHundreds: Bool) -> [UnitGroup] {
+        let hundreds = includeHundreds ? value / 100 : 0
+        let tens = includeHundreds ? (value % 100) / 10 : value / 10
+        let ones = value % 10
+
+        return [
+            UnitGroup(kind: .hundred, count: hundreds, valuePerUnit: 100),
+            UnitGroup(kind: .ten, count: tens, valuePerUnit: 10),
+            UnitGroup(kind: .one, count: ones, valuePerUnit: 1)
+        ].filter { $0.count > 0 }
+    }
+}

--- a/Domain/NumberStoryGenerator.swift
+++ b/Domain/NumberStoryGenerator.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+enum NumberStoryGenerator {
+    static func prompt(for problem: SliceProblem, themeId: String) -> NumberStoryPrompt {
+        let pack = pack(for: problem.target, themeId: themeId)
+        return pack.prompt(for: problem)
+    }
+
+    private static func pack(for target: Int, themeId: String) -> NumberStoryPack {
+        let normalizedTheme = themeId.lowercased()
+
+        let preferred: NumberStoryTemplateID
+        switch normalizedTheme {
+        case "vehicle", "vehicles", "vehicle_garage":
+            preferred = .vehicleGarage
+        case "garden", "garden_seed_shop":
+            preferred = .gardenSeedShop
+        case "festival", "festival_prep":
+            preferred = .festivalPrep
+        case "space", "space_cargo":
+            preferred = .spaceCargo
+        default:
+            preferred = classicTemplate(for: target)
+        }
+
+        if let pack = packs[preferred], pack.supports(target) {
+            return pack
+        }
+
+        return packs[.spaceCargo] ?? NumberStoryPack.spaceCargo
+    }
+
+    private static func classicTemplate(for target: Int) -> NumberStoryTemplateID {
+        switch target {
+        case 1...10:
+            return .gardenSeedShop
+        case 11...20:
+            return .spaceCargo
+        case 21...100:
+            return .festivalPrep
+        default:
+            return .spaceCargo
+        }
+    }
+
+    private static let packs: [NumberStoryTemplateID: NumberStoryPack] = [
+        .spaceCargo: .spaceCargo,
+        .vehicleGarage: .vehicleGarage,
+        .gardenSeedShop: .gardenSeedShop,
+        .festivalPrep: .festivalPrep,
+    ]
+}
+
+private struct NumberStoryPack {
+    let id: NumberStoryTemplateID
+    let title: String
+    let supportedRange: ClosedRange<Int>
+    let setting: String
+    let action: String
+    let objectNoun: String
+    let leftContainer: String
+    let rightContainer: String
+    let successVerb: String
+
+    func supports(_ target: Int) -> Bool {
+        supportedRange.contains(target)
+    }
+
+    func prompt(for problem: SliceProblem) -> NumberStoryPrompt {
+        let target = problem.target
+        let leftPart = problem.decompositionA
+        let rightPart = problem.decompositionB
+        let noun = objectNoun
+        let hint = NumberStoryRepresentationHint.forTarget(target)
+
+        return NumberStoryPrompt(
+            id: "\(id.rawValue)-\(target)-\(leftPart)-\(rightPart)",
+            templateID: id,
+            title: title,
+            spokenIntro: "\(setting) needs \(target) \(noun). \(action) \(leftPart) in \(leftContainer) and \(rightPart) in \(rightContainer).",
+            reminder: "Remember: \(target) \(noun).",
+            successLine: "Yes: \(leftPart) and \(rightPart) \(successVerb) \(target) \(noun).",
+            target: target,
+            leftPart: leftPart,
+            rightPart: rightPart,
+            objectNoun: noun,
+            leftContainer: leftContainer,
+            rightContainer: rightContainer,
+            representationHint: hint
+        )
+    }
+
+    static let spaceCargo = NumberStoryPack(
+        id: .spaceCargo,
+        title: "Space Cargo",
+        supportedRange: 1...1_000,
+        setting: "The rocket",
+        action: "Load",
+        objectNoun: "star bolts",
+        leftContainer: "the silver bay",
+        rightContainer: "the blue bay",
+        successVerb: "make"
+    )
+
+    static let vehicleGarage = NumberStoryPack(
+        id: .vehicleGarage,
+        title: "Vehicle Garage",
+        supportedRange: 1...1_000,
+        setting: "The garage",
+        action: "Park",
+        objectNoun: "wheels",
+        leftContainer: "the red lift",
+        rightContainer: "the blue lift",
+        successVerb: "make"
+    )
+
+    static let gardenSeedShop = NumberStoryPack(
+        id: .gardenSeedShop,
+        title: "Seed Shop",
+        supportedRange: 1...100,
+        setting: "The garden",
+        action: "Plant",
+        objectNoun: "seeds",
+        leftContainer: "the sunny bed",
+        rightContainer: "the shady bed",
+        successVerb: "grow into"
+    )
+
+    static let festivalPrep = NumberStoryPack(
+        id: .festivalPrep,
+        title: "Festival Prep",
+        supportedRange: 1...1_000,
+        setting: "The festival",
+        action: "Place",
+        objectNoun: "lanterns",
+        leftContainer: "the stage tray",
+        rightContainer: "the gate tray",
+        successVerb: "make"
+    )
+}
+
+private extension NumberStoryRepresentationHint {
+    static func forTarget(_ target: Int) -> NumberStoryRepresentationHint {
+        switch target {
+        case 1...10:
+            return .singles
+        case 11...20:
+            return .tenFrames
+        case 21...100:
+            return .tensAndOnes
+        case 1_000:
+            return .thousandBlock
+        default:
+            return .hundredsTensOnes
+        }
+    }
+}

--- a/Domain/NumberStoryModels.swift
+++ b/Domain/NumberStoryModels.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum NumberStoryTemplateID: String, Codable, CaseIterable, Identifiable {
+    case spaceCargo = "space_cargo"
+    case vehicleGarage = "vehicle_garage"
+    case gardenSeedShop = "garden_seed_shop"
+    case festivalPrep = "festival_prep"
+
+    var id: String { rawValue }
+}
+
+enum NumberStoryRepresentationHint: String, Codable {
+    case singles
+    case tenFrames
+    case tensAndOnes
+    case hundredsTensOnes
+    case thousandBlock
+}
+
+struct NumberStoryPrompt: Identifiable, Codable, Equatable {
+    let id: String
+    let templateID: NumberStoryTemplateID
+    let title: String
+    let spokenIntro: String
+    let reminder: String
+    let successLine: String
+    let target: Int
+    let leftPart: Int
+    let rightPart: Int
+    let objectNoun: String
+    let leftContainer: String
+    let rightContainer: String
+    let representationHint: NumberStoryRepresentationHint
+}

--- a/Domain/ProblemGenerator.swift
+++ b/Domain/ProblemGenerator.swift
@@ -30,7 +30,7 @@ enum ProblemGenerator {
     static func generateProblems(config: SliceConfig) -> [SliceProblem] {
         let tuples: [(Int, Int, Int)]
         if config.deterministicMode {
-            tuples = deterministicSeed.filter { config.targetRange.contains($0.0) }
+            tuples = deterministicTuples(in: config.targetRange, count: max(config.maxProblems, 6))
         } else {
             tuples = randomTuples(in: config.targetRange, count: max(config.maxProblems, 6))
         }
@@ -43,6 +43,44 @@ enum ProblemGenerator {
                 difficultyTier: difficultyTier(for: tuple.0, index: index)
             )
         }
+    }
+
+    private static func deterministicTuples(in range: ClosedRange<Int>, count: Int) -> [(Int, Int, Int)] {
+        let fixture = deterministicSeed.filter { range.contains($0.0) }
+        guard range.upperBound > 20 else { return fixture }
+
+        var tuples: [(Int, Int, Int)] = []
+        var usedTargets = Set<Int>()
+
+        func appendTarget(_ target: Int) {
+            guard range.contains(target), !usedTargets.contains(target) else { return }
+            usedTargets.insert(target)
+
+            if let seeded = deterministicSeed.first(where: { $0.0 == target }) {
+                tuples.append(seeded)
+            } else {
+                let decomposition = deterministicDecomposition(for: target, index: tuples.count)
+                tuples.append((target, decomposition.0, decomposition.1))
+            }
+        }
+
+        appendTarget(fixture.first?.0 ?? range.lowerBound)
+        appendTarget(fixture.dropFirst().first?.0 ?? min(range.lowerBound + 1, range.upperBound))
+
+        let highTargets = [
+            max(21, range.upperBound / 2),
+            range.upperBound,
+            max(21, (range.upperBound * 3) / 4),
+            max(21, range.upperBound / 3),
+        ]
+        highTargets.forEach(appendTarget)
+        fixture.dropFirst(2).forEach { appendTarget($0.0) }
+
+        for target in range where tuples.count < count {
+            appendTarget(target)
+        }
+
+        return tuples
     }
 
     private static func randomTuples(in range: ClosedRange<Int>, count: Int) -> [(Int, Int, Int)] {
@@ -94,6 +132,15 @@ enum ProblemGenerator {
         }
 
         return Bool.random() ? basePair : (basePair.1, basePair.0)
+    }
+
+    private static func deterministicDecomposition(for target: Int, index: Int) -> (Int, Int) {
+        guard target > 0 else { return (0, 0) }
+        guard target > 1 else { return (1, 0) }
+
+        let offset = index % 4
+        let left = min(max((target / 2) - offset, 1), target - 1)
+        return (left, target - left)
     }
 
     private static func difficultyTier(for target: Int, index: Int) -> Int {

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -300,17 +300,45 @@ struct BondMatchState: Equatable {
     let target: Int
     /// Canonical pair list ordered by ascending left value.
     var pairs: [ComplementPair]
+    static let highTargetPairLimit = 10
 
     var matchCount: Int { pairs.filter(\.isMatched).count }
     var isComplete: Bool { pairs.allSatisfy(\.isMatched) }
 
     /// Generate all unique complement pairs (a, b) where a ≤ b and a + b == target.
     /// Excludes (0, target) — zero is not a meaningful addend in this context.
+    /// For targets above 20, returns a small deterministic sample of exact pairs
+    /// so Bond Blast never creates hundreds of cards.
     static func makePairs(for target: Int) -> [ComplementPair] {
         guard target >= 2 else { return [] }
-        return (1...(target - 1))
+        if target <= 20 {
+            return allPairLeftValues(for: target)
+                .map { a in ComplementPair(left: a, right: target - a) }
+        }
+
+        let midpoint = target / 2
+        let candidateLeftValues = [
+            1,
+            2,
+            5,
+            10,
+            max(1, target / 10),
+            max(1, target / 4),
+            max(1, target / 3),
+            max(1, midpoint - 10),
+            max(1, midpoint - 1),
+            midpoint
+        ]
+
+        return Array(Set(candidateLeftValues))
             .filter { $0 <= target - $0 }
+            .sorted()
+            .prefix(highTargetPairLimit)
             .map { a in ComplementPair(left: a, right: target - a) }
+    }
+
+    private static func allPairLeftValues(for target: Int) -> [Int] {
+        (1...(target - 1)).filter { $0 <= target - $0 }
     }
 }
 

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -54,20 +54,65 @@ enum SliceEventType: String, Codable {
     case sumSprintCompleted = "sum_sprint_completed"
 }
 
+enum ParentTargetCap {
+    static let minimum = 10
+    static let maximum = 1_000
+    static let step = 10
+    static let quickPicks = [10, 20, 50, 100, 1_000]
+
+    static func normalize(_ value: Int) -> Int {
+        let clamped = min(max(value, minimum), maximum)
+        return (clamped / step) * step
+    }
+
+    static func displayLabel(for value: Int) -> String {
+        "Up to \(normalize(value))"
+    }
+}
+
 struct SliceConfig: Codable, Equatable {
-    private static let allowedTargets = 1...20
+    private static let allowedTargets = 1...1_000
 
     var maxProblems: Int = 6
-    var minTarget: Int = allowedTargets.lowerBound
-    var maxTarget: Int = allowedTargets.upperBound
+    var minTarget: Int = allowedTargets.lowerBound {
+        didSet { minTarget = Self.clampTarget(minTarget) }
+    }
+    var maxTarget: Int = 20 {
+        didSet { maxTarget = Self.clampTarget(maxTarget) }
+    }
     var showTransfer: Bool = true
     var audioEnabled: Bool = true
     var deterministicMode: Bool = true
 
+    init(
+        maxProblems: Int = 6,
+        minTarget: Int = allowedTargets.lowerBound,
+        maxTarget: Int = 20,
+        showTransfer: Bool = true,
+        audioEnabled: Bool = true,
+        deterministicMode: Bool = true
+    ) {
+        self.maxProblems = maxProblems
+        self.minTarget = Self.clampTarget(minTarget)
+        self.maxTarget = Self.clampTarget(maxTarget)
+        self.showTransfer = showTransfer
+        self.audioEnabled = audioEnabled
+        self.deterministicMode = deterministicMode
+    }
+
+    var parentTargetCap: Int {
+        get { ParentTargetCap.normalize(maxTarget) }
+        set { maxTarget = ParentTargetCap.normalize(newValue) }
+    }
+
     var targetRange: ClosedRange<Int> {
-        let lower = min(max(minTarget, Self.allowedTargets.lowerBound), Self.allowedTargets.upperBound)
-        let upper = min(max(maxTarget, Self.allowedTargets.lowerBound), Self.allowedTargets.upperBound)
+        let lower = Self.clampTarget(minTarget)
+        let upper = Self.clampTarget(maxTarget)
         return min(lower, upper)...max(lower, upper)
+    }
+
+    private static func clampTarget(_ value: Int) -> Int {
+        min(max(value, allowedTargets.lowerBound), allowedTargets.upperBound)
     }
 }
 

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -621,7 +621,7 @@ final class VerticalSliceEngine {
         let accuracy = completed == 0 ? 0 : Double(firstTryCount) / Double(completed)
 
         return ParentDigest(
-            objectiveTitle: "Make & Break 1–20",
+            objectiveTitle: "Make & Break up to \(config.parentTargetCap)",
             firstAttemptAccuracy: accuracy,
             medianLatencyMs: median,
             problemsCompleted: completed,
@@ -641,7 +641,7 @@ final class VerticalSliceEngine {
             return "Your child found the reverse (equation → counters) harder. Try this at home: write '3 + 4 =' on paper and ask them to show it with grapes or blocks."
         }
         if accuracy < 0.5 {
-            return "The concept is still new. Keep sessions short, use physical objects at home (up to 20 buttons or pebbles), and don't rush to the written equation."
+            return "The concept is still new. Keep sessions short, use a small set of physical objects at home, and don't rush to the written equation."
         }
         if accuracy < 0.7 {
             return "Repeat the same range with spoken prompts. At home, practise splitting groups of 4–12 objects into two parts and counting each."
@@ -649,7 +649,7 @@ final class VerticalSliceEngine {
         if accuracy < 0.9 {
             return "Solid progress! Try increasing to 7–8 problems next session when they seem relaxed."
         }
-        return "Excellent mastery. Try the full 1–20 range or introduce writing the equation on paper first before using the app."
+        return "Excellent mastery. Try a slightly larger target cap or introduce writing the equation on paper first before using the app."
     }
 
     private func logProblemPresented() {

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -197,6 +197,10 @@ final class VerticalSliceEngine {
 
     func adjustConcrete(by delta: Int, side: ConcreteGroup) {
         guard let currentProblem else { return }
+        guard currentProblem.target <= 20 else {
+            setConcreteTotal(concreteCount + delta)
+            return
+        }
         switch side {
         case .warm:
             let maxWarm = min(10, max(currentProblem.target - concreteAccentCount, 0))
@@ -834,6 +838,15 @@ final class VerticalSliceEngine {
     private func setConcreteTotal(_ total: Int) {
         let maxTotal = currentProblem?.target ?? 10
         let clamped = min(max(total, 0), maxTotal)
+        if maxTotal > 20 {
+            concreteWarmCount = clamped
+            concreteAccentCount = 0
+            recordInteraction(action: "place", value: concreteCount)
+            #if targetEnvironment(simulator)
+            print("[Mather][concrete] warm=\(concreteWarmCount) accent=\(concreteAccentCount) total=\(concreteCount)")
+            #endif
+            return
+        }
         concreteWarmCount = min(clamped, 10)
         concreteAccentCount = max(clamped - concreteWarmCount, 0)
         recordInteraction(action: "place", value: concreteCount)

--- a/Features/VerticalSlice1/ConcreteBuildView.swift
+++ b/Features/VerticalSlice1/ConcreteBuildView.swift
@@ -13,6 +13,10 @@ struct ConcreteBuildView: View {
     // We keep 5 columns so the child still sees familiar subitizing-friendly rows,
     // but expand the surface to 4 rows when needed.
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 10), count: 5)
+    private var currentCount: Int { warmCount + accentCount }
+    private var representation: GroupedNumberRepresentation {
+        GroupedNumberRepresentation(target)
+    }
 
     var body: some View {
         CardSurface {
@@ -26,31 +30,11 @@ struct ConcreteBuildView: View {
                         .foregroundStyle(MatherTheme.accent)
                 }
 
-                // Color.clear with aspectRatio is the reliable SwiftUI idiom for
-                // square grid cells — it constrains height = width without fighting
-                // the grid's flexible column width calculation.
-                // Cells are capped at 72pt so on wide screens (iPad) they don't grow
-                // to 130pt+ — "bigger circles" feedback and scrolling are eliminated.
-                LazyVGrid(columns: columns, spacing: 10) {
-                    ForEach(0..<min(max(target, 1), 20), id: \.self) { index in
-                        counterCell(index: index)
-                            .frame(maxWidth: 72, maxHeight: 72)
-                            .accessibilityIdentifier("counter-cell-\(index)")
-                            .accessibilityLabel("Counter \(index + 1)")
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                guard let tap = Self.tapAction(
-                                    for: index,
-                                    target: target,
-                                    warmCount: warmCount,
-                                    accentCount: accentCount
-                                ) else { return }
-                                onAdjust(tap.delta, tap.group)
-                            }
-                    }
+                if target <= 20 {
+                    tapCounterGrid
+                } else {
+                    groupedBuildControls
                 }
-                .frame(maxWidth: ResponsiveLayout.concreteGridMaxWidth(for: horizontalSizeClass))
-                .frame(maxWidth: .infinity)
 
 
                 // Number-bond display: live A + B = target as circles are tapped.
@@ -84,6 +68,70 @@ struct ConcreteBuildView: View {
                 .buttonStyle(PrimaryActionButtonStyle())
             }
         }
+    }
+
+    private var tapCounterGrid: some View {
+        LazyVGrid(columns: columns, spacing: 10) {
+            ForEach(0..<min(max(target, 1), 20), id: \.self) { index in
+                counterCell(index: index)
+                    .frame(maxWidth: 72, maxHeight: 72)
+                    .accessibilityIdentifier("counter-cell-\(index)")
+                    .accessibilityLabel("Counter \(index + 1)")
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        guard let tap = Self.tapAction(
+                            for: index,
+                            target: target,
+                            warmCount: warmCount,
+                            accentCount: accentCount
+                        ) else { return }
+                        onAdjust(tap.delta, tap.group)
+                    }
+            }
+        }
+        .frame(maxWidth: ResponsiveLayout.concreteGridMaxWidth(for: horizontalSizeClass))
+        .frame(maxWidth: .infinity)
+    }
+
+    private var groupedBuildControls: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                GroupedNumberView(value: currentCount, fill: MatherTheme.warm)
+                    .accessibilityIdentifier("concrete-current-grouped-representation")
+                Image(systemName: "arrow.right")
+                    .font(.title3.weight(.black))
+                    .foregroundStyle(.secondary)
+                GroupedNumberView(value: target, fill: MatherTheme.accent)
+                    .accessibilityIdentifier("concrete-target-grouped-representation")
+            }
+            .frame(maxWidth: .infinity)
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 96), spacing: 10)], spacing: 10) {
+                ForEach(representation.suggestedSteps, id: \.self) { step in
+                    groupedStepButton(step: -step)
+                    groupedStepButton(step: step)
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    private func groupedStepButton(step: Int) -> some View {
+        let canApply = step < 0 ? currentCount > 0 : currentCount < target
+        let clampedStep = step < 0 ? max(step, -currentCount) : min(step, target - currentCount)
+
+        return Button {
+            onAdjust(clampedStep, .warm)
+        } label: {
+            Label("\(step > 0 ? "+" : "-")\(abs(step))", systemImage: step > 0 ? "plus.circle.fill" : "minus.circle.fill")
+                .font(.headline.weight(.black))
+                .frame(minWidth: 88, minHeight: 80)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(canApply ? MatherTheme.warm : MatherTheme.warm.opacity(0.28))
+        .disabled(!canApply)
+        .accessibilityLabel(step > 0 ? "Add \(step)" : "Remove \(abs(step))")
+        .accessibilityIdentifier("concrete-step-\(step > 0 ? "plus" : "minus")-\(abs(step))")
     }
 
     nonisolated static func tapAction(

--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -199,34 +199,39 @@ struct GravitySplitView: View {
 
     private func panView(count: Int, fill: Color, side: String) -> some View {
         VStack(spacing: 6) {
-            // Counter dots in the pan (up to target, max display 10)
-            let display = min(state.target, 20)
-            LazyVGrid(
-                columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 5),
-                spacing: 4
-            ) {
-                ForEach(0..<display, id: \.self) { idx in
-                    Circle()
-                        .fill(idx < count ? fill : fill.opacity(0.15))
-                        .overlay(
-                            Circle()
-                                .strokeBorder(fill.opacity(idx < count ? 0.3 : 0.4), lineWidth: 1.5)
-                        )
-                        .shadow(color: idx < count ? fill.opacity(0.3) : .clear, radius: 3, y: 1)
-                        .aspectRatio(1, contentMode: .fit)
-                        .accessibilityIdentifier("gravity-\(side)-dot-\(idx)")
+            if state.target <= 20 {
+                let display = min(state.target, 20)
+                LazyVGrid(
+                    columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 5),
+                    spacing: 4
+                ) {
+                    ForEach(0..<display, id: \.self) { idx in
+                        Circle()
+                            .fill(idx < count ? fill : fill.opacity(0.15))
+                            .overlay(
+                                Circle()
+                                    .strokeBorder(fill.opacity(idx < count ? 0.3 : 0.4), lineWidth: 1.5)
+                            )
+                            .shadow(color: idx < count ? fill.opacity(0.3) : .clear, radius: 3, y: 1)
+                            .aspectRatio(1, contentMode: .fit)
+                            .accessibilityIdentifier("gravity-\(side)-dot-\(idx)")
+                    }
                 }
+            } else {
+                GroupedNumberView(value: count, fill: fill)
+                    .frame(minHeight: 74)
+                    .accessibilityIdentifier("gravity-\(side)-grouped-representation")
             }
-            .padding(8)
-            .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(fill.opacity(0.10))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .strokeBorder(fill.opacity(0.22), lineWidth: 1.5)
-                    )
-            )
         }
+        .padding(8)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(fill.opacity(0.10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .strokeBorder(fill.opacity(0.22), lineWidth: 1.5)
+                )
+        )
         .frame(maxWidth: .infinity)
     }
 
@@ -239,7 +244,8 @@ struct GravitySplitView: View {
                 fill: MatherTheme.warm,
                 side: "left",
                 canDecrement: state.leftCount > 0 && !state.isLocked,
-                canIncrement: state.leftCount < state.decompositionA && !state.isLocked
+                canIncrement: state.leftCount < state.decompositionA && !state.isLocked,
+                steps: gravitySteps
             ) { delta in
                 onTap(delta, .left)
             }
@@ -249,11 +255,16 @@ struct GravitySplitView: View {
                 fill: MatherTheme.accent,
                 side: "right",
                 canDecrement: state.rightCount > 0 && !state.isLocked,
-                canIncrement: state.rightCount < state.decompositionB && !state.isLocked
+                canIncrement: state.rightCount < state.decompositionB && !state.isLocked,
+                steps: gravitySteps
             ) { delta in
                 onTap(delta, .right)
             }
         }
+    }
+
+    private var gravitySteps: [Int] {
+        state.target <= 20 ? [1] : GroupedNumberRepresentation(state.target).suggestedSteps
     }
 
     private func panControlButtons(
@@ -262,39 +273,20 @@ struct GravitySplitView: View {
         side: String,
         canDecrement: Bool,
         canIncrement: Bool,
+        steps: [Int],
         action: @escaping (Int) -> Void
     ) -> some View {
-        HStack(spacing: 8) {
-            Button {
-                action(-1)
-            } label: {
-                Image(systemName: "minus.circle.fill")
-                    .font(.title.weight(.bold))
-                    .frame(minWidth: 48, minHeight: 48)
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(canDecrement ? fill : fill.opacity(0.3))
-            .disabled(!canDecrement)
-            .accessibilityLabel("Remove from \(label.lowercased()) pan")
-            .accessibilityIdentifier("gravity-\(side)-minus")
-
+        VStack(spacing: 8) {
             Text(label)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(fill)
                 .frame(minWidth: 38)
-
-            Button {
-                action(1)
-            } label: {
-                Image(systemName: "plus.circle.fill")
-                    .font(.title.weight(.bold))
-                    .frame(minWidth: 48, minHeight: 48)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: state.target <= 20 ? 48 : 82), spacing: 6)], spacing: 6) {
+                ForEach(steps, id: \.self) { step in
+                    gravityStepButton(step: -step, fill: fill, side: side, isEnabled: canDecrement, action: action)
+                    gravityStepButton(step: step, fill: fill, side: side, isEnabled: canIncrement, action: action)
+                }
             }
-            .buttonStyle(.plain)
-            .foregroundStyle(canIncrement ? fill : fill.opacity(0.3))
-            .disabled(!canIncrement)
-            .accessibilityLabel("Add to \(label.lowercased()) pan")
-            .accessibilityIdentifier("gravity-\(side)-plus")
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
@@ -303,6 +295,29 @@ struct GravitySplitView: View {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .fill(fill.opacity(0.08))
         )
+    }
+
+    private func gravityStepButton(
+        step: Int,
+        fill: Color,
+        side: String,
+        isEnabled: Bool,
+        action: @escaping (Int) -> Void
+    ) -> some View {
+        Button {
+            action(step)
+        } label: {
+            Label("\(step > 0 ? "+" : "-")\(abs(step))", systemImage: step > 0 ? "plus.circle.fill" : "minus.circle.fill")
+                .font(.subheadline.weight(.black))
+                .minimumScaleFactor(0.7)
+                .lineLimit(1)
+                .frame(minWidth: state.target <= 20 ? 48 : 80, minHeight: state.target <= 20 ? 48 : 80)
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(isEnabled ? fill : fill.opacity(0.3))
+        .disabled(!isEnabled)
+        .accessibilityLabel(step > 0 ? "Add \(step)" : "Remove \(abs(step))")
+        .accessibilityIdentifier("gravity-\(side)-\(step > 0 ? "plus" : "minus")-\(abs(step))")
     }
 
     // MARK: - Instruction

--- a/Features/VerticalSlice1/GroupedNumberView.swift
+++ b/Features/VerticalSlice1/GroupedNumberView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct GroupedNumberView: View {
+    let representation: GroupedNumberRepresentation
+    let fill: Color
+
+    init(value: Int, fill: Color) {
+        self.representation = GroupedNumberRepresentation(value)
+        self.fill = fill
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if representation.groups.isEmpty {
+                unitToken(text: "0", symbol: "circle")
+            } else {
+                ForEach(representation.groups) { group in
+                    unitToken(text: groupText(for: group), symbol: symbol(for: group.kind))
+                }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(representation.accessibilityText)
+    }
+
+    private func unitToken(text: String, symbol: String) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: symbol)
+                .font(.caption.weight(.black))
+            Text(text)
+                .font(.system(size: 17, weight: .black, design: .rounded))
+                .minimumScaleFactor(0.7)
+                .lineLimit(1)
+        }
+        .foregroundStyle(fill)
+        .frame(minHeight: 44)
+        .padding(.horizontal, 10)
+        .background(fill.opacity(0.11), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(fill.opacity(0.26), lineWidth: 1.5)
+        )
+    }
+
+    private func groupText(for group: GroupedNumberRepresentation.UnitGroup) -> String {
+        switch group.kind {
+        case .thousand:
+            return "1000"
+        case .hundred:
+            return "\(group.count)x100"
+        case .ten, .tenFrame:
+            return "\(group.count)x10"
+        case .one:
+            return "\(group.count)"
+        }
+    }
+
+    private func symbol(for kind: GroupedNumberRepresentation.UnitKind) -> String {
+        switch kind {
+        case .thousand:
+            return "cube.fill"
+        case .hundred:
+            return "square.grid.3x3.fill"
+        case .ten, .tenFrame:
+            return "rectangle.grid.1x2.fill"
+        case .one:
+            return "circle.fill"
+        }
+    }
+}

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -79,7 +79,7 @@ struct HomeView: View {
                             Text("Make & Break")
                                 .font(.title3.weight(.black))
                                 .foregroundStyle(.white)
-                            Text("1–20")
+                            Text("Targets")
                                 .font(.system(size: 36, weight: .black, design: .rounded))
                                 .foregroundStyle(.white)
                         }
@@ -141,7 +141,7 @@ struct HomeView: View {
     private var lockedActivityCard: some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 14) {
-                Text("Make & Break 1–20")
+                Text("Make & Break")
                     .font(.title2.weight(.bold))
                 Text("Enable the activity in Settings before handing the iPad to your child.")
                     .font(.headline)

--- a/Features/VerticalSlice1/SessionConfigView.swift
+++ b/Features/VerticalSlice1/SessionConfigView.swift
@@ -61,10 +61,22 @@ struct SessionConfigView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(MatherTheme.ink.opacity(0.6))
 
-                            HStack(spacing: 12) {
-                                targetCapButton(maxTarget: 10)
-                                targetCapButton(maxTarget: 20)
+                            LazyVGrid(columns: [GridItem(.adaptive(minimum: 96), spacing: 12)], spacing: 12) {
+                                ForEach(ParentTargetCap.quickPicks, id: \.self) { maxTarget in
+                                    targetCapButton(maxTarget: maxTarget)
+                                }
                             }
+
+                            Stepper(
+                                value: targetCapBinding,
+                                in: ParentTargetCap.minimum...ParentTargetCap.maximum,
+                                step: ParentTargetCap.step
+                            ) {
+                                Text(ParentTargetCap.displayLabel(for: appModel.engine.config.parentTargetCap))
+                                    .font(.headline.weight(.semibold))
+                                    .accessibilityIdentifier("target-cap-current-value")
+                            }
+                            .accessibilityIdentifier("target-cap-stepper")
                         }
 
                         Toggle("Speak prompts", isOn: Binding(
@@ -95,16 +107,24 @@ struct SessionConfigView: View {
         }
     }
 
+    private var targetCapBinding: Binding<Int> {
+        Binding(
+            get: { appModel.engine.config.parentTargetCap },
+            set: { appModel.engine.updateConfig(minTarget: 1, maxTarget: ParentTargetCap.normalize($0)) }
+        )
+    }
+
     private func targetCapButton(maxTarget: Int) -> some View {
-        let isSelected = appModel.engine.config.targetRange.upperBound == maxTarget
+        let normalizedTarget = ParentTargetCap.normalize(maxTarget)
+        let isSelected = appModel.engine.config.parentTargetCap == normalizedTarget
         return Button {
-            appModel.engine.updateConfig(minTarget: 1, maxTarget: maxTarget)
+            appModel.engine.updateConfig(minTarget: 1, maxTarget: normalizedTarget)
         } label: {
             VStack(spacing: 6) {
                 Text("Up to")
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(MatherTheme.ink.opacity(0.55))
-                Text("\(maxTarget)")
+                Text("\(normalizedTarget)")
                     .font(.title2.weight(.black))
                     .foregroundStyle(isSelected ? MatherTheme.warm : MatherTheme.ink)
             }
@@ -120,8 +140,8 @@ struct SessionConfigView: View {
             )
         }
         .buttonStyle(.plain)
-        .accessibilityIdentifier("target-cap-up-to-\(maxTarget)")
-        .accessibilityLabel("Target numbers up to \(maxTarget)")
+        .accessibilityIdentifier("target-cap-up-to-\(normalizedTarget)")
+        .accessibilityLabel("Target numbers up to \(normalizedTarget)")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 

--- a/Tests/MatherTests/BondMatchViewTests.swift
+++ b/Tests/MatherTests/BondMatchViewTests.swift
@@ -52,4 +52,21 @@ struct BondMatchViewTests {
         )
         #expect(wrongDrop == .mismatch(4))
     }
+
+    @Test func lowTargetsKeepAllUniquePairs() {
+        let pairs = BondMatchState.makePairs(for: 20)
+
+        #expect(pairs.count == 10)
+        #expect(pairs.map(\.left) == Array(1...10))
+        #expect(pairs.allSatisfy { $0.left + $0.right == 20 })
+    }
+
+    @Test func highTargetsUseSmallExactPairSample() {
+        let pairs = BondMatchState.makePairs(for: 1000)
+
+        #expect(pairs.count <= BondMatchState.highTargetPairLimit)
+        #expect(!pairs.isEmpty)
+        #expect(pairs.allSatisfy { $0.left <= $0.right })
+        #expect(pairs.allSatisfy { $0.left + $0.right == 1000 })
+    }
 }

--- a/Tests/MatherTests/GroupedNumberRepresentationTests.swift
+++ b/Tests/MatherTests/GroupedNumberRepresentationTests.swift
@@ -1,0 +1,67 @@
+import Testing
+@testable import Mather
+
+struct GroupedNumberRepresentationTests {
+    @Test func value8UsesOnesBand() {
+        let representation = GroupedNumberRepresentation(8)
+
+        #expect(representation.band == .ones)
+        #expect(representation.groups.map(\.kind) == [.one])
+        #expect(representation.groups.map(\.count) == [8])
+        #expect(representation.accessibilityText == "8 ones")
+    }
+
+    @Test func value14UsesTeenTenFramesBand() {
+        let representation = GroupedNumberRepresentation(14)
+
+        #expect(representation.band == .teenTenFrames)
+        #expect(representation.tenFrameSlots == 2)
+        #expect(representation.groups.map(\.kind) == [.tenFrame, .one])
+        #expect(representation.groups.map(\.count) == [1, 4])
+        #expect(representation.accessibilityText == "1 ten-frame, 4 ones")
+    }
+
+    @Test func value37UsesTensAndOnesBand() {
+        let representation = GroupedNumberRepresentation(37)
+
+        #expect(representation.band == .tensOnes)
+        #expect(representation.groups.map(\.kind) == [.ten, .one])
+        #expect(representation.groups.map(\.count) == [3, 7])
+        #expect(representation.suggestedSteps == [10, 1])
+    }
+
+    @Test func value100UsesTenTensWithoutHundredsBand() {
+        let representation = GroupedNumberRepresentation(100)
+
+        #expect(representation.band == .tensOnes)
+        #expect(representation.groups.map(\.kind) == [.ten])
+        #expect(representation.groups.map(\.count) == [10])
+        #expect(representation.accessibilityText == "10 tens")
+    }
+
+    @Test func value250UsesHundredsTensAndOnesBand() {
+        let representation = GroupedNumberRepresentation(250)
+
+        #expect(representation.band == .hundredsTensOnes)
+        #expect(representation.groups.map(\.kind) == [.hundred, .ten])
+        #expect(representation.groups.map(\.count) == [2, 5])
+        #expect(representation.suggestedSteps == [100, 10, 1])
+    }
+
+    @Test func value999UsesHundredsTensAndOnesBand() {
+        let representation = GroupedNumberRepresentation(999)
+
+        #expect(representation.band == .hundredsTensOnes)
+        #expect(representation.groups.map(\.kind) == [.hundred, .ten, .one])
+        #expect(representation.groups.map(\.count) == [9, 9, 9])
+    }
+
+    @Test func value1000UsesSingleThousandUnit() {
+        let representation = GroupedNumberRepresentation(1000)
+
+        #expect(representation.band == .thousand)
+        #expect(representation.groups.map(\.kind) == [.thousand])
+        #expect(representation.groups.map(\.count) == [1])
+        #expect(representation.accessibilityText == "1 thousand")
+    }
+}

--- a/Tests/MatherTests/NumberStoryGeneratorTests.swift
+++ b/Tests/MatherTests/NumberStoryGeneratorTests.swift
@@ -1,0 +1,138 @@
+import Testing
+@testable import Mather
+
+struct NumberStoryGeneratorTests {
+    @Test
+    func generatedPromptsCarryExactProblemNumbers() {
+        let cases = [
+            SliceProblem(target: 6, decompositionA: 2, decompositionB: 4),
+            SliceProblem(target: 10, decompositionA: 7, decompositionB: 3),
+            SliceProblem(target: 14, decompositionA: 8, decompositionB: 6),
+            SliceProblem(target: 20, decompositionA: 12, decompositionB: 8),
+            SliceProblem(target: 37, decompositionA: 20, decompositionB: 17),
+            SliceProblem(target: 100, decompositionA: 60, decompositionB: 40),
+            SliceProblem(target: 250, decompositionA: 100, decompositionB: 150),
+            SliceProblem(target: 1_000, decompositionA: 400, decompositionB: 600),
+        ]
+
+        for problem in cases {
+            let prompt = NumberStoryGenerator.prompt(for: problem, themeId: "space")
+
+            #expect(prompt.target == problem.target)
+            #expect(prompt.leftPart == problem.decompositionA)
+            #expect(prompt.rightPart == problem.decompositionB)
+            #expect(prompt.spokenIntro.contains("\(problem.target)"))
+            #expect(prompt.spokenIntro.contains("\(problem.decompositionA)"))
+            #expect(prompt.spokenIntro.contains("\(problem.decompositionB)"))
+            #expect(prompt.reminder.contains("\(problem.target)"))
+            #expect(prompt.successLine.contains("\(problem.target)"))
+            #expect(prompt.successLine.contains("\(problem.decompositionA)"))
+            #expect(prompt.successLine.contains("\(problem.decompositionB)"))
+        }
+    }
+
+    @Test
+    func promptGenerationIsDeterministicForSameProblemAndTheme() {
+        let problem = SliceProblem(target: 37, decompositionA: 20, decompositionB: 17)
+
+        let first = NumberStoryGenerator.prompt(for: problem, themeId: "classic")
+        let second = NumberStoryGenerator.prompt(for: problem, themeId: "classic")
+
+        #expect(first == second)
+    }
+
+    @Test
+    func classicAndVehicleThemesUseDifferentCuratedPacks() {
+        let problem = SliceProblem(target: 20, decompositionA: 12, decompositionB: 8)
+
+        let classic = NumberStoryGenerator.prompt(for: problem, themeId: "classic")
+        let vehicle = NumberStoryGenerator.prompt(for: problem, themeId: "vehicle")
+
+        #expect(classic.templateID != vehicle.templateID)
+        #expect(vehicle.templateID == .vehicleGarage)
+        #expect(vehicle.title == "Vehicle Garage")
+        #expect(vehicle.objectNoun == "wheels")
+        #expect(classic.target == vehicle.target)
+        #expect(classic.leftPart == vehicle.leftPart)
+        #expect(classic.rightPart == vehicle.rightPart)
+    }
+
+    @Test
+    func curatedPacksCoverRequiredFamiliesAndBands() {
+        let small = SliceProblem(target: 6, decompositionA: 2, decompositionB: 4)
+        let hundred = SliceProblem(target: 100, decompositionA: 60, decompositionB: 40)
+        let large = SliceProblem(target: 250, decompositionA: 100, decompositionB: 150)
+
+        #expect(NumberStoryGenerator.prompt(for: small, themeId: "space").templateID == .spaceCargo)
+        #expect(NumberStoryGenerator.prompt(for: small, themeId: "vehicle").templateID == .vehicleGarage)
+        #expect(NumberStoryGenerator.prompt(for: small, themeId: "garden").templateID == .gardenSeedShop)
+        #expect(NumberStoryGenerator.prompt(for: hundred, themeId: "festival").templateID == .festivalPrep)
+        #expect(NumberStoryGenerator.prompt(for: large, themeId: "garden").templateID == .spaceCargo)
+    }
+
+    @Test
+    func promptTextAvoidsBannedPressureAndDangerLanguage() {
+        let bannedTerms = [
+            "timer",
+            "hurry",
+            "fast",
+            "race",
+            "lose",
+            "lost",
+            "wrong",
+            "shame",
+            "scary",
+            "danger",
+            "rescue",
+            "punish",
+            "punishment",
+            "emergency",
+            "before it is too late",
+        ]
+        let problems = [
+            SliceProblem(target: 6, decompositionA: 2, decompositionB: 4),
+            SliceProblem(target: 10, decompositionA: 7, decompositionB: 3),
+            SliceProblem(target: 14, decompositionA: 8, decompositionB: 6),
+            SliceProblem(target: 20, decompositionA: 12, decompositionB: 8),
+            SliceProblem(target: 37, decompositionA: 20, decompositionB: 17),
+            SliceProblem(target: 100, decompositionA: 60, decompositionB: 40),
+            SliceProblem(target: 250, decompositionA: 100, decompositionB: 150),
+            SliceProblem(target: 1_000, decompositionA: 400, decompositionB: 600),
+        ]
+        let themeIds = ["classic", "space", "vehicle", "garden", "festival"]
+
+        for problem in problems {
+            for themeId in themeIds {
+                let prompt = NumberStoryGenerator.prompt(for: problem, themeId: themeId)
+                let text = prompt.searchableText.lowercased()
+
+                for term in bannedTerms {
+                    #expect(!text.contains(term))
+                }
+            }
+        }
+    }
+
+    @Test
+    func representationHintsFollowNumberBands() {
+        #expect(NumberStoryGenerator.prompt(for: SliceProblem(target: 6, decompositionA: 2, decompositionB: 4), themeId: "space").representationHint == .singles)
+        #expect(NumberStoryGenerator.prompt(for: SliceProblem(target: 14, decompositionA: 8, decompositionB: 6), themeId: "space").representationHint == .tenFrames)
+        #expect(NumberStoryGenerator.prompt(for: SliceProblem(target: 37, decompositionA: 20, decompositionB: 17), themeId: "space").representationHint == .tensAndOnes)
+        #expect(NumberStoryGenerator.prompt(for: SliceProblem(target: 250, decompositionA: 100, decompositionB: 150), themeId: "space").representationHint == .hundredsTensOnes)
+        #expect(NumberStoryGenerator.prompt(for: SliceProblem(target: 1_000, decompositionA: 400, decompositionB: 600), themeId: "space").representationHint == .thousandBlock)
+    }
+}
+
+private extension NumberStoryPrompt {
+    var searchableText: String {
+        [
+            title,
+            spokenIntro,
+            reminder,
+            successLine,
+            objectNoun,
+            leftContainer,
+            rightContainer,
+        ].joined(separator: " ")
+    }
+}

--- a/Tests/MatherTests/ProblemGeneratorTests.swift
+++ b/Tests/MatherTests/ProblemGeneratorTests.swift
@@ -22,6 +22,41 @@ struct ProblemGeneratorTests {
         #expect(config.targetRange == 1...20)
     }
 
+    @Test
+    func maxTargetClampsToOneThousand() {
+        var config = SliceConfig(maxTarget: 1_200)
+
+        #expect(config.maxTarget == 1_000)
+        #expect(config.targetRange == 1...1_000)
+
+        config.maxTarget = 2_000
+
+        #expect(config.maxTarget == 1_000)
+        #expect(config.targetRange == 1...1_000)
+    }
+
+    @Test
+    func parentTargetCapsNormalizeToMultiplesOfTen() {
+        var config = SliceConfig(maxTarget: 57)
+
+        #expect(config.maxTarget == 57)
+        #expect(config.parentTargetCap == 50)
+
+        config.parentTargetCap = 96
+
+        #expect(config.maxTarget == 90)
+        #expect(config.parentTargetCap == 90)
+
+        config.parentTargetCap = 9
+
+        #expect(config.maxTarget == 10)
+        #expect(config.parentTargetCap == 10)
+
+        config.parentTargetCap = 1_200
+
+        #expect(config.maxTarget == 1_000)
+        #expect(config.parentTargetCap == 1_000)
+    }
 
     @Test
     func deterministicGenerationRespectsParentFacingTargetCap() {
@@ -35,6 +70,18 @@ struct ProblemGeneratorTests {
     }
 
     @Test
+    func deterministicGenerationRespectsExpandedParentFacingTargetCap() {
+        let config = SliceConfig(maxProblems: 8, minTarget: 1, maxTarget: 50, showTransfer: true, audioEnabled: true, deterministicMode: true)
+
+        let problems = ProblemGenerator.generateProblems(config: config)
+
+        #expect(problems.count == 8)
+        #expect(problems.allSatisfy { (1...50).contains($0.target) })
+        #expect(problems.contains { $0.target > 20 })
+        #expect(problems.allSatisfy { $0.decompositionA + $0.decompositionB == $0.target })
+    }
+
+    @Test
     func randomGenerationRespectsUpToTenCap() {
         let config = SliceConfig(maxProblems: 12, minTarget: 1, maxTarget: 10, showTransfer: true, audioEnabled: true, deterministicMode: false)
 
@@ -42,6 +89,17 @@ struct ProblemGeneratorTests {
 
         #expect(problems.count == 12)
         #expect(problems.allSatisfy { (1...10).contains($0.target) })
+        #expect(problems.allSatisfy { $0.decompositionA + $0.decompositionB == $0.target })
+    }
+
+    @Test
+    func randomGenerationRespectsExpandedParentFacingTargetCap() {
+        let config = SliceConfig(maxProblems: 12, minTarget: 1, maxTarget: 100, showTransfer: true, audioEnabled: true, deterministicMode: false)
+
+        let problems = ProblemGenerator.generateProblems(config: config)
+
+        #expect(problems.count == 12)
+        #expect(problems.allSatisfy { (1...100).contains($0.target) })
         #expect(problems.allSatisfy { $0.decompositionA + $0.decompositionB == $0.target })
     }
 

--- a/Tests/MatherTests/SessionHistoryTests.swift
+++ b/Tests/MatherTests/SessionHistoryTests.swift
@@ -26,7 +26,7 @@ private func makeDraft(
         sessionId: sessionId,
         startedAt: startedAt,
         endedAt: startedAt.addingTimeInterval(300),
-        objectiveTitle: "Make & Break 1–20",
+        objectiveTitle: "Make & Break",
         problemsCompleted: problemsCompleted,
         firstAttemptAccuracy: accuracy,
         transferCorrectCount: transferCorrect,

--- a/wiki/Specs/Make-Break-Number-Story-Thread.md
+++ b/wiki/Specs/Make-Break-Number-Story-Thread.md
@@ -79,6 +79,8 @@ Acceptance:
 
 **Goal:** Every `SliceProblem` has a deterministic story prompt whose numbers exactly match the problem.
 
+**Implementation status:** Landed in Lane C / `feat/issue-400-c-story-prompts` as deterministic story-domain code only. Story Anchor UI/routing and AI variation remain in later milestones.
+
 Add:
 
 - `Domain/NumberStoryModels.swift`
@@ -86,7 +88,8 @@ Add:
   - `NumberStoryTemplateID`
 - `Domain/NumberStoryGenerator.swift`
   - `static func prompt(for problem: SliceProblem, themeId: String) -> NumberStoryPrompt`
-  - Curated templates for classic/vehicle themes.
+  - Curated packs for Space Cargo, Vehicle Garage, Garden Seed Shop, and Festival Prep.
+  - Number-band representation hints for singles, ten-frames, tens/ones, hundreds/tens/ones, and 1000 blocks.
 
 Rules:
 
@@ -95,13 +98,15 @@ Rules:
 - `prompt.rightPart == problem.decompositionB`.
 - Spoken intro is short, concrete, and reading-light.
 - No generated text in this milestone.
+- Theme selection is deterministic. Vehicle theme maps to Vehicle Garage; classic uses curated non-vehicle packs by target band; explicit pack IDs can request Space, Garden, or Festival.
 
 Tests:
 
 - `Tests/MatherTests/NumberStoryGeneratorTests.swift`
-  - Story numbers match `SliceProblem` for representative targets 6, 10, 14, 20.
+  - Story numbers match `SliceProblem` for representative targets 6, 10, 14, 20, 37, 100, 250, and 1000.
   - Generated story contains the exact target and both parts.
   - Deterministic output is stable for the same problem/theme.
+  - Prompt language avoids timer, pressure, shame, danger, punishment, scarcity panic, and rescue-in-danger terms.
 
 Acceptance:
 

--- a/wiki/Specs/Make-Break-Number-Storyline-Packs.md
+++ b/wiki/Specs/Make-Break-Number-Storyline-Packs.md
@@ -1,0 +1,412 @@
+# Secondary Research: Make & Break Number Storyline Packs
+
+**Issue:** #400
+**Status:** Proposed storyline catalogue
+**Date:** 2026-04-27
+
+## Purpose
+This is the second-pass research and curation layer for **Make & Break: Number Story Quest**. The goal is to turn the gameplay idea into a reusable set of storylines that help children remember the target number, understand its decomposition, and scale from small numbers to large parent-selected caps up to 1000.
+
+The storyline layer must serve the math. It should never become a long plot, a distracting cartoon wrapper, or a generated-AI free-for-all.
+
+## Research synthesis
+
+### Why story belongs here
+Story contexts are useful in early math when they make number relationships concrete and meaningful. They help children connect quantities to everyday situations and word-problem structure. For Mather, this means the story should encode the target number and two parts, then hand off quickly to concrete manipulation.
+
+This fits existing Mather research:
+- CPA first: story introduces a concrete scenario, the child manipulates objects, then symbols appear.
+- Play-based learning: math should be the play, not an interruption.
+- No mandatory reading: story is spoken first and visually represented.
+- Short sessions: story beats must be tiny.
+
+### Large numbers need concrete grouping
+For 10 and 20, individual objects are still manageable. For 100 and 1000, individual counters become noise. The storyline should shift from loose objects to grouped bundles:
+
+- ones: single items
+- tens: crates, baskets, rods, shelves, teams, rows
+- hundreds: pallets, rooms, big boxes, fields, pages
+- thousand: a festival storehouse, rocket cargo bay, library archive, kingdom treasury
+
+This aligns with Montessori-style place-value materials: units, tens, hundreds, thousands are concrete objects with different visual forms.
+
+## Storyline design rules
+
+### Non-negotiables
+1. Story must include the exact target number.
+2. If it includes parts, it must include the exact decomposition from `SliceProblem`.
+3. The story must be one action, not an episode.
+4. The child should know what object is being counted.
+5. The visual representation must preserve quantity structure.
+6. No scary, competitive, shame, danger, punishment, or scarcity pressure.
+7. No timer language.
+8. Apple Intelligence may vary wording, but cannot change math truth.
+
+### Word limits
+- Target ≤ 20: 12–22 spoken words
+- Target 30–100: 16–28 spoken words
+- Target 110–1000: 18–35 spoken words
+
+### Story grammar
+Use this deterministic grammar:
+
+```text
+[Character/team] needs [target] [objects] for [purpose].
+Put [leftPart] in/on [leftContainer] and [rightPart] in/on [rightContainer].
+```
+
+Optional simplified version for younger children:
+
+```text
+We need [target] [objects]. [leftPart] here, [rightPart] there.
+```
+
+## Number-band mapping
+
+| Band | Math focus | Story representation | Example object grouping |
+| --- | --- | --- | --- |
+| 1–10 | subitizing, make-ten, part-part-whole | single familiar objects | apples, cars, stars, fish |
+| 11–20 | teen numbers, two ten-frames | two trays / two rows | moon berries in two baskets |
+| 21–100 | tens + ones, counting by tens | crates, shelves, rows, teams | 4 crates of 10 + 7 loose |
+| 101–999 | hundreds/tens/ones | pallets, big boxes, pages, rooms | 2 hundred boxes + 5 ten crates + 3 singles |
+| 1000 | thousand as a concrete unit | one giant cube/storehouse plus subgroups | one thousand-cube cargo block |
+
+## Recommended storyline families
+
+### 1. Rocket Picnic / Space Cargo
+**Best for:** 1–1000
+**Objects:** moon berries, star bolts, rover batteries, oxygen leaves, comet stickers
+**Containers:** rocket trays, cargo crates, moon baskets, docking bays
+**Why it works:** Space supports both small fantasy objects and big cargo bundles. It scales naturally to 1000.
+
+Example small:
+> We need 14 moon berries for the rocket picnic. Put 8 in the warm basket and 6 in the blue basket.
+
+Example large:
+> The rocket needs 240 star bolts. Load 100 in the silver crate and 140 in the blue crate.
+
+Large-number visual metaphor:
+- 10 = a small tray
+- 100 = a cargo crate
+- 1000 = a full rocket cargo block
+
+### 2. Animal Rescue / Habitat Helpers
+**Best for:** 1–100
+**Objects:** fish, bird seeds, turtle snacks, leaf bundles, animal badges
+**Containers:** ponds, nests, barns, habitats
+**Why it works:** Links well to existing Memory animal/fish decks and child-friendly categories.
+
+Example:
+> The pond team needs 37 fish snacks. Put 20 by the lily pads and 17 by the rocks.
+
+Guardrail:
+Avoid “rescue in danger” framing. Use care/help language, not emergency pressure.
+
+### 3. Vehicle Garage / Delivery Depot
+**Best for:** 1–1000
+**Objects:** cars, wheels, packages, fuel stars, road cones
+**Containers:** parking bays, garages, delivery shelves, crates
+**Why it works:** The repo already has a Vehicle theme and research supports structured parking frames.
+
+Example:
+> The garage needs 20 wheels. Park 12 by the red lift and 8 by the blue lift.
+
+Large-number visual metaphor:
+- 10 = one parking row
+- 100 = one delivery pallet
+- 1000 = one full depot wall
+
+### 4. Garden / Seed Shop
+**Best for:** 1–100
+**Objects:** seeds, flowers, carrots, magic beans, watering drops
+**Containers:** garden beds, seed trays, baskets
+**Why it works:** Naturally supports grouping rows of 10 and calm non-competitive play.
+
+Example:
+> The garden needs 58 seeds. Plant 30 in the sunny bed and 28 in the shady bed.
+
+### 5. Library / Story Archive
+**Best for:** 10–1000
+**Objects:** books, pages, stickers, story cards
+**Containers:** shelves, boxes, rooms, archive carts
+**Why it works:** Excellent for large numbers because shelves/boxes/pages can represent tens and hundreds.
+
+Example:
+> The library has 250 story cards. Place 100 on the top shelf and 150 on the lower shelf.
+
+### 6. Festival / Celebration Prep
+**Best for:** 1–1000
+**Objects:** lanterns, beads, flags, sweets, flower petals
+**Containers:** trays, garlands, crates, booths
+**Why it works:** Joyful, culturally flexible, and naturally about collecting/preparing quantities.
+
+Example:
+> The festival needs 100 lanterns. Hang 60 near the stage and 40 near the gate.
+
+Guardrail:
+Avoid religious specificity unless explicitly provided as a theme pack.
+
+### 7. Ocean Lab / Aquarium
+**Best for:** 1–100
+**Objects:** fish, shells, bubbles, coral beads, sea stars
+**Containers:** tanks, tide pools, reef zones
+**Why it works:** Connects to fish feedback/future deck work; strong visual identity.
+
+Example:
+> The reef needs 27 bubbles. Send 10 to the coral cave and 17 to the turtle tunnel.
+
+### 8. Castle Workshop / Builder Guild
+**Best for:** 10–1000
+**Objects:** blocks, bricks, gems, flags, bridge stones
+**Containers:** towers, wagons, storehouses
+**Why it works:** Building naturally maps to CPA and grouped place-value representations.
+
+Example:
+> The castle needs 340 bricks. Stack 200 by the tower and 140 by the bridge.
+
+## Curation matrix
+
+| Story family | 1–10 | 11–20 | 21–100 | 101–1000 | Best first slice? |
+| --- | --- | --- | --- | --- | --- |
+| Rocket Picnic / Space Cargo | Yes | Yes | Yes | Yes | Yes |
+| Vehicle Garage / Delivery Depot | Yes | Yes | Yes | Yes | Yes |
+| Garden / Seed Shop | Yes | Yes | Yes | Maybe | Yes |
+| Festival Prep | Yes | Yes | Yes | Yes | Yes |
+| Animal Habitat Helpers | Yes | Yes | Yes | No | Later |
+| Library / Story Archive | Maybe | Yes | Yes | Yes | Later |
+| Ocean Lab / Aquarium | Yes | Yes | Yes | No | Later |
+| Castle Workshop | Maybe | Yes | Yes | Yes | Later |
+
+Recommended first shipped set:
+1. Space Cargo
+2. Vehicle Garage
+3. Garden Seed Shop
+4. Festival Prep
+
+These cover fantasy, existing vehicle theme, calm nature, and celebration.
+
+## Example prompts by target
+
+### Target 8: `3 + 5`
+Family: Garden
+- Title: “Seed Tray”
+- Spoken intro: “We need 8 magic seeds. Plant 3 in the sunny bed and 5 in the shady bed.”
+- Reminder: “Remember: 8 seeds.”
+- Success: “Yes — 3 and 5 grow into 8 seeds.”
+- Retell check: “How many seeds did the garden need?”
+
+### Target 14: `8 + 6`
+Family: Space
+- Title: “Rocket Picnic”
+- Spoken intro: “We need 14 moon berries. Put 8 in the warm basket and 6 in the blue basket.”
+- Reminder: “Remember: 14 moon berries.”
+- Success: “Yes — 8 and 6 make the 14-berry picnic.”
+- Sum Story Match cards: `8 + 6`, `14`, `moon berries`
+
+### Target 37: `20 + 17`
+Family: Ocean
+- Title: “Reef Bubbles”
+- Spoken intro: “The reef needs 37 bubbles. Send 20 to the coral cave and 17 to the turtle tunnel.”
+- Reminder: “Remember: 37 reef bubbles.”
+- Representation: two ten-bundles plus 17 as one ten-bundle and seven singles.
+
+### Target 100: `60 + 40`
+Family: Festival
+- Title: “Lantern Night”
+- Spoken intro: “The festival needs 100 lanterns. Hang 60 near the stage and 40 near the gate.”
+- Reminder: “Remember: 100 lanterns.”
+- Representation: ten bundles of 10 lanterns; split as 6 bundles and 4 bundles.
+
+### Target 250: `100 + 150`
+Family: Library
+- Title: “Story Archive”
+- Spoken intro: “The library has 250 story cards. Place 100 on the top shelf and 150 on the lower shelf.”
+- Reminder: “Remember: 250 story cards.”
+- Representation: 2 hundred boxes + 5 ten packs; split by shelves.
+
+### Target 1000: `400 + 600`
+Family: Space Cargo
+- Title: “Rocket Storehouse”
+- Spoken intro: “The rocket needs 1000 star bolts. Load 400 in the silver bay and 600 in the blue bay.”
+- Reminder: “Remember: 1000 star bolts.”
+- Representation: ten hundred-crates; split as 4 crates and 6 crates.
+
+## Storyline data model proposal
+
+```swift
+struct NumberStoryPack: Identifiable, Codable, Equatable {
+    let id: String
+    let displayName: String
+    let supportedRange: ClosedRange<Int>
+    let objectNouns: [String]
+    let containerPairs: [(left: String, right: String)]
+    let purposeTemplates: [String]
+    let representationHint: StoryRepresentationHint
+}
+
+enum StoryRepresentationHint: String, Codable {
+    case singles
+    case tenFrames
+    case tensAndOnes
+    case hundredsTensOnes
+}
+
+struct NumberStoryPrompt: Identifiable, Codable, Equatable {
+    let id: UUID
+    let packId: String
+    let title: String
+    let target: Int
+    let leftPart: Int
+    let rightPart: Int
+    let objectNoun: String
+    let leftContainer: String
+    let rightContainer: String
+    let spokenIntro: String
+    let reminder: String
+    let success: String
+    let representationHint: StoryRepresentationHint
+}
+```
+
+## Apple Intelligence prompt contract
+
+Apple Intelligence can rewrite within a strict envelope. It should receive structured numbers and a selected pack, then return only story copy.
+
+### Request
+```json
+{
+  "target": 37,
+  "leftPart": 20,
+  "rightPart": 17,
+  "pack": "ocean_lab",
+  "objectNoun": "bubbles",
+  "leftContainer": "coral cave",
+  "rightContainer": "turtle tunnel",
+  "maxWords": 24,
+  "readingLevel": "spoken-preschool"
+}
+```
+
+### Required validation
+Reject generated output unless:
+- it contains the target number exactly once or clearly once
+- it contains both parts if parts are requested
+- it contains no additional numbers except the provided ones
+- it is under the word limit
+- it contains no negative/fear/punishment language
+- it has no external factual claims that require verification
+
+### Fallback
+Always keep deterministic curated templates. AI is an enhancer, not a dependency.
+
+## Interaction placement
+
+### Before the problem
+Story Anchor card:
+- big target number
+- story object illustration
+- spoken intro
+- “I remember” / “Let’s make it” button
+
+### During Make It
+- small persistent reminder pill: “14 moon berries”
+- no long story text
+
+### During Gravity Split
+- containers named from story: warm basket / blue basket, coral cave / turtle tunnel
+
+### During Sum Story Match
+Cards can be:
+- expression: `8 + 6`
+- total: `14`
+- story icon/card: `moon berries`
+
+### After problem
+Optional retell check:
+- “How many moon berries did we need?”
+- three choices: target, near-lower, near-higher
+- no penalty; if wrong, replay reminder
+
+## Anti-patterns
+
+Do not ship:
+- “The dragon is angry unless you solve 14.”
+- “Hurry before the rocket leaves.”
+- “You lost 6 berries.”
+- Long multi-step stories requiring memory beyond the number.
+- AI-generated factual science explanations inside Make & Break.
+- Showing 1000 individual objects.
+
+## Recommended execution split
+
+### Slice B1 — deterministic story packs
+- Add `NumberStoryPack` and curated packs for Space, Vehicle, Garden, Festival.
+- Generate story prompt from `SliceProblem`.
+- Unit tests for exact number consistency and no extra numbers.
+
+### Slice B2 — Story Anchor UI
+- Add Story Anchor pre-stage/card.
+- Speak intro before Make It.
+- Add persistent reminder pill.
+
+### Slice B3 — grouped representation design
+- Implement representation hints for `10`, `20`, `30...100`, `101...1000`.
+- Do not overload current counter grid.
+
+### Slice B4 — story-aware stage vocabulary
+- Rename containers and prompts in Gravity Split / Sum Sprint from generic terms to story terms.
+- Keep fallback generic copy.
+
+### Slice D1 — AI variation adapter
+- Add bounded `NumberStoryAIAdapter`.
+- Validate output strictly.
+- Prove fallback behavior.
+
+## Recommended issue update
+Add this storyline pack artifact to #400 and make Slice B explicitly about deterministic curated story packs before AI.
+
+
+## Addendum from secondary synthesis
+
+### Additional candidate packs
+
+#### Train Ticket Station
+**Best for:** 20–1000
+**Objects:** tickets, seats, cargo tags
+**Containers:** platform A / platform B, front train / back train
+**Why it works:** strong for tens/hundreds grouping through ticket books, seat rows, and cargo crates.
+
+Example:
+> The train needs 37 tickets. Load 30 on platform A and 7 on platform B.
+
+#### Robot Workshop
+**Best for:** 20–1000
+**Objects:** bolts, chips, buttons
+**Containers:** build tray / repair tray
+**Why it works:** maps naturally to base-ten blocks and large-number guided mode.
+
+Example:
+> The robot workshop needs 250 bolts. Put 200 on the build tray and 50 on the repair tray.
+
+#### Treasure Shelves
+**Best for:** 1–1000
+**Objects:** gems, stickers, tokens
+**Containers:** gold shelf / blue shelf
+**Why it works:** highly motivating, but must avoid pirate/threat/stealing language.
+
+Example:
+> The treasure shelf needs 1000 gems. Put 600 on the gold shelf and 400 on the blue shelf.
+
+### Decomposition bias by band
+
+| Target band | Preferred early splits | Avoid early |
+| --- | --- | --- |
+| 1–10 | nonzero pairs, make-5, make-10, doubles/near-doubles | too many zero splits |
+| 11–20 | 10+n, 8+6, 9+5, near-ten pairs | arbitrary teen splits before two-ten-frame model is clear |
+| 30–100 | tens+ones, friendly tens, multiples of 10 | noisy splits like 43+29 before place value is explicit |
+| 101–200 | 100+n, clean tens | ones-heavy split without grouped representation |
+| 210–500 | 100s + 10s, multiples of 50/100 | unstructured arbitrary decomposition |
+| 510–1000 | hundreds splits such as 600+400 | showing 1000 individual items |
+
+### Product rule
+The parent-selected cap is a ceiling, not a demand that every problem be near the ceiling. For high caps, ramp deliberately and label the experience as guided/older-kid mode.


### PR DESCRIPTION
## Summary
- integrates Lane B grouped high-target representation from #405
- integrates Lane C deterministic number story prompts/storyline packs from #407
- keeps math truth deterministic from `SliceProblem.target`, `decompositionA`, and `decompositionB`
- prevents high target flows from rendering 1000 loose counters

This is the mainline integration PR because #405 and #407 were intentionally stacked onto the target-cap branch after #404 had already landed.

## Validation
- #405: Build & Test, workflow analysis, Dependency Review, and CodeQL passed before merge into the feature branch
- #407: Build & Test, workflow analysis, Dependency Review, and CodeQL passed before merge into the feature branch
- Integration CI will validate the combined feature-branch diff against `main`

Issue #400 Lanes B/C integration.
