### PR TITLE
Redesign Show it again transfer rebuild

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -259,6 +259,8 @@ final class VerticalSliceEngine {
 
     func adjustTransfer(by delta: Int, side: TransferSide) {
         guard let currentProblem else { return }
+        let previousLeft = transferLeftCount
+        let previousRight = transferRightCount
         switch side {
         case .left:
             transferLeftCount = min(max(transferLeftCount + delta, 0), currentProblem.target)
@@ -266,6 +268,10 @@ final class VerticalSliceEngine {
         case .right:
             transferRightCount = min(max(transferRightCount + delta, 0), currentProblem.target)
             recordInteraction(action: "transfer_right_place", value: transferRightCount)
+        }
+
+        if transferLeftCount != previousLeft || transferRightCount != previousRight {
+            hapticsService.counterSettle(enabled: featureFlags.hapticsEnabled)
         }
     }
 
@@ -792,7 +798,7 @@ final class VerticalSliceEngine {
         case .abstract:
             return activeTheme.abstractPrompt()
         case .transfer:
-            return "Show the same two parts with counters."
+            return TransferEquationCopy(problem: currentProblem).instruction
         case .gravitySplit:
             if let prompt = currentNumberStoryPrompt {
                 return NumberStoryStageVocabulary.vocabulary(for: prompt, stage: .gravitySplit).instruction
@@ -860,12 +866,13 @@ final class VerticalSliceEngine {
                 return "Type \(problem.decompositionA) on the left and \(problem.decompositionB) on the right."
             }
         case .transfer:
+            let copy = TransferEquationCopy(problem: problem)
             if attempts == 1 {
-                return "Show the same two parts with counters."
+                return "Keep rebuilding: \(copy.left) on the left and \(copy.right) on the right."
             } else if attempts == 2 {
-                return "Use the same two numbers you wrote and build them with counters."
+                return "Use the exact equation you wrote: \(copy.left) + \(copy.right) = \(copy.target)."
             } else {
-                return "Build the same equation again with counters, one group on each side."
+                return "Tap counters to rebuild \(copy.left) on the left and \(copy.right) on the right."
             }
         case .gravitySplit:
             if let prompt = currentNumberStoryPrompt {

--- a/Features/VerticalSlice1/TransferCheckView.swift
+++ b/Features/VerticalSlice1/TransferCheckView.swift
@@ -9,64 +9,38 @@ struct TransferCheckView: View {
     let onSubmit: () -> Void
     var theme: any SliceTheme = ClassicTheme()
 
+    private var equationCopy: TransferEquationCopy {
+        TransferEquationCopy(problem: problem)
+    }
+
     var body: some View {
         CardSurface {
-            VStack(alignment: .leading, spacing: 12) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Show it")
+            VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Show it again")
                         .font(.title.weight(.bold))
-                        .foregroundStyle(MatherTheme.coral)
+                        .foregroundStyle(MatherTheme.ink)
 
-                    ViewThatFits {
-                        HStack(spacing: 10) {
-                            hiddenEquationPill(fill: MatherTheme.warm)
-                            Text("+")
-                                .font(.title.weight(.black))
-                                .foregroundStyle(.secondary)
-                            hiddenEquationPill(fill: MatherTheme.accent)
-                            Text("=")
-                                .font(.title.weight(.black))
-                                .foregroundStyle(.secondary)
-                            Text("\(problem.target)")
-                                .font(.system(size: 34, weight: .black, design: .rounded))
-                                .foregroundStyle(MatherTheme.ink)
-                        }
+                    equationRecap
 
-                        VStack(alignment: .leading, spacing: 8) {
-                            HStack(spacing: 10) {
-                                hiddenEquationPill(fill: MatherTheme.warm)
-                                Text("+")
-                                    .font(.title2.weight(.black))
-                                    .foregroundStyle(.secondary)
-                                hiddenEquationPill(fill: MatherTheme.accent)
-                            }
-                            HStack(spacing: 10) {
-                                Text("=")
-                                    .font(.title2.weight(.black))
-                                    .foregroundStyle(.secondary)
-                                Text("\(problem.target)")
-                                    .font(.system(size: 34, weight: .black, design: .rounded))
-                                    .foregroundStyle(MatherTheme.ink)
-                            }
-                        }
-                    }
-                    .accessibilityIdentifier("transfer-equation")
-
-                    Text("Build the same two parts.")
+                    Text(equationCopy.instruction)
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 ViewThatFits {
                     HStack(spacing: 12) {
                         transferBucket(
                             title: "Left side",
+                            targetCount: problem.decompositionA,
                             count: leftCount,
                             fill: MatherTheme.warm,
                             side: .left
                         )
                         transferBucket(
                             title: "Right side",
+                            targetCount: problem.decompositionB,
                             count: rightCount,
                             fill: MatherTheme.accent,
                             side: .right
@@ -76,12 +50,14 @@ struct TransferCheckView: View {
                     VStack(spacing: 12) {
                         transferBucket(
                             title: "Left side",
+                            targetCount: problem.decompositionA,
                             count: leftCount,
                             fill: MatherTheme.warm,
                             side: .left
                         )
                         transferBucket(
                             title: "Right side",
+                            targetCount: problem.decompositionB,
                             count: rightCount,
                             fill: MatherTheme.accent,
                             side: .right
@@ -89,7 +65,7 @@ struct TransferCheckView: View {
                     }
                 }
 
-                Button("Check my groups") {
+                Button("Check my equation") {
                     onSubmit()
                 }
                 .buttonStyle(PrimaryActionButtonStyle())
@@ -97,78 +73,103 @@ struct TransferCheckView: View {
         }
     }
 
-    private func hiddenEquationPill(fill: Color) -> some View {
-        Text("?")
-            .font(.system(size: 28, weight: .black, design: .rounded))
-            .foregroundStyle(fill)
-            .frame(minWidth: 58, minHeight: 58)
-            .background(fill.opacity(0.14))
-            .overlay(
-                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                    .strokeBorder(fill.opacity(colorScheme == .dark ? 0.35 : 0.2), style: StrokeStyle(lineWidth: 1.5, dash: [5, 4]))
-            )
-            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-            .accessibilityLabel("Hidden part")
+    private var equationRecap: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Rebuild your equation")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .textCase(.uppercase)
+                .tracking(1.1)
+
+            ViewThatFits {
+                HStack(spacing: 10) {
+                    equationNumber("\(problem.decompositionA)", fill: MatherTheme.warm, label: "left part")
+                    equationOperator("+")
+                    equationNumber("\(problem.decompositionB)", fill: MatherTheme.accent, label: "right part")
+                    equationOperator("=")
+                    equationNumber("\(problem.target)", fill: MatherTheme.softBlue, label: "target")
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 10) {
+                        equationNumber("\(problem.decompositionA)", fill: MatherTheme.warm, label: "left part")
+                        equationOperator("+")
+                        equationNumber("\(problem.decompositionB)", fill: MatherTheme.accent, label: "right part")
+                    }
+                    HStack(spacing: 10) {
+                        equationOperator("=")
+                        equationNumber("\(problem.target)", fill: MatherTheme.softBlue, label: "target")
+                    }
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(equationCopy.recap)
+            .accessibilityIdentifier("transfer-equation-recap")
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(MatherTheme.panel.opacity(colorScheme == .dark ? 0.98 : 0.72))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .strokeBorder(colorScheme == .dark ? MatherTheme.panelDeep.opacity(0.78) : MatherTheme.panelDeep.opacity(0.42), lineWidth: 1)
+        )
     }
 
-    private func transferBucket(title: String, count: Int, fill: Color, side: TransferSide) -> some View {
-        let bucketBackground = colorScheme == .dark ? MatherTheme.panel.opacity(0.94) : MatherTheme.card
-        let bucketBorder = colorScheme == .dark ? MatherTheme.panelDeep.opacity(0.78) : fill.opacity(0.18)
+    private func equationNumber(_ value: String, fill: Color, label: String) -> some View {
+        Text(value)
+            .font(.system(size: 28, weight: .black, design: .rounded))
+            .foregroundStyle(MatherTheme.ink)
+            .frame(minWidth: 54, minHeight: 48)
+            .background(fill.opacity(colorScheme == .dark ? 0.28 : 0.20))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(fill.opacity(colorScheme == .dark ? 0.55 : 0.38), lineWidth: 1.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .accessibilityLabel("\(label) \(value)")
+    }
 
-        return VStack(spacing: 8) {
-            Text(title)
-                .font(.caption.weight(.bold))
-                .foregroundStyle(MatherTheme.ink)
-                .frame(maxWidth: .infinity, alignment: .leading)
+    private func equationOperator(_ symbol: String) -> some View {
+        Text(symbol)
+            .font(.title2.weight(.black))
+            .foregroundStyle(MatherTheme.ink.opacity(0.78))
+            .accessibilityLabel(symbol == "+" ? "plus" : "equals")
+    }
+
+    private func transferBucket(title: String, targetCount: Int, count: Int, fill: Color, side: TransferSide) -> some View {
+        let sideName = side == .left ? "left" : "right"
+        let bucketBackground = colorScheme == .dark ? MatherTheme.panel.opacity(0.96) : MatherTheme.card
+        let bucketBorder = colorScheme == .dark ? MatherTheme.panelDeep.opacity(0.78) : fill.opacity(0.24)
+
+        return VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(MatherTheme.ink)
+                Text("Make \(targetCount) here")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
 
             LazyVGrid(
                 columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 5),
                 spacing: 6
             ) {
                 ForEach(0..<problem.target, id: \.self) { idx in
-                    CounterView(
-                        index: idx,
-                        filled: idx < count,
-                        theme: theme,
-                        overrideColor: fill
-                    )
-                    .frame(maxWidth: 44, maxHeight: 44)
-                    .accessibilityIdentifier("transfer-\(side == .left ? "left" : "right")-cell-\(idx)")
+                    counterButton(index: idx, count: count, fill: fill, side: side)
                 }
             }
-            .accessibilityIdentifier("transfer-\(side == .left ? "left" : "right")-group")
+            .accessibilityIdentifier("transfer-\(sideName)-group")
 
-            HStack(spacing: 10) {
-                Button {
-                    onAdjust(-1, side)
-                } label: {
-                    Image(systemName: "minus.circle.fill")
-                        .font(.title.weight(.bold))
-                        .frame(minWidth: 44, minHeight: 44)
-                        .background(fill.opacity(0.15))
-                        .clipShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Remove from \(side == .left ? "left" : "right") group")
-                .accessibilityIdentifier("transfer-\(side == .left ? "left" : "right")-minus")
-
-                Button {
-                    onAdjust(1, side)
-                } label: {
-                    Image(systemName: "plus.circle.fill")
-                        .font(.title.weight(.bold))
-                        .frame(minWidth: 44, minHeight: 44)
-                        .background(fill.opacity(0.15))
-                        .clipShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Add to \(side == .left ? "left" : "right") group")
-                .accessibilityIdentifier("transfer-\(side == .left ? "left" : "right")-plus")
-            }
-            .foregroundStyle(fill)
+            Text("\(count) of \(targetCount)")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(count == targetCount ? MatherTheme.accent : MatherTheme.cardSubtitle)
+                .accessibilityIdentifier("transfer-\(sideName)-count")
         }
         .padding(12)
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 22, style: .continuous)
                 .fill(bucketBackground)
@@ -181,5 +182,63 @@ struct TransferCheckView: View {
             RoundedRectangle(cornerRadius: 22, style: .continuous)
                 .strokeBorder(.white.opacity(colorScheme == .dark ? 0.06 : 0), lineWidth: 1)
         )
+    }
+
+    private func counterButton(index idx: Int, count: Int, fill: Color, side: TransferSide) -> some View {
+        let sideName = side == .left ? "left" : "right"
+        let tap = TransferCounterTap(index: idx, currentCount: count)
+        let nextCount = tap.nextCount
+        let delta = tap.delta
+
+        return Button {
+            guard delta != 0 else { return }
+            onAdjust(delta, side)
+        } label: {
+            CounterView(
+                index: idx,
+                filled: idx < count,
+                theme: theme,
+                overrideColor: fill
+            )
+            .frame(maxWidth: 44, maxHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Set \(sideName) side to \(nextCount)")
+        .accessibilityValue(idx < count ? "filled" : "empty")
+        .accessibilityIdentifier("transfer-\(sideName)-counter-\(idx)")
+    }
+}
+
+struct TransferCounterTap: Equatable {
+    let index: Int
+    let currentCount: Int
+
+    var nextCount: Int {
+        index < currentCount ? index : index + 1
+    }
+
+    var delta: Int {
+        nextCount - currentCount
+    }
+}
+
+struct TransferEquationCopy: Equatable {
+    let left: Int
+    let right: Int
+    let target: Int
+
+    init(problem: SliceProblem) {
+        left = problem.decompositionA
+        right = problem.decompositionB
+        target = problem.target
+    }
+
+    var recap: String {
+        "Rebuild your equation: \(left) + \(right) = \(target)"
+    }
+
+    var instruction: String {
+        "Tap counters to make \(left) on the left and \(right) on the right."
     }
 }

--- a/Tests/MatherTests/TransferIntentTests.swift
+++ b/Tests/MatherTests/TransferIntentTests.swift
@@ -15,17 +15,51 @@ struct TransferIntentTests {
     }
 
     @Test
-    func transferPromptReferencesShowingTheSameEquationAgain() async throws {
+    func transferPromptReferencesTheExactEquationToRebuild() async throws {
         let engine = makeEngine()
         engine.startSession()
 
         guard let problem = engine.currentProblem else { return }
         try await advanceToTransfer(engine, problem: problem)
 
-        #expect(engine.feedbackMessage.localizedCaseInsensitiveContains("same two"))
-        #expect(!engine.feedbackMessage.contains("\(problem.decompositionA)"))
-        #expect(!engine.feedbackMessage.contains("\(problem.decompositionB)"))
-        #expect(engine.feedbackMessage.localizedCaseInsensitiveContains("counters"))
+        #expect(engine.feedbackMessage.contains("\(problem.decompositionA)"))
+        #expect(engine.feedbackMessage.contains("\(problem.decompositionB)"))
+        #expect(engine.feedbackMessage.contains("left"))
+        #expect(engine.feedbackMessage.contains("right"))
+    }
+
+    @Test
+    func transferEquationCopyMakesEquationAssociationExplicit() {
+        let copy = TransferEquationCopy(problem: SliceProblem(target: 9, decompositionA: 4, decompositionB: 5))
+
+        #expect(copy.recap == "Rebuild your equation: 4 + 5 = 9")
+        #expect(copy.instruction == "Tap counters to make 4 on the left and 5 on the right.")
+    }
+
+
+    @Test
+    func transferCounterTapAddsOrRemovesThroughTappedBubble() {
+        #expect(TransferCounterTap(index: 0, currentCount: 0).nextCount == 1)
+        #expect(TransferCounterTap(index: 3, currentCount: 1).delta == 3)
+        #expect(TransferCounterTap(index: 2, currentCount: 5).nextCount == 2)
+        #expect(TransferCounterTap(index: 2, currentCount: 5).delta == -3)
+    }
+
+    @Test
+    func transferSideAdjustmentClampsEachSideIndependently() {
+        let engine = makeEngine()
+        engine.startSession()
+        guard let problem = engine.currentProblem else { return }
+
+        engine.adjustTransfer(by: problem.target + 5, side: .left)
+        engine.adjustTransfer(by: -3, side: .left)
+        engine.adjustTransfer(by: problem.target + 2, side: .right)
+
+        #expect(engine.transferLeftCount == max(problem.target - 3, 0))
+        #expect(engine.transferRightCount == problem.target)
+
+        engine.adjustTransfer(by: -(problem.target + 10), side: .right)
+        #expect(engine.transferRightCount == 0)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace the hidden-part Show it UI with an explicit equation recap: A + B = target.
- Make transfer counters directly tappable per side and route changes through existing adjustment/haptic flow.
- Keep independent left/right transfer validation and add regression coverage for exact equation association, tap-to-set behavior, bounds, and total-only failures.
- Use semantic/theme colors for transfer copy/cards in light and dark modes.

## Validation
- `git diff --check` ✅
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 16,OS=18.3.1" -only-testing:MatherTests/TransferIntentTests -only-testing:MatherTests/TransferExactRebuildTests` ⚠️ blocked by known unrelated Swift frontend crash while type-checking `Features/ParentSummary/SettingsView.swift` before tests could run. Output included: `While evaluating request TypeCheckPrimaryFileRequest(source_file "/tmp/mather-showit-test.zuuDrA/mather/Features/ParentSummary/SettingsView.swift")`; `Command SwiftCompile failed with a nonzero exit code`; `Testing cancelled because the build failed.`

Fixes #703
Fixes #712
Fixes #716