### PR TITLE
Add story anchor stage for Make & Break V2

### DIFF
--- a/Domain/ClassicTheme.swift
+++ b/Domain/ClassicTheme.swift
@@ -25,6 +25,7 @@ struct ClassicTheme: SliceTheme {
 
     func stageSuccessPhrase(for stage: SliceStage, target: Int) -> String {
         switch stage {
+        case .storyAnchor: return "Story ready."
         case .concrete:   return "Yes. You made \(target)."
         case .pictorial:  return "That break still makes \(target)."
         case .abstract:   return "Your equation matches the split."

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftData
 
 enum SliceStage: String, Codable, CaseIterable, Identifiable {
+    case storyAnchor
     case concrete
     case pictorial
     case abstract
@@ -15,6 +16,7 @@ enum SliceStage: String, Codable, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
+        case .storyAnchor: "Story"
         case .concrete:     "Make it"
         case .pictorial:    "Bond Blast!"
         case .abstract:     "Write it"

--- a/Domain/SliceStateMachine.swift
+++ b/Domain/SliceStateMachine.swift
@@ -11,6 +11,7 @@ enum SliceStateMachine {
         switch routeMode {
         case .makeBreakLoopV2:
             switch stage {
+            case .storyAnchor: return .concrete
             case .concrete: return .gravitySplit
             case .gravitySplit: return .sumSprint
             case .sumSprint: return .bondMatch
@@ -51,6 +52,8 @@ enum SliceStateMachine {
         guard success else { return stage }
 
         switch stage {
+        case .storyAnchor:
+            return .concrete
         case .concrete:
             if makeBreakLoopV2Enabled { return .gravitySplit }
             return .pictorial

--- a/Domain/VehicleSpec.swift
+++ b/Domain/VehicleSpec.swift
@@ -36,6 +36,7 @@ extension VehicleSpec {
         transferPromptFn: { _, _ in "Park the cars to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
+            case .storyAnchor: return "Story ready."
             case .concrete:   return "You filled the garage!"
             case .pictorial:  return "Both zones together make the same number."
             case .abstract:   return "Your equation matches the split."
@@ -61,6 +62,7 @@ extension VehicleSpec {
         transferPromptFn: { _, _ in "Park the trucks to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
+            case .storyAnchor: return "Story ready."
             case .concrete:   return "All trucks loaded!"
             case .pictorial:  return "Both groups add up to the same number."
             case .abstract:   return "Your equation matches the split."
@@ -86,6 +88,7 @@ extension VehicleSpec {
         transferPromptFn: { _, _ in "Park the vans to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
+            case .storyAnchor: return "Story ready."
             case .concrete:   return "Warehouse full!"
             case .pictorial:  return "Both routes carry the same total."
             case .abstract:   return "Your equation matches the split."
@@ -111,6 +114,7 @@ extension VehicleSpec {
         transferPromptFn: { _, _ in "Park the buses to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
+            case .storyAnchor: return "Story ready."
             case .concrete:   return "All aboard!"
             case .pictorial:  return "Both stops total the same."
             case .abstract:   return "Your equation matches the split."
@@ -136,6 +140,7 @@ extension VehicleSpec {
         transferPromptFn: { _, _ in "Place the bulldozers to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
+            case .storyAnchor: return "Story ready."
             case .concrete:   return "Site ready!"
             case .pictorial:  return "Both zones cover the same total."
             case .abstract:   return "Your equation matches the split."
@@ -161,6 +166,7 @@ extension VehicleSpec {
         transferPromptFn: { _, _ in "Land the helicopters to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
+            case .storyAnchor: return "Story ready."
             case .concrete:   return "All landed!"
             case .pictorial:  return "Both pads together hold the same total."
             case .abstract:   return "Your equation matches the split."
@@ -186,6 +192,7 @@ extension VehicleSpec {
         transferPromptFn: { _, _ in "Park the planes to show the same total from memory." },
         stageSuccessFn: { stage, _ in
             switch stage {
+            case .storyAnchor: return "Story ready."
             case .concrete:   return "All planes at the gate!"
             case .pictorial:  return "Both terminals hold the same total."
             case .abstract:   return "Your equation matches the split."

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -99,6 +99,10 @@ final class VerticalSliceEngine {
         return NumberStoryGenerator.prompt(for: currentProblem, themeId: featureFlags.selectedThemeId)
     }
 
+    var currentStoryPrompt: NumberStoryPrompt? {
+        currentNumberStoryPrompt
+    }
+
     var progressLabel: String {
         guard !problems.isEmpty else { return "0 / 0" }
         return "\(min(currentProblemIndex + 1, problems.count)) / \(problems.count)"
@@ -147,8 +151,8 @@ final class VerticalSliceEngine {
             problems = ProblemGenerator.generateProblems(config: config)
         }
         currentProblemIndex = 0
-        currentStage = .concrete
-        currentProblemState = ProblemState()
+        currentStage = initialStageForCurrentRoute()
+        currentProblemState = ProblemState(stage: currentStage)
         currentSession = SliceSession(
             sessionId: UUID(),
             startedAt: .now,
@@ -167,13 +171,17 @@ final class VerticalSliceEngine {
         gravitySplitState = nil
         sumSprintBurstState = nil
         gravitySplitNeutralRoll = nil
-        feedbackMessage = activeTheme.sessionStartFeedback()
+        feedbackMessage = promptForCurrentStage()
         showCelebration = false
         completedSummary = nil
         sessionStartedAt = .now
         problemStartedAt = .now
         speechService.resetSession()
-        speechService.speakSessionIntro(activeTheme.sessionIntroPhrase())
+        if currentStage == .storyAnchor, let currentStoryPrompt {
+            speechService.speak(currentStoryPrompt.spokenIntro, enabled: featureFlags.audioEnabled)
+        } else {
+            speechService.speakSessionIntro(activeTheme.sessionIntroPhrase())
+        }
 
         do {
             try telemetryWriter.beginSession(sessionId: currentSession.sessionId, featureFlags: featureFlags)
@@ -270,6 +278,8 @@ final class VerticalSliceEngine {
 
         let isCorrect: Bool
         switch currentStage {
+        case .storyAnchor:
+            isCorrect = true
         case .concrete:
             isCorrect = concreteCount == currentProblem.target
         case .pictorial:
@@ -303,6 +313,15 @@ final class VerticalSliceEngine {
 
     func replayPrompt() {
         speechService.speak(promptForCurrentStage(), enabled: featureFlags.audioEnabled)
+    }
+
+    func startBuildingFromStoryAnchor() {
+        guard currentStage == .storyAnchor else { return }
+        let next = resolvedNextStage(after: currentStage)
+        recordStageTransition(from: currentStage, to: next)
+        currentStage = next
+        currentProblemState.stage = next
+        prepareForStage(next)
     }
 
     func selectSumSprintCard(id: UUID) {
@@ -502,6 +521,8 @@ final class VerticalSliceEngine {
 
     private func prepareForStage(_ stage: SliceStage) {
         switch stage {
+        case .storyAnchor:
+            break
         case .pictorial:
             if let problem = currentProblem {
                 bondMatchState = BondMatchState(
@@ -574,8 +595,8 @@ final class VerticalSliceEngine {
             if !problemThemes.isEmpty {
                 activeTheme = problemThemes[currentProblemIndex % problemThemes.count]
             }
-            currentStage = .concrete
-            currentProblemState = ProblemState()
+            currentStage = initialStageForCurrentRoute()
+            currentProblemState = ProblemState(stage: currentStage)
             concreteWarmCount = 0
             concreteAccentCount = 0
             splitLeftCount = 0
@@ -588,6 +609,7 @@ final class VerticalSliceEngine {
             sumSprintBurstState = nil
             problemStartedAt = .now
             feedbackMessage = promptForCurrentStage()
+            speechService.speak(feedbackMessage, enabled: featureFlags.audioEnabled)
             logProblemPresented()
         } else {
             endSession()
@@ -739,6 +761,8 @@ final class VerticalSliceEngine {
     private func promptForCurrentStage() -> String {
         guard let currentProblem else { return "Start a session to play." }
         switch currentStage {
+        case .storyAnchor:
+            return currentStoryPrompt?.spokenIntro ?? activeTheme.sessionStartFeedback()
         case .concrete:
             return activeTheme.concretePrompt(target: currentProblem.target)
         case .pictorial, .bondMatch:
@@ -792,6 +816,9 @@ final class VerticalSliceEngine {
     }
 
     private func successMessage(for stage: SliceStage, problem: SliceProblem) -> String {
+        if stage == .storyAnchor, let currentStoryPrompt {
+            return currentStoryPrompt.successLine
+        }
         if stage == .sumSprint {
             if let prompt = currentNumberStoryPrompt {
                 return "Nice match. Now make pairs for \(prompt.target) \(prompt.objectNoun)."
@@ -804,6 +831,8 @@ final class VerticalSliceEngine {
     private func feedbackMessageForFailure(stage: SliceStage, problem: SliceProblem) -> String {
         let attempts = currentProblemState.attempts
         switch stage {
+        case .storyAnchor:
+            return currentStoryPrompt?.spokenIntro ?? activeTheme.sessionStartFeedback()
         case .concrete:
             if attempts == 1 {
                 return "Keep counting. Make exactly \(problem.target)."
@@ -902,6 +931,10 @@ final class VerticalSliceEngine {
             showGravitySplit: featureFlags.vs1GravitySplitEnabled,
             showBondMatch: featureFlags.vs1BondMatchEnabled && isLastProblem
         )
+    }
+
+    private func initialStageForCurrentRoute() -> SliceStage {
+        featureFlags.makeBreakLoopV2Enabled ? .storyAnchor : .concrete
     }
 
 }

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -76,6 +76,15 @@ struct SliceSessionView: View {
     @ViewBuilder
     private func stageView(for problem: SliceProblem) -> some View {
         switch appModel.engine.currentStage {
+        case .storyAnchor:
+            if let prompt = appModel.engine.currentStoryPrompt {
+                StoryAnchorView(
+                    prompt: prompt,
+                    onStartBuilding: appModel.engine.startBuildingFromStoryAnchor
+                )
+            } else {
+                CardSurface { Text("Loading Story...") }
+            }
         case .concrete:
             ConcreteBuildView(
                 target: problem.target,
@@ -354,6 +363,7 @@ struct SliceSessionView: View {
 
     private func stageColour(_ stage: SliceStage) -> Color {
         switch stage {
+        case .storyAnchor:   MatherTheme.accent
         case .concrete:  MatherTheme.warm
         case .pictorial: MatherTheme.softBlue
         case .abstract:  MatherTheme.accent

--- a/Features/VerticalSlice1/StoryAnchorView.swift
+++ b/Features/VerticalSlice1/StoryAnchorView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct StoryAnchorView: View {
+    let prompt: NumberStoryPrompt
+    let onStartBuilding: () -> Void
+
+    var body: some View {
+        VS1Card {
+            VStack(alignment: .leading, spacing: 22) {
+                Text(prompt.title)
+                    .font(.system(size: 34, weight: .black, design: .rounded))
+                    .foregroundStyle(MatherTheme.ink)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(prompt.spokenIntro)
+                    .font(.system(size: 26, weight: .bold, design: .rounded))
+                    .foregroundStyle(MatherTheme.ink)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(prompt.reminder)
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(MatherTheme.accent)
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 18)
+                    .background(
+                        Capsule(style: .continuous)
+                            .fill(MatherTheme.accent.opacity(0.14))
+                    )
+                    .overlay(
+                        Capsule(style: .continuous)
+                            .strokeBorder(MatherTheme.accent.opacity(0.35), lineWidth: 2)
+                    )
+                    .accessibilityIdentifier("story-anchor-reminder-pill")
+
+                VS1PrimaryButton(title: "Start building", systemImage: "play.fill", action: onStartBuilding)
+                    .accessibilityIdentifier("story-anchor-start-button")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .accessibilityIdentifier("story-anchor-card")
+    }
+}

--- a/Tests/MatherTests/SliceStateMachineTests.swift
+++ b/Tests/MatherTests/SliceStateMachineTests.swift
@@ -4,6 +4,7 @@ import Testing
 struct SliceStateMachineTests {
     @Test
     func loopV2TransitionsAdvanceInRecoveryOrder() {
+        #expect(SliceStateMachine.nextStage(after: .storyAnchor, success: true, routeMode: .makeBreakLoopV2) == .concrete)
         #expect(SliceStateMachine.nextStage(after: .concrete, success: true, routeMode: .makeBreakLoopV2) == .gravitySplit)
         #expect(SliceStateMachine.nextStage(after: .gravitySplit, success: true, routeMode: .makeBreakLoopV2) == .sumSprint)
         #expect(SliceStateMachine.nextStage(after: .sumSprint, success: true, routeMode: .makeBreakLoopV2) == .bondMatch)
@@ -23,6 +24,7 @@ struct SliceStateMachineTests {
         #expect(SliceStateMachine.canTransition(from: .concrete, to: .abstract, showTransfer: true) == false)
         #expect(SliceStateMachine.canTransition(from: .abstract, to: .done, showTransfer: true) == false)
         #expect(SliceStateMachine.canTransition(from: .abstract, to: .done, showTransfer: false))
+        #expect(SliceStateMachine.canTransition(from: .storyAnchor, to: .concrete, routeMode: .makeBreakLoopV2))
         #expect(SliceStateMachine.canTransition(from: .concrete, to: .abstract, routeMode: .makeBreakLoopV2) == false)
         #expect(SliceStateMachine.canTransition(from: .gravitySplit, to: .bondMatch, routeMode: .makeBreakLoopV2) == false)
     }
@@ -85,6 +87,7 @@ struct SliceStateMachineTests {
 
     @Test
     func makeBreakLoopV2UsesFourStagePerTargetRoute() {
+        #expect(SliceStateMachine.nextStage(after: .storyAnchor, success: true, showTransfer: true, makeBreakLoopV2Enabled: true) == .concrete)
         #expect(SliceStateMachine.nextStage(after: .concrete, success: true, showTransfer: true, makeBreakLoopV2Enabled: true) == .gravitySplit)
         #expect(SliceStateMachine.nextStage(after: .gravitySplit, success: true, showTransfer: true, showBondMatch: true, makeBreakLoopV2Enabled: true) == .sumSprint)
         #expect(SliceStateMachine.nextStage(after: .sumSprint, success: true, showTransfer: true, showBondMatch: true, makeBreakLoopV2Enabled: true) == .bondMatch)

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -185,7 +185,7 @@ struct ThemeTests {
             saveSummary: { _ in }
         )
         engine.startSession()
-        #expect(engine.feedbackMessage == "Park the cars in the garage.")
+        #expect(engine.feedbackMessage == "Park 6 cars in the garage.")
         #expect(engine.activeTheme.celebrationEmoji == "🚗")
         if case .vehicle = engine.activeTheme.counterKind { } else {
             Issue.record("Expected .vehicle counter kind after startSession with selectedThemeId=vehicle")
@@ -206,7 +206,7 @@ struct ThemeTests {
             saveSummary: { _ in }
         )
         engine.startSession()
-        #expect(engine.feedbackMessage == "Make the target number with the big counters.")
+        #expect(engine.feedbackMessage == "Make 6 with the counters.")
         #expect(engine.activeTheme.celebrationEmoji == "⭐️")
         if case .circle = engine.activeTheme.counterKind { } else {
             Issue.record("Expected .circle counter kind after startSession with selectedThemeId=classic")
@@ -244,7 +244,7 @@ struct ThemeTests {
             saveSummary: { _ in }
         )
         engine.startSession()
-        #expect(engine.feedbackMessage == "Place the rockets on the pad.")
+        #expect(engine.feedbackMessage == "Launch 6 rockets.")
     }
 
     @MainActor
@@ -260,7 +260,7 @@ struct ThemeTests {
             saveSummary: { _ in }
         )
         engine.startSession()
-        #expect(engine.feedbackMessage == "Make the target number with the big counters.")
+        #expect(engine.feedbackMessage == "Make 6 with the counters.")
     }
 
     @MainActor

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -175,6 +175,7 @@ struct ThemeTests {
     @Test func startSessionWithVehicleThemeIdActivatesVehicleTheme() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
         flags.selectedThemeId = "vehicle"
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -195,6 +196,7 @@ struct ThemeTests {
     @Test func startSessionWithClassicThemeIdActivatesClassicTheme() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
         flags.selectedThemeId = "classic"
         let engine = VerticalSliceEngine(
             featureFlags: flags,
@@ -232,6 +234,7 @@ struct ThemeTests {
     @Test func engineUsesInjectedThemeSessionStartFeedback() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
         let engine = VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),
@@ -248,6 +251,7 @@ struct ThemeTests {
     @Test func engineUsesClassicThemeSessionStartFeedbackByDefault() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
         let engine = VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),
@@ -299,6 +303,7 @@ struct ThemeTests {
     @Test func engineConcreteFailureHintUsesThemeCounterNoun() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
         let engine = VerticalSliceEngine(
             featureFlags: flags,
             telemetryWriter: TelemetryWriter(),

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -67,6 +67,9 @@ struct VerticalSliceEngineTests {
 
         engine.startSession()
         guard let problem = engine.currentProblem else { return }
+        #expect(engine.currentStage == .storyAnchor)
+        engine.startBuildingFromStoryAnchor()
+        #expect(engine.currentStage == .concrete)
 
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()
@@ -93,10 +96,38 @@ struct VerticalSliceEngineTests {
         }
 
         await waitFor("advance to next problem after loop v2 bond blast") {
-            engine.currentProblemIndex == 1 && engine.currentStage == .concrete
+            engine.currentProblemIndex == 1 && engine.currentStage == .storyAnchor
         }
         #expect(engine.currentProblemIndex == 1)
+        #expect(engine.currentStage == .storyAnchor)
+    }
+
+    @Test
+    func loopV2StartsWithDeterministicStoryAnchorPrompt() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = true
+        flags.selectedThemeId = "vehicle"
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        guard let problem = engine.currentProblem else { return }
+        let expectedPrompt = NumberStoryGenerator.prompt(for: problem, themeId: "vehicle")
+
+        #expect(engine.currentStage == .storyAnchor)
+        #expect(engine.currentStoryPrompt == expectedPrompt)
+
+        engine.startBuildingFromStoryAnchor()
         #expect(engine.currentStage == .concrete)
+        #expect(engine.currentProblem == problem)
+        #expect(engine.currentStoryPrompt == expectedPrompt)
     }
 
     @Test
@@ -547,6 +578,9 @@ struct VerticalSliceEngineTests {
         engine.startSession()
 
         #expect(engine.currentProblem?.target == 1)
+        #expect(engine.currentStage == .storyAnchor)
+        engine.startBuildingFromStoryAnchor()
+        #expect(engine.currentStage == .concrete)
 
         engine.adjustConcrete(by: 1)
         engine.submitCurrentStage()
@@ -872,6 +906,9 @@ struct VerticalSliceEngineTests {
 
         engine.startSession()
         guard let problem = engine.currentProblem else { return }
+        #expect(engine.currentStage == .storyAnchor)
+        engine.startBuildingFromStoryAnchor()
+        #expect(engine.currentStage == .concrete)
 
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()
@@ -908,6 +945,9 @@ struct VerticalSliceEngineTests {
 
         engine.startSession()
         guard let problem = engine.currentProblem else { return }
+        #expect(engine.currentStage == .storyAnchor)
+        engine.startBuildingFromStoryAnchor()
+        #expect(engine.currentStage == .concrete)
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()
         await waitFor("gravity split after concrete") { engine.currentStage == .gravitySplit }
@@ -933,6 +973,9 @@ struct VerticalSliceEngineTests {
 
         engine.startSession()
         guard let problem = engine.currentProblem else { return }
+        #expect(engine.currentStage == .storyAnchor)
+        engine.startBuildingFromStoryAnchor()
+        #expect(engine.currentStage == .concrete)
         engine.adjustConcrete(by: problem.target)
         engine.submitCurrentStage()
         await waitFor("gravity split after concrete") { engine.currentStage == .gravitySplit }

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -219,6 +219,7 @@ struct VerticalSliceEngineTests {
     func hapticsStageSuccessFiredOnConcreteStageClear() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
         flags.hapticsEnabled = true
         let haptics = HapticsService()
 
@@ -310,6 +311,7 @@ struct VerticalSliceEngineTests {
     func hapticsFailureFiredOnWrongAnswer() {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
         flags.hapticsEnabled = true
         let haptics = HapticsService()
 

--- a/wiki/Specs/Make-Break-Number-Story-Thread.md
+++ b/wiki/Specs/Make-Break-Number-Story-Thread.md
@@ -2,7 +2,7 @@
 
 **Status:** Implementation-ready plan for issue #400  
 **Issue:** https://github.com/ganesh47/mather/issues/400  
-**Lane:** lane-e-story-vocabulary in progress
+**Lane:** Lane D story anchor merged with Lane E story vocabulary follow-up
 **Last updated:** 2026-04-27
 
 ## Scope lock
@@ -29,8 +29,8 @@ Out of scope for #400:
 ## Current repo truth inspected
 
 - `Domain/SliceModels.swift`
-  - `SliceConfig` already carries `minTarget` / `maxTarget` and clamps to `1...20`.
-  - `SliceStage` currently starts at `.concrete`; no story stage exists yet.
+  - `SliceConfig` already carries `minTarget` / `maxTarget` and clamps to `1...1_000`.
+  - Lane D adds `.storyAnchor` for the Make & Break V2 route; legacy flow still starts at `.concrete`.
 - `Domain/ProblemGenerator.swift`
   - Deterministic seed spans `1...20`.
   - Generation already filters by `config.targetRange`.
@@ -38,7 +38,7 @@ Out of scope for #400:
   - Exposes theme, problem count, and speech prompts.
   - Does not expose target cap before this issue slice.
 - `Domain/SliceStateMachine.swift`
-  - Make & Break V2 route is `concrete -> gravitySplit -> sumSprint -> bondMatch -> done`.
+  - Lane D updates Make & Break V2 route to `storyAnchor -> concrete -> gravitySplit -> sumSprint -> bondMatch -> done`.
 - `Domain/VerticalSliceEngine.swift`
   - `updateConfig(minTarget:maxTarget:)` already exists.
   - Embedded Sum Sprint/Bond Blast state is initialized from `currentProblem`.
@@ -116,6 +116,8 @@ Acceptance:
 ### M2 — Story Anchor pre-stage
 
 **Goal:** Add a short encoding stage before Make It.
+
+**Implementation status:** Landed in Lane D / `feat/issue-400-story-anchor`. Story Anchor is deterministic, reading-light, and advances with one touch; it is not a quiz or failure gate. AI variation and stage vocabulary are intentionally left out of this lane.
 
 Files:
 


### PR DESCRIPTION
## Summary
- Add an explicit `storyAnchor` stage before Concrete Build in the Make & Break V2 route.
- Add `StoryAnchorView` with deterministic `NumberStoryPrompt` title, spoken intro, reminder pill, and a touch-first start button.
- Expose `currentStoryPrompt` from the engine and bind it to the current `SliceProblem` plus selected theme id.
- Update route/engine tests and the issue #400 story-thread spec status.

## Validation
- `git diff --check`
- Blocked locally: this environment has no `xcodegen`, `xcodebuild`, `swift`, `xcrun`, or `brew`, so Xcode project regeneration and Swift tests could not be run here. CI is configured to install XcodeGen and run `xcodegen generate` before building.

## Notes
- No AI path is added; story copy remains deterministic via `NumberStoryGenerator`.
- The Story Anchor is not a quiz or failure gate; the start button advances to Concrete Build.