### PR TITLE
Fix Parent Summary game score states

### DIFF
--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -18,6 +18,7 @@ struct MatherApp: App {
             )
             let appModel = AppModel(modelContext: container.mainContext)
             Self.seedSessionHistoryIfRequested(using: appModel)
+            Self.seedGameHistoryIfRequested(using: appModel)
             _appModel = State(initialValue: appModel)
         } catch {
             fatalError("Failed to create model container: \(error)")
@@ -53,6 +54,7 @@ private extension MatherApp {
               let requestedCount = Int(arguments[flagIndex + 1]) else { return }
 
         appModel.historyStore.clearAllProfiles()
+        appModel.gameSessionStore.clearAllProfiles()
 
         for index in 0..<max(requestedCount, 0) {
             let startedAt = Date.now.addingTimeInterval(TimeInterval(-index * 3_600))
@@ -70,6 +72,33 @@ private extension MatherApp {
                 exportFileName: "swiftdata://session/\(sessionId)"
             )
             appModel.historyStore.save(draft)
+        }
+    }
+
+    static func seedGameHistoryIfRequested(using appModel: AppModel) {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let flagIndex = arguments.firstIndex(of: "-uiTest.seedGameHistory"),
+              arguments.indices.contains(flagIndex + 1),
+              let requestedCount = Int(arguments[flagIndex + 1]) else { return }
+
+        appModel.historyStore.clearAllProfiles()
+        appModel.gameSessionStore.clearAllProfiles()
+
+        let fixtures = [
+            ("Sum Sprint", "correct", "Fluency practice"),
+            ("Angle Cannon", "targets hit", "Angle practice"),
+            ("Memory", "rounds", "Pattern recall")
+        ]
+
+        for index in 0..<max(requestedCount, 0) {
+            let fixture = fixtures[index % fixtures.count]
+            appModel.gameSessionStore.save(
+                gameName: fixture.0,
+                startedAt: Date.now.addingTimeInterval(TimeInterval(-index * 2_400)),
+                scoreValue: 6 + index,
+                scoreLabel: fixture.1,
+                detail: fixture.2
+            )
         }
     }
 }

