### PR TITLE
Add VS1 Planets space theme

### DIFF
--- a/Domain/NumberStoryGenerator.swift
+++ b/Domain/NumberStoryGenerator.swift
@@ -17,7 +17,7 @@ enum NumberStoryGenerator {
             preferred = .gardenSeedShop
         case "festival", "festival_prep":
             preferred = .festivalPrep
-        case "space", "space_cargo":
+        case "space", "planets", "space_cargo":
             preferred = .spaceCargo
         default:
             preferred = classicTemplate(for: target)

--- a/Domain/SliceTheme.swift
+++ b/Domain/SliceTheme.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Describes how a counter cell is rendered — shape, SF Symbol, or local image asset.
 enum CounterKind: Equatable {
     case circle
-    case vehicle(symbolName: String, assetName: String?)
+    case themedSymbol(symbolName: String, assetName: String?)
 }
 
 /// A theme controls the vocabulary and counter appearance for a VS1 session.
@@ -39,4 +39,65 @@ protocol SliceTheme {
     func sessionEndPhrase() -> String
     /// Shown as `feedbackMessage` at the start of a session (before first prompt).
     func sessionStartFeedback() -> String
+}
+
+/// A space-themed VS1 session for the parent-facing Planets setup card.
+///
+/// Uses a simple SF Symbol counter so the first slice stays asset-light while
+/// still giving the child space vocabulary in the CPA loop.
+struct SpaceTheme: SliceTheme {
+    var counterKind: CounterKind { .themedSymbol(symbolName: "sparkles", assetName: nil) }
+    var celebrationEmoji: String { "🚀" }
+    var counterNoun: String { "star bolts" }
+
+    func concretePrompt(target: Int) -> String {
+        "Load \(target) star bolts for the rocket."
+    }
+
+    func pictorialPrompt(target: Int) -> String {
+        "Split \(target) star bolts between two space bays."
+    }
+
+    func abstractPrompt() -> String {
+        "Type the same space split as an equation."
+    }
+
+    func transferPrompt(decompositionA: Int, decompositionB: Int) -> String {
+        "Load the same star bolt total from memory."
+    }
+
+    func stageSuccessPhrase(for stage: SliceStage, target: Int) -> String {
+        switch stage {
+        case .storyAnchor:
+            return "Mission ready."
+        case .concrete:
+            return "Yes. You loaded \(target) star bolts."
+        case .pictorial:
+            return "Those bays still make \(target)."
+        case .abstract:
+            return "Your equation matches the space split."
+        case .transfer:
+            return "You loaded the same total from memory."
+        case .bondMatch:
+            return "Those bonds are ready."
+        case .gravitySplit:
+            return "Space balance made."
+        case .sumSprint:
+            return "Space burst complete."
+        case .done:
+            return "Problem complete."
+        }
+    }
+
+    func sessionIntroPhrase() -> String {
+        "Let's make and break numbers with space cargo."
+    }
+
+    func sessionEndPhrase() -> String {
+        "Mission complete. You made and broke numbers with space cargo."
+    }
+
+    func sessionStartFeedback() -> String {
+        "Load the star bolts on the rocket pad."
+    }
 }

--- a/Domain/VehicleTheme.swift
+++ b/Domain/VehicleTheme.swift
@@ -17,7 +17,7 @@ struct VehicleTheme: SliceTheme {
 
     init(spec: VehicleSpec = .car) { self.spec = spec }
 
-    var counterKind: CounterKind { .vehicle(symbolName: spec.symbolName, assetName: spec.assetName) }
+    var counterKind: CounterKind { .themedSymbol(symbolName: spec.symbolName, assetName: spec.assetName) }
     var celebrationEmoji: String { spec.celebrationEmoji }
     var counterNoun: String { spec.counterNoun }
 

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -132,7 +132,8 @@ final class VerticalSliceEngine {
         // Freeze the active theme from the user's current selection — unless a custom
         // theme was injected at init time (e.g. in unit tests using an arbitrary theme).
         if !hasInjectedTheme {
-            if featureFlags.selectedThemeId == "vehicle" {
+            switch featureFlags.selectedThemeId {
+            case "vehicle":
                 config.audioEnabled = featureFlags.audioEnabled
                 config.deterministicMode = featureFlags.testModeEnabled
                 problems = ProblemGenerator.generateProblems(config: config)
@@ -141,7 +142,13 @@ final class VerticalSliceEngine {
                     : Self.randomizedVehiclePool(from: VehicleSpec.pool)
                 problemThemes = problems.indices.map { i in VehicleTheme(spec: pool[i % pool.count]) }
                 activeTheme = problemThemes[0]
-            } else {
+            case "space", "planets":
+                activeTheme = SpaceTheme()
+                problemThemes = []
+                config.audioEnabled = featureFlags.audioEnabled
+                config.deterministicMode = featureFlags.testModeEnabled
+                problems = ProblemGenerator.generateProblems(config: config)
+            default:
                 activeTheme = ClassicTheme()
                 problemThemes = []
                 config.audioEnabled = featureFlags.audioEnabled

--- a/Features/VerticalSlice1/CounterView.swift
+++ b/Features/VerticalSlice1/CounterView.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 /// A single counter cell in the 2×5 ten-frame grid.
 ///
-/// Renders as a filled/empty circle (ClassicTheme) or a local generated vehicle asset
-/// with SF Symbol fallback (VehicleTheme) depending on the active theme's `counterKind`.
+/// Renders as a filled/empty circle (ClassicTheme) or a local generated theme asset
+/// with SF Symbol fallback depending on the active theme's `counterKind`.
 /// The 2×5 grid structure is preserved regardless of theme — subitising
 /// depends on spatial arrangement, not object shape (Clements, 2002).
 ///
@@ -35,8 +35,8 @@ struct CounterView: View {
         switch theme.counterKind {
         case .circle:
             circleCounter
-        case .vehicle(let symbolName, let assetName):
-            vehicleCounter(symbolName: symbolName, assetName: assetName)
+        case .themedSymbol(let symbolName, let assetName):
+            themedCounter(symbolName: symbolName, assetName: assetName)
         }
     }
 
@@ -57,7 +57,7 @@ struct CounterView: View {
     }
 
     @ViewBuilder
-    private func vehicleCounter(symbolName: String, assetName: String?) -> some View {
+    private func themedCounter(symbolName: String, assetName: String?) -> some View {
         if filled {
             ZStack {
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
@@ -78,8 +78,6 @@ struct CounterView: View {
                 }
             }
         } else {
-            // Dashed parking-space outline — clearly signals an empty slot
-            // without the ghost-car silhouette that reads as decorative background.
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .strokeBorder(
                     Color.secondary.opacity(0.3),

--- a/Features/VerticalSlice1/SessionConfigView.swift
+++ b/Features/VerticalSlice1/SessionConfigView.swift
@@ -10,6 +10,7 @@ private struct ThemeOption: Identifiable {
 private let themeOptions: [ThemeOption] = [
     ThemeOption(id: "classic", name: "Classic", iconSystemName: "circle.fill", color: MatherTheme.warm),
     ThemeOption(id: "vehicle", name: "Vehicles", iconSystemName: "car.fill", color: MatherTheme.softBlue),
+    ThemeOption(id: "space", name: "Planets", iconSystemName: "sparkles", color: MatherTheme.accent),
 ]
 
 struct SessionConfigView: View {
@@ -37,7 +38,7 @@ struct SessionConfigView: View {
                                 .font(.title3.weight(.semibold))
                                 .accessibilityIdentifier("session-setup-theme-section")
 
-                            // Theme picker — two cards, selected card gets accent border.
+                            // Theme picker — selected card gets accent border.
                             // Tapping sets selectedThemeId; engine reads it at startSession().
                             HStack(spacing: 12) {
                                 ForEach(themeOptions) { option in
@@ -167,6 +168,7 @@ struct SessionConfigView: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("theme-card-\(option.id)")
+        .accessibilityLabel("\(option.name) theme")
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 }

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -45,7 +45,7 @@ final class FeatureFlagService {
     }
 
     /// Identifies the active theme for the next session.
-    /// Valid values: `"classic"` (default), `"vehicle"`.
+    /// Valid values: `"classic"` (default), `"vehicle"`, `"space"` (`"planets"` alias).
     /// Injected via launch argument `-feature.selectedThemeId classic` in UI tests.
     var selectedThemeId: String {
         didSet { defaults.set(selectedThemeId, forKey: Keys.selectedThemeId) }

--- a/Tests/MatherTests/NumberStoryGeneratorTests.swift
+++ b/Tests/MatherTests/NumberStoryGeneratorTests.swift
@@ -64,6 +64,7 @@ struct NumberStoryGeneratorTests {
         let large = SliceProblem(target: 250, decompositionA: 100, decompositionB: 150)
 
         #expect(NumberStoryGenerator.prompt(for: small, themeId: "space").templateID == .spaceCargo)
+        #expect(NumberStoryGenerator.prompt(for: small, themeId: "planets").templateID == .spaceCargo)
         #expect(NumberStoryGenerator.prompt(for: small, themeId: "vehicle").templateID == .vehicleGarage)
         #expect(NumberStoryGenerator.prompt(for: small, themeId: "garden").templateID == .gardenSeedShop)
         #expect(NumberStoryGenerator.prompt(for: hundred, themeId: "festival").templateID == .festivalPrep)
@@ -99,7 +100,7 @@ struct NumberStoryGeneratorTests {
             SliceProblem(target: 250, decompositionA: 100, decompositionB: 150),
             SliceProblem(target: 1_000, decompositionA: 400, decompositionB: 600),
         ]
-        let themeIds = ["classic", "space", "vehicle", "garden", "festival"]
+        let themeIds = ["classic", "space", "planets", "vehicle", "garden", "festival"]
 
         for problem in problems {
             for themeId in themeIds {

--- a/Tests/MatherTests/ThemeTests.swift
+++ b/Tests/MatherTests/ThemeTests.swift
@@ -112,13 +112,13 @@ struct ThemeTests {
 
     // MARK: - VehicleTheme (PR4)
 
-    @Test func vehicleThemeCounterKindIsVehicle() {
+    @Test func vehicleThemeCounterKindIsThemedSymbol() {
         let theme = VehicleTheme()
-        if case .vehicle(let sym, let assetName) = theme.counterKind {
+        if case .themedSymbol(let sym, let assetName) = theme.counterKind {
             #expect(sym == "car.fill")
             #expect(assetName == "VS1VehicleCar")
         } else {
-            Issue.record("Expected .vehicle counter kind with 'car.fill' symbol")
+            Issue.record("Expected themed symbol counter kind with 'car.fill' symbol")
         }
     }
 
@@ -160,11 +160,42 @@ struct ThemeTests {
         #expect(prompt.localizedCaseInsensitiveContains("memory"))
     }
 
+    // MARK: - SpaceTheme
+
+    @Test func spaceThemeCounterKindIsThemedSymbol() {
+        let theme = SpaceTheme()
+        if case .themedSymbol(let sym, let assetName) = theme.counterKind {
+            #expect(sym == "sparkles")
+            #expect(assetName == nil)
+        } else {
+            Issue.record("Expected themed symbol counter kind for SpaceTheme")
+        }
+    }
+
+    @Test func spaceThemePromptsAreDistinctFromClassic() {
+        let classic = ClassicTheme()
+        let space = SpaceTheme()
+        #expect(space.concretePrompt(target: 7) != classic.concretePrompt(target: 7))
+        #expect(space.pictorialPrompt(target: 5) != classic.pictorialPrompt(target: 5))
+        #expect(space.abstractPrompt() != classic.abstractPrompt())
+        #expect(space.transferPrompt(decompositionA: 3, decompositionB: 4) != classic.transferPrompt(decompositionA: 3, decompositionB: 4))
+        #expect(space.celebrationEmoji != classic.celebrationEmoji)
+    }
+
+    @Test func spaceTransferPromptDoesNotRevealDecompositionNumbers() {
+        let prompt = SpaceTheme().transferPrompt(decompositionA: 2, decompositionB: 5)
+        #expect(!prompt.contains("2"))
+        #expect(!prompt.contains("5"))
+        #expect(prompt.localizedCaseInsensitiveContains("memory"))
+    }
+
     // MARK: - Celebration emoji (PR8)
 
     @Test func celebrationEmojiDistinctBetweenThemes() {
         #expect(VehicleTheme().celebrationEmoji != ClassicTheme().celebrationEmoji)
+        #expect(SpaceTheme().celebrationEmoji != ClassicTheme().celebrationEmoji)
         #expect(!VehicleTheme().celebrationEmoji.isEmpty)
+        #expect(!SpaceTheme().celebrationEmoji.isEmpty)
         #expect(!ClassicTheme().celebrationEmoji.isEmpty)
     }
 
@@ -188,9 +219,52 @@ struct ThemeTests {
         engine.startSession()
         #expect(engine.feedbackMessage == "Park 6 cars in the garage.")
         #expect(engine.activeTheme.celebrationEmoji == "🚗")
-        if case .vehicle = engine.activeTheme.counterKind { } else {
-            Issue.record("Expected .vehicle counter kind after startSession with selectedThemeId=vehicle")
+        if case .themedSymbol = engine.activeTheme.counterKind { } else {
+            Issue.record("Expected themed symbol counter kind after startSession with selectedThemeId=vehicle")
         }
+    }
+
+    @MainActor
+    @Test func startSessionWithSpaceThemeIdActivatesSpaceTheme() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.selectedThemeId = "space"
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        #expect(engine.feedbackMessage == "Load 6 star bolts for the rocket.")
+        #expect(engine.activeTheme.counterNoun == "star bolts")
+        #expect(engine.activeTheme.celebrationEmoji == "🚀")
+        if case .themedSymbol(let sym, let assetName) = engine.activeTheme.counterKind {
+            #expect(sym == "sparkles")
+            #expect(assetName == nil)
+        } else {
+            Issue.record("Expected themed symbol counter kind after startSession with selectedThemeId=space")
+        }
+    }
+
+    @MainActor
+    @Test func startSessionWithPlanetsAliasActivatesSpaceTheme() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        flags.selectedThemeId = "planets"
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        #expect(engine.activeTheme.counterNoun == "star bolts")
+        #expect(engine.activeTheme.celebrationEmoji == "🚀")
     }
 
     @MainActor
@@ -299,6 +373,10 @@ struct ThemeTests {
         #expect(VehicleTheme().counterNoun == "cars")
     }
 
+    @Test func spaceThemeCounterNounIsStarBolts() {
+        #expect(SpaceTheme().counterNoun == "star bolts")
+    }
+
     /// After 3 concrete failures with VehicleTheme, the feedback hint must say "cars" not "circles".
     @MainActor
     @Test func engineConcreteFailureHintUsesThemeCounterNoun() {
@@ -319,6 +397,27 @@ struct ThemeTests {
         engine.submitCurrentStage() // attempt 2
         engine.submitCurrentStage() // attempt 3 → counterNoun hint
         #expect(engine.feedbackMessage.contains("cars"))
+        #expect(!engine.feedbackMessage.contains("circles"))
+    }
+
+    @MainActor
+    @Test func engineConcreteFailureHintUsesSpaceCounterNoun() {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            activeTheme: SpaceTheme(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        engine.submitCurrentStage()
+        engine.submitCurrentStage()
+        engine.submitCurrentStage()
+        #expect(engine.feedbackMessage.contains("star bolts"))
         #expect(!engine.feedbackMessage.contains("circles"))
     }
 }

--- a/Tests/MatherTests/VehicleSpecTests.swift
+++ b/Tests/MatherTests/VehicleSpecTests.swift
@@ -101,11 +101,11 @@ struct VehicleSpecTests {
         let theme = VehicleTheme()
         #expect(theme.counterNoun == "cars")
         #expect(theme.celebrationEmoji == "🚗")
-        if case .vehicle(let sym, let assetName) = theme.counterKind {
+        if case .themedSymbol(let sym, let assetName) = theme.counterKind {
             #expect(sym == "car.fill")
             #expect(assetName == "VS1VehicleCar")
         } else {
-            Issue.record("Expected .vehicle counterKind for default VehicleTheme")
+            Issue.record("Expected themed symbol counterKind for default VehicleTheme")
         }
     }
 
@@ -113,11 +113,11 @@ struct VehicleSpecTests {
         let theme = VehicleTheme(spec: .helicopter)
         #expect(theme.counterNoun == "helicopters")
         #expect(theme.celebrationEmoji == "🚁")
-        if case .vehicle(let sym, let assetName) = theme.counterKind {
+        if case .themedSymbol(let sym, let assetName) = theme.counterKind {
             #expect(sym == "helicopter")
             #expect(assetName == nil)
         } else {
-            Issue.record("Expected .vehicle counterKind for helicopter spec")
+            Issue.record("Expected themed symbol counterKind for helicopter spec")
         }
     }
 

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -52,6 +52,8 @@ final class CompactLayoutTests: XCTestCase {
 
         XCTAssertTrue(app.buttons["theme-card-vehicle"].waitForExistence(timeout: 5))
         app.buttons["theme-card-vehicle"].tap()
+        XCTAssertTrue(app.buttons["theme-card-space"].waitForExistence(timeout: 5))
+        app.buttons["theme-card-space"].tap()
 
         let targetCap50 = app.buttons["target-cap-up-to-50"]
         if !targetCap50.waitForExistence(timeout: 3) {

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -78,6 +78,17 @@ final class ScreenshotTests: XCTestCase {
         snapshot(app, "SessionConfig")
     }
 
+    func testScreenshot_SessionConfig_PlanetsTheme() {
+        let app = launchWithVS1()
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
+
+        app.buttons["Play"].tap()
+        _ = app.staticTexts["Session setup"].waitForExistence(timeout: 10)
+        XCTAssertTrue(app.buttons["theme-card-space"].waitForExistence(timeout: 5))
+        app.buttons["theme-card-space"].tap()
+        snapshot(app, "SessionConfig-PlanetsTheme")
+    }
+
     // MARK: - Concrete stage
 
     func testScreenshot_ConcreteBuildView() {

--- a/wiki/Specs/VS1-Theme-Framework.md
+++ b/wiki/Specs/VS1-Theme-Framework.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The VS1 theme framework lets a parent select a visual and vocabulary theme for a session before it starts. The first content pack is **Vehicles** — generated local vehicle assets with SF Symbol fallback and vehicle/worksite vocabulary replace the default abstract circles and neutral prompts.
+The VS1 theme framework lets a parent select a visual and vocabulary theme for a session before it starts. Available themes include **Vehicles** — generated local vehicle assets with SF Symbol fallback and vehicle/worksite vocabulary — and **Planets**, an asset-light space cargo theme using SF Symbols.
 
 Themes are a purely additive layer. The CPA learning loop, stage rules, equation logic, and scoring are completely unchanged.
 
@@ -37,8 +37,8 @@ protocol SliceTheme {
 
 ```swift
 enum CounterKind: Equatable {
-    case circle                                      // filled/empty circle (ClassicTheme)
-    case vehicle(symbolName: String, assetName: String?) // local asset with SF Symbol fallback
+    case circle
+    case themedSymbol(symbolName: String, assetName: String?) // local asset with SF Symbol fallback
 }
 ```
 
@@ -47,7 +47,7 @@ enum CounterKind: Equatable {
 ## Session lifecycle
 
 1. **SessionConfigView** — parent taps a theme card → sets `featureFlags.selectedThemeId`
-2. **startSession()** — engine reads `selectedThemeId`, resolves `ClassicTheme` or `VehicleTheme`, stores as `activeTheme`
+2. **startSession()** — engine reads `selectedThemeId`, resolves a registered theme, stores it as `activeTheme`
 3. **During session** — `activeTheme` is frozen (never changes mid-session)
 4. **Views** — `ConcreteBuildView`, `SplitView`, `TransferCheckView` all receive `theme: any SliceTheme` and pass it to `CounterView`
 5. **Speech** — `promptForCurrentStage()`, `successMessage()`, `startSession()`, `endSession()` all delegate to `activeTheme`
@@ -60,6 +60,7 @@ enum CounterKind: Equatable {
 |---|---|---|---|---|
 | `classic` | `ClassicTheme` | Circle | ⭐️ | "Let's make and break numbers to ten." |
 | `vehicle` | `VehicleTheme` | Generated vehicle asset with SF Symbol fallback | 🚗 / per-vehicle | Per-problem vehicle/worksite intro |
+| `space` | `SpaceTheme` | SF Symbol space counter | 🚀 | "Let's make and break numbers with space cargo." |
 
 ---
 
@@ -68,6 +69,8 @@ enum CounterKind: Equatable {
 Vehicle sessions use `VehicleSpec.pool` one spec per problem, preserving a stable noun/image/prompt within that problem. In test mode the pool order is deterministic for screenshot and unit-test stability. In normal play the pool is shuffled per session and avoids starting with the default car, so build-58-style sessions do not always open on repeated car counters.
 
 Issue #750 added local generated 512×512 transparent PNG counter assets for car, pickup truck, bulldozer, dump truck, cement mixer, and mining haul truck. Provenance is recorded in `wiki/Specs/Issue-750-VS1-Vehicle-Counter-Provenance.yml`; assets without a local PNG continue to use their SF Symbol fallback.
+
+Issue #737 added the parent-facing **Planets** setup card, internally using `selectedThemeId == "space"` so the existing Space Cargo story pack and telemetry segmentation can be reused. This first slice intentionally uses SF Symbols only; no new bundled planet PNGs were introduced.
 
 ## CounterView
 
@@ -100,6 +103,6 @@ Replacing circles with generated vehicle assets or SF Symbols preserves all subi
 3. Add a card to `themeOptions` in `SessionConfigView.swift`
 4. Add vocabulary tests in `ThemeTests.swift`
 
-No changes to `CounterKind`, `SliceStateMachine`, or any engine logic are required for a theme that uses an existing vehicle asset/SF Symbol counter path.
+No changes to `SliceStateMachine` are required for a theme that uses the existing `themedSymbol` asset/SF Symbol counter path.
 
 To add a new counter shape, extend `CounterKind` and handle the new case in `CounterView.counterShape`.


### PR DESCRIPTION
## Summary
- Adds a third VS1 setup theme card labeled **Planets** using internal theme ID `space`.
- Adds `SpaceTheme` with space cargo/star-bolt vocabulary and SF Symbol counters, and registers `space` plus a `planets` alias in session/story routing.
- Generalizes the existing themed counter case from vehicle-specific naming to `themedSymbol` so future non-vehicle themes can use the same renderer.
- Updates focused unit/UI coverage and the VS1 theme framework doc.

Closes #737.

## Tests
- `git diff --check`
- `xcodegen generate` not run locally: `xcodegen` is not installed in this worker.
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO` not run locally: `xcodebuild` is not installed in this worker.

Expected CI coverage: macOS CI should regenerate the project and run the Swift/Xcode test suite.

## Asset / Proof Notes
- No new image assets were generated or bundled in this slice. The Planets theme uses SF Symbols (`sparkles`) for counters, so there is no new PNG provenance manifest.
- Added UI screenshot coverage for selecting the Planets setup card; visual proof will come from CI artifacts or a macOS simulator run.