### PR TITLE
fix(settings): simplify family settings surface

### DIFF
--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -54,15 +54,21 @@ struct SettingsView: View {
                         LazyVGrid(columns: ResponsiveLayout.settingsColumns(for: horizontalSizeClass), alignment: .leading, spacing: 20) {
                             settingsCard
                             profilesCard
-                            historyCard
-                            smokeTestCard
+                            historySummaryCard
+                            dataResetCard
+                            if appModel.featureFlags.testModeEnabled {
+                                smokeTestCard
+                            }
                         }
                     } else {
                         VStack(spacing: 16) {
                             settingsCard
                             profilesCard
-                            historyCard
-                            smokeTestCard
+                            historySummaryCard
+                            dataResetCard
+                            if appModel.featureFlags.testModeEnabled {
+                                smokeTestCard
+                            }
                         }
                     }
 
@@ -101,7 +107,7 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Settings")
                         .font(.largeTitle.weight(.black))
-                    Text("Child experience, profiles, and local history controls.")
+                    Text("Quick parent controls. History and data actions stay compact here.")
                         .font(.subheadline.weight(.medium))
                         .foregroundStyle(MatherTheme.cardSubtitle)
                         .fixedSize(horizontal: false, vertical: true)
@@ -207,61 +213,50 @@ struct SettingsView: View {
         }
     }
 
-    private var historyCard: some View {
+    private var historySummaryCard: some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 12) {
                 Text("Session history")
                     .font(.title2.weight(.bold))
-                let rows = ParentSummaryHistoryRow.recentRows(summaries: summaries, gameSessions: gameSessions, limit: 8)
-                Text("\(summaries.count + gameSessions.count) saved locally across all games")
+                let savedCount = summaries.count + gameSessions.count
+                Text(savedCount == 0 ? "No history saved yet." : "\(savedCount) saved locally across all games")
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(MatherTheme.cardSubtitle)
-                ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
-                    HStack {
-                        VStack(alignment: .leading) {
-                            Text("Session \(index + 1)")
-                                .font(.caption.weight(.bold))
-                                .foregroundStyle(MatherTheme.accent)
-                            Text(row.title)
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(MatherTheme.cardSubtitle)
-                            Text(row.startedAt.formatted(date: .abbreviated, time: .shortened))
-                            Text(row.detail)
-                                .foregroundStyle(MatherTheme.cardSubtitle)
-                        }
-                        Spacer()
-                    }
-                    .padding(.vertical, 4)
-                    .accessibilityElement(children: .combine)
-                    .accessibilityIdentifier("settings-history-session-\(index)")
-                }
-                if rows.isEmpty {
-                    Text("No history yet.")
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                }
+                    .accessibilityIdentifier("settings-history-summary")
+                Text("Open Parent Summary for the full timeline, trends, and next-step guidance.")
+                    .font(.caption)
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
 
