### PR TITLE
Improve settings and scorecard usability

### DIFF
--- a/Features/ParentSummary/ParentSummaryView.swift
+++ b/Features/ParentSummary/ParentSummaryView.swift
@@ -11,6 +11,7 @@ struct ParentSummaryView: View {
     var body: some View {
         let digest = appModel.telemetryWriter.digest(from: summaries)
         let recentRows = ParentSummaryHistoryRow.recentRows(summaries: summaries, gameSessions: gameSessions, limit: 5)
+        let trendPoints = ParentSummaryTrendPoint.recentPoints(from: summaries, limit: 6)
 
         ZStack {
             MatherTheme.background.ignoresSafeArea()
@@ -73,6 +74,9 @@ struct ParentSummaryView: View {
                                 color: Color.purple.opacity(0.7)
                             )
                         }
+                        .accessibilityIdentifier("parent-summary-scorecard")
+
+                        recentProgressCard(points: trendPoints)
 
                         if ResponsiveLayout.isWide(horizontalSizeClass) {
                             LazyVGrid(
@@ -207,6 +211,66 @@ struct ParentSummaryView: View {
         }
     }
 
+    private func recentProgressCard(points: [ParentSummaryTrendPoint]) -> some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Recent progress")
+                            .font(.title3.weight(.bold))
+                        Text("Local, on-device history from recent Make & Break sessions.")
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer(minLength: 8)
+                    Image(systemName: "chart.xyaxis.line")
+                        .font(.title3.weight(.bold))
+                        .foregroundStyle(MatherTheme.accent)
+                        .accessibilityHidden(true)
+                }
+
+                if points.count < 2 {
+                    Text("Complete more sessions to see a trend.")
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.ink)
+                        .frame(maxWidth: .infinity, minHeight: 96, alignment: .center)
+                        .background(MatherTheme.panel.opacity(0.55))
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                } else {
+                    TrendSparkline(points: points)
+                        .frame(height: 132)
+                        .accessibilityIdentifier("parent-summary-recent-progress-chart")
+                    HStack(alignment: .top, spacing: 12) {
+                        trendSummary(label: "First try", value: points.last?.accuracyLabel ?? "—")
+                        trendSummary(label: "Latest pace", value: points.last?.paceLabel ?? "—")
+                        trendSummary(label: "Problems", value: points.last.map { "\($0.problemsCompleted)" } ?? "—")
+                    }
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("parent-summary-recent-progress")
+        }
+    }
+
+    private func trendSummary(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label.uppercased())
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .tracking(1.1)
+            Text(value)
+                .font(.headline.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+                .minimumScaleFactor(0.8)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(MatherTheme.panel.opacity(0.55))
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
 }
 
 
@@ -257,6 +321,109 @@ struct ParentSummaryHistoryRow: Identifiable, Equatable {
     }
 }
 
