### PR TITLE
fix(room-quest): accept almost place with parent consent

### DIFF
--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -263,6 +263,48 @@ final class RoomQuestEngine {
         }
     }
 
+    var currentSpotParentConsentTitle: String {
+        switch scanState {
+        case .almost:
+            return "Grown-up confirms this is the place"
+        case .failed:
+            return "Grown-up confirms fallback"
+        case .idle:
+            return currentStation?.role.fallbackButtonTitle ?? "I found it"
+        case .scanning, .celebrating:
+            return currentStation?.role.fallbackButtonTitle ?? "I found it"
+        }
+    }
+
+    func acceptCurrentSpotWithParentConsent() {
+        guard case .spot(let index) = phase,
+              let station = stations[safe: index],
+              shouldShowSpotManualFallback
+        else { return }
+
+        let scanOutcome: String = {
+            switch scanState {
+            case .almost: return "almost"
+            case .failed: return "failed"
+            case .idle: return "manual_fallback"
+            case .scanning: return "scanning"
+            case .celebrating: return "celebrating"
+            }
+        }()
+        try? telemetryWriter.append(SliceEvent(
+            type: .interaction,
+            payload: [
+                "action": "room_quest_parent_consent_accept",
+                "station_role": station.role.rawValue,
+                "spot_index": String(index),
+                "scan_outcome": scanOutcome
+            ]
+        ))
+        feedbackMessage = "Grown-up confirmed this place. Collect \(station.quantity) \(station.quantity == 1 ? "token" : "tokens")."
+        scanState = .idle
+        markSpotVisited(index: index)
+    }
+
     func markSetupComplete() {
         guard let p = problem else { return }
         guard allStationsRegistered else {

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -129,7 +129,7 @@ struct SpotPromptView: View {
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(MatherTheme.ink)
                 Text(engine.shouldShowSpotManualFallback
-                     ? "The camera missed this place. A grown-up can use fallback now."
+                     ? "If the child is at the right place, a grown-up can consent and accept it now."
                      : "Start with a camera check. Fallback stays hidden unless the scan misses, so the camera feels like the real helper.")
                     .font(.subheadline)
                     .foregroundStyle(MatherTheme.cardSubtitle)
@@ -161,8 +161,8 @@ struct SpotPromptView: View {
             }
 
             if engine.shouldShowSpotManualFallback {
-                Button(station?.role.fallbackButtonTitle ?? "I found it") {
-                    engine.markSpotVisited(index: spotIndex)
+                Button(engine.currentSpotParentConsentTitle) {
+                    engine.acceptCurrentSpotWithParentConsent()
                 }
                 .accessibilityIdentifier("room-spot-confirm-button")
                 .buttonStyle(.plain)

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -306,9 +306,13 @@ struct RoomQuestEngineTests {
             #expect(recheckingEngine.currentSpotReferenceLabel.localizedCaseInsensitiveContains("saved camera place"))
             #expect(recheckingEngine.currentSpotStatusTitle.localizedCaseInsensitiveContains("almost there"))
             #expect(recheckingEngine.currentSpotSearchGuidance.localizedCaseInsensitiveContains("move a little closer"))
+            #expect(recheckingEngine.currentSpotParentConsentTitle.localizedCaseInsensitiveContains("grown-up confirms"))
         } else {
             Issue.record("Expected almost scan state after saved-reference payload mismatch")
         }
+
+        recheckingEngine.acceptCurrentSpotWithParentConsent()
+        #expect(recheckingEngine.phase == .spot(index: 1))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a parent-consent acceptance path for Room Quest "Almost there"/miss fallback states
- update SpotPromptView copy/button to say a grown-up can consent and accept the place
- extend RoomQuestEngine coverage so an `almost` saved-place mismatch can advance only through the consent fallback gate

Fixes #738.

## Validation
- Attempted: `swift test --filter RoomQuestEngineTests` on worker VM; blocked because `swift` is not installed.
- Attempted remote Mac validation via `ssh ganesh-mba` / `ganesh@Ganeshs-MacBook-Air.local`; blocked by hostname DNS resolution failure from worker session.
- CI is the validation gate for this PR.
