### PR TITLE
fix: tap gravity split zone when add control is hidden

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -470,14 +470,16 @@ final class ScreenshotTests: XCTestCase {
             tapGravityIncrement(
                 in: app,
                 identifiers: ["gravity-left-add-button", "gravity-left-plus"],
-                failureMessage: "Expected a left gravity increment control"
+                zoneIdentifier: "gravity-left-zone",
+                failureMessage: "Expected a left gravity increment control or zone"
             )
         }
         for _ in 0..<rightPanCount {
             tapGravityIncrement(
                 in: app,
                 identifiers: ["gravity-right-add-button", "gravity-right-plus"],
-                failureMessage: "Expected a right gravity increment control"
+                zoneIdentifier: "gravity-right-zone",
+                failureMessage: "Expected a right gravity increment control or zone"
             )
         }
 
@@ -502,32 +504,52 @@ final class ScreenshotTests: XCTestCase {
     }
 
 
-    private func tapGravityIncrement(in app: XCUIApplication, identifiers: [String], failureMessage: String) {
-        guard let control = firstExistingControl(in: app, identifiers: identifiers, timeout: 5) else {
+    private func tapGravityIncrement(
+        in app: XCUIApplication,
+        identifiers: [String],
+        zoneIdentifier: String,
+        failureMessage: String
+    ) {
+        if let control = firstExistingControl(in: app, identifiers: identifiers, timeout: 2) {
+            control.tap()
+            return
+        }
+
+        guard let zone = firstExistingControl(in: app, identifiers: [zoneIdentifier], timeout: 5) else {
             XCTFail(failureMessage)
             return
         }
-        control.tap()
+
+        // Hosted UI review currently loses the compact SwiftUI add control from
+        // the accessibility hierarchy even when the surrounding Gravity Split
+        // destination zone remains discoverable. Keep the stronger identifier
+        // contract above, then fall back to the user-visible interaction point:
+        // the add affordance is rendered at the bottom center of each zone.
+        zone.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.86)).tap()
     }
 
     /// Gravity Split is intentionally touch-first now. SwiftUI can expose the
-    /// compact bordered add controls as generic accessibility descendants rather
-    /// than `XCUIElementTypeButton` on some simulator/device combinations, so the
-    /// issue #222 UI review should honor the accessibility identifier contract
-    /// across all descendant types while keeping the legacy button lookup first.
+    /// compact bordered add controls as generic accessibility descendants — or,
+    /// on hosted iPhone/iPad runners, hide them behind the destination-zone
+    /// composition altogether. The issue #222 UI review therefore keeps the
+    /// add-control identifier lookup first and falls back to a discoverable zone
+    /// element with the same visible user interaction point.
     private func firstExistingControl(in app: XCUIApplication, identifiers: [String], timeout: TimeInterval) -> XCUIElement? {
         let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
+        repeat {
             for identifier in identifiers {
                 if let button = firstExistingElement(in: app.buttons, identifier: identifier) {
                     return button
+                }
+                if let otherElement = firstExistingElement(in: app.otherElements, identifier: identifier) {
+                    return otherElement
                 }
                 if let descendant = firstExistingElement(in: app.descendants(matching: .any), identifier: identifier) {
                     return descendant
                 }
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.2))
-        }
+        } while Date() < deadline
         return nil
     }
 


### PR DESCRIPTION
## Summary
- keep the Gravity Split add-control identifier lookup first
- add a hosted-runner fallback that finds `gravity-left-zone` / `gravity-right-zone` and taps the bottom-center add affordance when the compact SwiftUI add element is absent from XCUI
- preserve the #222 route validation: the test still builds Gravity Split, then requires Sum Sprint and Bond Blast for all four targets including 12

## Why #726/#727 were not enough
#726 broadened the UI test query from `Button` to any descendant with the add-control identifiers. #727 then replaced the SwiftUI `Button` with a custom `HStack` + `onTapGesture` accessibility element. The main iOS UI Review still failed on both hosted iPhone and iPad, which means the compact add affordance can be omitted/collapsed from the hosted XCUI accessibility hierarchy entirely, not merely exposed under a different element type.

## Why this should hold on hosted iPhone + iPad
The surrounding Gravity Split destination zones are larger, stable, and already carry explicit identifiers (`gravity-left-zone`, `gravity-right-zone`). If hosted XCUI can no longer discover the compact add control, the fallback taps the same user-visible interaction point where the add affordance is rendered: bottom center of the appropriate zone. This keeps the test aligned to the real interaction instead of skipping Gravity Split or weakening the Sum Sprint/Bond Blast assertions.

## Validation
- `git diff --check` passed locally.
- Attempted remote Mac validation on `ganesh@mba` from a fresh `/tmp` clone:
  - `xcodebuild build-for-testing -project Mather.xcodeproj -scheme Mather -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO`
  - `xcodebuild build-for-testing -project Mather.xcodeproj -scheme Mather -destination "id=3A1BD382-28BD-4285-83B4-B6913DF496C4" ONLY_ACTIVE_ARCH=YES CODE_SIGNING_ALLOWED=NO`
- Both remote builds were blocked by an unrelated Swift 6.3.1/Xcode 26.4.1 frontend crash while type-checking `Features/ParentSummary/SettingsView.swift`, before exercising this UI-test change. Hosted iOS UI Review remains the proof gate for the actual accessibility behavior.
