### PR TITLE
Handle story anchor after screenshot session start

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -439,9 +439,11 @@ final class ScreenshotTests: XCTestCase {
 
         XCTAssertTrue(startButton.waitForExistence(timeout: 5), "Expected Start Session button before entering concrete stage")
         startButton.tap()
+        advanceStoryAnchorIfPresent(in: app, snapshotPrefix: "SessionStart", shouldSnapshot: false)
 
         if !makePrompt.waitForExistence(timeout: 8), startButton.exists {
             startButton.tap()
+            advanceStoryAnchorIfPresent(in: app, snapshotPrefix: "SessionStart-Retry", shouldSnapshot: false)
         }
 
         XCTAssertTrue(makePrompt.waitForExistence(timeout: 15), "Expected concrete stage after tapping Start Session")


### PR DESCRIPTION
## Summary\n- update the shared screenshot-test session-start helper to advance the loop-v2 story anchor after tapping Start Session\n- keep the existing retry path, also advancing the story anchor on retry\n\n## Evidence\n- Latest main iOS UI Review run 25109810028 failed on both iPhone and iPad after PR #765 because loop-v2 tests reached the Story Anchor instead of the concrete Make prompt.\n- Legacy screenshot flows passed in the same run; failures were testScreenshot_ConcreteBuildView and testScreenshot_Issue222LoopV2_AcrossFourTargetsIncludingTwelve.\n- git diff --check