### PR TITLE
Fix parent summary settings UI screenshot tap

### DIFF
--- a/Features/ParentSummary/ParentSummaryView.swift
+++ b/Features/ParentSummary/ParentSummaryView.swift
@@ -103,11 +103,13 @@ struct ParentSummaryView: View {
                             appModel.engine.showSettings()
                         }
                         .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.7)))
+                        .accessibilityIdentifier("parent-summary-settings")
 
                         Button("Home") {
                             appModel.engine.showHome()
                         }
                         .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.7)))
+                        .accessibilityIdentifier("parent-summary-home")
                     }
                 }
                 .padding(ResponsiveLayout.contentPadding(for: horizontalSizeClass))

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -158,16 +158,12 @@ final class ScreenshotTests: XCTestCase {
         snapshot(app, "ParentSummary-Empty")
 
         // Navigate to Settings from Parent Summary
-        let settingsButton = app.buttons["Settings"]
-        _ = settingsButton.waitForExistence(timeout: 5)
-        settingsButton.tap()
+        tapWhenHittable(app.buttons["parent-summary-settings"], in: app)
         _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
         snapshot(app, "Settings-FromParentSummary")
 
         // Tap clear — confirm dialog should appear
-        let clearButton = app.buttons["Clear session history"]
-        _ = clearButton.waitForExistence(timeout: 5)
-        clearButton.tap()
+        tapWhenHittable(app.buttons["settings-clear-history"], in: app)
         _ = app.alerts["Clear all session data?"].waitForExistence(timeout: 5)
         snapshot(app, "Settings-ClearConfirmDialog")
 
@@ -453,6 +449,24 @@ final class ScreenshotTests: XCTestCase {
         attachment.name = name
         attachment.lifetime = .keepAlways
         add(attachment)
+    }
+
+    private func tapWhenHittable(_ element: XCUIElement, in app: XCUIApplication) {
+        XCTAssertTrue(element.waitForExistence(timeout: 5))
+        for _ in 0..<6 {
+            if element.isHittable {
+                element.tap()
+                return
+            }
+            app.scrollViews.firstMatch.swipeUp()
+        }
+
+        if element.exists {
+            element.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+            return
+        }
+
+        XCTFail("Expected element to exist before tap fallback: \(element)")
     }
 
     private func completeLoopV2Problem(


### PR DESCRIPTION
## Summary
- Add stable accessibility identifiers for the Parent Summary Settings/Home action buttons.
- Update `ScreenshotTests.testScreenshot_ParentSummary()` to tap the Parent Summary Settings button by identifier and scroll until the target is hittable.
- Use the same robust tap path for the Settings clear-history control after navigating from Parent Summary.

## Root cause
The red main iOS UI Review run 25104818209 failed on both iPad and iPhone at `Tests/MatherUITests/ScreenshotTests.swift:163` while tapping the generic `Settings` button after the `ParentSummary-Empty` screenshot. The Settings route still exists, but the action is in scrollable Parent Summary content and the test held a generic/stale element query after screenshot capture.

## Validation
- `git diff --check`

Local simulator validation was not available in this worker because `xcodebuild`/`xcodegen` are not installed. CI should rerun the relevant workflow:

```bash
xcodebuild test-without-building \
  -project Mather.xcodeproj \
  -scheme Mather \
  -destination '<CI simulator>' \
  -only-testing MatherUITests/ScreenshotTests/testScreenshot_ParentSummary \
  CODE_SIGNING_ALLOWED=NO
```

## References
- Fixes red main iOS UI Review run 25104818209 (`ScreenshotTests.testScreenshot_ParentSummary`)