+struct ParentSummaryTrendPoint: Identifiable, Equatable {
+    var id: String
+    var startedAt: Date
+    var accuracy: Double
+    var problemsCompleted: Int
+    var medianLatencyMs: Int
+    var profileId: String
+
+    var accuracyLabel: String {
+        "\(Int((accuracy * 100).rounded()))%"
+    }
+
+    var paceLabel: String {
+        guard medianLatencyMs > 0 else { return "—" }
+        let seconds = medianLatencyMs / 1000
+        return seconds < 60 ? "\(seconds)s" : "\(seconds / 60)m \(seconds % 60)s"
+    }
+
+    static func recentPoints(
+        from summaries: [StoredSessionSummary],
+        limit: Int = 6,
+        profileId: String? = nil
+    ) -> [ParentSummaryTrendPoint] {
+        summaries
+            .filter { profileId == nil || $0.profileId == profileId }
+            .sorted { $0.startedAt < $1.startedAt }
+            .suffix(limit)
+            .map {
+                ParentSummaryTrendPoint(
+                    id: $0.sessionId,
+                    startedAt: $0.startedAt,
+                    accuracy: min(max($0.firstAttemptAccuracy, 0), 1),
+                    problemsCompleted: max($0.problemsCompleted, 0),
+                    medianLatencyMs: max($0.medianLatencyMs, 0),
+                    profileId: $0.profileId
+                )
+            }
+    }
+}
+
+private struct TrendSparkline: View {
+    let points: [ParentSummaryTrendPoint]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            GeometryReader { proxy in
+                let size = proxy.size
+                let coordinates = chartCoordinates(in: size)
+
+                ZStack(alignment: .bottomLeading) {
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(MatherTheme.panel.opacity(0.55))
+
+                    Path { path in
+                        guard let first = coordinates.first else { return }
+                        path.move(to: first)
+                        coordinates.dropFirst().forEach { path.addLine(to: $0) }
+                    }
+                    .stroke(MatherTheme.accent, style: StrokeStyle(lineWidth: 4, lineCap: .round, lineJoin: .round))
+
+                    ForEach(Array(coordinates.enumerated()), id: \.offset) { index, coordinate in
+                        Circle()
+                            .fill(index == coordinates.count - 1 ? MatherTheme.warm : MatherTheme.accent)
+                            .overlay(Circle().stroke(MatherTheme.card, lineWidth: 3))
+                            .frame(width: 15, height: 15)
+                            .position(coordinate)
+                    }
+                }
+            }
+            .frame(minHeight: 84)
+
+            HStack {
+                Text("Oldest")
+                Spacer()
+                Text("Latest")
+            }
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(MatherTheme.cardSubtitle)
+        }
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        let labels = points.map { "\($0.startedAt.formatted(date: .abbreviated, time: .omitted)): \($0.accuracyLabel) first try, \($0.problemsCompleted) problems, \($0.paceLabel) pace" }
+        return "Recent progress trend. " + labels.joined(separator: "; ")
+    }
+
+    private func chartCoordinates(in size: CGSize) -> [CGPoint] {
+        let inset: CGFloat = 16
+        let width = max(size.width - inset * 2, 1)
+        let height = max(size.height - inset * 2, 1)
+        let maxProblems = max(points.map(\.problemsCompleted).max() ?? 1, 1)
+
+        return points.enumerated().map { index, point in
+            let xProgress = points.count <= 1 ? 0.5 : CGFloat(index) / CGFloat(points.count - 1)
+            let accuracyWeight = CGFloat(point.accuracy) * 0.72
+            let progressWeight = (CGFloat(point.problemsCompleted) / CGFloat(maxProblems)) * 0.28
+            let yProgress = min(max(accuracyWeight + progressWeight, 0), 1)
+            return CGPoint(x: inset + width * xProgress, y: inset + height * (1 - yProgress))
+        }
+    }
+}
+
 private struct StatTile: View {
     let value: String
     let label: String
@@ -264,20 +431,39 @@ private struct StatTile: View {
     let color: Color
 
     var body: some View {
-        VStack(spacing: 8) {
-            Image(systemName: icon)
-                .font(.title2)
-                .foregroundStyle(color)
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: icon)
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(color)
+                    .accessibilityHidden(true)
+                Spacer(minLength: 0)
+            }
             Text(value)
-                .font(.system(size: 34, weight: .black, design: .rounded))
+                .font(.system(.title, design: .rounded).weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+                .minimumScaleFactor(0.72)
+                .lineLimit(1)
             Text(label)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 12)
-        .background(color.opacity(0.1))
+        .frame(minHeight: 118, alignment: .topLeading)
+        .padding(16)
+        .background(MatherTheme.card)
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .strokeBorder(color.opacity(0.36), lineWidth: 1.5)
+        )
+        .overlay(alignment: .leading) {
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(color.opacity(0.9))
+                .frame(width: 5)
+        }
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("parent-summary-stat-\(label.lowercased().replacingOccurrences(of: " ", with: "-"))")
     }
 }

