### PR TITLE
fix: accept equivalent Sum Sprint totals

### DIFF
--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -360,6 +360,20 @@ enum SumSprintBurstCardContent: Equatable {
             return String(value)
         }
     }
+
+    var promptTotal: Int? {
+        guard case .prompt(let value) = self else { return nil }
+        let addends = value
+            .split(separator: "+")
+            .compactMap { Int(String($0).trimmingCharacters(in: .whitespacesAndNewlines)) }
+        guard addends.count == 2 else { return nil }
+        return addends.reduce(0, +)
+    }
+
+    var sumValue: Int? {
+        guard case .sum(let value) = self else { return nil }
+        return value
+    }
 }
 
 struct SumSprintBurstCard: Identifiable, Equatable {
@@ -380,15 +394,25 @@ struct SumSprintBurstState: Equatable {
     }
 
     var matchedPairs: Int {
-        Set(cards.filter { $0.isMatched }.map(\.pairId)).count
+        cards.filter(\.isMatched).count / 2
     }
 
     var isComplete: Bool {
-        matchedPairs == totalPairs && totalPairs > 0
+        cards.allSatisfy(\.isMatched) && totalPairs > 0
     }
 
     var progressLabel: String {
         "\(matchedPairs) / \(totalPairs)"
+    }
+
+    static func cardsFormValidMatch(_ lhs: SumSprintBurstCard, _ rhs: SumSprintBurstCard) -> Bool {
+        if let promptTotal = lhs.content.promptTotal, let sumValue = rhs.content.sumValue {
+            return promptTotal == sumValue
+        }
+        if let promptTotal = rhs.content.promptTotal, let sumValue = lhs.content.sumValue {
+            return promptTotal == sumValue
+        }
+        return false
     }
 
     static func make(for problem: SliceProblem) -> SumSprintBurstState {

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -355,8 +355,7 @@ final class VerticalSliceEngine {
 
             let selectedCard = state.cards[selectedIndex]
             let tappedCard = state.cards[tappedIndex]
-            let isMatch = selectedCard.pairId == tappedCard.pairId
-                && selectedCard.content != tappedCard.content
+            let isMatch = SumSprintBurstState.cardsFormValidMatch(selectedCard, tappedCard)
 
             state.cards[selectedIndex].isSelected = false
             state.cards[tappedIndex].isSelected = false

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -642,6 +642,32 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
+    func sumSprintAcceptsEquivalentTotalCardsWhenTotalsRepeat() {
+        let state = SumSprintBurstState.make(for: SliceProblem(target: 5, decompositionA: 1, decompositionB: 4))
+
+        let prompt = state.cards.first { card in
+            if case .prompt("1 + 4") = card.content { return true }
+            return false
+        }!
+        let equivalentTotalFromOtherPair = state.cards.first { card in
+            guard card.pairId != prompt.pairId,
+                  case .sum(5) = card.content else { return false }
+            return true
+        }!
+
+        #expect(SumSprintBurstState.cardsFormValidMatch(prompt, equivalentTotalFromOtherPair))
+
+        var crossMatchedState = state
+        let promptIndex = crossMatchedState.cards.firstIndex(where: { $0.id == prompt.id })!
+        let totalIndex = crossMatchedState.cards.firstIndex(where: { $0.id == equivalentTotalFromOtherPair.id })!
+        crossMatchedState.cards[promptIndex].isMatched = true
+        crossMatchedState.cards[totalIndex].isMatched = true
+
+        #expect(crossMatchedState.matchedPairs == 1)
+        #expect(!crossMatchedState.isComplete)
+    }
+
+    @Test
     func matchPairGracefullyIgnoresUnknownPairId() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true


### PR DESCRIPTION
## Summary
- Accept any Sum Sprint total card whose displayed value equals the selected sum sentence, instead of requiring hidden pair IDs to match.
- Count progress by matched card pairs so cross-pair matches with repeated totals do not prematurely complete the stage.
- Add regression coverage for the TestFlight #402 target-5 duplicate-total case.

## Testing
- Attempted local `swift test --filter VerticalSliceEngineTests/sumSprint`; blocked because `swift` is not installed on this Linux worker.

Fixes ganesh47/mather#402