### PR TITLE
Make VS1 recall stages story-aware

### DIFF
--- a/Domain/NumberStoryStageVocabulary.swift
+++ b/Domain/NumberStoryStageVocabulary.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+enum NumberStoryStage {
+    case gravitySplit
+    case sumSprint
+    case bondBlast
+}
+
+struct NumberStoryStageVocabulary: Equatable {
+    let title: String
+    let targetReminder: String
+    let instruction: String
+    let leftLabel: String
+    let rightLabel: String
+    let accessibilityLabel: String
+
+    static func vocabulary(for prompt: NumberStoryPrompt, stage: NumberStoryStage) -> NumberStoryStageVocabulary {
+        switch stage {
+        case .gravitySplit:
+            return NumberStoryStageVocabulary(
+                title: "Gravity Split",
+                targetReminder: "\(prompt.target) \(prompt.objectNoun)",
+                instruction: "Split \(prompt.target) \(prompt.objectNoun): \(prompt.leftPart) in \(prompt.leftContainer), \(prompt.rightPart) in \(prompt.rightContainer).",
+                leftLabel: prompt.leftContainer.capitalized,
+                rightLabel: prompt.rightContainer.capitalized,
+                accessibilityLabel: "Gravity Split. Split \(prompt.target) \(prompt.objectNoun). \(prompt.leftPart) in \(prompt.leftContainer). \(prompt.rightPart) in \(prompt.rightContainer)."
+            )
+        case .sumSprint:
+            return NumberStoryStageVocabulary(
+                title: "Story Matches",
+                targetReminder: "\(prompt.target) \(prompt.objectNoun)",
+                instruction: "Match each story number sentence to \(prompt.target) \(prompt.objectNoun).",
+                leftLabel: "Sentence",
+                rightLabel: "Total",
+                accessibilityLabel: "Story Matches. Match story number sentences to \(prompt.target) \(prompt.objectNoun)."
+            )
+        case .bondBlast:
+            return NumberStoryStageVocabulary(
+                title: "Bond Blast!",
+                targetReminder: "\(prompt.target) \(prompt.objectNoun)",
+                instruction: "Match pairs that make \(prompt.target) \(prompt.objectNoun).",
+                leftLabel: "Pick",
+                rightLabel: "Match",
+                accessibilityLabel: "Bond Blast matching board. Match pairs that make \(prompt.target) \(prompt.objectNoun)."
+            )
+        }
+    }
+
+    static func fallback(stage: NumberStoryStage, target: Int) -> NumberStoryStageVocabulary {
+        switch stage {
+        case .gravitySplit:
+            return NumberStoryStageVocabulary(
+                title: "Gravity Split",
+                targetReminder: "Make \(target)",
+                instruction: "Use plus and minus to build the split from zero.",
+                leftLabel: "Left",
+                rightLabel: "Right",
+                accessibilityLabel: "Balance scale. Make \(target)."
+            )
+        case .sumSprint:
+            return NumberStoryStageVocabulary(
+                title: "Sum Sprint",
+                targetReminder: "Make \(target)",
+                instruction: "Tap a sum sentence, then tap its total.",
+                leftLabel: "Sentence",
+                rightLabel: "Total",
+                accessibilityLabel: "Sum Sprint. Match each sum sentence to its total."
+            )
+        case .bondBlast:
+            return NumberStoryStageVocabulary(
+                title: "Bond Blast!",
+                targetReminder: "Make \(target)",
+                instruction: "Match the pairs that make \(target).",
+                leftLabel: "Pick",
+                rightLabel: "Match",
+                accessibilityLabel: "Bond Blast matching board. Make \(target)."
+            )
+        }
+    }
+}

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -94,6 +94,11 @@ final class VerticalSliceEngine {
         return problems[currentProblemIndex]
     }
 