--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -50,21 +50,21 @@ struct SettingsView: View {
             MatherTheme.background.ignoresSafeArea()
             ScrollView {
                 VStack(spacing: 20) {
-                    LazyVGrid(columns: ResponsiveLayout.settingsColumns(for: horizontalSizeClass), alignment: .leading, spacing: 20) {
-                        settingsCard
-                        profilesCard
-                        historyCard
-                        smokeTestCard
+                    if ResponsiveLayout.isWide(horizontalSizeClass) {
+                        LazyVGrid(columns: ResponsiveLayout.settingsColumns(for: horizontalSizeClass), alignment: .leading, spacing: 20) {
+                            settingsCard
+                            profilesCard
+                            historyCard
+                            smokeTestCard
+                        }
+                    } else {
+                        VStack(spacing: 16) {
+                            settingsCard
+                            profilesCard
+                            historyCard
+                            smokeTestCard
+                        }
                     }
-
-                    Button(role: .destructive) {
-                        showingClearConfirmation = true
-                    } label: {
-                        Text("Clear session history")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(PrimaryActionButtonStyle())
-                    .tint(MatherTheme.danger)
 
                     Group {
                         if ResponsiveLayout.isWide(horizontalSizeClass) {
@@ -97,49 +97,60 @@ struct SettingsView: View {
 
     private var settingsCard: some View {
         CardSurface {
-            VStack(alignment: .leading, spacing: 16) {
-                Text("Settings")
-                    .font(.largeTitle.weight(.black))
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Settings")
+                        .font(.largeTitle.weight(.black))
+                    Text("Child experience, profiles, and local history controls.")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
-                Text("Make & Break")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .padding(.top, 4)
-                Text("The repeated Make it → Gravity Split → Sum Sprint → Bond Blast route is now built in for every target.")
-                    .font(.subheadline)
-                    .foregroundStyle(MatherTheme.cardSubtitle)
-                    .fixedSize(horizontal: false, vertical: true)
+                settingsSection(title: "Child experience", systemImage: "sparkles") {
+                    Text("Make & Break route")
+                        .font(.headline.weight(.bold))
+                    Text("Make it → Gravity Split → Sum Sprint → Bond Blast is built in for every target.")
+                        .font(.subheadline)
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                    RoomQuestSettingsEntry(appModel: appModel)
+                }
 
-                Divider()
+                settingsSection(title: "Feedback", systemImage: "speaker.wave.2.fill") {
+                    Toggle("Audio prompts", isOn: audioBinding)
+                        .tint(MatherTheme.accent)
+                    Toggle("Haptics", isOn: hapticsBinding)
+                        .tint(MatherTheme.accent)
+                }
 
-                RoomQuestSettingsEntry(appModel: appModel)
-
-                Divider()
-
-                Text("Feedback")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                Toggle("Audio prompts", isOn: audioBinding)
-                Toggle("Haptics", isOn: hapticsBinding)
-
-                Divider()
-
-                Text("Advanced")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                VS1ToggleRow(
-                    title: "Motion controls",
-                    subtitle: "Lets the child wave the iPad to celebrate correct answers.",
-                    isOn: motionBinding
-                )
-                VS1ToggleRow(
-                    title: "Clap reaction (mic)",
-                    subtitle: "On by default. Listens for a clap to trigger celebrations when microphone access is available.",
-                    isOn: soundReactionBinding
-                )
-            }
-            .font(.title3.weight(.semibold))
+                settingsSection(title: "Advanced controls", systemImage: "slider.horizontal.3") {
+                    VS1ToggleRow(
+                        title: "Motion controls",
+                        subtitle: "Lets the child wave the iPad to celebrate correct answers.",
+                        isOn: motionBinding
+                    )
+                    VS1ToggleRow(
+                        title: "Clap reaction (mic)",
+                        subtitle: "On by default. Listens for a clap to trigger celebrations when microphone access is available.",
+                        isOn: soundReactionBinding
+                    )
+                 }
+             }
         }
+    }
+
+    private func settingsSection<Content: View>(title: String, systemImage: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: systemImage)
+                .font(.headline.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            content()
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MatherTheme.panel.opacity(0.45))
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
     }
 
     private var profilesCard: some View {
@@ -177,6 +188,7 @@ struct SettingsView: View {
                     newProfileName = ""
                 }
                 .buttonStyle(PrimaryActionButtonStyle())
+                .accessibilityIdentifier("settings-add-profile")
             }
         }
     }
@@ -227,6 +239,29 @@ struct SettingsView: View {
                     Text("No history yet.")
                         .foregroundStyle(MatherTheme.cardSubtitle)
                 }
+
+                Divider()
+                    .padding(.top, 4)
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Data reset")
+                        .font(.headline.weight(.bold))
+                    Text("Use only when you want to remove saved summaries and events from this device.")
+                        .font(.caption)
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Button(role: .destructive) {
+                        showingClearConfirmation = true
+                    } label: {
+                        Label("Clear session history", systemImage: "trash")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(DestructiveOutlineButtonStyle())
+                    .accessibilityIdentifier("settings-clear-history")
+                }
+                .padding(12)
+                .background(MatherTheme.danger.opacity(0.08))
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
             }
         }
     }
@@ -280,10 +315,12 @@ private struct RoomQuestSettingsEntry: View {
             Button("Open Room Quest setup") {
                 appModel.engine.showRoomQuest()
             }
-            .font(.subheadline.weight(.medium))
-            .foregroundStyle(MatherTheme.accent)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 4)
+            .font(.headline.weight(.bold))
+            .foregroundStyle(MatherTheme.ink)
+            .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+            .padding(.horizontal, 12)
+            .background(MatherTheme.softBlue.opacity(0.45))
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
             .accessibilityIdentifier("settings-roomquest-open")
 
             Text(appModel.featureFlags.roomQuestSafetyAcknowledged ? "Safety checklist already acknowledged on this device." : "The one-time safety checklist appears when you open Room Quest.")
@@ -291,5 +328,22 @@ private struct RoomQuestSettingsEntry: View {
                 .foregroundStyle(MatherTheme.cardSubtitle)
                 .fixedSize(horizontal: false, vertical: true)
         }
+    }
+}
+
+
+private struct DestructiveOutlineButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.headline.weight(.bold))
+            .foregroundStyle(MatherTheme.danger)
+            .padding(.vertical, 14)
+            .padding(.horizontal, 16)
+            .background(configuration.isPressed ? MatherTheme.danger.opacity(0.16) : MatherTheme.danger.opacity(0.08))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(MatherTheme.danger.opacity(0.55), lineWidth: 1.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 }

