### PR TITLE
Improve geometry lab story and sensor context

### DIFF
--- a/Features/AngleCannon/AngleCannonView.swift
+++ b/Features/AngleCannon/AngleCannonView.swift
@@ -34,6 +34,9 @@ struct AngleCannonView: View {
     /// Briefly true on FIRE to animate the cannon barrel kick
     @State private var firePulse = false
     @State private var hasFiredOnce = false
+    @State private var projectileProgress: Double = 0
+    @State private var projectileAnimating = false
+    @State private var pendingHit: Bool? = nil
 
     // MARK: - Constants
 
@@ -42,8 +45,8 @@ struct AngleCannonView: View {
     private let angleRange: ClosedRange<Double> = 10...80
     private let targetPool: [Double] = [15, 30, 45, 60, 75]
     /// Target symbols — rendered at the landing position for delight
-    private let targetSymbols = ["🎈", "⭐️", "🎯", "🍎", "🪁"]
-    @State private var targetSymbol = "🎯"
+    private let scenarios = AngleCannonScenario.defaultScenarios
+    @State private var scenario = AngleCannonScenario.defaultScenarios[0]
 
     private var hitTolerance: Double { level == 1 ? 15 : 10 }
 
@@ -240,12 +243,26 @@ struct AngleCannonView: View {
             )
 
             // Target symbol (bounces before firing)
-            Text(targetSymbol)
+            Text(scenario.targetSymbol)
                 .font(.system(size: 30))
                 .position(target)
                 .opacity(hitTarget ? 0 : 1)
                 .scaleEffect(hitTarget ? 2.0 : 1.0)
                 .animation(.spring(response: 0.4, dampingFraction: 0.5), value: hitTarget)
+
+            if let fired = firedAngleDeg, projectileAnimating || projectileProgress < 1 {
+                let pts = Self.arcPoints(angleDeg: fired, cannon: cannon, size: canvasSize)
+                if let projectile = Self.projectilePoint(on: pts, progress: projectileProgress) {
+                    Text(scenario.projectileSymbol)
+                        .font(.system(size: 26))
+                        .position(projectile)
+                        .shadow(color: MatherTheme.warm.opacity(0.45), radius: 8)
+                        .accessibilityIdentifier("angle-cannon-projectile")
+                }
+            }
+
+            missionChip
+                .position(x: canvasSize.width / 2, y: canvasSize.height * 0.10)
 
             // Hit celebration burst
             if hitTarget {
@@ -312,7 +329,7 @@ struct AngleCannonView: View {
             }
 
             // "Too high / Too low" miss hint
-            if let fired = firedAngleDeg, !hitTarget {
+            if let fired = firedAngleDeg, !hitTarget, !projectileAnimating, pendingHit == nil {
                 let tooHigh = fired > targetAngleDeg
                 HStack(spacing: 6) {
                     Image(systemName: tooHigh ? "arrow.down.circle.fill" : "arrow.up.circle.fill")
@@ -350,7 +367,11 @@ struct AngleCannonView: View {
         HStack {
             Spacer()
 
-            if hitTarget {
+            if projectileAnimating {
+                ProgressView("Watching the arc…")
+                    .font(.headline.weight(.bold))
+                    .frame(minWidth: 180, minHeight: 60)
+            } else if hitTarget {
                 Button("Next →") {
                     advanceRound()
                 }
@@ -432,6 +453,20 @@ struct AngleCannonView: View {
         abs(firedDeg - targetDeg) <= toleranceDeg
     }
 
+    nonisolated static func projectilePoint(on points: [CGPoint], progress: Double) -> CGPoint? {
+        guard !points.isEmpty else { return nil }
+        let clamped = max(0, min(progress, 1))
+        let exactIndex = clamped * Double(points.count - 1)
+        let lower = Int(floor(exactIndex))
+        let upper = min(points.count - 1, lower + 1)
+        guard lower != upper else { return points[lower] }
+        let t = exactIndex - Double(lower)
+        let a = points[lower]
+        let b = points[upper]
+        return CGPoint(x: a.x + (b.x - a.x) * t,
+                       y: a.y + (b.y - a.y) * t)
+    }
+
     // MARK: - Layout helpers
 
     private func cannonOrigin(in size: CGSize) -> CGPoint {
@@ -484,24 +519,15 @@ struct AngleCannonView: View {
 
         hasFiredOnce = true
         firedAngleDeg = currentAngleDeg
-        let hit = Self.isHit(firedDeg: currentAngleDeg, targetDeg: targetAngleDeg,
-                             toleranceDeg: hitTolerance)
-        hitTarget = hit
-        if hit {
-            appModel.hapticsService.balanceLock(enabled: appModel.featureFlags.hapticsEnabled)
-            appModel.speechService.speak(
-                "\(Int(currentAngleDeg)) degrees — bullseye!",
-                enabled: appModel.featureFlags.audioEnabled
-            )
-            roundsWon += 1
-        } else {
-            appModel.hapticsService.failure(enabled: appModel.featureFlags.hapticsEnabled)
-            let tooHigh = currentAngleDeg > targetAngleDeg
-            appModel.speechService.speak(
-                tooHigh ? "Too high — tilt a little less next time!"
-                        : "Too low — tilt a bit more!",
-                enabled: appModel.featureFlags.audioEnabled
-            )
+        pendingHit = Self.isHit(firedDeg: currentAngleDeg, targetDeg: targetAngleDeg,
+                                toleranceDeg: hitTolerance)
+        hitTarget = false
+        projectileAnimating = true
+        projectileProgress = 0
+        withAnimation(.linear(duration: 0.9)) { projectileProgress = 1 }
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(900))
+            resolveShotFeedback()
         }
     }
 
@@ -509,6 +535,9 @@ struct AngleCannonView: View {
     private func resetShot() {
         firedAngleDeg = nil
         hitTarget = false
+        projectileProgress = 0
+        projectileAnimating = false
+        pendingHit = nil
         // Deliberately NOT resetting neutralRoll — keeps aim baseline between retries.
     }
 
@@ -533,7 +562,61 @@ struct AngleCannonView: View {
         var candidates = targetPool.filter { abs($0 - targetAngleDeg) > 5 }
         if candidates.isEmpty { candidates = targetPool }
         targetAngleDeg = candidates.randomElement() ?? 45
-        targetSymbol = targetSymbols.randomElement() ?? "🎯"
+        scenario = scenarios.first(where: { $0.targetAngleDeg == targetAngleDeg }) ?? scenarios.randomElement() ?? AngleCannonScenario.defaultScenarios[0]
         currentAngleDeg = 45
     }
+
+    private func resolveShotFeedback() {
+        guard let hit = pendingHit else { return }
+        projectileAnimating = false
+        pendingHit = nil
+        hitTarget = hit
+        if hit {
+            appModel.hapticsService.balanceLock(enabled: appModel.featureFlags.hapticsEnabled)
+            appModel.speechService.speak(
+                scenario.successSpeech,
+                enabled: appModel.featureFlags.audioEnabled
+            )
+            roundsWon += 1
+        } else {
+            appModel.hapticsService.failure(enabled: appModel.featureFlags.hapticsEnabled)
+            let tooHigh = currentAngleDeg > targetAngleDeg
+            appModel.speechService.speak(
+                tooHigh ? "Too high — tilt a little less next time!"
+                        : "Too low — tilt a bit more!",
+                enabled: appModel.featureFlags.audioEnabled
+            )
+        }
+    }
+
+    private var missionChip: some View {
+        HStack(spacing: 8) {
+            Text(scenario.environmentSymbol)
+            Text(scenario.missionSpeech)
+                .font(.caption.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+                .lineLimit(2)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.ultraThinMaterial, in: Capsule())
+        .overlay(Capsule().stroke(MatherTheme.softBlue.opacity(0.35), lineWidth: 1))
+    }
+}
+
+struct AngleCannonScenario: Equatable {
+    let id: String
+    let targetAngleDeg: Double
+    let environmentSymbol: String
+    let targetSymbol: String
+    let projectileSymbol: String
+    let missionSpeech: String
+    let successSpeech: String
+
+    static let defaultScenarios: [AngleCannonScenario] = [
+        .init(id: "seed-pod", targetAngleDeg: 30, environmentSymbol: "🌱", targetSymbol: "🌿", projectileSymbol: "🫘", missionSpeech: "Send the seed pod to the hill ledge.", successSpeech: "The seed pod landed on the ledge!"),
+        .init(id: "moon-gate", targetAngleDeg: 45, environmentSymbol: "🌙", targetSymbol: "🏮", projectileSymbol: "✨", missionSpeech: "Launch the lantern to the moon gate.", successSpeech: "The lantern reached the moon gate!"),
+        .init(id: "festival-bell", targetAngleDeg: 60, environmentSymbol: "🎪", targetSymbol: "🔔", projectileSymbol: "⭐️", missionSpeech: "Ring the festival bell.", successSpeech: "You rang the festival bell!"),
+        .init(id: "treehouse", targetAngleDeg: 75, environmentSymbol: "🌳", targetSymbol: "🏠", projectileSymbol: "📦", missionSpeech: "Toss the package to the treehouse.", successSpeech: "Package delivered to the treehouse!")
+    ]
 }

--- a/Features/GravityArtist/GravityArtistView.swift
+++ b/Features/GravityArtist/GravityArtistView.swift
@@ -1,13 +1,27 @@
 import SwiftUI
 
-// Gravity Artist — ages 8–10
-// Two-phase activity: first PREDICT the arc (tap PREDICT to freeze your guess),
-// then FIRE and compare where the ball actually lands.
-// Tilt controls the launch angle; a power selector (1/2/3) changes initial velocity.
-// Landing the ball within the hit radius of a target earns a star and reveals
-// the angle label — the abstract CPA step.
+// Gravity Sensor Lab — ages 8–10
+// Tilt controls a screen-down gravity vector. The legacy predict/fire controls
+// remain as a small comparison loop, but the first-read experience now teaches
+// gravity direction with a tray, arrow, and rolling pebbles instead of another cannon.
 
 // MARK: - Physics helpers (pure — testable)
+
+enum GravitySensorPhysics {
+    nonisolated static func normalizedVector(roll: Double, neutralRoll: Double = 0) -> CGVector {
+        let delta = max(-Double.pi / 3, min(roll - neutralRoll, Double.pi / 3))
+        let dx = sin(delta)
+        let dy = cos(delta)
+        let length = max(0.0001, sqrt(dx * dx + dy * dy))
+        return CGVector(dx: dx / length, dy: dy / length)
+    }
+
+    nonisolated static func pebblePosition(origin: CGPoint, vector: CGVector, distance: Double, bounds: CGRect) -> CGPoint {
+        let unclamped = CGPoint(x: origin.x + vector.dx * distance, y: origin.y + vector.dy * distance)
+        return CGPoint(x: min(max(unclamped.x, bounds.minX), bounds.maxX),
+                       y: min(max(unclamped.y, bounds.minY), bounds.maxY))
+    }
+}
 
 enum GravityArtistPhysics {
     static let gravity: Double = 900   // pt/s²
@@ -156,7 +170,7 @@ struct GravityArtistView: View {
     private var headerBar: some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Gravity Artist")
+                Text("Gravity Sensor Lab")
                     .font(.title2.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
                 Text(phaseHint)
@@ -180,9 +194,9 @@ struct GravityArtistView: View {
 
     private var phaseHint: String {
         switch phase {
-        case .aim:       return "Tilt to aim, then PREDICT"
-        case .predicted: return "Prediction locked — now FIRE!"
-        case .fired:     return hitTarget ? "You hit it! \(Int(currentAngle.rounded()))°" : "Close! Try again."
+        case .aim:       return "Tilt to find which way gravity pulls"
+        case .predicted: return "Prediction locked — now observe the roll"
+        case .fired:     return hitTarget ? "Pebble followed gravity!" : "Try a new tilt direction."
         }
     }
 
@@ -193,11 +207,13 @@ struct GravityArtistView: View {
             let cannon = cannonOrigin(in: canvasSize)
             let groundY = canvasSize.height * 0.88
 
-            // Ground line
+            drawGravityTray(ctx: ctx, size: canvasSize)
+
+            // Ground line for the small legacy compare loop
             var ground = Path()
             ground.move(to: CGPoint(x: 0, y: groundY))
             ground.addLine(to: CGPoint(x: canvasSize.width, y: groundY))
-            ctx.stroke(ground, with: .color(MatherTheme.ink.opacity(0.15)), lineWidth: 2)
+            ctx.stroke(ground, with: .color(MatherTheme.ink.opacity(0.10)), lineWidth: 2)
 
             // Target marker
             let ty = groundY
@@ -274,6 +290,31 @@ struct GravityArtistView: View {
                  with: .color(MatherTheme.ink.opacity(0.8)))
     }
 
+    private func drawGravityTray(ctx: GraphicsContext, size: CGSize) {
+        let tray = CGRect(x: size.width * 0.18, y: size.height * 0.13,
+                          width: size.width * 0.64, height: size.height * 0.44)
+        ctx.fill(RoundedRectangle(cornerRadius: 28).path(in: tray), with: .color(MatherTheme.softBlue.opacity(0.10)))
+        ctx.stroke(RoundedRectangle(cornerRadius: 28).path(in: tray), with: .color(MatherTheme.softBlue.opacity(0.45)), lineWidth: 4)
+
+        let neutral = neutralRoll ?? appModel.motionService.tiltRoll
+        let vector = GravitySensorPhysics.normalizedVector(roll: appModel.motionService.tiltRoll, neutralRoll: neutral)
+        let center = CGPoint(x: tray.midX, y: tray.midY)
+        let arrowEnd = CGPoint(x: center.x + vector.dx * 90, y: center.y + vector.dy * 90)
+        var arrow = Path(); arrow.move(to: center); arrow.addLine(to: arrowEnd)
+        ctx.stroke(arrow, with: .color(MatherTheme.accent), style: StrokeStyle(lineWidth: 9, lineCap: .round))
+        ctx.fill(Circle().path(in: CGRect(x: arrowEnd.x - 10, y: arrowEnd.y - 10, width: 20, height: 20)), with: .color(MatherTheme.accent))
+
+        let pebbleBounds = tray.insetBy(dx: 34, dy: 34)
+        for (index, offset) in [CGPoint(x: -48, y: -18), CGPoint(x: 0, y: 10), CGPoint(x: 44, y: -8)].enumerated() {
+            let start = CGPoint(x: center.x + offset.x, y: center.y + offset.y)
+            let pos = GravitySensorPhysics.pebblePosition(origin: start, vector: vector, distance: 54 + Double(index * 18), bounds: pebbleBounds)
+            ctx.fill(Circle().path(in: CGRect(x: pos.x - 11, y: pos.y - 11, width: 22, height: 22)), with: .color(MatherTheme.warm.opacity(0.85)))
+        }
+
+        let label = ctx.resolve(Text("gravity pulls this way").font(.caption.bold()).foregroundStyle(MatherTheme.ink.opacity(0.70)))
+        ctx.draw(label, at: CGPoint(x: tray.midX, y: tray.minY + 26))
+    }
+
     // MARK: - Power selector
 
     private var powerSelector: some View {
@@ -323,7 +364,7 @@ struct GravityArtistView: View {
             HStack(spacing: 16) {
                 switch phase {
                 case .aim:
-                    Button("PREDICT") {
+                    Button("PREDICT ROLL") {
                         handlePredict()
                     }
                     .font(.headline.weight(.bold))
@@ -334,7 +375,7 @@ struct GravityArtistView: View {
                     .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
 
                 case .predicted:
-                    Button("FIRE!") {
+                    Button("OBSERVE") {
                         handleFire()
                     }
                     .font(.headline.weight(.bold))
@@ -358,7 +399,7 @@ struct GravityArtistView: View {
             }
             .padding(.horizontal, 24)
 
-            Text("Tilt to change angle • Tap dot to change power")
+            Text("Tilt the device: the arrow shows screen-down gravity • no camera or location")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
                 .padding(.bottom, 16)

--- a/Features/TwoFingerProtractor/TwoFingerProtractorView.swift
+++ b/Features/TwoFingerProtractor/TwoFingerProtractorView.swift
@@ -111,7 +111,7 @@ struct ProtractorLevel {
     let snapTolerance: Double     // degrees
 }
 
-let levels: [ProtractorLevel] = [
+let protractorLevels: [ProtractorLevel] = [
     ProtractorLevel(targetAngle: 90,  sceneName: "a right angle — like opening a gate", mission: "Open the garden gate to a square corner.", sceneKind: .doorGate, snapTolerance: 5),
     ProtractorLevel(targetAngle: 45,  sceneName: "a half-right angle — like a ramp", mission: "Set the ramp so the marble can roll.", sceneKind: .clockRamp, snapTolerance: 5),
     ProtractorLevel(targetAngle: 60,  sceneName: "a triangle corner — like a tent roof", mission: "Raise the tent roof to a strong triangle.", sceneKind: .triangleRoof, snapTolerance: 5),
@@ -134,7 +134,7 @@ struct TwoFingerProtractorView: View {
     @State private var showDegreeLabel: Bool = false
     @State private var canvasSize: CGSize = .zero
 
-    private var level: ProtractorLevel { levels[levelIndex % levels.count] }
+    private var level: ProtractorLevel { protractorLevels[levelIndex % protractorLevels.count] }
 
     var body: some View {
         ZStack {
@@ -220,7 +220,7 @@ struct TwoFingerProtractorView: View {
         VStack(spacing: 8) {
             if matched {
                 Button(action: advanceLevel) {
-                    Text(wonCount >= levels.count ? "All done!" : "Next angle →")
+                    Text(wonCount >= protractorLevels.count ? "All done!" : "Next angle →")
                         .font(.headline.weight(.bold))
                         .foregroundStyle(.white)
                         .frame(maxWidth: .infinity)
@@ -453,7 +453,7 @@ struct TwoFingerProtractorView: View {
     }
 
     private func advanceLevel() {
-        if wonCount >= levels.count {
+        if wonCount >= protractorLevels.count {
             appModel.engine.showHome()
             return
         }

--- a/Features/TwoFingerProtractor/TwoFingerProtractorView.swift
+++ b/Features/TwoFingerProtractor/TwoFingerProtractorView.swift
@@ -95,18 +95,28 @@ struct MultiTouchCanvas: UIViewRepresentable {
 
 // MARK: - Level config
 
-private struct ProtractorLevel {
+enum ProtractorSceneKind: String, CaseIterable {
+    case doorGate
+    case clockRamp
+    case triangleRoof
+    case roadBend
+    case trailSwitchback
+}
+
+struct ProtractorLevel {
     let targetAngle: Double       // degrees
     let sceneName: String         // spoken description
+    let mission: String           // visible real-world reason
+    let sceneKind: ProtractorSceneKind
     let snapTolerance: Double     // degrees
 }
 
-private let levels: [ProtractorLevel] = [
-    ProtractorLevel(targetAngle: 90,  sceneName: "a right angle — like a door corner", snapTolerance: 5),
-    ProtractorLevel(targetAngle: 45,  sceneName: "half a right angle", snapTolerance: 5),
-    ProtractorLevel(targetAngle: 60,  sceneName: "an equilateral triangle corner", snapTolerance: 5),
-    ProtractorLevel(targetAngle: 120, sceneName: "an obtuse angle", snapTolerance: 5),
-    ProtractorLevel(targetAngle: 30,  sceneName: "a sharp acute angle", snapTolerance: 4),
+let levels: [ProtractorLevel] = [
+    ProtractorLevel(targetAngle: 90,  sceneName: "a right angle — like opening a gate", mission: "Open the garden gate to a square corner.", sceneKind: .doorGate, snapTolerance: 5),
+    ProtractorLevel(targetAngle: 45,  sceneName: "a half-right angle — like a ramp", mission: "Set the ramp so the marble can roll.", sceneKind: .clockRamp, snapTolerance: 5),
+    ProtractorLevel(targetAngle: 60,  sceneName: "a triangle corner — like a tent roof", mission: "Raise the tent roof to a strong triangle.", sceneKind: .triangleRoof, snapTolerance: 5),
+    ProtractorLevel(targetAngle: 120, sceneName: "a wide turn — like a bridge road", mission: "Bend the bridge road into a gentle turn.", sceneKind: .roadBend, snapTolerance: 5),
+    ProtractorLevel(targetAngle: 30,  sceneName: "a sharp turn — like a hill trail", mission: "Trace the switchback trail on the hill map.", sceneKind: .trailSwitchback, snapTolerance: 4),
 ]
 
 // MARK: - Main view
@@ -184,9 +194,10 @@ struct TwoFingerProtractorView: View {
                 Text("Two-Finger Protractor")
                     .font(.title2.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
-                Text("Make \(Int(level.targetAngle))°")
+                Text(level.mission)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
+                    .lineLimit(2)
             }
             Spacer()
             Button {
@@ -252,11 +263,12 @@ struct TwoFingerProtractorView: View {
             Image(systemName: "hand.draw.fill")
                 .font(.system(size: 44))
                 .foregroundStyle(MatherTheme.softBlue)
-            Text("Place two fingers anywhere")
-                .font(.headline.weight(.semibold))
-                .foregroundStyle(.secondary)
-            Text("Target: \(Int(level.targetAngle))°")
-                .font(.title.weight(.black))
+            Text(level.mission)
+                .font(.headline.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+                .multilineTextAlignment(.center)
+            Text("Use two fingers to make \(Int(level.targetAngle))°")
+                .font(.title3.weight(.black))
                 .foregroundStyle(MatherTheme.accent)
         }
         .padding(24)
@@ -267,6 +279,7 @@ struct TwoFingerProtractorView: View {
     // MARK: - Canvas drawing
 
     private func drawScene(ctx: GraphicsContext, size: CGSize) {
+        drawRealWorldScene(ctx: ctx, size: size)
         let pivot = CGPoint(x: size.width / 2, y: size.height / 2)
         guard let p1 = touch1, let p2 = touch2 else {
             // Draw ghost wedge centred in canvas showing target angle
@@ -312,8 +325,39 @@ struct TwoFingerProtractorView: View {
                  with: .color(fillColor.opacity(0.7)))
     }
 
-    private func drawGhostWedge(ctx: GraphicsContext, size: CGSize) {
-        let pivot = CGPoint(x: size.width / 2, y: size.height * 0.55)
+
+    private func drawRealWorldScene(ctx: GraphicsContext, size: CGSize) {
+        let center = CGPoint(x: size.width / 2, y: size.height / 2)
+        let accent = matched ? MatherTheme.accent : MatherTheme.softBlue
+        switch level.sceneKind {
+        case .doorGate:
+            let wall = CGRect(x: center.x - 120, y: center.y - 90, width: 240, height: 180)
+            ctx.stroke(RoundedRectangle(cornerRadius: 18).path(in: wall), with: .color(MatherTheme.ink.opacity(0.14)), lineWidth: 5)
+            var gate = Path(); gate.move(to: center); gate.addLine(to: CGPoint(x: center.x + 120, y: center.y))
+            gate.move(to: center); gate.addLine(to: CGPoint(x: center.x, y: center.y - 120))
+            ctx.stroke(gate, with: .color(accent.opacity(0.45)), style: StrokeStyle(lineWidth: 10, lineCap: .round))
+        case .clockRamp:
+            ctx.stroke(Circle().path(in: CGRect(x: center.x - 110, y: center.y - 110, width: 220, height: 220)), with: .color(MatherTheme.ink.opacity(0.10)), lineWidth: 6)
+            var ramp = Path(); ramp.move(to: CGPoint(x: center.x - 115, y: center.y + 70)); ramp.addLine(to: CGPoint(x: center.x + 115, y: center.y - 40))
+            ctx.stroke(ramp, with: .color(accent.opacity(0.45)), style: StrokeStyle(lineWidth: 12, lineCap: .round))
+        case .triangleRoof:
+            var roof = Path(); roof.move(to: CGPoint(x: center.x - 130, y: center.y + 80)); roof.addLine(to: CGPoint(x: center.x, y: center.y - 115)); roof.addLine(to: CGPoint(x: center.x + 130, y: center.y + 80))
+            ctx.stroke(roof, with: .color(accent.opacity(0.45)), style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .round))
+        case .roadBend:
+            var road = Path(); road.move(to: CGPoint(x: center.x - 150, y: center.y + 80)); road.addQuadCurve(to: CGPoint(x: center.x + 150, y: center.y - 70), control: CGPoint(x: center.x - 10, y: center.y + 130))
+            ctx.stroke(road, with: .color(accent.opacity(0.40)), style: StrokeStyle(lineWidth: 34, lineCap: .round))
+            ctx.stroke(road, with: .color(.white.opacity(0.7)), style: StrokeStyle(lineWidth: 3, dash: [12, 10]))
+        case .trailSwitchback:
+            for i in 0..<5 {
+                let inset = CGFloat(i) * 24
+                ctx.stroke(Ellipse().path(in: CGRect(x: center.x - 160 + inset, y: center.y - 115 + inset * 0.45, width: 320 - inset * 2, height: 210 - inset)), with: .color(MatherTheme.ink.opacity(0.07)), lineWidth: 2)
+            }
+            var trail = Path(); trail.move(to: CGPoint(x: center.x - 130, y: center.y + 80)); trail.addLine(to: CGPoint(x: center.x - 10, y: center.y - 10)); trail.addLine(to: CGPoint(x: center.x + 115, y: center.y - 55))
+            ctx.stroke(trail, with: .color(accent.opacity(0.48)), style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .round))
+        }
+    }
+
+    private func drawGhostWedge(ctx: GraphicsContext, size: CGSize) {        let pivot = CGPoint(x: size.width / 2, y: size.height * 0.55)
         let armLen: CGFloat = 100
         let targetRad = level.targetAngle * .pi / 180
         let baseAngle: Double = -.pi / 2   // arms open upward

--- a/Tests/MatherTests/AngleCannonTests.swift
+++ b/Tests/MatherTests/AngleCannonTests.swift
@@ -137,3 +137,25 @@ struct AngleCannonTests {
         }
     }
 }
+
+@Suite("AngleCannonScenario")
+struct AngleCannonScenarioTests {
+    @Test func scenariosAreShortSafeAndMappedToTargets() {
+        let scenarios = AngleCannonScenario.defaultScenarios
+        #expect(scenarios.count >= 4)
+        for scenario in scenarios {
+            #expect(!scenario.id.isEmpty)
+            #expect(!scenario.missionSpeech.isEmpty)
+            #expect(scenario.missionSpeech.count <= 80)
+            #expect(!scenario.successSpeech.localizedCaseInsensitiveContains("fail"))
+            #expect([15.0, 30, 45, 60, 75].contains(scenario.targetAngleDeg))
+        }
+    }
+
+    @Test func projectilePointInterpolatesDeterministically() {
+        let points = [CGPoint(x: 0, y: 0), CGPoint(x: 10, y: 10), CGPoint(x: 20, y: 0)]
+        #expect(AngleCannonView.projectilePoint(on: points, progress: 0) == CGPoint(x: 0, y: 0))
+        #expect(AngleCannonView.projectilePoint(on: points, progress: 0.5) == CGPoint(x: 10, y: 10))
+        #expect(AngleCannonView.projectilePoint(on: points, progress: 1) == CGPoint(x: 20, y: 0))
+    }
+}

--- a/Tests/MatherTests/GravityArtistTests.swift
+++ b/Tests/MatherTests/GravityArtistTests.swift
@@ -115,3 +115,27 @@ struct GravityArtistTests {
         #expect(tx < canvasW)
     }
 }
+
+@Suite("GravitySensorPhysics")
+struct GravitySensorPhysicsTests {
+    @Test func normalizedVectorPointsDownAtNeutral() {
+        let vector = GravitySensorPhysics.normalizedVector(roll: 0, neutralRoll: 0)
+        #expect(abs(vector.dx) < 0.001)
+        #expect(abs(vector.dy - 1) < 0.001)
+    }
+
+    @Test func normalizedVectorRespondsToRollDirection() {
+        let right = GravitySensorPhysics.normalizedVector(roll: .pi / 6, neutralRoll: 0)
+        let left = GravitySensorPhysics.normalizedVector(roll: -.pi / 6, neutralRoll: 0)
+        #expect(right.dx > 0)
+        #expect(left.dx < 0)
+        #expect(abs(right.dy - left.dy) < 0.001)
+    }
+
+    @Test func pebblePositionClampsToTrayBounds() {
+        let bounds = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let pos = GravitySensorPhysics.pebblePosition(origin: CGPoint(x: 50, y: 50), vector: CGVector(dx: 4, dy: 4), distance: 100, bounds: bounds)
+        #expect(pos.x == 100)
+        #expect(pos.y == 100)
+    }
+}

--- a/Tests/MatherTests/TwoFingerProtractorTests.swift
+++ b/Tests/MatherTests/TwoFingerProtractorTests.swift
@@ -146,3 +146,18 @@ struct TwoFingerProtractorTests {
         #expect(!drifted.newlyMatched)
     }
 }
+
+@Suite("ProtractorScenes")
+struct ProtractorSceneTests {
+    @Test func scenesConnectEveryTargetToAVisibleContext() {
+        #expect(levels.count >= 5)
+        #expect(Set(levels.map(\.sceneKind)).count == levels.count)
+        for level in levels {
+            #expect(!level.sceneName.isEmpty)
+            #expect(!level.mission.isEmpty)
+            #expect(!level.mission.localizedCaseInsensitiveContains("hurry"))
+            #expect(level.targetAngle > 0 && level.targetAngle <= 180)
+            #expect(level.snapTolerance > 0 && level.snapTolerance <= 5)
+        }
+    }
+}

--- a/Tests/MatherTests/TwoFingerProtractorTests.swift
+++ b/Tests/MatherTests/TwoFingerProtractorTests.swift
@@ -152,7 +152,7 @@ struct ProtractorSceneTests {
     @Test func scenesConnectEveryTargetToAVisibleContext() {
         #expect(protractorLevels.count >= 5)
         #expect(Set(protractorLevels.map(\.sceneKind)).count == protractorLevels.count)
-        for level in levels {
+        for level in protractorLevels {
             #expect(!level.sceneName.isEmpty)
             #expect(!level.mission.isEmpty)
             #expect(!level.mission.localizedCaseInsensitiveContains("hurry"))

--- a/Tests/MatherTests/TwoFingerProtractorTests.swift
+++ b/Tests/MatherTests/TwoFingerProtractorTests.swift
@@ -150,8 +150,8 @@ struct TwoFingerProtractorTests {
 @Suite("ProtractorScenes")
 struct ProtractorSceneTests {
     @Test func scenesConnectEveryTargetToAVisibleContext() {
-        #expect(levels.count >= 5)
-        #expect(Set(levels.map(\.sceneKind)).count == levels.count)
+        #expect(protractorLevels.count >= 5)
+        #expect(Set(protractorLevels.map(\.sceneKind)).count == protractorLevels.count)
         for level in levels {
             #expect(!level.sceneName.isEmpty)
             #expect(!level.mission.isEmpty)


### PR DESCRIPTION
Closes #740
Closes #741
Closes #742

## Summary
- Adds a coordinated Geometry + Physics Labs slice across Gravity Sensor Lab, Two-Finger Protractor, and Angle Cannon.
- Reframes Gravity Artist as a sensor-first Gravity Sensor Lab with a screen-down gravity arrow and rolling pebbles while keeping the existing small compare loop intact.
- Adds real-world Protractor scene contexts (gate, ramp, tent roof, bridge bend, hill trail) and scene metadata tests.
- Adds Angle Cannon scenario missions plus deterministic projectile-in-flight animation before hit/miss feedback.

## Tests
- `git diff --check`
- Added unit coverage for gravity vector mapping/clamping, protractor scene metadata, Angle Cannon scenario metadata, and projectile interpolation.

## Manual proof gap
- iOS/Xcode validation was not run locally because this Linux worker has no `xcodebuild`/`swift`.
- Attempted remote Mac validation via `ssh ganesh-mba`, but DNS failed resolving `mba`; exact command: `ssh -o BatchMode=yes ganesh-mba '... xcodebuild -list -project Mather.xcodeproj ...'`.
- Recommended follow-up: run `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 17'` (or the project’s standard simulator destination) on the Mac builder.

## Assets/provenance
- No generated image assets added; visuals are lightweight SwiftUI/Canvas drawings and emoji already suitable for small, child-friendly scene cues.
