### PR TITLE
test: auto-complete Gravity Split in issue 222 UI review

### DIFF
--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -102,6 +102,18 @@ struct SliceSessionView: View {
         }
     }
 
+    private var shouldAutoCompleteGravitySplitForUITests: Bool {
+        ProcessInfo.processInfo.arguments.contains("-uiTest.autoCompleteGravitySplit")
+    }
+
+    private func scheduleGravitySplitUITestAutoComplete() {
+        guard shouldAutoCompleteGravitySplitForUITests else { return }
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2))
+            appModel.engine.completeGravitySplitForUITest()
+        }
+    }
+
     @ViewBuilder
     private func stageView(for problem: SliceProblem) -> some View {
         switch appModel.engine.currentStage {
@@ -190,7 +202,10 @@ struct SliceSessionView: View {
                 .overlay(alignment: .bottom) {
                     gravitySplitUITestControls
                 }
-                .onAppear { appModel.motionService.startUpdates() }
+                .onAppear {
+                    appModel.motionService.startUpdates()
+                    scheduleGravitySplitUITestAutoComplete()
+                }
                 .onDisappear { appModel.motionService.stopUpdates() }
             } else {
                 CardSurface { Text("Loading Balance...") }

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -342,6 +342,7 @@ final class ScreenshotTests: XCTestCase {
             "-feature.soundReactionEnabled", "NO",
             "-feature.testModeEnabled", "YES",
             "-feature.skipProfilePicker", "YES",
+            "-uiTest.autoCompleteGravitySplit",
         ]
         if let appearance {
             launchArguments += ["-uiTest.appearance", appearance.launchValue]


### PR DESCRIPTION
## Summary
- add an explicit issue #222 UI-test launch flag that auto-completes Gravity Split shortly after the screenshot is captured
- keep the existing direct completion button/fallback taps, but stop relying on hosted XCUI button actions to advance the stage
- scope the behavior to `launchWithLoopV2()` via `-uiTest.autoCompleteGravitySplit`

## Validation
- git diff --check
- xcodebuild unavailable on this Linux coordinator host

Follow-up to main iOS UI Review run 25045550530: hosted logs show `gravity-complete-split-button` was found/tapped, but Sum Sprint still did not appear.