-                Divider()
-                    .padding(.top, 4)
-
-                VStack(alignment: .leading, spacing: 10) {
-                    Text("Data reset")
-                        .font(.headline.weight(.bold))
-                    Text("Use only when you want to remove saved summaries and events from this device.")
-                        .font(.caption)
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .fixedSize(horizontal: false, vertical: true)
-                    Button(role: .destructive) {
-                        showingClearConfirmation = true
-                    } label: {
-                        Label("Clear session history", systemImage: "trash")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(DestructiveOutlineButtonStyle())
-                    .accessibilityIdentifier("settings-clear-history")
+                Button {
+                    appModel.engine.showParentSummary()
+                } label: {
+                    Label("View full history", systemImage: "chart.line.uptrend.xyaxis")
+                        .frame(maxWidth: .infinity)
                 }
-                .padding(12)
-                .background(MatherTheme.danger.opacity(0.08))
-                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.7)))
+                .accessibilityIdentifier("settings-view-full-history")
+            }
+        }
+    }
+
+    private var dataResetCard: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Data reset")
+                    .font(.title2.weight(.bold))
+                Text("Clears saved summaries, cross-game sessions, and telemetry events for the active kid profile on this device.")
+                    .font(.subheadline)
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button(role: .destructive) {
+                    showingClearConfirmation = true
+                } label: {
+                    Label("Clear session history", systemImage: "trash")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(DestructiveOutlineButtonStyle())
+                .accessibilityIdentifier("settings-clear-history")
             }
         }
     }

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -190,19 +190,35 @@ final class ScreenshotTests: XCTestCase {
         _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
         XCTAssertTrue(app.staticTexts["2 saved locally"].waitForExistence(timeout: 5))
 
-        XCTAssertTrue(waitForHistoryRow(app, identifier: "settings-history-session-1", fallbackLabel: "Session 2", timeout: 5))
+        XCTAssertTrue(app.buttons["settings-view-full-history"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.otherElements["settings-history-session-1"].exists)
+    }
+
+
+    func testFamilySettingsHidesPilotRunbookAndInlineHistoryRows() {
+        let app = launchFamilySettingsWithSeededHistory(count: 7)
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
+
+        app.buttons["Settings"].tap()
+        _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
+        XCTAssertTrue(app.staticTexts["7 saved locally across all games"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["settings-view-full-history"].exists)
+        XCTAssertTrue(app.buttons["settings-clear-history"].exists)
+        XCTAssertFalse(app.staticTexts["Pilot smoke test"].exists)
+        XCTAssertFalse(app.otherElements["settings-history-session-0"].exists)
+        snapshot(app, "Settings-FamilySimplified")
     }
 
     // MARK: - iPhone layout / pilot runbook
 
     /// Verifies the full session flow renders without crash and screenshots the
-    /// pilot runbook in Settings — covers the M8 smoke-test acceptance criterion.
+    /// pilot-only runbook. Family Settings keeps this hidden unless test mode is active.
     func testScreenshot_PilotRunbook() {
         let app = launchWithLegacyVS1()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
         snapshot(app, "iPhone-Home")
 
-        // Navigate to Settings and capture the pilot runbook
+        // Navigate to Settings and capture the pilot-only runbook
         app.buttons["Settings"].tap()
         _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
         XCTAssertFalse(app.switches["settings-loop-v2-toggle"].exists)
@@ -384,6 +400,16 @@ final class ScreenshotTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
+            "-uiTest.seedHistory", "\(count)"
+        ])
+    }
+
+
+    private func launchFamilySettingsWithSeededHistory(count: Int) -> XCUIApplication {
+        launchApp(with: [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.skipProfilePicker", "YES",
             "-uiTest.seedHistory", "\(count)"
         ])
     }


### PR DESCRIPTION
Closes #751.

## Summary
- Simplifies Settings by replacing the inline session feed with a compact history summary and a "View full history" handoff to Parent Summary.
- Pulls Data reset into its own Settings card so destructive actions are not buried below every history row.
- Keeps the pilot smoke-test runbook behind `testModeEnabled`, so family Settings defaults stay shorter while UI-test/pilot flows can still reach it.
- Updates screenshot UI coverage for compact family Settings with seeded history and the new no-inline-history expectation.

## Tests
- `git diff --check`
- local brace-count syntax sanity for changed Swift files
- attempted on `mba`: `xcodebuild -project Mather.xcodeproj -resolvePackageDependencies -scheme Mather && xcodebuild build-for-testing -project Mather.xcodeproj -scheme Mather -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO`
  - `resolvePackageDependencies` completed; `build-for-testing` failed with existing project/target membership errors such as missing `KidProfileStore`, `RoomQuestEngine`, and `SliceTheme` types while compiling unrelated files. No changed-file Swift diagnostics were surfaced before the target failure.

## Manual proof gap
- Compact screenshots should be captured in CI/device run for Settings with 0, 2, and 7+ saved sessions.
