### PR TITLE
Fix Story Anchor card layout

### DIFF
--- a/Features/VerticalSlice1/FeedbackBannerView.swift
+++ b/Features/VerticalSlice1/FeedbackBannerView.swift
@@ -34,6 +34,7 @@ struct FeedbackBannerView: View {
                     lineWidth: 1.5
                 )
         )
+        .accessibilityIdentifier("feedback-banner")
         .animation(.easeInOut(duration: 0.2), value: isCelebrating)
         .onChange(of: isCelebrating) { _, celebrating in
             guard celebrating else { return }

--- a/Features/VerticalSlice1/VS1SharedUI.swift
+++ b/Features/VerticalSlice1/VS1SharedUI.swift
@@ -9,8 +9,13 @@ struct VS1Card<Content: View>: View {
     }
 
     var body: some View {
-        RoundedRectangle(cornerRadius: 28, style: .continuous)
-            .fill(MatherTheme.panel.opacity(colorScheme == .dark ? 0.96 : 0.72))
+        content
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .fill(MatherTheme.panel.opacity(colorScheme == .dark ? 0.96 : 0.72))
+            )
             .overlay(
                 RoundedRectangle(cornerRadius: 28, style: .continuous)
                     .strokeBorder(
@@ -23,7 +28,6 @@ struct VS1Card<Content: View>: View {
                     .strokeBorder(.white.opacity(colorScheme == .dark ? 0.06 : 0), lineWidth: 1)
             )
             .shadow(color: .black.opacity(colorScheme == .dark ? 0.22 : 0.08), radius: colorScheme == .dark ? 22 : 18, x: 0, y: colorScheme == .dark ? 10 : 8)
-            .overlay(content.padding(24))
     }
 }
 

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -77,6 +77,55 @@ final class CompactLayoutTests: XCTestCase {
         XCTAssertTrue(back.isHittable, "Expected Back to Home to remain reachable by scrolling on compact setup")
     }
 
+    func testStoryAnchorCompactVehicleSessionKeepsBannerAndStorySeparated() {
+        let app = launchWithVS1()
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
+
+        app.buttons["Play"].tap()
+        _ = app.staticTexts["Session setup"].waitForExistence(timeout: 10)
+
+        XCTAssertTrue(app.buttons["theme-card-vehicle"].waitForExistence(timeout: 5))
+        app.buttons["theme-card-vehicle"].tap()
+
+        let targetCap50 = app.buttons["target-cap-up-to-50"]
+        if !targetCap50.waitForExistence(timeout: 3) {
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        XCTAssertTrue(targetCap50.waitForExistence(timeout: 5))
+        targetCap50.tap()
+
+        let startSession = app.buttons["start-session-button"]
+        if !startSession.isHittable {
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        XCTAssertTrue(startSession.waitForExistence(timeout: 5))
+        startSession.tap()
+
+        let banner = app.otherElements["feedback-banner"]
+        let storyCard = app.otherElements["story-anchor-card"]
+        let spokenIntro = app.descendants(matching: .any)["story-anchor-spoken-intro"]
+        let reminder = app.descendants(matching: .any)["story-anchor-reminder-pill"]
+        let startBuilding = app.buttons["story-anchor-start-button"]
+
+        XCTAssertTrue(banner.waitForExistence(timeout: 5), "Expected story-stage feedback banner before the Story Anchor card")
+        XCTAssertTrue(storyCard.waitForExistence(timeout: 5), "Expected Story Anchor card before advancing to concrete")
+        XCTAssertTrue(spokenIntro.waitForExistence(timeout: 5), "Expected visible story copy on the Story Anchor card")
+        XCTAssertTrue(reminder.waitForExistence(timeout: 5), "Expected reminder pill on the Story Anchor card")
+        XCTAssertTrue(startBuilding.waitForExistence(timeout: 5), "Expected Start building button on the Story Anchor card")
+        XCTAssertTrue(startBuilding.isHittable, "Expected Start building to be reachable on compact Story Anchor")
+
+        XCTAssertGreaterThanOrEqual(
+            storyCard.frame.minY,
+            banner.frame.maxY,
+            "Expected the content-sized Story Anchor card to be laid out below the feedback banner"
+        )
+        XCTAssertGreaterThanOrEqual(
+            spokenIntro.frame.minY,
+            banner.frame.maxY,
+            "Expected the story sentence to stay out of the feedback banner area"
+        )
+    }
+
     func testRoomQuestCompactSpotScreenKeepsPrimaryActionReachableWithoutSwipe() {
         let app = launch()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)


### PR DESCRIPTION
## Summary

Closes #768.

- Makes `VS1Card` content-sized instead of measuring from a decorative rounded rectangle with overlay content.
- Adds a stable `feedback-banner` accessibility identifier for layout proof.
- Adds compact UI coverage that starts a vehicle VS1 session, stops on Story Anchor, and asserts the banner, story card, story text, reminder pill, and Start building button are present with the story laid out below the banner.

## Root cause

`VS1Card` used a `RoundedRectangle` as the primary laid-out view and attached its actual content through `.overlay(content.padding(24))`. Overlay content does not drive the parent stack's measured height, so long Story Anchor text could paint into the feedback banner area even though the stack reserved too little space for the card.

## Tests

- `git diff --check`

Not run locally: `xcodegen`, `xcodebuild`, and `swift` are not installed in this Linux worker environment. Expected CI coverage: macOS/Xcode build plus the updated `CompactLayoutTests` UI regression.

## Asset / Proof Gaps

- No new visual assets were needed; this is a layout/container sizing fix.
- I could not capture simulator screenshots locally because Xcode tooling is unavailable in this worker. A next-build compact phone screenshot or CI artifact should confirm the build-59 Story Anchor/banner overlap is gone before closing the feedback loop.