### PR TITLE
Show all saved game sessions in history

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -5,10 +5,15 @@ import SwiftUI
 struct RootView: View {
     @Bindable var appModel: AppModel
     @Query(sort: \StoredSessionSummary.startedAt, order: .reverse) private var sessionSummaries: [StoredSessionSummary]
+    @Query(sort: \StoredGameSession.startedAt, order: .reverse) private var gameSessions: [StoredGameSession]
     @Query(sort: \StoredKidProfile.createdAt) private var kidProfiles: [StoredKidProfile]
 
     private var activeProfileSummaries: [StoredSessionSummary] {
         sessionSummaries.filter { $0.profileId == appModel.profileStore.activeProfileId }
+    }
+
+    private var activeProfileGameSessions: [StoredGameSession] {
+        gameSessions.filter { $0.profileId == appModel.profileStore.activeProfileId }
     }
 
     var body: some View {
@@ -24,9 +29,9 @@ struct RootView: View {
                 case .sessionSummary:
                     SessionSummaryView(appModel: appModel)
                 case .parentSummary:
-                    ParentSummaryView(appModel: appModel, summaries: sessionSummaries, profiles: kidProfiles)
+                    ParentSummaryView(appModel: appModel, summaries: sessionSummaries, gameSessions: gameSessions, profiles: kidProfiles)
                 case .settings:
-                    SettingsView(appModel: appModel, summaries: activeProfileSummaries)
+                    SettingsView(appModel: appModel, summaries: activeProfileSummaries, gameSessions: activeProfileGameSessions)
                 case .roomQuest:
                     RoomSessionView(engine: appModel.roomQuestEngine, vsEngine: appModel.engine)
                         .sheet(item: Binding(

--- a/Features/ParentSummary/ParentSummaryView.swift
+++ b/Features/ParentSummary/ParentSummaryView.swift
@@ -4,12 +4,13 @@ import SwiftUI
 struct ParentSummaryView: View {
     @Bindable var appModel: AppModel
     let summaries: [StoredSessionSummary]
+    let gameSessions: [StoredGameSession]
     let profiles: [StoredKidProfile]
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
         let digest = appModel.telemetryWriter.digest(from: summaries)
-        let recentSummaries = Array(summaries.prefix(5))
+        let recentRows = ParentSummaryHistoryRow.recentRows(summaries: summaries, gameSessions: gameSessions, limit: 5)
 
         ZStack {
             MatherTheme.background.ignoresSafeArea()
@@ -25,7 +26,7 @@ struct ParentSummaryView: View {
                         }
                     }
 
-                    if summaries.isEmpty {
+                    if summaries.isEmpty && gameSessions.isEmpty {
                         CardSurface {
                             VStack(spacing: 12) {
                                 Image(systemName: "chart.bar.xaxis")
@@ -79,13 +80,13 @@ struct ParentSummaryView: View {
                                 alignment: .leading,
                                 spacing: 16
                             ) {
-                                profileOverviewCard(summaries: summaries)
+                                profileOverviewCard(summaries: summaries, gameSessions: gameSessions)
                                 nextTargetCard(digest: digest)
                             }
-                            recentSessionsCard(summaries: summaries, recentSummaries: recentSummaries)
+                            recentSessionsCard(rows: recentRows, totalCount: summaries.count + gameSessions.count)
                         } else {
-                            profileOverviewCard(summaries: summaries)
-                            recentSessionsCard(summaries: summaries, recentSummaries: recentSummaries)
+                            profileOverviewCard(summaries: summaries, gameSessions: gameSessions)
+                            recentSessionsCard(rows: recentRows, totalCount: summaries.count + gameSessions.count)
                             nextTargetCard(digest: digest)
                         }
                     }
@@ -121,18 +122,18 @@ struct ParentSummaryView: View {
     private func historyCaption(totalCount: Int, visibleCount: Int) -> String {
         guard totalCount > 0 else { return "No saved sessions yet." }
         if totalCount == visibleCount {
-            return "\(totalCount) saved locally"
+            return "\(totalCount) saved locally across all games"
         }
-        return "Showing latest \(visibleCount) of \(totalCount) saved locally"
+        return "Showing latest \(visibleCount) of \(totalCount) saved locally across all games"
     }
 
-    private func profileOverviewCard(summaries: [StoredSessionSummary]) -> some View {
+    private func profileOverviewCard(summaries: [StoredSessionSummary], gameSessions: [StoredGameSession]) -> some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 10) {
                 Text("Profile overview")
                     .font(.title3.weight(.bold))
                 ForEach(profiles, id: \.id) { profile in
-                    let count = summaries.filter { $0.profileId == profile.id }.count
+                    let count = summaries.filter { $0.profileId == profile.id }.count + gameSessions.filter { $0.profileId == profile.id }.count
                     HStack {
                         Text("\(profile.emoji) \(profile.name)")
                         Spacer()
@@ -157,33 +158,36 @@ struct ParentSummaryView: View {
         }
     }
 
-    private func recentSessionsCard(summaries: [StoredSessionSummary], recentSummaries: [StoredSessionSummary]) -> some View {
+    private func recentSessionsCard(rows: [ParentSummaryHistoryRow], totalCount: Int) -> some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 10) {
                 Text("Recent sessions")
                     .font(.title3.weight(.bold))
-                Text(historyCaption(totalCount: summaries.count, visibleCount: recentSummaries.count))
+                Text(historyCaption(totalCount: totalCount, visibleCount: rows.count))
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(MatherTheme.cardSubtitle)
-                ForEach(Array(recentSummaries.enumerated()), id: \.element.sessionId) { index, summary in
+                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
                     HStack {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Session \(index + 1)")
                                 .font(.caption.weight(.bold))
                                 .foregroundStyle(MatherTheme.accent)
-                            if let profile = profiles.first(where: { $0.id == summary.profileId }) {
+                            Text(row.title)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                            if let profile = profiles.first(where: { $0.id == row.profileId }) {
                                 Text("\(profile.emoji) \(profile.name)")
                                     .font(.caption)
                                     .foregroundStyle(MatherTheme.cardSubtitle)
                             }
-                            Text(summary.startedAt.formatted(date: .abbreviated, time: .shortened))
+                            Text(row.startedAt.formatted(date: .abbreviated, time: .shortened))
                                 .font(.subheadline.weight(.semibold))
-                            Text("\(summary.problemsCompleted) problems · \(Int(summary.firstAttemptAccuracy * 100))% first try")
+                            Text(row.detail)
                                 .font(.caption)
                                 .foregroundStyle(MatherTheme.cardSubtitle)
                         }
                         Spacer()
-                        if summary.sessionId == summaries.first?.sessionId {
+                        if index == 0 {
                             Text("Latest")
                                 .font(.caption.weight(.bold))
                                 .foregroundStyle(MatherTheme.accent)
@@ -194,13 +198,62 @@ struct ParentSummaryView: View {
                         }
                     }
                     .padding(10)
-                    .background(summary.sessionId == summaries.first?.sessionId ? MatherTheme.warm.opacity(0.2) : Color.secondary.opacity(0.06))
+                    .background(index == 0 ? MatherTheme.warm.opacity(0.2) : Color.secondary.opacity(0.06))
                     .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                     .accessibilityElement(children: .combine)
                     .accessibilityIdentifier("parent-summary-session-\(index)")
                 }
             }
         }
+    }
+
+}
+
+
+struct ParentSummaryHistoryRow: Identifiable, Equatable {
+    enum Source: Equatable {
+        case makeAndBreak
+        case game
+    }
+
+    var id: String
+    var source: Source
+    var profileId: String
+    var title: String
+    var startedAt: Date
+    var detail: String
+
+    static func recentRows(
+        summaries: [StoredSessionSummary],
+        gameSessions: [StoredGameSession],
+        limit: Int
+    ) -> [ParentSummaryHistoryRow] {
+        let makeAndBreakRows = summaries.map { summary in
+            ParentSummaryHistoryRow(
+                id: "make-break-\(summary.sessionId)",
+                source: .makeAndBreak,
+                profileId: summary.profileId,
+                title: summary.objectiveTitle,
+                startedAt: summary.startedAt,
+                detail: "\(summary.problemsCompleted) problems · \(Int(summary.firstAttemptAccuracy * 100))% first try"
+            )
+        }
+
+        let gameRows = gameSessions.map { session in
+            ParentSummaryHistoryRow(
+                id: "game-\(session.id)",
+                source: .game,
+                profileId: session.profileId,
+                title: session.gameName,
+                startedAt: session.startedAt,
+                detail: "\(session.scoreValue) \(session.scoreLabel)"
+            )
+        }
+
+        return (makeAndBreakRows + gameRows)
+            .sorted { $0.startedAt > $1.startedAt }
+            .prefix(limit)
+            .map { $0 }
     }
 }
 

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -5,6 +5,7 @@ struct SettingsView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Bindable var appModel: AppModel
     let summaries: [StoredSessionSummary]
+    let gameSessions: [StoredGameSession]
 
     @State private var showingClearConfirmation = false
     @State private var newProfileName = ""
@@ -86,6 +87,7 @@ struct SettingsView: View {
             Button("Cancel", role: .cancel) {}
             Button("Clear", role: .destructive) {
                 appModel.historyStore.clearAll()
+                appModel.gameSessionStore.clearAll()
                 appModel.telemetryWriter.clearEventsForActiveProfile()
             }
         } message: {
@@ -198,29 +200,30 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: 12) {
                 Text("Session history")
                     .font(.title2.weight(.bold))
-                Text("\(summaries.count) saved locally")
+                let rows = ParentSummaryHistoryRow.recentRows(summaries: summaries, gameSessions: gameSessions, limit: 8)
+                Text("\(summaries.count + gameSessions.count) saved locally across all games")
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(MatherTheme.cardSubtitle)
-                ForEach(Array(summaries.prefix(8).enumerated()), id: \.element.sessionId) { index, summary in
+                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
                     HStack {
                         VStack(alignment: .leading) {
                             Text("Session \(index + 1)")
                                 .font(.caption.weight(.bold))
                                 .foregroundStyle(MatherTheme.accent)
-                            Text(summary.startedAt.formatted(date: .abbreviated, time: .shortened))
-                            Text("Accuracy \(Int(summary.firstAttemptAccuracy * 100))%")
+                            Text(row.title)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                            Text(row.startedAt.formatted(date: .abbreviated, time: .shortened))
+                            Text(row.detail)
                                 .foregroundStyle(MatherTheme.cardSubtitle)
                         }
                         Spacer()
-                        Text(summary.exportFileName.replacingOccurrences(of: "swiftdata://session/", with: "Session ID "))
-                            .font(.caption)
-                            .foregroundStyle(MatherTheme.cardSubtitle)
                     }
                     .padding(.vertical, 4)
                     .accessibilityElement(children: .combine)
                     .accessibilityIdentifier("settings-history-session-\(index)")
                 }
-                if summaries.isEmpty {
+                if rows.isEmpty {
                     Text("No history yet.")
                         .foregroundStyle(MatherTheme.cardSubtitle)
                 }

--- a/Tests/MatherTests/SessionHistoryTests.swift
+++ b/Tests/MatherTests/SessionHistoryTests.swift
@@ -193,3 +193,72 @@ struct TelemetryWriterDigestTests {
         #expect(digest.problemsCompleted == 0)
     }
 }
+
+// MARK: - Parent summary history row tests
+
+@MainActor
+struct ParentSummaryHistoryRowTests {
+    @Test
+    func recentRowsMergeMakeAndBreakAndExplorerGameSessions() throws {
+        let now = Date(timeIntervalSinceReferenceDate: 10_000)
+        let makeAndBreak = StoredSessionSummary(
+            from: makeDraft(sessionId: "make-break-old", problemsCompleted: 2, startedAt: now.addingTimeInterval(-120)),
+            profileId: "test-profile"
+        )
+        let sumSprint = StoredGameSession(
+            id: "sum-sprint-new",
+            profileId: "test-profile",
+            gameName: "Sum Sprint",
+            startedAt: now,
+            durationSeconds: 30,
+            scoreValue: 8,
+            scoreLabel: "correct"
+        )
+
+        let rows = ParentSummaryHistoryRow.recentRows(
+            summaries: [makeAndBreak],
+            gameSessions: [sumSprint],
+            limit: 5
+        )
+
+        #expect(rows.map(\.title) == ["Sum Sprint", "Make & Break"])
+        #expect(rows.map(\.source) == [.game, .makeAndBreak])
+        #expect(rows[0].detail == "8 correct")
+        #expect(rows[1].detail == "2 problems · 80% first try")
+    }
+
+    @Test
+    func recentRowsRespectsLimitAfterSortingAllSessionTypes() throws {
+        let now = Date(timeIntervalSinceReferenceDate: 20_000)
+        let oldest = StoredSessionSummary(
+            from: makeDraft(sessionId: "oldest", startedAt: now.addingTimeInterval(-300)),
+            profileId: "test-profile"
+        )
+        let newest = StoredGameSession(
+            id: "newest",
+            profileId: "test-profile",
+            gameName: "Angle Cannon",
+            startedAt: now,
+            durationSeconds: 10,
+            scoreValue: 3,
+            scoreLabel: "hits"
+        )
+        let middle = StoredGameSession(
+            id: "middle",
+            profileId: "test-profile",
+            gameName: "Memory",
+            startedAt: now.addingTimeInterval(-60),
+            durationSeconds: 20,
+            scoreValue: 6,
+            scoreLabel: "matches"
+        )
+
+        let rows = ParentSummaryHistoryRow.recentRows(
+            summaries: [oldest],
+            gameSessions: [middle, newest],
+            limit: 2
+        )
+
+        #expect(rows.map(\.title) == ["Angle Cannon", "Memory"])
+    }
+}


### PR DESCRIPTION
## Summary
- Include non-Make & Break saved game sessions in Parent Summary and Settings history lists.
- Merge Make & Break summaries and saved game sessions by recency, across all games.
- Clear saved game sessions when the user clears session history.
- Add row-model coverage for merged/sorted/limited history rows.

## Validation
- `git diff --check`
- Attempted targeted Xcode test on ganesh-mba; blocked by local simulator/project compilation errors unrelated to this slice (`Cannot find type KidProfileStore`, `RoomQuestEngine`, `SliceTheme`, etc.) while compiling the app target from a temp copy. CI will validate the branch.