### PR TITLE
Fix build 58 phone layout regressions

### DIFF
--- a/Features/VerticalSlice1/SessionConfigView.swift
+++ b/Features/VerticalSlice1/SessionConfigView.swift
@@ -19,99 +19,92 @@ struct SessionConfigView: View {
     var body: some View {
         ZStack {
             MatherTheme.background.ignoresSafeArea()
-            VStack(spacing: 20) {
-                CardSurface {
-                    VStack(alignment: .leading, spacing: 16) {
-                        Text("Session setup")
-                            .font(.title.weight(.black))
-                        Text("Keep sessions short and consistent.")
-                            .font(.headline)
-                            .foregroundStyle(MatherTheme.ink.opacity(0.6))
-                            .fixedSize(horizontal: false, vertical: true)
 
-                        Divider()
-
-                        Text("Theme")
-                            .font(.title3.weight(.semibold))
-
-                        // Theme picker — two cards, selected card gets accent border.
-                        // Tapping sets selectedThemeId; engine reads it at startSession().
-                        HStack(spacing: 12) {
-                            ForEach(themeOptions) { option in
-                                themeCard(option)
-                            }
-                        }
-
-                        Divider()
-
-                        Stepper(value: Binding(
-                            get: { appModel.engine.config.maxProblems },
-                            set: { appModel.engine.updateConfig(problemCount: $0) }
-                        ), in: 4...8) {
-                            Text("Problems: \(appModel.engine.config.maxProblems)")
-                                .font(.title3.weight(.semibold))
-                        }
-
-                        Divider()
-
-                        VStack(alignment: .leading, spacing: 10) {
-                            Text("Target numbers")
-                                .font(.title3.weight(.semibold))
-                            Text("Choose the largest number this session can ask for.")
-                                .font(.subheadline)
+            ScrollView {
+                VStack(spacing: 20) {
+                    CardSurface {
+                        VStack(alignment: .leading, spacing: 16) {
+                            Text("Session setup")
+                                .font(.title.weight(.black))
+                            Text("Keep sessions short and consistent.")
+                                .font(.headline)
                                 .foregroundStyle(MatherTheme.ink.opacity(0.6))
+                                .fixedSize(horizontal: false, vertical: true)
 
-                            LazyVGrid(columns: [GridItem(.adaptive(minimum: 96), spacing: 12)], spacing: 12) {
-                                ForEach(ParentTargetCap.quickPicks, id: \.self) { maxTarget in
-                                    targetCapButton(maxTarget: maxTarget)
+                            Divider()
+
+                            Text("Theme")
+                                .font(.title3.weight(.semibold))
+                                .accessibilityIdentifier("session-setup-theme-section")
+
+                            // Theme picker — two cards, selected card gets accent border.
+                            // Tapping sets selectedThemeId; engine reads it at startSession().
+                            HStack(spacing: 12) {
+                                ForEach(themeOptions) { option in
+                                    themeCard(option)
                                 }
                             }
 
-                            Stepper(
-                                value: targetCapBinding,
-                                in: ParentTargetCap.minimum...ParentTargetCap.maximum,
-                                step: ParentTargetCap.step
-                            ) {
-                                Text(ParentTargetCap.displayLabel(for: appModel.engine.config.parentTargetCap))
-                                    .font(.headline.weight(.semibold))
-                                    .accessibilityIdentifier("target-cap-current-value")
-                            }
-                            .accessibilityIdentifier("target-cap-stepper")
-                        }
+                            Divider()
 
-                        Toggle("Speak prompts", isOn: Binding(
-                            get: { appModel.featureFlags.audioEnabled },
-                            set: {
-                                appModel.featureFlags.audioEnabled = $0
-                                appModel.engine.updateConfig(audioEnabled: $0)
+                            Stepper(value: Binding(
+                                get: { appModel.engine.config.maxProblems },
+                                set: { appModel.engine.updateConfig(problemCount: $0) }
+                            ), in: 4...8) {
+                                Text("Problems: \(appModel.engine.config.maxProblems)")
+                                    .font(.title3.weight(.semibold))
                             }
-                        ))
-                        .font(.title3.weight(.semibold))
+                            .accessibilityIdentifier("problems-stepper")
 
-                        Button("Start Session") {
-                            appModel.engine.startSession()
+                            Divider()
+
+                            VStack(alignment: .leading, spacing: 10) {
+                                Text("Target numbers")
+                                    .font(.title3.weight(.semibold))
+                                Text("Choose the largest number this session can ask for.")
+                                    .font(.subheadline)
+                                    .foregroundStyle(MatherTheme.ink.opacity(0.6))
+
+                                LazyVGrid(columns: [GridItem(.adaptive(minimum: 96), spacing: 12)], spacing: 12) {
+                                    ForEach(ParentTargetCap.quickPicks, id: \.self) { maxTarget in
+                                        targetCapButton(maxTarget: maxTarget)
+                                    }
+                                }
+                            }
+                            .accessibilityIdentifier("target-cap-section")
+
+                            Toggle("Speak prompts", isOn: Binding(
+                                get: { appModel.featureFlags.audioEnabled },
+                                set: {
+                                    appModel.featureFlags.audioEnabled = $0
+                                    appModel.engine.updateConfig(audioEnabled: $0)
+                                }
+                            ))
+                            .font(.title3.weight(.semibold))
+                            .accessibilityIdentifier("speak-prompts-toggle")
+
+                            Button("Start Session") {
+                                appModel.engine.startSession()
+                            }
+                            .buttonStyle(PrimaryActionButtonStyle())
+                            .accessibilityIdentifier("start-session-button")
                         }
-                        .buttonStyle(PrimaryActionButtonStyle())
-                        .accessibilityIdentifier("start-session-button")
                     }
-                }
 
-                Button("Back to Home") {
-                    appModel.engine.showHome()
+                    Button("Back to Home") {
+                        appModel.engine.showHome()
+                    }
+                    .font(.headline.weight(.semibold))
+                    .accessibilityIdentifier("back-to-home-button")
                 }
-                .font(.headline.weight(.semibold))
+                .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.horizontal, 24)
+                .padding(.top, 24)
+                .padding(.bottom, 32)
             }
-            .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-            .padding(24)
+            .scrollIndicators(.visible)
         }
-    }
-
-    private var targetCapBinding: Binding<Int> {
-        Binding(
-            get: { appModel.engine.config.parentTargetCap },
-            set: { appModel.engine.updateConfig(minTarget: 1, maxTarget: ParentTargetCap.normalize($0)) }
-        )
     }
 
     private func targetCapButton(maxTarget: Int) -> some View {
@@ -141,7 +134,7 @@ struct SessionConfigView: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("target-cap-up-to-\(normalizedTarget)")
-        .accessibilityLabel("Target numbers up to \(normalizedTarget)")
+        .accessibilityLabel("Target numbers up to \(normalizedTarget)\(isSelected ? ", selected" : "")")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -25,7 +25,7 @@ struct SliceSessionView: View {
 
                 ScrollView {
                     VStack(spacing: 20) {
-                        FeedbackBannerView(message: appModel.engine.feedbackMessage, isCelebrating: appModel.engine.showCelebration)
+                        FeedbackBannerView(message: childFacingBannerMessage, isCelebrating: appModel.engine.showCelebration)
 
                         if let currentProblem = appModel.engine.currentProblem {
                             stageView(for: currentProblem)
@@ -73,6 +73,15 @@ struct SliceSessionView: View {
         .animation(.easeOut(duration: 0.25), value: appModel.engine.showCelebration)
     }
 
+
+    private var childFacingBannerMessage: String {
+        if appModel.engine.currentStage == .storyAnchor,
+           appModel.engine.currentStoryPrompt != nil,
+           !appModel.engine.showCelebration {
+            return "Listen for the numbers, then start building."
+        }
+        return appModel.engine.feedbackMessage
+    }
 
     @ViewBuilder
     private var gravitySplitUITestControls: some View {

--- a/Features/VerticalSlice1/SplitView.swift
+++ b/Features/VerticalSlice1/SplitView.swift
@@ -105,6 +105,7 @@ struct SplitView: View {
             dotGrid(rows: rows, fill: fill, delta: delta)
         }
         .frame(maxWidth: .infinity)
+        .accessibilityLabel("\(count) of \(target)")
     }
 
     @ViewBuilder
@@ -134,12 +135,14 @@ struct SplitView: View {
         .onTapGesture { onAdjust(delta) }
     }
 
-    // Lay out `count` filled dots and (capacity - count) empty dots in rows of 5.
+    // Lay out filled dots in rows of 5. Very large story targets can otherwise
+    // create 7+ rows per bucket on phone screens; cap the visual scaffold at
+    // 20 slots and keep the exact amount in the large numeric label above.
     private func dotRows(count: Int, capacity: Int) -> [[Bool]] {
-        let total = max(capacity, 1)
+        let total = min(max(capacity, 1), 20)
         var rows: [[Bool]] = []
         var remaining = total
-        var filled = count
+        var filled = min(count, total)
         while remaining > 0 {
             let rowSize = min(remaining, 5)
             let row = (0..<rowSize).map { i -> Bool in

--- a/Features/VerticalSlice1/StoryAnchorView.swift
+++ b/Features/VerticalSlice1/StoryAnchorView.swift
@@ -6,22 +6,27 @@ struct StoryAnchorView: View {
 
     var body: some View {
         VS1Card {
-            VStack(alignment: .leading, spacing: 22) {
+            VStack(alignment: .leading, spacing: 18) {
                 Text(prompt.title)
-                    .font(.system(size: 34, weight: .black, design: .rounded))
+                    .font(.system(size: 30, weight: .black, design: .rounded))
                     .foregroundStyle(MatherTheme.ink)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.82)
                     .fixedSize(horizontal: false, vertical: true)
 
                 Text(prompt.spokenIntro)
-                    .font(.system(size: 26, weight: .bold, design: .rounded))
+                    .font(.system(size: 22, weight: .bold, design: .rounded))
                     .foregroundStyle(MatherTheme.ink)
+                    .lineLimit(4)
+                    .minimumScaleFactor(0.78)
                     .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("story-anchor-spoken-intro")
 
                 Text(prompt.reminder)
                     .font(.headline.weight(.black))
                     .foregroundStyle(MatherTheme.accent)
-                    .padding(.vertical, 12)
-                    .padding(.horizontal, 18)
+                    .padding(.vertical, 10)
+                    .padding(.horizontal, 16)
                     .background(
                         Capsule(style: .continuous)
                             .fill(MatherTheme.accent.opacity(0.14))

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -42,6 +42,41 @@ final class CompactLayoutTests: XCTestCase {
         XCTAssertTrue(rightFive.isHittable, "Expected Bond Blast actions to be reachable without additional scrolling")
     }
 
+
+    func testSessionSetupCompactTargetCapUsesSingleScrollablePresetControl() {
+        let app = launchWithVS1()
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
+
+        app.buttons["Play"].tap()
+        _ = app.staticTexts["Session setup"].waitForExistence(timeout: 10)
+
+        XCTAssertTrue(app.buttons["theme-card-vehicle"].waitForExistence(timeout: 5))
+        app.buttons["theme-card-vehicle"].tap()
+
+        let targetCap50 = app.buttons["target-cap-up-to-50"]
+        if !targetCap50.waitForExistence(timeout: 3) {
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        XCTAssertTrue(targetCap50.waitForExistence(timeout: 5))
+        XCTAssertTrue(targetCap50.isHittable, "Expected target-cap preset cards to be reachable on compact setup")
+        targetCap50.tap()
+        XCTAssertFalse(app.steppers["target-cap-stepper"].exists, "Expected setup to expose only preset target-cap cards, not duplicate plus/minus controls")
+
+        let start = app.buttons["start-session-button"]
+        if !start.isHittable {
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        XCTAssertTrue(start.waitForExistence(timeout: 5))
+        XCTAssertTrue(start.isHittable, "Expected Start Session to be reachable by scrolling on compact setup")
+
+        let back = app.buttons["back-to-home-button"]
+        if !back.isHittable {
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        XCTAssertTrue(back.waitForExistence(timeout: 5))
+        XCTAssertTrue(back.isHittable, "Expected Back to Home to remain reachable by scrolling on compact setup")
+    }
+
     func testRoomQuestCompactSpotScreenKeepsPrimaryActionReachableWithoutSwipe() {
         let app = launch()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)


### PR DESCRIPTION
## Summary
- make Session setup scroll on compact phones and expose stable accessibility IDs for setup controls
- remove the duplicate target-cap stepper so the preset cards are the single visible control model
- shorten the story-stage feedback banner and clamp story prompt typography to avoid header/banner overlap
- cap Split bucket visual scaffolds for large targets so build-58-style `35 wheels` stories do not create oversized/cropped phone layouts

Fixes #745
Fixes #746
Fixes #747
Fixes #748

## Validation
- `git diff --check` ✅
- Remote Mac attempted: `xcodebuild build -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.3.1' CODE_SIGNING_ALLOWED=NO SWIFT_COMPILATION_MODE=wholemodule` ❌ blocked by Swift 6.3.1 frontend crash while type-checking existing `Features/ParentSummary/SettingsView.swift:156` (`SettingsView.profilesCard`), before producing actionable project diagnostics.
- Earlier remote attempt: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' CODE_SIGNING_ALLOWED=NO` hit the same Swift frontend crash in `SettingsView.profilesCard`.

## Notes
- The build-58 screenshot strings `Red Lift` / `Blue Lift` were not present in current main (`f149c94+`) source; current vehicle story code uses the `vehicle_garage` number-story pack with `wheels`. This PR fixes the reproducible current-path compact layout risks rather than guessing at removed/generated build text.
