### PR TITLE
test: tap lower gravity affordance when subtree is hidden

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -544,7 +544,12 @@ final class ScreenshotTests: XCTestCase {
         // visible add affordance area by screen position only after all identifier
         // lookups fail and the Gravity Split title proves we are on the right stage.
         let xOffset: CGFloat = fallbackSide == .left ? 0.32 : 0.68
-        app.coordinate(withNormalizedOffset: CGVector(dx: xOffset, dy: 0.57)).tap()
+        // The direct-token board sits below the source tray; the add affordance
+        // is in the lower half of each destination zone. Earlier center-zone
+        // screen taps hit the empty token grid on hosted runners and left the
+        // split unlocked, so use the same lower visible target as the zone
+        // fallback when the whole subtree is missing from XCUI.
+        app.coordinate(withNormalizedOffset: CGVector(dx: xOffset, dy: 0.68)).tap()
     }
 
     /// Gravity Split is intentionally touch-first now. SwiftUI can expose the


### PR DESCRIPTION
Follow-up for issue #222 after main iOS UI Review run 25039678468 showed the screen-coordinate fallback tapped the middle of the hidden Gravity Split destination zones and left the split unlocked.

This keeps identifier and zone lookups first, but moves the final screen-position fallback down to the visible add affordance area for hosted XCUI when the entire subtree is missing.

Evidence: main run 25039678468 failed both iPhone and iPad at `Expected Sum Sprint after Gravity Split target 6`; logs show all six fallback taps at `[0.32/0.68, 0.57]` followed by no Sum Sprint transition.