+    var currentNumberStoryPrompt: NumberStoryPrompt? {
+        guard let currentProblem else { return nil }
+        return NumberStoryGenerator.prompt(for: currentProblem, themeId: featureFlags.selectedThemeId)
+    }
+
     var progressLabel: String {
         guard !problems.isEmpty else { return "0 / 0" }
         return "\(min(currentProblemIndex + 1, problems.count)) / \(problems.count)"
@@ -737,17 +742,30 @@ final class VerticalSliceEngine {
         case .concrete:
             return activeTheme.concretePrompt(target: currentProblem.target)
         case .pictorial, .bondMatch:
+            if let prompt = currentNumberStoryPrompt {
+                return NumberStoryStageVocabulary.vocabulary(for: prompt, stage: .bondBlast).instruction
+            }
             return "Bond Blast! Match the pairs that make \(currentProblem.target)!"
         case .sumSprint:
-            if let burst = sumSprintBurstState {
-                return "Quick Sum Sprint. Match each sum sentence to its total: \(burst.progressLabel) pairs found."
+            if let prompt = currentNumberStoryPrompt {
+                let vocabulary = NumberStoryStageVocabulary.vocabulary(for: prompt, stage: .sumSprint)
+                if let burst = sumSprintBurstState {
+                    return "\(vocabulary.instruction) Matches \(burst.progressLabel)."
+                }
+                return vocabulary.instruction
             }
-            return "Quick Sum Sprint! Match each sum sentence to its total, then finish with Bond Blast."
+            if let burst = sumSprintBurstState {
+                return "Sum Sprint. Match each sum sentence to its total: \(burst.progressLabel) pairs found."
+            }
+            return "Sum Sprint. Match each sum sentence to its total, then finish with Bond Blast."
         case .abstract:
             return activeTheme.abstractPrompt()
         case .transfer:
             return "Show the same two parts with counters."
         case .gravitySplit:
+            if let prompt = currentNumberStoryPrompt {
+                return NumberStoryStageVocabulary.vocabulary(for: prompt, stage: .gravitySplit).instruction
+            }
             let a = currentProblem.decompositionA
             let b = currentProblem.decompositionB
             return "Use plus and minus to build \(a) on one side and \(b) on the other."
@@ -775,7 +793,10 @@ final class VerticalSliceEngine {
 
     private func successMessage(for stage: SliceStage, problem: SliceProblem) -> String {
         if stage == .sumSprint {
-            return "Nice burst! Now finish with Bond Blast for \(problem.target)."
+            if let prompt = currentNumberStoryPrompt {
+                return "Nice match. Now make pairs for \(prompt.target) \(prompt.objectNoun)."
+            }
+            return "Nice match. Now finish with Bond Blast for \(problem.target)."
         }
         return activeTheme.stageSuccessPhrase(for: stage, target: problem.target)
     }
@@ -792,6 +813,9 @@ final class VerticalSliceEngine {
                 return "Try tapping the \(activeTheme.counterNoun) one by one until you reach \(problem.target)."
             }
         case .pictorial, .bondMatch:
+            if let prompt = currentNumberStoryPrompt {
+                return "Try another pair that makes \(prompt.target) \(prompt.objectNoun)."
+            }
             return "Try another pair. Look for two numbers that add up to \(problem.target)."
         case .abstract:
             if attempts == 1 {
@@ -810,9 +834,15 @@ final class VerticalSliceEngine {
                 return "Build the same equation again with counters, one group on each side."
             }
         case .gravitySplit:
+            if let prompt = currentNumberStoryPrompt {
+                return "Keep building the split. Put \(prompt.leftPart) in \(prompt.leftContainer) and \(prompt.rightPart) in \(prompt.rightContainer)."
+            }
             return "Keep building the split. Put \(problem.decompositionA) on one side and \(problem.decompositionB) on the other."
         case .sumSprint:
-            return "Keep going. Finish this quick sprint before Bond Blast."
+            if let prompt = currentNumberStoryPrompt {
+                return "Keep matching story sentences for \(prompt.target) \(prompt.objectNoun)."
+            }
+            return "Keep matching sum sentences before Bond Blast."
         case .done:
             return "Try again."
         }

--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -21,6 +21,7 @@ struct BondMatchView: View {
     // MARK: - Inputs
 
     let state: BondMatchState
+    let storyPrompt: NumberStoryPrompt?
     let tiltPitch: Double
     let tiltRoll: Double
     let shakeDetected: Bool
@@ -60,6 +61,13 @@ struct BondMatchView: View {
     private var cardSize: CGFloat { ResponsiveLayout.isWide(horizontalSizeClass) ? 110 : 88 }
     private let cardSpacing: CGFloat = 12
 
+    private var vocabulary: NumberStoryStageVocabulary {
+        if let storyPrompt {
+            return NumberStoryStageVocabulary.vocabulary(for: storyPrompt, stage: .bondBlast)
+        }
+        return NumberStoryStageVocabulary.fallback(stage: .bondBlast, target: state.target)
+    }
+
     // MARK: - Tilt drift
 
     /// Subtle positional drift applied to unselected, unmatched left cards.
@@ -96,21 +104,21 @@ struct BondMatchView: View {
             onClapHandled()
         }
         .sensoryFeedback(.success, trigger: state.matchCount)
-        .accessibilityLabel("Bond Blast matching board. Make \(state.target). \(state.matchCount) of \(state.pairs.count) matched.")
+        .accessibilityLabel("\(vocabulary.accessibilityLabel) \(state.matchCount) of \(state.pairs.count) matched.")
     }
 
     // MARK: - Subviews
 
     private var headerView: some View {
         VStack(spacing: 6) {
-            Text("Bond Blast!")
+            Text(vocabulary.title)
                 .font(.system(size: 28, weight: .black, design: .rounded))
                 .foregroundStyle(MatherTheme.accent)
                 .accessibilityAddTraits(.isHeader)
-            Text("Make \(state.target)")
+            Text(vocabulary.targetReminder)
                 .font(.title2.weight(.bold))
                 .foregroundStyle(MatherTheme.warm)
-            Text(selectedPairId == nil ? "Pick a number first" : "Now find its match")
+            Text(selectedPairId == nil ? vocabulary.instruction : "Now find its match")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.secondary)
         }
@@ -121,7 +129,7 @@ struct BondMatchView: View {
         HStack(alignment: .top, spacing: 16) {
             // Left column: selectable source cards
             VStack(spacing: cardSpacing) {
-                columnLabel("Pick")
+                columnLabel(vocabulary.leftLabel)
                 ForEach(state.pairs) { pair in
                     leftCard(pair: pair)
                 }
@@ -138,7 +146,7 @@ struct BondMatchView: View {
 
             // Right column: shuffle targets (complement values)
             VStack(spacing: cardSpacing) {
-                columnLabel("Match")
+                columnLabel(vocabulary.rightLabel)
                 ForEach(shuffledRightValues, id: \.self) { rightVal in
                     rightCard(value: rightVal)
                 }

--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -10,6 +10,7 @@ struct GravitySplitView: View {
     // MARK: - Inputs
 
     let state: GravitySplitState
+    let storyPrompt: NumberStoryPrompt?
     let tiltRoll: Double
     let shakeDetected: Bool
     let onAdjustTilt: (Double) -> Void
@@ -36,6 +37,13 @@ struct GravitySplitView: View {
         let solvedBias = Double(state.decompositionA - state.decompositionB) / Double(max(state.target, 1))
         let builtBias = Double(state.leftCount - state.rightCount) / Double(max(state.target, 1))
         return (solvedBias - builtBias) * maxBeamAngle
+    }
+
+    private var vocabulary: NumberStoryStageVocabulary {
+        if let storyPrompt {
+            return NumberStoryStageVocabulary.vocabulary(for: storyPrompt, stage: .gravitySplit)
+        }
+        return NumberStoryStageVocabulary.fallback(stage: .gravitySplit, target: state.target)
     }
 
     // MARK: - Body
@@ -75,7 +83,7 @@ struct GravitySplitView: View {
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(
-            "Balance scale. Make \(state.target). Left: \(state.leftCount). Right: \(state.rightCount)."
+            "\(vocabulary.accessibilityLabel) \(vocabulary.leftLabel): \(state.leftCount). \(vocabulary.rightLabel): \(state.rightCount)."
         )
     }
 
@@ -84,9 +92,13 @@ struct GravitySplitView: View {
     private var headerRow: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Gravity Split")
+                Text(vocabulary.title)
                     .font(.title2.weight(.black))
                     .foregroundStyle(MatherTheme.coral)
+
+                Text(vocabulary.targetReminder)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(MatherTheme.warm)
 
                 HStack(spacing: 8) {
                     counterPill(value: state.leftCount, fill: MatherTheme.warm)
@@ -240,7 +252,7 @@ struct GravitySplitView: View {
     private var tapControlRow: some View {
         HStack(spacing: 12) {
             panControlButtons(
-                label: "Left",
+                label: vocabulary.leftLabel,
                 fill: MatherTheme.warm,
                 side: "left",
                 canDecrement: state.leftCount > 0 && !state.isLocked,
@@ -251,7 +263,7 @@ struct GravitySplitView: View {
             }
 
             panControlButtons(
-                label: "Right",
+                label: vocabulary.rightLabel,
                 fill: MatherTheme.accent,
                 side: "right",
                 canDecrement: state.rightCount > 0 && !state.isLocked,
@@ -280,6 +292,9 @@ struct GravitySplitView: View {
             Text(label)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(fill)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+                .minimumScaleFactor(0.75)
                 .frame(minWidth: 38)
             LazyVGrid(columns: [GridItem(.adaptive(minimum: state.target <= 20 ? 48 : 82), spacing: 6)], spacing: 6) {
                 ForEach(steps, id: \.self) { step in
@@ -327,7 +342,7 @@ struct GravitySplitView: View {
             Image(systemName: "gyroscope")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MatherTheme.coral.opacity(0.8))
-            Text("Use plus and minus to build the split from zero")
+            Text(vocabulary.instruction)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MatherTheme.cardSubtitle)
         }

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -89,6 +89,7 @@ struct SliceSessionView: View {
             if let bondState = appModel.engine.bondMatchState {
                 BondMatchView(
                     state: bondState,
+                    storyPrompt: appModel.engine.currentNumberStoryPrompt,
                     tiltPitch: appModel.motionService.tiltPitch,
                     tiltRoll: appModel.motionService.tiltRoll,
                     shakeDetected: appModel.motionService.shakeDetected,
@@ -139,6 +140,7 @@ struct SliceSessionView: View {
             if let splitState = appModel.engine.gravitySplitState {
                 GravitySplitView(
                     state: splitState,
+                    storyPrompt: appModel.engine.currentNumberStoryPrompt,
                     tiltRoll: appModel.motionService.tiltRoll,
                     shakeDetected: appModel.motionService.shakeDetected,
                     onAdjustTilt: appModel.engine.adjustGravitySplitByTilt,
@@ -153,14 +155,18 @@ struct SliceSessionView: View {
             }
         case .sumSprint:
             if let burst = appModel.engine.sumSprintBurstState {
+                let vocabulary = sumSprintVocabulary(target: burst.target)
                 CardSurface {
                     VStack(alignment: .leading, spacing: 16) {
-                        Text("Sum Sprint")
+                        Text(vocabulary.title)
                             .font(.title.weight(.black))
+                        Text(vocabulary.targetReminder)
+                            .font(.headline.weight(.bold))
+                            .foregroundStyle(MatherTheme.warm)
                         Text("Matches \(burst.progressLabel)")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.secondary)
-                        Text("Tap a sum sentence, then tap its total.")
+                        Text(vocabulary.instruction)
                             .font(.headline)
                         LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), spacing: 12)], spacing: 12) {
                             ForEach(burst.cards) { card in
@@ -180,6 +186,7 @@ struct SliceSessionView: View {
                                         }
                                 }
                                 .accessibilityIdentifier(sumSprintCardIdentifier(for: card, in: burst))
+                                .accessibilityLabel(sumSprintCardAccessibilityLabel(for: card, vocabulary: vocabulary))
                                 .buttonStyle(.plain)
                                 .disabled(card.isMatched)
                             }
@@ -193,6 +200,7 @@ struct SliceSessionView: View {
             if let bondState = appModel.engine.bondMatchState {
                 BondMatchView(
                     state: bondState,
+                    storyPrompt: appModel.engine.currentNumberStoryPrompt,
                     tiltPitch: appModel.motionService.tiltPitch,
                     tiltRoll: appModel.motionService.tiltRoll,
                     shakeDetected: appModel.motionService.shakeDetected,
@@ -242,6 +250,20 @@ struct SliceSessionView: View {
 
     private func cardForeground(for card: SumSprintBurstCard) -> Color {
         card.isMatched ? MatherTheme.softBlue : .primary
+    }
+
+    private func sumSprintVocabulary(target: Int) -> NumberStoryStageVocabulary {
+        if let prompt = appModel.engine.currentNumberStoryPrompt {
+            return NumberStoryStageVocabulary.vocabulary(for: prompt, stage: .sumSprint)
+        }
+        return NumberStoryStageVocabulary.fallback(stage: .sumSprint, target: target)
+    }
+
+    private func sumSprintCardAccessibilityLabel(
+        for card: SumSprintBurstCard,
+        vocabulary: NumberStoryStageVocabulary
+    ) -> String {
+        "\(vocabulary.accessibilityLabel) Card \(card.content.displayText)\(card.isMatched ? ", matched" : "")"
     }
 
     private var header: some View {

--- a/Tests/MatherTests/NumberStoryStageVocabularyTests.swift
+++ b/Tests/MatherTests/NumberStoryStageVocabularyTests.swift
@@ -1,0 +1,109 @@
+import Testing
+@testable import Mather
+
+struct NumberStoryStageVocabularyTests {
+    @Test
+    func gravitySplitVocabularyUsesExactStoryTargetAndParts() {
+        let problem = SliceProblem(target: 14, decompositionA: 8, decompositionB: 6)
+        let prompt = NumberStoryGenerator.prompt(for: problem, themeId: "space")
+
+        let vocabulary = NumberStoryStageVocabulary.vocabulary(for: prompt, stage: .gravitySplit)
+        let searchableText = vocabulary.searchableText
+
+        #expect(searchableText.contains("14"))
+        #expect(searchableText.contains("8"))
+        #expect(searchableText.contains("6"))
+        #expect(searchableText.contains(prompt.objectNoun))
+        #expect(searchableText.contains(prompt.leftContainer))
+        #expect(searchableText.contains(prompt.rightContainer))
+        #expect(prompt.target == problem.target)
+        #expect(prompt.leftPart == problem.decompositionA)
+        #expect(prompt.rightPart == problem.decompositionB)
+    }
+
+    @Test
+    func recallVocabularyUsesStoryTargetWithoutChangingMathTruth() {
+        let problem = SliceProblem(target: 20, decompositionA: 12, decompositionB: 8)
+        let prompt = NumberStoryGenerator.prompt(for: problem, themeId: "vehicle")
+
+        let sumVocabulary = NumberStoryStageVocabulary.vocabulary(for: prompt, stage: .sumSprint)
+        let bondVocabulary = NumberStoryStageVocabulary.vocabulary(for: prompt, stage: .bondBlast)
+        let burst = SumSprintBurstState.make(for: problem)
+        let bondPairs = BondMatchState.makePairs(for: problem.target)
+
+        #expect(sumVocabulary.searchableText.contains("20"))
+        #expect(sumVocabulary.searchableText.contains(prompt.objectNoun))
+        #expect(bondVocabulary.searchableText.contains("20"))
+        #expect(bondVocabulary.searchableText.contains(prompt.objectNoun))
+        #expect(burst.target == problem.target)
+        #expect(burst.cards.allSatisfy { card in
+            switch card.content {
+            case .prompt:
+                return true
+            case .sum(let value):
+                return value == problem.target
+            }
+        })
+        #expect(bondPairs.allSatisfy { $0.left + $0.right == problem.target })
+    }
+
+    @Test
+    func storyStageVocabularyAvoidsPressureAndDangerLanguage() {
+        let bannedTerms = [
+            "timer",
+            "hurry",
+            "fast",
+            "race",
+            "sprint",
+            "lose",
+            "lost",
+            "wrong",
+            "shame",
+            "scary",
+            "danger",
+            "rescue",
+            "punish",
+            "punishment",
+            "emergency",
+            "before it is too late",
+        ]
+        let problems = [
+            SliceProblem(target: 6, decompositionA: 2, decompositionB: 4),
+            SliceProblem(target: 10, decompositionA: 7, decompositionB: 3),
+            SliceProblem(target: 37, decompositionA: 20, decompositionB: 17),
+            SliceProblem(target: 100, decompositionA: 60, decompositionB: 40),
+            SliceProblem(target: 1_000, decompositionA: 400, decompositionB: 600),
+        ]
+        let themeIds = ["classic", "space", "vehicle", "garden", "festival"]
+        let stages: [NumberStoryStage] = [.gravitySplit, .sumSprint, .bondBlast]
+
+        for problem in problems {
+            for themeId in themeIds {
+                let prompt = NumberStoryGenerator.prompt(for: problem, themeId: themeId)
+                for stage in stages {
+                    let text = NumberStoryStageVocabulary
+                        .vocabulary(for: prompt, stage: stage)
+                        .searchableText
+                        .lowercased()
+
+                    for term in bannedTerms {
+                        #expect(!text.contains(term))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private extension NumberStoryStageVocabulary {
+    var searchableText: String {
+        [
+            title,
+            targetReminder,
+            instruction,
+            leftLabel,
+            rightLabel,
+            accessibilityLabel,
+        ].joined(separator: " ")
+    }
+}

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -277,7 +277,7 @@ struct ThemeTests {
         // The pictorial slot now uses Bond Blast copy rather than the theme-specific split prompt.
         engine.adjustConcrete(by: engine.currentProblem?.target ?? 0)
         engine.submitCurrentStage()
-        let expected = "Bond Blast! Match the pairs that make 6!"
+        let expected = "Match pairs that make 6 seeds."
         await waitFor("bond blast prompt after concrete submit") {
             engine.feedbackMessage == expected
         }

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -476,11 +476,15 @@ final class ScreenshotTests: XCTestCase {
             gravityGoButton.tap()
         }
 
+        let leftPlus = app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", "gravity-left-plus")).firstMatch
+        let rightPlus = app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", "gravity-right-plus")).firstMatch
         for _ in 0..<leftPanCount {
-            app.buttons["gravity-left-plus"].tap()
+            XCTAssertTrue(leftPlus.waitForExistence(timeout: 5), "Expected a left gravity increment button")
+            leftPlus.tap()
         }
         for _ in 0..<rightPanCount {
-            app.buttons["gravity-right-plus"].tap()
+            XCTAssertTrue(rightPlus.waitForExistence(timeout: 5), "Expected a right gravity increment button")
+            rightPlus.tap()
         }
 
         let sumSprintTitle = app.staticTexts["Sum Sprint"]

--- a/wiki/Specs/Make-Break-Number-Story-Thread.md
+++ b/wiki/Specs/Make-Break-Number-Story-Thread.md
@@ -2,7 +2,7 @@
 
 **Status:** Implementation-ready plan for issue #400  
 **Issue:** https://github.com/ganesh47/mather/issues/400  
-**Lane:** mather-124dc7028c  
+**Lane:** lane-e-story-vocabulary in progress
 **Last updated:** 2026-04-27
 
 ## Scope lock
@@ -146,6 +146,8 @@ Acceptance:
 - Story Anchor is not a quiz/failure gate.
 
 ### M3 — Story-aware Sum Sprint and Bond Blast recall
+
+**Lane E status:** Gravity Split, embedded Sum Sprint, and Bond Blast now use `NumberStoryStageVocabulary` to derive child-facing story labels, instructions, and accessibility reminders from `NumberStoryPrompt`. Math truth remains owned by `SliceProblem`, `SumSprintBurstState.make(for:)`, and `BondMatchState.makePairs(for:)`.
 
 **Goal:** Reinforce the same story target during recall stages.
 


### PR DESCRIPTION
## Summary
- Add `NumberStoryStageVocabulary` for story-safe Gravity Split, embedded Sum Sprint, and Bond Blast copy derived from `NumberStoryPrompt`.
- Thread the current prompt into Gravity Split, Sum Sprint UI, and Bond Blast without changing `SliceProblem`, `SumSprintBurstState`, or `BondMatchState` math truth.
- Add unit coverage for exact story target/parts, preserved card/pair math, and banned pressure/danger language.
- Update the #400 story-thread spec with Lane E status.

## Validation
- `git diff --check` passed.
- Source scan passed for new pressure/danger terms in touched runtime files.
- Swift/Xcode tests not run locally: this worker has no `xcodegen`, `xcodebuild`, or `swift` executable on PATH, so the generated `.xcodeproj` was intentionally left untouched per repo instructions.