### PR TITLE
Fix speaker prompt replay wiring

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -315,6 +315,13 @@ final class VerticalSliceEngine {
         speechService.speak(promptForCurrentStage(), enabled: featureFlags.audioEnabled)
     }
 
+    func playPromptFromSpeakerButton() {
+        if !featureFlags.audioEnabled {
+            featureFlags.audioEnabled = true
+        }
+        replayPrompt()
+    }
+
     func startBuildingFromStoryAnchor() {
         guard currentStage == .storyAnchor else { return }
         let next = resolvedNextStage(after: currentStage)

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -291,7 +291,7 @@ struct SliceSessionView: View {
                     }
                     Spacer()
                     Button {
-                        appModel.featureFlags.audioEnabled.toggle()
+                        appModel.engine.playPromptFromSpeakerButton()
                     } label: {
                         Image(systemName: appModel.featureFlags.audioEnabled ? "speaker.wave.2.fill" : "speaker.slash.fill")
                             .font(.title2.weight(.bold))
@@ -301,9 +301,10 @@ struct SliceSessionView: View {
                             .overlay(Circle().strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1))
                             .clipShape(Circle())
                     }
-                    .accessibilityLabel(appModel.featureFlags.audioEnabled ? "Mute audio" : "Enable audio")
+                    .accessibilityLabel(appModel.featureFlags.audioEnabled ? "Play prompt" : "Enable audio and play prompt")
+                    .accessibilityHint("Speaks the current instruction aloud.")
                     Button {
-                        appModel.engine.replayPrompt()
+                        appModel.engine.playPromptFromSpeakerButton()
                     } label: {
                         Image(systemName: "arrow.counterclockwise.circle.fill")
                             .font(.title2.weight(.bold))
@@ -314,6 +315,7 @@ struct SliceSessionView: View {
                             .clipShape(Circle())
                     }
                     .accessibilityLabel("Replay prompt")
+                    .accessibilityHint("Speaks the current instruction aloud.")
                     // Adult escape hatch — secondary styling so child ignores it
                     Button {
                         appModel.engine.showHome()

--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -9,6 +9,8 @@ import FoundationModels
 final class SpeechService {
     private let synthesizer = AVSpeechSynthesizer()
     private var lastUtteranceID = UUID()
+    private(set) var lastSpokenText: String?
+    private(set) var lastSpeechDiagnostic: String?
     var hasSpokenSessionIntro = false
 
     init() {
@@ -16,16 +18,29 @@ final class SpeechService {
         // ringer/silent switch is off. .spokenAudio mode pauses other audio
         // during speech; .duckOthers lowers (rather than cuts) background audio.
         // The in-app audio toggle (speak(_:enabled:)) remains the parent's control.
-        try? AVAudioSession.sharedInstance().setCategory(
-            .playback,
-            mode: .spokenAudio,
-            options: .duckOthers
-        )
-        try? AVAudioSession.sharedInstance().setActive(true)
+        do {
+            try AVAudioSession.sharedInstance().setCategory(
+                .playback,
+                mode: .spokenAudio,
+                options: .duckOthers
+            )
+            try AVAudioSession.sharedInstance().setActive(true)
+            lastSpeechDiagnostic = nil
+        } catch {
+            lastSpeechDiagnostic = "Audio session setup failed: \(error.localizedDescription)"
+            print("[Mather][SpeechService] \(lastSpeechDiagnostic!)")
+        }
     }
 
     func speak(_ text: String, enabled: Bool) {
-        guard enabled, !text.isEmpty else { return }
+        guard !text.isEmpty else { return }
+        guard enabled else {
+            lastSpeechDiagnostic = "Speech skipped because audio prompts are disabled."
+            print("[Mather][SpeechService] \(lastSpeechDiagnostic!)")
+            return
+        }
+        lastSpokenText = text
+        lastSpeechDiagnostic = nil
         synthesizer.stopSpeaking(at: .immediate)
         let utterance = AVSpeechUtterance(string: text)
         utterance.rate = 0.45

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -131,6 +131,32 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
+    func speakerButtonEnablesAudioAndReplaysCurrentPrompt() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = true
+        flags.audioEnabled = false
+        let speechService = SpeechService()
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: speechService,
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+
+        engine.startSession()
+        #expect(flags.audioEnabled == false)
+
+        engine.playPromptFromSpeakerButton()
+
+        #expect(flags.audioEnabled == true)
+        #expect(speechService.lastSpokenText == engine.feedbackMessage)
+        #expect(speechService.lastSpeechDiagnostic == nil)
+    }
+
+    @Test
     func sessionRoutesThroughBondBlastThenWriteItThenTransfer() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true


### PR DESCRIPTION
## Summary
- Rewired the in-session speaker button to play the current prompt instead of only toggling audio.
- If audio was disabled, the speaker/replay affordances now re-enable audio before replaying the prompt.
- Added SpeechService diagnostics for skipped/failed speech setup and test-visible last spoken text.
- Added regression coverage for the speaker button path enabling audio and replaying the current prompt.

Fixes #700

## Validation
- `git diff --check HEAD~1..HEAD`

## Blocked validation
- Remote Xcode validation could not run because the configured Mac host is not resolvable from this environment: `ssh ganesh-mba` -> `Could not resolve hostname mba: Temporary failure in name resolution`. Tried `mba.local`, `Ganeshs-MacBook-Air.local`, and `ganesh-mba.local` with the same DNS resolution failure.
- Local Linux host has no `xcodebuild` or `swift`, so iOS unit tests could not be executed here.
