### PR TITLE
test: expose gravity split test controls outside hidden subtree

### DIFF
--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -73,6 +73,30 @@ struct SliceSessionView: View {
         .animation(.easeOut(duration: 0.25), value: appModel.engine.showCelebration)
     }
 
+
+    @ViewBuilder
+    private var gravitySplitUITestControls: some View {
+        if appModel.featureFlags.testModeEnabled {
+            HStack(spacing: 32) {
+                Button("Add left") {
+                    appModel.engine.adjustGravitySplitByTap(1, .left)
+                }
+                .accessibilityIdentifier("gravity-left-add-button")
+
+                Button("Add right") {
+                    appModel.engine.adjustGravitySplitByTap(1, .right)
+                }
+                .accessibilityIdentifier("gravity-right-add-button")
+            }
+            .buttonStyle(.plain)
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(.clear)
+            .frame(height: 44)
+            .padding(.horizontal, 24)
+            .background(Color.clear.contentShape(Rectangle()))
+        }
+    }
+
     @ViewBuilder
     private func stageView(for problem: SliceProblem) -> some View {
         switch appModel.engine.currentStage {
@@ -158,6 +182,9 @@ struct SliceSessionView: View {
                     onShakeHandled: { appModel.motionService.resetShake(); appModel.engine.resetGravitySplit() },
                     onSubmit: appModel.engine.submitCurrentStage
                 )
+                .overlay(alignment: .bottom) {
+                    gravitySplitUITestControls
+                }
                 .onAppear { appModel.motionService.startUpdates() }
                 .onDisappear { appModel.motionService.stopUpdates() }
             } else {

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -79,12 +79,12 @@ struct SliceSessionView: View {
         if appModel.featureFlags.testModeEnabled {
             HStack(spacing: 32) {
                 Button("Add left") {
-                    appModel.engine.adjustGravitySplitByTap(1, .left)
+                    appModel.engine.adjustGravitySplitByTap(delta: 1, side: .left)
                 }
                 .accessibilityIdentifier("gravity-left-add-button")
 
                 Button("Add right") {
-                    appModel.engine.adjustGravitySplitByTap(1, .right)
+                    appModel.engine.adjustGravitySplitByTap(delta: 1, side: .right)
                 }
                 .accessibilityIdentifier("gravity-right-add-button")
             }


### PR DESCRIPTION
Follow-up for issue #222 after main iOS UI Review run 25041515096 failed on both iPhone and iPad even after lower screen-coordinate fallback.

Hosted XCUI still cannot discover the SwiftUI Gravity Split destination subtree, and coordinate taps at `[0.32/0.68, 0.68]` leave the split locked on Gravity Split instead of advancing to Sum Sprint.

This adds test-mode-only overlay controls at the SliceSessionView boundary, outside the hidden GravitySplitView accessibility subtree. They call the same `adjustGravitySplitByTap` engine path and use the existing `gravity-left-add-button` / `gravity-right-add-button` identifiers, so the UI test can keep identifier lookup first without relying on brittle screen coordinates. The overlay is only present when `feature.testModeEnabled` is on.

Evidence: main run 25041515096 failed at `Expected Sum Sprint after Gravity Split target 6`; logs show the lower fallback taps happened but no Sum Sprint transition occurred.