--- a/Tests/MatherTests/SessionHistoryTests.swift
+++ b/Tests/MatherTests/SessionHistoryTests.swift
@@ -262,3 +262,58 @@ struct ParentSummaryHistoryRowTests {
         #expect(rows.map(\.title) == ["Angle Cannon", "Memory"])
     }
 }
+
+// MARK: - Parent summary trend tests
+
+@MainActor
+struct ParentSummaryTrendPointTests {
+    @Test
+    func recentPointsReturnsEmptyForEmptyHistory() {
+        let points = ParentSummaryTrendPoint.recentPoints(from: [])
+
+        #expect(points.isEmpty)
+    }
+
+    @Test
+    func recentPointsOrdersOldestToLatestAfterTakingRecentLimit() {
+        let base = Date(timeIntervalSinceReferenceDate: 30_000)
+        let old = StoredSessionSummary(
+            from: makeDraft(sessionId: "old", problemsCompleted: 2, accuracy: 0.5, startedAt: base.addingTimeInterval(-300)),
+            profileId: "test-profile"
+        )
+        let middle = StoredSessionSummary(
+            from: makeDraft(sessionId: "middle", problemsCompleted: 4, accuracy: 0.75, startedAt: base.addingTimeInterval(-120)),
+            profileId: "test-profile"
+        )
+        let latest = StoredSessionSummary(
+            from: makeDraft(sessionId: "latest", problemsCompleted: 6, accuracy: 1.0, startedAt: base),
+            profileId: "test-profile"
+        )
+
+        let points = ParentSummaryTrendPoint.recentPoints(from: [latest, old, middle], limit: 2)
+
+        #expect(points.map(\.id) == ["middle", "latest"])
+        #expect(points.map(\.accuracyLabel) == ["75%", "100%"])
+        #expect(points.last?.problemsCompleted == 6)
+    }
+
+    @Test
+    func recentPointsFiltersByProfileAndClampsLegacyValues() {
+        let base = Date(timeIntervalSinceReferenceDate: 40_000)
+        let selected = StoredSessionSummary(
+            from: makeDraft(sessionId: "selected", problemsCompleted: -2, accuracy: 1.4, medianLatencyMs: -100, startedAt: base),
+            profileId: "profile-a"
+        )
+        let otherProfile = StoredSessionSummary(
+            from: makeDraft(sessionId: "other", problemsCompleted: 5, accuracy: 0.8, startedAt: base.addingTimeInterval(60)),
+            profileId: "profile-b"
+        )
+
+        let points = ParentSummaryTrendPoint.recentPoints(from: [otherProfile, selected], profileId: "profile-a")
+
+        #expect(points.map(\.id) == ["selected"])
+        #expect(points[0].accuracy == 1)
+        #expect(points[0].problemsCompleted == 0)
+        #expect(points[0].paceLabel == "—")
+    }
+}


### PR DESCRIPTION
## Summary
- Improves Settings on compact/large-text layouts with a linear compact stack, clearer section cards, larger touch targets, and a safer separated data-reset area.
- Improves Parent Summary scorecard contrast/readability and adds accessibility identifiers for stat cards.
- Adds a lightweight on-device “Recent progress” sparkline using existing `StoredSessionSummary` data for first-try/progress/pace trends.
- Adds regression coverage for trend helper empty/recent-order/profile-filter cases while preserving existing mixed history ordering tests.

Fixes #701
Fixes #702

## Validation
- `git diff --check` ✅
- `xcodebuild -list -project Mather.xcodeproj` on `mba` ✅
- Focused local test attempt on `mba`:
  - Command: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 16,OS=18.3.1" -only-testing:MatherTests/ParentSummaryTrendPointTests -only-testing:MatherTests/ParentSummaryHistoryRowTests`
  - Result: build failed before tests because the checked-in `Mather.xcodeproj` does not include several source files referenced by current `project.yml`/CI-generated project (e.g. `KidProfileStore`, `SliceTheme`, `MemoryAnimal`). Local `xcodegen` is not installed on `mba`; GitHub CI installs `xcodegen generate` before building, so CI is the final gate.