--- a/Features/ParentSummary/ParentSummaryView.swift
+++ b/Features/ParentSummary/ParentSummaryView.swift
@@ -9,9 +9,10 @@ struct ParentSummaryView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     var body: some View {
-        let digest = appModel.telemetryWriter.digest(from: summaries)
+        let overview = ParentSummaryOverview.make(summaries: summaries, gameSessions: gameSessions)
+        let digest = appModel.telemetryWriter.digest(from: overview.validMakeBreakSummaries)
         let recentRows = ParentSummaryHistoryRow.recentRows(summaries: summaries, gameSessions: gameSessions, limit: 5)
-        let trendPoints = ParentSummaryTrendPoint.recentPoints(from: summaries, limit: 6)
+        let trendPoints = ParentSummaryTrendPoint.recentPoints(from: overview.validMakeBreakSummaries, limit: 6)
 
         ZStack {
             MatherTheme.background.ignoresSafeArea()
@@ -21,7 +22,7 @@ struct ParentSummaryView: View {
                         VStack(alignment: .leading, spacing: 12) {
                             Text("Parent Summary")
                                 .font(.largeTitle.weight(.black))
-                            Text(digest.objectiveTitle)
+                            Text(overview.hasValidMakeBreakProgress ? digest.objectiveTitle : overview.headerSubtitle)
                                 .font(.headline.weight(.semibold))
                                 .foregroundStyle(MatherTheme.cardSubtitle)
 
@@ -29,7 +30,7 @@ struct ParentSummaryView: View {
                         }
                     }
 
-                    if summaries.isEmpty && gameSessions.isEmpty {
+                    if !overview.hasAnyHistory {
                         CardSurface {
                             VStack(spacing: 12) {
                                 Image(systemName: "chart.bar.xaxis")
@@ -47,38 +48,19 @@ struct ParentSummaryView: View {
                             .padding(.vertical, 8)
                         }
                     } else {
-                        LazyVGrid(
-                            columns: ResponsiveLayout.statColumns(for: horizontalSizeClass),
-                            spacing: 12
-                        ) {
-                            StatTile(
-                                value: "\(digest.problemsCompleted)",
-                                label: "Problems done",
-                                icon: "checkmark.circle.fill",
-                                color: MatherTheme.accent
-                            )
-                            StatTile(
-                                value: "\(Int(digest.firstAttemptAccuracy * 100))%",
-                                label: "First try",
-                                icon: "star.fill",
-                                color: MatherTheme.warm
-                            )
-                            StatTile(
-                                value: "\(digest.transferCorrectCount)",
-                                label: "Transfers",
-                                icon: "arrow.triangle.2.circlepath",
-                                color: MatherTheme.softBlue
-                            )
-                            StatTile(
-                                value: paceLabel(digest.medianLatencyMs),
-                                label: "Avg pace",
-                                icon: "clock.fill",
-                                color: Color.purple.opacity(0.7)
-                            )
+                        if overview.hasValidMakeBreakProgress {
+                            makeBreakScorecard(digest: digest)
+                        } else {
+                            makeBreakInsufficientProgressCard(hasGameScores: overview.hasGameScores)
                         }
-                        .accessibilityIdentifier("parent-summary-scorecard")
 
-                        recentProgressCard(points: trendPoints)
+                        if overview.hasGameScores {
+                            recentGameScoresCard(scores: overview.gameScores)
+                        }
+
+                        if overview.hasValidMakeBreakProgress {
+                            recentProgressCard(points: trendPoints)
+                        }
 
                         if ResponsiveLayout.isWide(horizontalSizeClass) {
                             LazyVGrid(
@@ -87,13 +69,17 @@ struct ParentSummaryView: View {
                                 spacing: 16
                             ) {
                                 profileOverviewCard(summaries: summaries, gameSessions: gameSessions)
-                                nextTargetCard(digest: digest)
+                                if overview.hasValidMakeBreakProgress {
+                                    nextTargetCard(digest: digest)
+                                }
                             }
                             recentSessionsCard(rows: recentRows, totalCount: summaries.count + gameSessions.count)
                         } else {
                             profileOverviewCard(summaries: summaries, gameSessions: gameSessions)
                             recentSessionsCard(rows: recentRows, totalCount: summaries.count + gameSessions.count)
-                            nextTargetCard(digest: digest)
+                            if overview.hasValidMakeBreakProgress {
+                                nextTargetCard(digest: digest)
+                            }
                         }
                     }
                 }
@@ -128,12 +114,111 @@ struct ParentSummaryView: View {
         return seconds < 60 ? "\(seconds)s" : "\(seconds / 60)m \(seconds % 60)s"
     }
 
+    private func makeBreakScorecard(digest: ParentDigest) -> some View {
+        LazyVGrid(
+            columns: ResponsiveLayout.statColumns(for: horizontalSizeClass),
+            spacing: 12
+        ) {
+            StatTile(
+                value: "\(digest.problemsCompleted)",
+                label: "Problems done",
+                icon: "checkmark.circle.fill",
+                color: MatherTheme.accent
+            )
+            StatTile(
+                value: "\(Int(digest.firstAttemptAccuracy * 100))%",
+                label: "First try",
+                icon: "star.fill",
+                color: MatherTheme.warm
+            )
+            StatTile(
+                value: "\(digest.transferCorrectCount)",
+                label: "Transfers",
+                icon: "arrow.triangle.2.circlepath",
+                color: MatherTheme.softBlue
+            )
+            StatTile(
+                value: paceLabel(digest.medianLatencyMs),
+                label: "Avg pace",
+                icon: "clock.fill",
+                color: Color.purple.opacity(0.7)
+            )
+        }
+        .accessibilityIdentifier("parent-summary-scorecard")
+    }
+
+    private func makeBreakInsufficientProgressCard(hasGameScores: Bool) -> some View {
+        CardSurface {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "chart.bar.doc.horizontal")
+                    .foregroundStyle(MatherTheme.accent)
+                    .font(.title3.weight(.bold))
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("No completed Make & Break practice yet")
+                        .font(.title3.weight(.bold))
+                    Text(hasGameScores ? "Make & Break mastery scores appear after a completed Make & Break session. Recent game scores are shown below." : "Complete Make & Break to see mastery scores here.")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityIdentifier("parent-summary-make-break-insufficient-progress")
+        }
+    }
+
     private func historyCaption(totalCount: Int, visibleCount: Int) -> String {
         guard totalCount > 0 else { return "No saved sessions yet." }
         if totalCount == visibleCount {
             return "\(totalCount) saved locally across all games"
         }
         return "Showing latest \(visibleCount) of \(totalCount) saved locally across all games"
+    }
+
+    private func recentGameScoresCard(scores: [ParentSummaryGameScore]) -> some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Game scores")
+                    .font(.title3.weight(.bold))
+                Text("Recent scores saved locally across non-Make & Break games.")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
+                ForEach(scores) { score in
+                    HStack(alignment: .top, spacing: 12) {
+                        Image(systemName: "gamecontroller.fill")
+                            .font(.headline.weight(.bold))
+                            .foregroundStyle(MatherTheme.warm)
+                            .frame(width: 28, height: 28)
+                            .accessibilityHidden(true)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(score.gameName)
+                                .font(.headline.weight(.bold))
+                            Text(score.scoreText)
+                                .font(.title3.weight(.black))
+                                .foregroundStyle(MatherTheme.ink)
+                                .fixedSize(horizontal: false, vertical: true)
+                            if let detail = score.detail {
+                                Text(detail)
+                                    .font(.caption.weight(.medium))
+                                    .foregroundStyle(MatherTheme.cardSubtitle)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            Text(score.startedAt.formatted(date: .abbreviated, time: .shortened))
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                    .padding(12)
+                    .background(MatherTheme.panel.opacity(0.55))
+                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .accessibilityElement(children: .combine)
+                }
+            }
+            .accessibilityIdentifier("parent-summary-game-scores")
+        }
     }
 
     private func profileOverviewCard(summaries: [StoredSessionSummary], gameSessions: [StoredGameSession]) -> some View {
@@ -278,6 +363,64 @@ struct ParentSummaryView: View {
 
 }
 
+
+struct ParentSummaryOverview {
+    var hasAnyHistory: Bool
+    var validMakeBreakSummaries: [StoredSessionSummary]
+    var gameScores: [ParentSummaryGameScore]
+
+    var hasValidMakeBreakProgress: Bool {
+        !validMakeBreakSummaries.isEmpty
+    }
+
+    var hasGameScores: Bool {
+        !gameScores.isEmpty
+    }
+
+    var headerSubtitle: String {
+        hasGameScores ? "Game scores" : "Make & Break"
+    }
+
+    static func make(
+        summaries: [StoredSessionSummary],
+        gameSessions: [StoredGameSession],
+        gameScoreLimit: Int = 3
+    ) -> ParentSummaryOverview {
+        ParentSummaryOverview(
+            hasAnyHistory: !summaries.isEmpty || !gameSessions.isEmpty,
+            validMakeBreakSummaries: summaries.filter { $0.problemsCompleted > 0 },
+            gameScores: ParentSummaryGameScore.recentScores(from: gameSessions, limit: gameScoreLimit)
+        )
+    }
+}
+
+struct ParentSummaryGameScore: Identifiable, Equatable {
+    var id: String
+    var profileId: String
+    var gameName: String
+    var startedAt: Date
+    var scoreText: String
+    var detail: String?
+
+    static func recentScores(
+        from gameSessions: [StoredGameSession],
+        limit: Int
+    ) -> [ParentSummaryGameScore] {
+        gameSessions
+            .sorted { $0.startedAt > $1.startedAt }
+            .prefix(limit)
+            .map {
+                ParentSummaryGameScore(
+                    id: $0.id,
+                    profileId: $0.profileId,
+                    gameName: $0.gameName,
+                    startedAt: $0.startedAt,
+                    scoreText: "\($0.scoreValue) \($0.scoreLabel)",
+                    detail: $0.detail
+                )
+            }
+    }
+}
 
 struct ParentSummaryHistoryRow: Identifiable, Equatable {
     enum Source: Equatable {

--- a/Persistence/GameSessionStore.swift
+++ b/Persistence/GameSessionStore.swift
@@ -60,4 +60,11 @@ final class GameSessionStore {
         sessions.forEach { modelContext.delete($0) }
         try? modelContext.save()
     }
+
+    func clearAllProfiles() {
+        let descriptor = FetchDescriptor<StoredGameSession>()
+        guard let sessions = try? modelContext.fetch(descriptor) else { return }
+        sessions.forEach { modelContext.delete($0) }
+        try? modelContext.save()
+    }
 }

--- a/Tests/MatherTests/SessionHistoryTests.swift
+++ b/Tests/MatherTests/SessionHistoryTests.swift
@@ -36,6 +36,27 @@ private func makeDraft(
     )
 }
 
+private func makeGameSession(
+    id: String = UUID().uuidString,
+    profileId: String = "test-profile",
+    gameName: String = "Sum Sprint",
+    startedAt: Date = .now,
+    scoreValue: Int = 8,
+    scoreLabel: String = "correct",
+    detail: String? = nil
+) -> StoredGameSession {
+    StoredGameSession(
+        id: id,
+        profileId: profileId,
+        gameName: gameName,
+        startedAt: startedAt,
+        durationSeconds: 45,
+        scoreValue: scoreValue,
+        scoreLabel: scoreLabel,
+        detail: detail
+    )
+}
+
 // MARK: - SessionHistoryStore tests
 
 @MainActor
@@ -197,6 +218,62 @@ struct TelemetryWriterDigestTests {
 // MARK: - Parent summary history row tests
 
 @MainActor
+struct ParentSummaryOverviewTests {
+    @Test
+    func overviewTreatsGameOnlyHistoryAsScoresWithoutMakeBreakProgress() {
+        let game = makeGameSession(scoreValue: 7, scoreLabel: "correct", detail: "Level 2")
+
+        let overview = ParentSummaryOverview.make(summaries: [], gameSessions: [game])
+
+        #expect(overview.hasAnyHistory)
+        #expect(!overview.hasValidMakeBreakProgress)
+        #expect(overview.hasGameScores)
+        #expect(overview.headerSubtitle == "Game scores")
+        #expect(overview.gameScores.map(\.scoreText) == ["7 correct"])
+        #expect(overview.gameScores.first?.detail == "Level 2")
+    }
+
+    @Test
+    func overviewIgnoresZeroProblemMakeBreakForMasteryScores() {
+        let zeroProblem = StoredSessionSummary(
+            from: makeDraft(sessionId: "zero", problemsCompleted: 0, accuracy: 0, medianLatencyMs: 0),
+            profileId: "test-profile"
+        )
+
+        let overview = ParentSummaryOverview.make(summaries: [zeroProblem], gameSessions: [])
+
+        #expect(overview.hasAnyHistory)
+        #expect(!overview.hasValidMakeBreakProgress)
+        #expect(!overview.hasGameScores)
+        #expect(overview.validMakeBreakSummaries.isEmpty)
+    }
+
+    @Test
+    func overviewKeepsValidMakeBreakProgressSeparateFromGameScores() {
+        let base = Date(timeIntervalSinceReferenceDate: 50_000)
+        let makeAndBreak = StoredSessionSummary(
+            from: makeDraft(sessionId: "valid", problemsCompleted: 4, startedAt: base.addingTimeInterval(-120)),
+            profileId: "test-profile"
+        )
+        let latestGame = makeGameSession(id: "latest-game", gameName: "Angle Cannon", startedAt: base, scoreValue: 5, scoreLabel: "targets hit")
+        let olderGame = makeGameSession(id: "older-game", gameName: "Memory", startedAt: base.addingTimeInterval(-60), scoreValue: 3, scoreLabel: "rounds")
+
+        let overview = ParentSummaryOverview.make(
+            summaries: [makeAndBreak],
+            gameSessions: [olderGame, latestGame],
+            gameScoreLimit: 1
+        )
+
+        #expect(overview.hasValidMakeBreakProgress)
+        #expect(overview.validMakeBreakSummaries.map(\.sessionId) == ["valid"])
+        #expect(overview.gameScores.map(\.gameName) == ["Angle Cannon"])
+        #expect(overview.gameScores.map(\.scoreText) == ["5 targets hit"])
+    }
+}
+
+// MARK: - Parent summary history row tests
+
+@MainActor
 struct ParentSummaryHistoryRowTests {
     @Test
     func recentRowsMergeMakeAndBreakAndExplorerGameSessions() throws {
@@ -205,15 +282,7 @@ struct ParentSummaryHistoryRowTests {
             from: makeDraft(sessionId: "make-break-old", problemsCompleted: 2, startedAt: now.addingTimeInterval(-120)),
             profileId: "test-profile"
         )
-        let sumSprint = StoredGameSession(
-            id: "sum-sprint-new",
-            profileId: "test-profile",
-            gameName: "Sum Sprint",
-            startedAt: now,
-            durationSeconds: 30,
-            scoreValue: 8,
-            scoreLabel: "correct"
-        )
+        let sumSprint = makeGameSession(id: "sum-sprint-new", startedAt: now)
 
         let rows = ParentSummaryHistoryRow.recentRows(
             summaries: [makeAndBreak],
@@ -234,24 +303,8 @@ struct ParentSummaryHistoryRowTests {
             from: makeDraft(sessionId: "oldest", startedAt: now.addingTimeInterval(-300)),
             profileId: "test-profile"
         )
-        let newest = StoredGameSession(
-            id: "newest",
-            profileId: "test-profile",
-            gameName: "Angle Cannon",
-            startedAt: now,
-            durationSeconds: 10,
-            scoreValue: 3,
-            scoreLabel: "hits"
-        )
-        let middle = StoredGameSession(
-            id: "middle",
-            profileId: "test-profile",
-            gameName: "Memory",
-            startedAt: now.addingTimeInterval(-60),
-            durationSeconds: 20,
-            scoreValue: 6,
-            scoreLabel: "matches"
-        )
+        let newest = makeGameSession(id: "newest", gameName: "Angle Cannon", startedAt: now, scoreValue: 3, scoreLabel: "hits")
+        let middle = makeGameSession(id: "middle", gameName: "Memory", startedAt: now.addingTimeInterval(-60), scoreValue: 6, scoreLabel: "matches")
 
         let rows = ParentSummaryHistoryRow.recentRows(
             summaries: [oldest],

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -184,6 +184,19 @@ final class ScreenshotTests: XCTestCase {
         XCTAssertFalse(app.otherElements["settings-history-session-1"].exists)
     }
 
+    func testParentSummaryShowsGameScoresWhenMakeBreakHasNoProgress() {
+        let app = launchWithSeededGameHistory(count: 2)
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
+
+        app.buttons["Parent Summary"].tap()
+        _ = app.staticTexts["Parent Summary"].waitForExistence(timeout: 10)
+
+        XCTAssertTrue(app.staticTexts["No completed Make & Break practice yet"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Game scores"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Sum Sprint"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.otherElements["parent-summary-scorecard"].exists)
+    }
+
 
     func testFamilySettingsHidesPilotRunbookAndInlineHistoryRows() {
         let app = launchFamilySettingsWithSeededHistory(count: 7)
@@ -387,6 +400,15 @@ final class ScreenshotTests: XCTestCase {
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
             "-uiTest.seedHistory", "\(count)"
+        ])
+    }
+
+    private func launchWithSeededGameHistory(count: Int) -> XCUIApplication {
+        launchApp(with: [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.testModeEnabled", "YES",
+            "-uiTest.seedGameHistory", "\(count)"
         ])
     }
 


### PR DESCRIPTION
## Summary
- Closes #773.
- Makes Parent Summary treat Make & Break mastery metrics as Make & Break-specific instead of showing a global-looking all-zero scorecard for game-only or zero-problem history.
- Adds a visible Game scores section for recent StoredGameSession records, while keeping the existing merged Recent sessions timeline.
- Adds UI-test seeding for game-only history and focused unit coverage for the new parent-summary display helper.

## Tests
- `git diff --check`

Not run locally:
- `xcodegen generate` because `xcodegen` is not installed in this worker (`command not found`).
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO` because `xcodebuild` is not installed in this worker (`command not found`).

Expected CI coverage: Swift unit tests for `ParentSummaryOverview` and existing session history helpers, plus the new UI test fixture for game-only Parent Summary.

## Asset / Proof Gaps
- No generated or bundled visual assets were needed; this is a data/UX state fix using existing SwiftUI/SF Symbols.
- Local simulator screenshots could not be captured because the worker lacks the Xcode/simulator toolchain.
