### PR TITLE
Add Protractor angle match prelude

### DIFF
--- a/Features/TwoFingerProtractor/TwoFingerProtractorView.swift
+++ b/Features/TwoFingerProtractor/TwoFingerProtractorView.swift
@@ -119,6 +119,172 @@ let protractorLevels: [ProtractorLevel] = [
     ProtractorLevel(targetAngle: 30,  sceneName: "a sharp turn — like a hill trail", mission: "Trace the switchback trail on the hill map.", sceneKind: .trailSwitchback, snapTolerance: 4),
 ]
 
+// MARK: - Angle match prelude
+
+enum ProtractorMode: Equatable {
+    case angleMatch
+    case touchBuild
+}
+
+enum AngleCardSide: String, Equatable {
+    case visual
+    case value
+}
+
+struct AngleMatchPair: Identifiable, Equatable {
+    let id: String
+    let levelIndex: Int
+    let targetAngle: Double
+    let sceneKind: ProtractorSceneKind
+    let sceneName: String
+    let mission: String
+    let valueLabel: String
+
+    init(level: ProtractorLevel, levelIndex: Int) {
+        id = "angle-\(Int(level.targetAngle))"
+        self.levelIndex = levelIndex
+        targetAngle = level.targetAngle
+        sceneKind = level.sceneKind
+        sceneName = level.sceneName
+        mission = level.mission
+        valueLabel = "\(Int(level.targetAngle))°"
+    }
+}
+
+struct AngleMatchCard: Identifiable, Equatable {
+    let id: String
+    let pairID: String
+    let side: AngleCardSide
+    var isSelected = false
+    var isMatched = false
+
+    init(pairID: String, side: AngleCardSide) {
+        id = "\(pairID)-\(side.rawValue)"
+        self.pairID = pairID
+        self.side = side
+    }
+}
+
+enum AngleMatchSelectionOutcome: Equatable {
+    case selected
+    case deselected
+    case matched(pairID: String, completed: Bool)
+    case mismatched
+    case ignored
+}
+
+struct AngleMatchState: Equatable {
+    private(set) var pairs: [AngleMatchPair]
+    private(set) var cards: [AngleMatchCard]
+    private(set) var completedPairID: String?
+
+    var selectedCardID: String? {
+        cards.first { $0.isSelected }?.id
+    }
+
+    var isComplete: Bool {
+        !cards.isEmpty && cards.allSatisfy { $0.isMatched }
+    }
+
+    var completedLevelIndex: Int? {
+        guard let completedPairID else { return nil }
+        return pairs.first { $0.id == completedPairID }?.levelIndex
+    }
+
+    static func prelude(from levels: [ProtractorLevel], pairCount: Int = 3) -> AngleMatchState {
+        let pairs = levels.prefix(pairCount).enumerated().map { levelIndex, level in
+            AngleMatchPair(level: level, levelIndex: levelIndex)
+        }
+        let cards = pairs.flatMap { pair in
+            [
+                AngleMatchCard(pairID: pair.id, side: .visual),
+                AngleMatchCard(pairID: pair.id, side: .value)
+            ]
+        }
+        return AngleMatchState(pairs: pairs, cards: cards, completedPairID: nil)
+    }
+
+    mutating func select(cardID: String) -> AngleMatchSelectionOutcome {
+        guard let cardIndex = cards.firstIndex(where: { $0.id == cardID }) else { return .ignored }
+        guard !cards[cardIndex].isMatched else { return .ignored }
+
+        if cards[cardIndex].isSelected {
+            cards[cardIndex].isSelected = false
+            return .deselected
+        }
+
+        guard let selectedID = selectedCardID,
+              let selectedIndex = cards.firstIndex(where: { $0.id == selectedID }) else {
+            clearSelection()
+            cards[cardIndex].isSelected = true
+            return .selected
+        }
+
+        let selectedCard = cards[selectedIndex]
+        let nextCard = cards[cardIndex]
+        clearSelection()
+
+        if selectedCard.pairID == nextCard.pairID && selectedCard.side != nextCard.side {
+            markMatched(pairID: nextCard.pairID)
+            completedPairID = nextCard.pairID
+            return .matched(pairID: nextCard.pairID, completed: isComplete)
+        }
+
+        return .mismatched
+    }
+
+    func pair(for card: AngleMatchCard) -> AngleMatchPair? {
+        pairs.first { $0.id == card.pairID }
+    }
+
+    private mutating func clearSelection() {
+        for index in cards.indices {
+            cards[index].isSelected = false
+        }
+    }
+
+    private mutating func markMatched(pairID: String) {
+        for index in cards.indices where cards[index].pairID == pairID {
+            cards[index].isMatched = true
+        }
+    }
+}
+
+private enum ProtractorSceneRenderer {
+    static func drawRealWorldScene(ctx: GraphicsContext,
+                                   size: CGSize,
+                                   sceneKind: ProtractorSceneKind,
+                                   accent: Color) {
+        let center = CGPoint(x: size.width / 2, y: size.height / 2)
+        switch sceneKind {
+        case .doorGate:
+            let wall = CGRect(x: center.x - 120, y: center.y - 90, width: 240, height: 180)
+            ctx.stroke(RoundedRectangle(cornerRadius: 18).path(in: wall), with: .color(MatherTheme.ink.opacity(0.14)), lineWidth: 5)
+            var gate = Path(); gate.move(to: center); gate.addLine(to: CGPoint(x: center.x + 120, y: center.y))
+            gate.move(to: center); gate.addLine(to: CGPoint(x: center.x, y: center.y - 120))
+            ctx.stroke(gate, with: .color(accent.opacity(0.45)), style: StrokeStyle(lineWidth: 10, lineCap: .round))
+        case .clockRamp:
+            ctx.stroke(Circle().path(in: CGRect(x: center.x - 110, y: center.y - 110, width: 220, height: 220)), with: .color(MatherTheme.ink.opacity(0.10)), lineWidth: 6)
+            var ramp = Path(); ramp.move(to: CGPoint(x: center.x - 115, y: center.y + 70)); ramp.addLine(to: CGPoint(x: center.x + 115, y: center.y - 40))
+            ctx.stroke(ramp, with: .color(accent.opacity(0.45)), style: StrokeStyle(lineWidth: 12, lineCap: .round))
+        case .triangleRoof:
+            var roof = Path(); roof.move(to: CGPoint(x: center.x - 130, y: center.y + 80)); roof.addLine(to: CGPoint(x: center.x, y: center.y - 115)); roof.addLine(to: CGPoint(x: center.x + 130, y: center.y + 80))
+            ctx.stroke(roof, with: .color(accent.opacity(0.45)), style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .round))
+        case .roadBend:
+            var road = Path(); road.move(to: CGPoint(x: center.x - 150, y: center.y + 80)); road.addQuadCurve(to: CGPoint(x: center.x + 150, y: center.y - 70), control: CGPoint(x: center.x - 10, y: center.y + 130))
+            ctx.stroke(road, with: .color(accent.opacity(0.40)), style: StrokeStyle(lineWidth: 34, lineCap: .round))
+            ctx.stroke(road, with: .color(.white.opacity(0.7)), style: StrokeStyle(lineWidth: 3, dash: [12, 10]))
+        case .trailSwitchback:
+            for i in 0..<5 {
+                let inset = CGFloat(i) * 24
+                ctx.stroke(Ellipse().path(in: CGRect(x: center.x - 160 + inset, y: center.y - 115 + inset * 0.45, width: 320 - inset * 2, height: 210 - inset)), with: .color(MatherTheme.ink.opacity(0.07)), lineWidth: 2)
+            }
+            var trail = Path(); trail.move(to: CGPoint(x: center.x - 130, y: center.y + 80)); trail.addLine(to: CGPoint(x: center.x - 10, y: center.y - 10)); trail.addLine(to: CGPoint(x: center.x + 115, y: center.y - 55))
+            ctx.stroke(trail, with: .color(accent.opacity(0.48)), style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .round))
+        }
+    }
+}
+
 // MARK: - Main view
 
 struct TwoFingerProtractorView: View {
@@ -133,6 +299,8 @@ struct TwoFingerProtractorView: View {
     @State private var sessionStart: Date = .now
     @State private var showDegreeLabel: Bool = false
     @State private var canvasSize: CGSize = .zero
+    @State private var mode: ProtractorMode = .angleMatch
+    @State private var angleMatch = AngleMatchState.prelude(from: protractorLevels)
 
     private var level: ProtractorLevel { protractorLevels[levelIndex % protractorLevels.count] }
 
@@ -141,40 +309,52 @@ struct TwoFingerProtractorView: View {
             MatherTheme.background.ignoresSafeArea()
             VStack(spacing: 0) {
                 headerBar
-                GeometryReader { geo in
-                    ZStack {
-                        // Multi-touch capture layer (full area)
-                        MultiTouchCanvas { t1, t2 in
-                            touch1 = t1
-                            touch2 = t2
-                            canvasSize = geo.size
-                            updateAngle(canvasSize: geo.size)
-                        }
+                switch mode {
+                case .angleMatch:
+                    angleMatchPrelude
+                case .touchBuild:
+                    GeometryReader { geo in
+                        ZStack {
+                            // Multi-touch capture layer (full area)
+                            MultiTouchCanvas { t1, t2 in
+                                touch1 = t1
+                                touch2 = t2
+                                canvasSize = geo.size
+                                updateAngle(canvasSize: geo.size)
+                            }
 
-                        // Wedge drawing canvas
-                        Canvas { ctx, size in
-                            drawScene(ctx: ctx, size: size)
-                        }
-                        .allowsHitTesting(false)
+                            // Wedge drawing canvas
+                            Canvas { ctx, size in
+                                drawScene(ctx: ctx, size: size)
+                            }
+                            .allowsHitTesting(false)
 
-                        // Degree reveal label — shown only on snap
-                        if showDegreeLabel {
-                            degreeLabel
-                                .transition(.scale.combined(with: .opacity))
-                        }
+                            // Degree reveal label — shown only on snap
+                            if showDegreeLabel {
+                                degreeLabel
+                                    .transition(.scale.combined(with: .opacity))
+                            }
 
-                        // Hint when no fingers
-                        if touch1 == nil {
-                            hintOverlay
+                            // Hint when no fingers
+                            if touch1 == nil {
+                                hintOverlay
+                            }
                         }
                     }
+                    bottomBar
                 }
-                bottomBar
             }
         }
+        .animation(.easeInOut(duration: 0.2), value: mode)
         .animation(.easeInOut(duration: 0.2), value: showDegreeLabel)
         .animation(.easeInOut(duration: 0.15), value: matched)
-        .onAppear { sessionStart = .now }
+        .onAppear {
+            sessionStart = .now
+            appModel.speechService.speak(
+                "Match each angle picture to its degrees. Then make one with your fingers.",
+                enabled: appModel.featureFlags.audioEnabled
+            )
+        }
         .onDisappear {
             guard wonCount > 0 else { return }
             appModel.gameSessionStore.save(
@@ -194,7 +374,7 @@ struct TwoFingerProtractorView: View {
                 Text("Two-Finger Protractor")
                     .font(.title2.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
-                Text(level.mission)
+                Text(mode == .angleMatch ? "Match angle pictures to degree cards." : level.mission)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
@@ -212,6 +392,150 @@ struct TwoFingerProtractorView: View {
         .padding(.horizontal, 24)
         .padding(.top, 20)
         .padding(.bottom, 8)
+    }
+
+    // MARK: - Angle match cards
+
+    private var angleMatchPrelude: some View {
+        ScrollView(showsIndicators: false) {
+            VStack(spacing: 18) {
+                matchColumns
+                Text("Then use two fingers to feel the matched angle.")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .padding(.bottom, 16)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+        }
+        .accessibilityIdentifier("protractor-angle-match-prelude")
+    }
+
+    private var matchColumns: some View {
+        let visualCards = angleMatch.cards.filter { $0.side == .visual }
+        let valueCards = angleMatch.cards.filter { $0.side == .value }.reversed()
+
+        return HStack(alignment: .top, spacing: 14) {
+            angleCardColumn(title: "Pictures", cards: Array(visualCards))
+            angleCardColumn(title: "Degrees", cards: Array(valueCards))
+        }
+        .frame(maxWidth: 760)
+        .frame(maxWidth: .infinity)
+    }
+
+    private func angleCardColumn(title: String, cards: [AngleMatchCard]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+            ForEach(cards) { card in
+                angleCardButton(card)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .top)
+    }
+
+    private func angleCardButton(_ card: AngleMatchCard) -> some View {
+        let pair = angleMatch.pair(for: card)
+        let isVisual = card.side == .visual
+        return Button {
+            handleAngleCardTap(card.id)
+        } label: {
+            VStack(spacing: 10) {
+                if isVisual, let pair {
+                    ProtractorSceneThumbnail(pair: pair)
+                        .frame(height: 104)
+                } else {
+                    Text(pair?.valueLabel ?? "")
+                        .font(.system(size: 40, weight: .black, design: .rounded))
+                        .foregroundStyle(card.isMatched ? MatherTheme.accent : MatherTheme.ink)
+                        .frame(maxWidth: .infinity, minHeight: 104)
+                }
+
+                Text(isVisual ? (pair?.sceneName ?? "") : "degrees")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .minimumScaleFactor(0.78)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, minHeight: 152)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(card.isMatched ? MatherTheme.accent.opacity(0.12) : MatherTheme.card)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(angleCardBorderColor(card), lineWidth: card.isSelected ? 4 : 2)
+            )
+            .scaleEffect(card.isMatched ? 0.96 : 1)
+            .opacity(card.isMatched ? 0.70 : 1)
+        }
+        .buttonStyle(.plain)
+        .disabled(card.isMatched)
+        .accessibilityIdentifier("protractor-angle-card-\(card.id)")
+        .accessibilityLabel(angleCardAccessibilityLabel(card))
+    }
+
+    private func angleCardBorderColor(_ card: AngleMatchCard) -> Color {
+        if card.isSelected { return MatherTheme.warm }
+        if card.isMatched { return MatherTheme.accent }
+        return MatherTheme.panelDeep.opacity(0.28)
+    }
+
+    private func angleCardAccessibilityLabel(_ card: AngleMatchCard) -> String {
+        guard let pair = angleMatch.pair(for: card) else { return "Angle card" }
+        switch card.side {
+        case .visual:
+            return "Angle picture, \(pair.sceneName)"
+        case .value:
+            return "Degree value, \(pair.valueLabel)"
+        }
+    }
+
+    private func handleAngleCardTap(_ cardID: String) {
+        let outcome = angleMatch.select(cardID: cardID)
+        switch outcome {
+        case .selected, .deselected:
+            appModel.hapticsService.cardPickup(enabled: appModel.featureFlags.hapticsEnabled)
+        case .matched(let pairID, let completed):
+            appModel.hapticsService.cardSnapCorrect(enabled: appModel.featureFlags.hapticsEnabled)
+            if let pair = angleMatch.pairs.first(where: { $0.id == pairID }) {
+                appModel.speechService.speak(
+                    "\(pair.valueLabel). \(pair.sceneName).",
+                    enabled: appModel.featureFlags.audioEnabled
+                )
+            }
+            if completed {
+                appModel.hapticsService.bondMatchComplete(enabled: appModel.featureFlags.hapticsEnabled)
+                startTouchBuildFromMatch()
+            }
+        case .mismatched:
+            appModel.hapticsService.cardSnapMismatch(enabled: appModel.featureFlags.hapticsEnabled)
+            appModel.speechService.speak(
+                "Try another angle card.",
+                enabled: appModel.featureFlags.audioEnabled
+            )
+        case .ignored:
+            break
+        }
+    }
+
+    private func startTouchBuildFromMatch() {
+        if let completedLevelIndex = angleMatch.completedLevelIndex {
+            levelIndex = completedLevelIndex
+        }
+        matched = false
+        showDegreeLabel = false
+        touch1 = nil
+        touch2 = nil
+        measuredAngle = 0
+        mode = .touchBuild
+        appModel.speechService.speak(
+            "Now use two fingers to make \(Int(level.targetAngle)) degrees.",
+            enabled: appModel.featureFlags.audioEnabled
+        )
     }
 
     // MARK: - Bottom bar
@@ -327,37 +651,12 @@ struct TwoFingerProtractorView: View {
 
 
     private func drawRealWorldScene(ctx: GraphicsContext, size: CGSize) {
-        let center = CGPoint(x: size.width / 2, y: size.height / 2)
         let accent = matched ? MatherTheme.accent : MatherTheme.softBlue
-        switch level.sceneKind {
-        case .doorGate:
-            let wall = CGRect(x: center.x - 120, y: center.y - 90, width: 240, height: 180)
-            ctx.stroke(RoundedRectangle(cornerRadius: 18).path(in: wall), with: .color(MatherTheme.ink.opacity(0.14)), lineWidth: 5)
-            var gate = Path(); gate.move(to: center); gate.addLine(to: CGPoint(x: center.x + 120, y: center.y))
-            gate.move(to: center); gate.addLine(to: CGPoint(x: center.x, y: center.y - 120))
-            ctx.stroke(gate, with: .color(accent.opacity(0.45)), style: StrokeStyle(lineWidth: 10, lineCap: .round))
-        case .clockRamp:
-            ctx.stroke(Circle().path(in: CGRect(x: center.x - 110, y: center.y - 110, width: 220, height: 220)), with: .color(MatherTheme.ink.opacity(0.10)), lineWidth: 6)
-            var ramp = Path(); ramp.move(to: CGPoint(x: center.x - 115, y: center.y + 70)); ramp.addLine(to: CGPoint(x: center.x + 115, y: center.y - 40))
-            ctx.stroke(ramp, with: .color(accent.opacity(0.45)), style: StrokeStyle(lineWidth: 12, lineCap: .round))
-        case .triangleRoof:
-            var roof = Path(); roof.move(to: CGPoint(x: center.x - 130, y: center.y + 80)); roof.addLine(to: CGPoint(x: center.x, y: center.y - 115)); roof.addLine(to: CGPoint(x: center.x + 130, y: center.y + 80))
-            ctx.stroke(roof, with: .color(accent.opacity(0.45)), style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .round))
-        case .roadBend:
-            var road = Path(); road.move(to: CGPoint(x: center.x - 150, y: center.y + 80)); road.addQuadCurve(to: CGPoint(x: center.x + 150, y: center.y - 70), control: CGPoint(x: center.x - 10, y: center.y + 130))
-            ctx.stroke(road, with: .color(accent.opacity(0.40)), style: StrokeStyle(lineWidth: 34, lineCap: .round))
-            ctx.stroke(road, with: .color(.white.opacity(0.7)), style: StrokeStyle(lineWidth: 3, dash: [12, 10]))
-        case .trailSwitchback:
-            for i in 0..<5 {
-                let inset = CGFloat(i) * 24
-                ctx.stroke(Ellipse().path(in: CGRect(x: center.x - 160 + inset, y: center.y - 115 + inset * 0.45, width: 320 - inset * 2, height: 210 - inset)), with: .color(MatherTheme.ink.opacity(0.07)), lineWidth: 2)
-            }
-            var trail = Path(); trail.move(to: CGPoint(x: center.x - 130, y: center.y + 80)); trail.addLine(to: CGPoint(x: center.x - 10, y: center.y - 10)); trail.addLine(to: CGPoint(x: center.x + 115, y: center.y - 55))
-            ctx.stroke(trail, with: .color(accent.opacity(0.48)), style: StrokeStyle(lineWidth: 10, lineCap: .round, lineJoin: .round))
-        }
+        ProtractorSceneRenderer.drawRealWorldScene(ctx: ctx, size: size, sceneKind: level.sceneKind, accent: accent)
     }
 
-    private func drawGhostWedge(ctx: GraphicsContext, size: CGSize) {        let pivot = CGPoint(x: size.width / 2, y: size.height * 0.55)
+    private func drawGhostWedge(ctx: GraphicsContext, size: CGSize) {
+        let pivot = CGPoint(x: size.width / 2, y: size.height * 0.55)
         let armLen: CGFloat = 100
         let targetRad = level.targetAngle * .pi / 180
         let baseAngle: Double = -.pi / 2   // arms open upward
@@ -467,5 +766,39 @@ struct TwoFingerProtractorView: View {
             "Now make \(Int(level.targetAngle)) degrees.",
             enabled: appModel.featureFlags.audioEnabled
         )
+    }
+}
+
+private struct ProtractorSceneThumbnail: View {
+    let pair: AngleMatchPair
+
+    var body: some View {
+        Canvas { ctx, size in
+            ProtractorSceneRenderer.drawRealWorldScene(
+                ctx: ctx,
+                size: size,
+                sceneKind: pair.sceneKind,
+                accent: MatherTheme.softBlue
+            )
+            drawWedge(ctx: ctx, size: size)
+        }
+        .background(MatherTheme.softBlue.opacity(0.10))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func drawWedge(ctx: GraphicsContext, size: CGSize) {
+        let pivot = CGPoint(x: size.width * 0.50, y: size.height * 0.68)
+        let radius = min(size.width, size.height) * 0.30
+        let targetRad = pair.targetAngle * .pi / 180
+        let baseAngle = -Double.pi / 2
+        let a1 = baseAngle - targetRad / 2
+        let a2 = baseAngle + targetRad / 2
+
+        var wedge = Path()
+        wedge.move(to: pivot)
+        wedge.addArc(center: pivot, radius: radius, startAngle: .radians(a1), endAngle: .radians(a2), clockwise: false)
+        wedge.closeSubpath()
+        ctx.fill(wedge, with: .color(MatherTheme.warm.opacity(0.32)))
+        ctx.stroke(wedge, with: .color(MatherTheme.warm.opacity(0.75)), lineWidth: 3)
     }
 }

--- a/Tests/MatherTests/TwoFingerProtractorTests.swift
+++ b/Tests/MatherTests/TwoFingerProtractorTests.swift
@@ -161,3 +161,82 @@ struct ProtractorSceneTests {
         }
     }
 }
+
+@Suite("AngleMatchPrelude")
+struct AngleMatchPreludeTests {
+    @Test func preludeBuildsVisualAndValueCardsFromProtractorLevels() {
+        let state = AngleMatchState.prelude(from: protractorLevels, pairCount: 3)
+
+        #expect(state.pairs.count == 3)
+        #expect(state.cards.count == 6)
+        #expect(Set(state.pairs.map(\.id)).count == 3)
+        #expect(Set(state.cards.map(\.id)).count == 6)
+        #expect(state.pairs.map(\.targetAngle) == Array(protractorLevels.prefix(3).map(\.targetAngle)))
+
+        for pair in state.pairs {
+            let pairCards = state.cards.filter { $0.pairID == pair.id }
+            #expect(pairCards.count == 2)
+            #expect(pairCards.contains { $0.side == .visual })
+            #expect(pairCards.contains { $0.side == .value })
+            #expect(!pair.mission.isEmpty)
+            #expect(!pair.sceneName.isEmpty)
+            #expect(pair.valueLabel == "\(Int(pair.targetAngle))°")
+        }
+    }
+
+    @Test func correctVisualAndValueSelectionMarksThePairMatched() {
+        var state = AngleMatchState.prelude(from: protractorLevels, pairCount: 2)
+        let pair = state.pairs[0]
+        let visual = state.cards.first { $0.pairID == pair.id && $0.side == .visual }!
+        let value = state.cards.first { $0.pairID == pair.id && $0.side == .value }!
+
+        #expect(state.select(cardID: visual.id) == .selected)
+        #expect(state.select(cardID: value.id) == .matched(pairID: pair.id, completed: false))
+
+        let matchedCards = state.cards.filter { $0.pairID == pair.id }
+        #expect(matchedCards.allSatisfy { $0.isMatched })
+        #expect(state.completedLevelIndex == pair.levelIndex)
+        #expect(!state.isComplete)
+    }
+
+    @Test func mismatchClearsSelectionWithoutMatchingCards() {
+        var state = AngleMatchState.prelude(from: protractorLevels, pairCount: 2)
+        let firstVisual = state.cards.first { $0.pairID == state.pairs[0].id && $0.side == .visual }!
+        let secondValue = state.cards.first { $0.pairID == state.pairs[1].id && $0.side == .value }!
+
+        #expect(state.select(cardID: firstVisual.id) == .selected)
+        #expect(state.select(cardID: secondValue.id) == .mismatched)
+
+        #expect(state.selectedCardID == nil)
+        #expect(!state.cards.contains { $0.isMatched })
+        #expect(!state.isComplete)
+    }
+
+    @Test func completionHappensOnlyAfterAllPairsMatch() {
+        var state = AngleMatchState.prelude(from: protractorLevels, pairCount: 2)
+        let pairs = state.pairs
+
+        for (index, pair) in pairs.enumerated() {
+            let visual = state.cards.first { $0.pairID == pair.id && $0.side == .visual }!
+            let value = state.cards.first { $0.pairID == pair.id && $0.side == .value }!
+            #expect(state.select(cardID: visual.id) == .selected)
+            let expectedCompleted = index == pairs.count - 1
+            #expect(state.select(cardID: value.id) == .matched(pairID: pair.id, completed: expectedCompleted))
+        }
+
+        #expect(state.isComplete)
+        #expect(state.completedLevelIndex == state.pairs.last?.levelIndex)
+    }
+
+    @Test func childFacingAngleMatchCopyAvoidsPressureWords() {
+        let state = AngleMatchState.prelude(from: protractorLevels, pairCount: 3)
+        let blockedWords = ["hurry", "timer", "score", "wrong", "beat"]
+
+        for pair in state.pairs {
+            let copy = "\(pair.mission) \(pair.sceneName) \(pair.valueLabel)"
+            for blockedWord in blockedWords {
+                #expect(!copy.localizedCaseInsensitiveContains(blockedWord))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a short Angle Match prelude to Two-Finger Protractor that asks children to match visual angle cards with degree-value cards before entering touch construction.
- Generates the visual/value pairs from existing `protractorLevels` so scene metadata and target angles stay in sync.
- Reuses existing card haptics for pickup, correct match, mismatch, and round completion, then hands off to the existing two-finger Protractor flow for the last matched target.
- Adds pure reducer/model tests for pair generation, correct match, mismatch, completion, and pressure-word guardrails.

Closes #772.

## Tests
- `git diff --check`

Not run locally: `xcodegen generate`, `xcodebuild test`, and Swift parsing/build commands because this worker does not have `xcodegen`, `xcodebuild`, or `swift` installed. CI should cover the generated Xcode project and Swift Testing suite.

## Asset / Proof Gaps
- No new bitmap or third-party assets were added; angle thumbnails are code-drawn from existing Protractor scene metadata.
- Device proof is still needed for haptics and the two-finger feel path, since simulator/local validation is unavailable in this worker.