### PR TITLE
fix: expose gravity split add controls to UI review

### DIFF
--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -241,20 +241,7 @@ struct GravitySplitView: View {
             }
             .frame(minHeight: 68, alignment: .topLeading)
 
-            Button {
-                guard !state.isLocked else { return }
-                onTap(1, side)
-            } label: {
-                Label("Add \(label)", systemImage: "plus.circle.fill")
-                    .font(.caption.weight(.black))
-                    .frame(maxWidth: .infinity, minHeight: 38)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            .tint(fill)
-            .disabled(state.isLocked || sourceCount == 0 || count >= target)
-            .accessibilityIdentifier("gravity-\(side == .left ? "left" : "right")-add-button")
+            addTokenControl(label: label, count: count, target: target, fill: fill, side: side)
         }
         .padding(10)
         .background(
@@ -267,6 +254,51 @@ struct GravitySplitView: View {
         )
         .frame(maxWidth: .infinity)
         .accessibilityIdentifier("gravity-\(side == .left ? "left" : "right")-zone")
+    }
+
+    private func addTokenControl(
+        label: String,
+        count: Int,
+        target: Int,
+        fill: Color,
+        side: TransferSide
+    ) -> some View {
+        let canAdd = !state.isLocked && sourceCount > 0 && count < target
+        let sideName = side == .left ? "left" : "right"
+
+        return HStack(spacing: 6) {
+            Image(systemName: "plus.circle.fill")
+                .imageScale(.medium)
+            Text("Add \(label)")
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+        }
+        .font(.caption.weight(.black))
+        .foregroundStyle(canAdd ? fill : MatherTheme.cardSubtitle.opacity(0.55))
+        .frame(maxWidth: .infinity, minHeight: 38)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(canAdd ? fill.opacity(0.10) : Color.secondary.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(canAdd ? fill.opacity(0.34) : Color.secondary.opacity(0.16), lineWidth: 1)
+        )
+        .contentShape(Rectangle())
+        .opacity(canAdd ? 1 : 0.72)
+        .onTapGesture {
+            guard canAdd else { return }
+            onTap(1, side)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Add \(label)")
+        .accessibilityHint(canAdd ? "Adds one token to the \(label) side." : "This side cannot accept more tokens right now.")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityIdentifier("gravity-\(sideName)-add-button")
+        .accessibilityAction {
+            guard canAdd else { return }
+            onTap(1, side)
+        }
     }
 
     private func tokenGrid(


### PR DESCRIPTION
## Summary
- Replaces the Gravity Split add controls with an explicit SwiftUI accessibility control surface instead of relying on the compact bordered `Button` export.
- Keeps the child-built Gravity Split interaction intact: tapping the left/right add control still moves exactly one token, respects locked/full/empty-source states, and the token-removal path is unchanged.
- Preserves the issue #222 UI review validation by exposing the same stable `gravity-left-add-button` / `gravity-right-add-button` identifiers as real tappable controls rather than weakening the screenshot test.

## Why PR #726 was insufficient
PR #726 broadened the UI test lookup from `app.buttons` to all XCUI descendants. The main UI Review still failed on both iPhone and iPad because the hosted accessibility tree did not expose the original compact bordered add `Button` under either `gravity-left-add-button` or `gravity-left-plus`. That proved the gap was in the app accessibility contract, not just the test query.

## Why this fixes the contract
The add affordance is now a non-collapsed accessibility element with:
- a stable side-specific identifier (`gravity-left-add-button` / `gravity-right-add-button`),
- button traits, label, hint, and default accessibility action,
- the same tap behavior and state guards as the previous Button.

This gives XCUI a stable descendant to find and tap across hosted iPhone/iPad runners while preserving the actual Gravity Split behavior.

## Validation
- Pushed branch successfully.
- Local Linux runner has no Swift/Xcode toolchain.
- Attempted remote Mac validation with `ssh ganesh-mba ... xcodebuild ...`, but the host alias currently fails DNS resolution (`Could not resolve hostname mba`).
- Hosted iOS UI Review remains the definitive proof for this failure mode.
