### PR TITLE
Harden iPhone screenshot start-session navigation

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -89,12 +89,7 @@ final class ScreenshotTests: XCTestCase {
         playButton.tap()
         _ = app.staticTexts["Session setup"].waitForExistence(timeout: 10)
 
-        let startButton = app.buttons["Start Session"]
-        _ = startButton.waitForExistence(timeout: 5)
-        startButton.tap()
-
-        let makePredicate = NSPredicate(format: "label BEGINSWITH 'Make '")
-        _ = app.staticTexts.element(matching: makePredicate).waitForExistence(timeout: 15)
+        startSessionAndWaitForConcrete(in: app)
         snapshot(app, "ConcreteBuild-Initial")
     }
 
@@ -111,12 +106,7 @@ final class ScreenshotTests: XCTestCase {
         playButton.tap()
         _ = app.staticTexts["Session setup"].waitForExistence(timeout: 10)
 
-        let startButton = app.buttons["Start Session"]
-        _ = startButton.waitForExistence(timeout: 5)
-        startButton.tap()
-
-        let makePredicate = NSPredicate(format: "label BEGINSWITH 'Make '")
-        _ = app.staticTexts.element(matching: makePredicate).waitForExistence(timeout: 15)
+        startSessionAndWaitForConcrete(in: app)
         snapshot(app, "ConcreteBuild-BeforeInput")
 
         // Submit with count at 0 to trigger failure feedback
@@ -232,11 +222,7 @@ final class ScreenshotTests: XCTestCase {
         _ = app.staticTexts["Session setup"].waitForExistence(timeout: 10)
         snapshot(app, "iPhone-SessionConfig")
 
-        _ = app.buttons["Start Session"].waitForExistence(timeout: 5)
-        app.buttons["Start Session"].tap()
-
-        let makePredicate = NSPredicate(format: "label BEGINSWITH 'Make '")
-        _ = app.staticTexts.element(matching: makePredicate).waitForExistence(timeout: 15)
+        startSessionAndWaitForConcrete(in: app)
         snapshot(app, "iPhone-ConcreteBuild-AdaptiveGrid")
 
         // Fill the deterministic target of 6 with five warm counters plus one accent counter.
@@ -272,7 +258,7 @@ final class ScreenshotTests: XCTestCase {
 
         app.buttons["Play"].tap()
         _ = app.staticTexts["Session setup"].waitForExistence(timeout: 10)
-        app.buttons["Start Session"].tap()
+        startSessionAndWaitForConcrete(in: app)
 
         completeLoopV2Problem(
             in: app,
@@ -444,6 +430,21 @@ final class ScreenshotTests: XCTestCase {
         }
         app.launch()
         return app
+    }
+
+    private func startSessionAndWaitForConcrete(in app: XCUIApplication) {
+        let makePredicate = NSPredicate(format: "label BEGINSWITH 'Make '")
+        let makePrompt = app.staticTexts.element(matching: makePredicate)
+        let startButton = app.buttons["start-session-button"]
+
+        XCTAssertTrue(startButton.waitForExistence(timeout: 5), "Expected Start Session button before entering concrete stage")
+        startButton.tap()
+
+        if !makePrompt.waitForExistence(timeout: 8), startButton.exists {
+            startButton.tap()
+        }
+
+        XCTAssertTrue(makePrompt.waitForExistence(timeout: 15), "Expected concrete stage after tapping Start Session")
     }
 
     /// Attaches a full-screen screenshot to the test result with `.keepAlways` lifetime.


### PR DESCRIPTION
## Summary\n- add a shared screenshot-test helper that taps Start Session by accessibility identifier\n- retry once if the concrete prompt does not appear, then assert with a clearer failure\n- use the helper in concrete/iPhone/issue-222 screenshot flows\n\n## Evidence\n- Latest main iOS UI Review run 25107092993 rerun failed only on iPhone job 73575722556: testScreenshot_ConcreteBuild_FailureThenSuccess stayed on Session setup after tapping Start Session and could not find a submit button.\n- git diff --check