### PR TITLE
Fix Parent Summary Settings navigation

### DIFF
--- a/Features/ParentSummary/ParentSummaryView.swift
+++ b/Features/ParentSummary/ParentSummaryView.swift
@@ -18,12 +18,14 @@ struct ParentSummaryView: View {
             ScrollView {
                 VStack(spacing: 16) {
                     CardSurface {
-                        VStack(alignment: .leading, spacing: 8) {
+                        VStack(alignment: .leading, spacing: 12) {
                             Text("Parent Summary")
                                 .font(.largeTitle.weight(.black))
                             Text(digest.objectiveTitle)
                                 .font(.headline.weight(.semibold))
                                 .foregroundStyle(MatherTheme.cardSubtitle)
+
+                            parentActionButtons
                         }
                     }
 
@@ -94,26 +96,29 @@ struct ParentSummaryView: View {
                             nextTargetCard(digest: digest)
                         }
                     }
-
-                    LazyVGrid(
-                        columns: ResponsiveLayout.parentActionColumns(for: horizontalSizeClass),
-                        spacing: 16
-                    ) {
-                        Button("Settings") {
-                            appModel.engine.showSettings()
-                        }
-                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.7)))
-
-                        Button("Home") {
-                            appModel.engine.showHome()
-                        }
-                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.7)))
-                    }
                 }
                 .padding(ResponsiveLayout.contentPadding(for: horizontalSizeClass))
                 .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
                 .frame(maxWidth: .infinity)
             }
+        }
+    }
+
+
+    private var parentActionButtons: some View {
+        LazyVGrid(
+            columns: ResponsiveLayout.parentActionColumns(for: horizontalSizeClass),
+            spacing: 16
+        ) {
+            Button("Settings") {
+                appModel.engine.showSettings()
+            }
+            .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.7)))
+
+            Button("Home") {
+                appModel.engine.showHome()
+            }
+            .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.7)))
         }
     }
 


### PR DESCRIPTION
## Summary
- Moves Parent Summary Settings/Home actions into the top summary card so they are immediately visible and accessible on empty-state layouts.
- Removes the bottom-only action placement that could fall below the initial screenshot viewport after recent layout changes.

## Why
Latest main UI Review (run 25104818209) failed on both iPhone and iPad in `ScreenshotTests.testScreenshot_ParentSummary()` because the test could not tap a `Settings` button after opening Parent Summary. The button still existed in code, but on the empty-state screen it was placed after the no-session card, so it was not reliably exposed/hittable in the initial accessibility tree. This preserves user navigation rather than weakening the test.

References #745 / #748.

## Validation
- `git diff --check`
- Attempted targeted remote UI test on ganesh@mba with Xcode 26.4.1; blocked because the remote does not have XcodeGen installed and the checked-in project/scheme is stale for `MatherUITests` (`MatherUITests isn’t a member of the specified test plan or scheme`). PR CI should generate the project with XcodeGen like GitHub workflows do.
