### PR TITLE
fix: keep gravity zone from swallowing add controls

### DIFF
--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -253,7 +253,7 @@ struct GravitySplitView: View {
                 )
         )
         .frame(maxWidth: .infinity)
-        .accessibilityIdentifier("gravity-\(side == .left ? "left" : "right")-zone")
+        .accessibilityElement(children: .contain)
     }
 
     private func addTokenControl(


### PR DESCRIPTION
## Summary
- Stops the Gravity Split destination zone container from taking its own accessibility identifier and potentially collapsing/swallowing its children.
- Keeps the explicit add controls added by #727 exposed as contained children with stable `gravity-left-add-button` / `gravity-right-add-button` identifiers.
- Preserves the child-built Gravity Split behavior; this is an accessibility-contract fix only.

## Why #726 and #727 were insufficient
- #726 only broadened the UI test lookup. Main UI Review proved the app still did not expose the add-control identifiers.
- #727 replaced the bordered SwiftUI Button with an explicit accessible add-control surface, and PR CI passed, but the manually triggered iPad UI Review still could not find `gravity-left-add-button`.
- The likely remaining blocker is the destination zone container identifier (`gravity-left-zone` / `gravity-right-zone`) promoting the whole zone as the exported accessibility element on hosted runners, hiding the add-control child from XCUI.

## Why this fixes the contract
The zone now uses `.accessibilityElement(children: .contain)` instead of taking an identifier for itself, so XCUI can traverse into the contained add controls. The controls retain their stable identifiers, button traits, labels, hints, and default accessibility action.

## Validation
- #727 PR checks passed before merge: Build & Test, CodeQL, dependency review, workflow lint.
- Manually triggered `iOS UI Review (main)` on #727's branch: iPad failed at the same missing left gravity add-control assertion, confirming the container-child exposure issue remained.
- This PR is intentionally a one-line containment fix on top of main. Hosted iOS UI Review is the definitive proof for this accessibility-tree behavior.
