### PR TITLE
Fix UI screenshots for story anchor stage

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -451,6 +451,14 @@ final class ScreenshotTests: XCTestCase {
         snapshotPrefix: String,
         skipInitialConcreteSnapshot: Bool = false
     ) {
+        let storyAnchorStart = app.buttons["story-anchor-start-button"]
+        if storyAnchorStart.waitForExistence(timeout: 5) {
+            if !skipInitialConcreteSnapshot {
+                snapshot(app, "\(snapshotPrefix)-StoryAnchor")
+            }
+            storyAnchorStart.tap()
+        }
+
         let concreteSubmit = app.buttons["That is \(target)"]
         XCTAssertTrue(concreteSubmit.waitForExistence(timeout: 15), "Expected concrete stage for target \(target)")
         if !skipInitialConcreteSnapshot {


### PR DESCRIPTION
## Summary
- Teach the Make & Break loop screenshot helper to advance through the new Story Anchor stage before looking for the concrete submit button.
- Captures the Story Anchor screenshot when the helper is already taking initial stage screenshots.

## Validation
- `git diff --check`
- Main failure addressed: iOS UI Review run 25011164196 failed because `testScreenshot_Issue222LoopV2_AcrossFourTargetsIncludingTwelve` expected concrete first after #482 introduced Story Anchor.