### PR TITLE
feat: add Packing Cards multiplication prelude

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -54,6 +54,8 @@ struct RootView: View {
                         }
                 case .rectangleFactory:
                     RectangleFactoryView(appModel: appModel)
+                case .factoryCards:
+                    FactoryCardsView(appModel: appModel)
                 case .sumSprint:
                     switch appModel.sumSprintEngine.phase {
                     case .idle:

--- a/Domain/ArrayPreludeModels.swift
+++ b/Domain/ArrayPreludeModels.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+enum ArrayPreludeDifficulty: String, CaseIterable, Equatable {
+    case easy
+    case standard
+    case flip
+
+    var menuLabel: String {
+        switch self {
+        case .easy: "Easy"
+        case .standard: "Standard"
+        case .flip: "Flip mode"
+        }
+    }
+
+    var pairCount: Int {
+        switch self {
+        case .easy: 3
+        case .standard: 4
+        case .flip: 4
+        }
+    }
+
+    var showsEquation: Bool {
+        switch self {
+        case .easy: false
+        case .standard, .flip: true
+        }
+    }
+
+    var startsFaceDown: Bool {
+        self == .flip
+    }
+}
+
+struct ArrayFact: Identifiable, Hashable {
+    let rows: Int
+    let columns: Int
+
+    init(rows: Int, columns: Int) {
+        precondition(rows > 1, "Array prelude facts should avoid 1-row multiplication introductions.")
+        precondition(columns > 1, "Array prelude facts should avoid 1-column multiplication introductions.")
+        self.rows = rows
+        self.columns = columns
+    }
+
+    var id: String { canonicalKey }
+    var product: Int { rows * columns }
+    var canonicalRows: Int { min(rows, columns) }
+    var canonicalColumns: Int { max(rows, columns) }
+    var canonicalKey: String { "\(canonicalRows)x\(canonicalColumns)" }
+    var rowColumnPhrase: String { "\(rows) rows of \(columns)" }
+    var spokenPrompt: String { "Pack \(product) boxes as \(rows) rows of \(columns)." }
+    var equationText: String { "\(rows) x \(columns) = \(product)" }
+
+    func matches(product: Int) -> Bool {
+        self.product == product
+    }
+}
+
+struct ArrayPreludeRound: Equatable {
+    struct Step: Identifiable, Equatable {
+        let fact: ArrayFact
+        let totalChoices: [Int]
+
+        var id: String { fact.id }
+    }
+
+    let difficulty: ArrayPreludeDifficulty
+    let steps: [Step]
+
+    static let teachingFacts: [ArrayFact] = [
+        ArrayFact(rows: 2, columns: 2),
+        ArrayFact(rows: 2, columns: 3),
+        ArrayFact(rows: 3, columns: 2),
+        ArrayFact(rows: 2, columns: 4),
+        ArrayFact(rows: 3, columns: 3),
+        ArrayFact(rows: 3, columns: 4),
+        ArrayFact(rows: 4, columns: 3)
+    ]
+
+    static func make(difficulty: ArrayPreludeDifficulty, seed: Int = 0) -> ArrayPreludeRound {
+        let rotated = rotatedFacts(seed: seed)
+        let uniqueFacts = uniqueByCanonicalKey(rotated).prefix(difficulty.pairCount)
+        let steps = uniqueFacts.map { fact in
+            Step(fact: fact, totalChoices: totalChoices(for: fact))
+        }
+        return ArrayPreludeRound(difficulty: difficulty, steps: Array(steps))
+    }
+
+    static func handoffTarget(after round: ArrayPreludeRound) -> Int {
+        round.steps.last?.fact.product ?? 4
+    }
+
+    private static func rotatedFacts(seed: Int) -> [ArrayFact] {
+        guard !teachingFacts.isEmpty else { return [] }
+        let offset = abs(seed) % teachingFacts.count
+        return Array(teachingFacts.dropFirst(offset)) + Array(teachingFacts.prefix(offset))
+    }
+
+    private static func uniqueByCanonicalKey(_ facts: [ArrayFact]) -> [ArrayFact] {
+        var seen: Set<String> = []
+        return facts.filter { fact in
+            seen.insert(fact.canonicalKey).inserted
+        }
+    }
+
+    private static func totalChoices(for fact: ArrayFact) -> [Int] {
+        let candidates = [
+            fact.product,
+            fact.product + fact.rows,
+            max(2, fact.product - fact.columns),
+            fact.product + fact.columns
+        ]
+        var seen: Set<Int> = []
+        return candidates
+            .filter { $0 >= 2 }
+            .filter { seen.insert($0).inserted }
+            .prefix(3)
+            .sorted()
+    }
+}

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -12,6 +12,7 @@ enum AppRoute {
     case sumSprint
     case symmetryFold
     case rectangleFactory
+    case factoryCards
     case angleCannon
     case twoFingerProtractor
     case gravityArtist
@@ -120,6 +121,7 @@ final class VerticalSliceEngine {
     func showSumSprint() { route = .sumSprint }
     func showSymmetryFold() { route = .symmetryFold }
     func showRectangleFactory() { route = .rectangleFactory }
+    func showFactoryCards() { route = .factoryCards }
     func showAngleCannon() { route = .angleCannon }
     func showTwoFingerProtractor() { route = .twoFingerProtractor }
     func showGravityArtist() { route = .gravityArtist }

--- a/Features/FactoryCards/FactoryCardsView.swift
+++ b/Features/FactoryCards/FactoryCardsView.swift
@@ -1,0 +1,339 @@
+import SwiftUI
+
+struct FactoryCardsView: View {
+    @Bindable var appModel: AppModel
+
+    @State private var difficulty: ArrayPreludeDifficulty = .easy
+    @State private var round = ArrayPreludeRound.make(difficulty: .easy)
+    @State private var currentIndex = 0
+    @State private var correctCount = 0
+    @State private var attemptedStepIds: Set<String> = []
+    @State private var selectedTotal: Int?
+    @State private var faceUp = true
+    @State private var sessionStart: Date = .now
+    @State private var savedSession = false
+
+    private var currentStep: ArrayPreludeRound.Step? {
+        guard round.steps.indices.contains(currentIndex) else { return nil }
+        return round.steps[currentIndex]
+    }
+
+    private var roundComplete: Bool {
+        currentIndex >= round.steps.count
+    }
+
+    var body: some View {
+        ZStack {
+            MatherTheme.background.ignoresSafeArea()
+
+            VStack(spacing: 18) {
+                header
+                difficultyPicker
+
+                if let step = currentStep {
+                    cardSurface(for: step)
+                    totalChoices(for: step)
+                } else {
+                    completionView
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(24)
+        }
+        .onAppear {
+            sessionStart = .now
+            resetRound(speak: true)
+        }
+        .onDisappear {
+            saveIfNeeded()
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Packing Cards")
+                    .font(.title2.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text("Build equal rows before the factory challenge")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer()
+            Button {
+                appModel.engine.showLab()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 30))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 44, height: 44)
+            }
+            .accessibilityLabel("Done")
+        }
+    }
+
+    private var difficultyPicker: some View {
+        HStack(spacing: 8) {
+            ForEach(ArrayPreludeDifficulty.allCases, id: \.rawValue) { option in
+                Button {
+                    difficulty = option
+                    resetRound(speak: true)
+                } label: {
+                    Text(option.menuLabel)
+                        .font(.subheadline.weight(.black))
+                        .foregroundStyle(option == difficulty ? .white : MatherTheme.ink)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                        .frame(maxWidth: .infinity, minHeight: 54)
+                        .padding(.horizontal, 8)
+                        .background(option == difficulty ? MatherTheme.accent : MatherTheme.card)
+                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                }
+                .accessibilityLabel("\(option.menuLabel) packing cards")
+            }
+        }
+    }
+
+    private func cardSurface(for step: ArrayPreludeRound.Step) -> some View {
+        VStack(spacing: 14) {
+            HStack {
+                Label("Factory order \(currentIndex + 1) of \(round.steps.count)", systemImage: "shippingbox.fill")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.coral)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(MatherTheme.coral.opacity(0.12))
+                    .clipShape(Capsule())
+                Spacer()
+                Text("\(correctCount) packed")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
+
+            ZStack {
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .fill(MatherTheme.card)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20, style: .continuous)
+                            .strokeBorder(MatherTheme.panelDeep.opacity(0.22), lineWidth: 1)
+                    )
+
+                if faceUp {
+                    VStack(spacing: 14) {
+                        PackingArrayView(fact: step.fact)
+                            .frame(maxWidth: 320, minHeight: 180, maxHeight: 240)
+                            .padding(.top, 18)
+
+                        Text(step.fact.rowColumnPhrase)
+                            .font(.system(size: 28, weight: .black, design: .rounded))
+                            .foregroundStyle(MatherTheme.ink)
+                            .minimumScaleFactor(0.72)
+
+                        if difficulty.showsEquation {
+                            Text(step.fact.equationText)
+                                .font(.system(size: 24, weight: .black, design: .rounded))
+                                .foregroundStyle(MatherTheme.accent)
+                                .minimumScaleFactor(0.72)
+                        }
+                    }
+                    .padding(18)
+                } else {
+                    Button {
+                        faceUp = true
+                        speakCurrentPrompt()
+                    } label: {
+                        VStack(spacing: 14) {
+                            Image(systemName: "rectangle.grid.2x2.fill")
+                                .font(.system(size: 56, weight: .bold))
+                                .foregroundStyle(MatherTheme.softBlue)
+                            Text("Tap to see the packing card")
+                                .font(.headline.weight(.black))
+                                .foregroundStyle(MatherTheme.ink)
+                                .multilineTextAlignment(.center)
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 260)
+                    }
+                    .accessibilityLabel("Flip packing card")
+                }
+            }
+            .frame(maxHeight: 360)
+        }
+    }
+
+    private func totalChoices(for step: ArrayPreludeRound.Step) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Choose the packed total")
+                .font(.headline.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+
+            HStack(spacing: 12) {
+                ForEach(step.totalChoices, id: \.self) { total in
+                    Button {
+                        choose(total, for: step)
+                    } label: {
+                        Text("\(total)")
+                            .font(.system(size: 28, weight: .black, design: .rounded))
+                            .foregroundStyle(choiceForeground(total: total, step: step))
+                            .frame(maxWidth: .infinity, minHeight: 84)
+                            .background(choiceBackground(total: total, step: step))
+                            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    }
+                    .disabled(selectedTotal != nil || !faceUp)
+                    .accessibilityLabel("\(total) boxes")
+                }
+            }
+        }
+    }
+
+    private var completionView: some View {
+        VStack(spacing: 18) {
+            Image(systemName: "shippingbox.and.arrow.backward.fill")
+                .font(.system(size: 62, weight: .bold))
+                .foregroundStyle(MatherTheme.coral)
+            Text("Cards packed")
+                .font(.system(size: 34, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+            Text("Now resize rectangles for the same factory idea.")
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .multilineTextAlignment(.center)
+
+            Button {
+                saveIfNeeded()
+                appModel.engine.showRectangleFactory()
+            } label: {
+                Label("Factory Challenge", systemImage: "arrow.right.circle.fill")
+            }
+            .buttonStyle(PrimaryActionButtonStyle())
+
+            Button {
+                saveIfNeeded()
+                resetRound(speak: true)
+            } label: {
+                Label("Play Cards Again", systemImage: "arrow.clockwise")
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(MatherTheme.accent)
+                    .frame(maxWidth: .infinity, minHeight: 64)
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity)
+        .background(MatherTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+    }
+
+    private func resetRound(speak: Bool) {
+        round = ArrayPreludeRound.make(difficulty: difficulty, seed: Int(Date().timeIntervalSince1970))
+        currentIndex = 0
+        correctCount = 0
+        attemptedStepIds = []
+        selectedTotal = nil
+        faceUp = !difficulty.startsFaceDown
+        savedSession = false
+        if speak {
+            speakCurrentPrompt()
+        }
+    }
+
+    private func choose(_ total: Int, for step: ArrayPreludeRound.Step) {
+        selectedTotal = total
+        attemptedStepIds.insert(step.id)
+
+        if step.fact.matches(product: total) {
+            correctCount += 1
+            appModel.hapticsService.cardSnapCorrect(enabled: appModel.featureFlags.hapticsEnabled)
+            appModel.speechService.speak("Yes. \(step.fact.rowColumnPhrase) makes \(step.fact.product).", enabled: appModel.featureFlags.audioEnabled)
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 750_000_000)
+                currentIndex += 1
+                selectedTotal = nil
+                faceUp = !difficulty.startsFaceDown
+                if roundComplete {
+                    appModel.hapticsService.bondMatchComplete(enabled: appModel.featureFlags.hapticsEnabled)
+                    appModel.speechService.speak("Cards packed. Ready for the factory challenge.", enabled: appModel.featureFlags.audioEnabled)
+                } else {
+                    speakCurrentPrompt()
+                }
+            }
+        } else {
+            appModel.hapticsService.cardSnapMismatch(enabled: appModel.featureFlags.hapticsEnabled)
+            appModel.speechService.speak("Try again. Count each row.", enabled: appModel.featureFlags.audioEnabled)
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 550_000_000)
+                selectedTotal = nil
+            }
+        }
+    }
+
+    private func speakCurrentPrompt() {
+        guard let currentStep else { return }
+        appModel.speechService.speak(currentStep.fact.spokenPrompt, enabled: appModel.featureFlags.audioEnabled)
+    }
+
+    private func choiceForeground(total: Int, step: ArrayPreludeRound.Step) -> Color {
+        guard let selectedTotal else { return MatherTheme.ink }
+        if total == selectedTotal, step.fact.matches(product: total) { return .white }
+        if total == selectedTotal { return .white }
+        return MatherTheme.ink
+    }
+
+    private func choiceBackground(total: Int, step: ArrayPreludeRound.Step) -> Color {
+        guard let selectedTotal else { return MatherTheme.softBlue.opacity(0.34) }
+        if total == selectedTotal, step.fact.matches(product: total) { return MatherTheme.accent }
+        if total == selectedTotal { return MatherTheme.danger }
+        return MatherTheme.softBlue.opacity(0.18)
+    }
+
+    private func saveIfNeeded() {
+        guard !savedSession, correctCount > 0 else { return }
+        savedSession = true
+        appModel.gameSessionStore.save(
+            gameName: "Packing Cards",
+            startedAt: sessionStart,
+            scoreValue: correctCount,
+            scoreLabel: "cards packed",
+            detail: difficulty.rawValue
+        )
+    }
+}
+
+private struct PackingArrayView: View {
+    let fact: ArrayFact
+
+    var body: some View {
+        GeometryReader { proxy in
+            let cell = min(
+                proxy.size.width / CGFloat(fact.columns),
+                proxy.size.height / CGFloat(fact.rows)
+            )
+            let packageSize = max(18, min(48, cell * 0.58))
+            let gap = max(8, cell * 0.16)
+
+            VStack(spacing: gap) {
+                ForEach(0..<fact.rows, id: \.self) { row in
+                    HStack(spacing: gap) {
+                        ForEach(0..<fact.columns, id: \.self) { column in
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill((row + column).isMultiple(of: 2) ? MatherTheme.warm : MatherTheme.softBlue)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                        .strokeBorder(MatherTheme.ink.opacity(0.12), lineWidth: 1)
+                                )
+                                .frame(width: packageSize, height: packageSize)
+                                .accessibilityHidden(true)
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .fill(MatherTheme.panel.opacity(0.68))
+            )
+            .accessibilityLabel("\(fact.rows) rows of \(fact.columns) boxes")
+        }
+    }
+}

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -38,6 +38,11 @@ struct LabView: View {
                      fill: MatherTheme.softBlue) {
                 appModel.pickProfileThenRun { appModel.engine.showRectangleFactory() }
             },
+            GameTile(emoji: "📦", name: "Packing Cards",
+                     tagline: "Practice equal rows first",
+                     fill: MatherTheme.panelDeep) {
+                appModel.pickProfileThenRun { appModel.engine.showFactoryCards() }
+            },
             GameTile(emoji: "💥", name: "Angle Cannon",
                      tagline: "Tilt to aim — hit the target",
                      fill: MatherTheme.warm) {

--- a/Tests/MatherTests/ArrayPreludeModelsTests.swift
+++ b/Tests/MatherTests/ArrayPreludeModelsTests.swift
@@ -1,0 +1,52 @@
+import Testing
+@testable import Mather
+
+@Suite("Array Prelude Models")
+struct ArrayPreludeModelsTests {
+    @Test func arrayFactUsesCanonicalKeyButKeepsTeachingOrientation() {
+        let fact = ArrayFact(rows: 3, columns: 2)
+
+        #expect(fact.product == 6)
+        #expect(fact.canonicalKey == "2x3")
+        #expect(fact.rowColumnPhrase == "3 rows of 2")
+        #expect(fact.spokenPrompt == "Pack 6 boxes as 3 rows of 2.")
+        #expect(fact.equationText == "3 x 2 = 6")
+    }
+
+    @Test func difficultiesMatchRequestedCardProgression() {
+        #expect(ArrayPreludeDifficulty.easy.pairCount == 3)
+        #expect(ArrayPreludeDifficulty.standard.pairCount == 4)
+        #expect(ArrayPreludeDifficulty.flip.pairCount == 4)
+        #expect(ArrayPreludeDifficulty.easy.showsEquation == false)
+        #expect(ArrayPreludeDifficulty.standard.showsEquation == true)
+        #expect(ArrayPreludeDifficulty.flip.startsFaceDown == true)
+        #expect(ArrayPreludeDifficulty.flip.menuLabel == "Flip mode")
+    }
+
+    @Test func generatedRoundsAvoidOneByNAndDuplicateCanonicalFacts() {
+        for difficulty in ArrayPreludeDifficulty.allCases {
+            let round = ArrayPreludeRound.make(difficulty: difficulty, seed: 2)
+            let keys = round.steps.map { $0.fact.canonicalKey }
+
+            #expect(round.steps.count == difficulty.pairCount)
+            #expect(Set(keys).count == keys.count)
+            #expect(round.steps.allSatisfy { $0.fact.rows > 1 && $0.fact.columns > 1 })
+        }
+    }
+
+    @Test func choicesContainAnswerAndStayDistinct() {
+        let round = ArrayPreludeRound.make(difficulty: .standard, seed: 0)
+
+        for step in round.steps {
+            #expect(step.totalChoices.contains(step.fact.product))
+            #expect(Set(step.totalChoices).count == step.totalChoices.count)
+            #expect(step.totalChoices.count == 3)
+        }
+    }
+
+    @Test func handoffTargetUsesLastPracticedProduct() {
+        let round = ArrayPreludeRound.make(difficulty: .easy, seed: 0)
+
+        #expect(ArrayPreludeRound.handoffTarget(after: round) == round.steps.last!.fact.product)
+    }
+}

--- a/wiki/Specs/Multiplication-Array-Prelude.md
+++ b/wiki/Specs/Multiplication-Array-Prelude.md
@@ -1,0 +1,46 @@
+# Multiplication Array Prelude
+
+## Status
+
+Implementation slice for TestFlight feedback issue #767. This is the first small slice, not the full multiplication curriculum.
+
+## Goal
+
+Teach multiplication as equal rows and packing before asking the child to resize rectangles in Rectangle Factory.
+
+The prelude should make this sequence visible and speakable:
+
+1. See boxes packed in equal rows.
+2. Count the packed total.
+3. Hear row language such as "2 rows of 3 makes 6."
+4. Move to Rectangle Factory as reinforcement.
+
+## Product Shape
+
+- Name: Packing Cards.
+- Entry: Explorer Lab tile next to Rectangle Factory.
+- Exit: completion screen offers the Rectangle Factory challenge.
+- Direct Rectangle Factory entry remains available for older or ready children.
+
+## Difficulty Progression
+
+- Easy: 3 face-up picture-first cards. No multiplication symbol is required.
+- Standard: 4 face-up cards. The equation appears after the picture and row language.
+- Flip mode: 4 cards that begin face-down before revealing the same picture/equation pairing.
+
+The TestFlight note used "fillipi"; this slice maps that to the existing Memory Match idea of "Flip mode" without exposing the typo.
+
+## Fact Set
+
+First teaching avoids `1 x n`, primes, and large products. The initial fact pool uses small rectangles such as `2 x 2`, `2 x 3`, `3 x 2`, `2 x 4`, `3 x 3`, `3 x 4`, and `4 x 3`.
+
+## Asset Policy
+
+This slice uses project-owned SwiftUI drawings for trays and packages. No bitmap or third-party image assets are added, so no external asset provenance is required.
+
+## Follow-Ups
+
+- Route Rectangle Factory to start with a product just practiced in Packing Cards.
+- Add memory-pair matching instead of single-card total choices for a richer Flip mode.
+- Add local telemetry for facts seen, first-try choices, hand-off, and first Rectangle Factory factor latency after prelude.
+- Add UI screenshot coverage for compact phone and iPad layouts.


### PR DESCRIPTION
Closes #767.

## Summary
- Adds a small `Packing Cards` Lab activity before Rectangle Factory so the child sees equal rows and packing totals before resizing rectangles.
- Adds pure array-prelude models for facts, difficulty progression, generated rounds, and hand-off target selection.
- Wires the new route into `VerticalSliceEngine`, `RootView`, and the Explorer Lab.
- Documents the first-slice product shape, difficulty meanings, asset policy, and follow-up gaps in `wiki/Specs/Multiplication-Array-Prelude.md`.

## Tests
- `git diff --check`
- `git diff --cached --check`

## Local validation gaps
- `xcodegen generate` could not run in this worker: `xcodegen: command not found`.
- Swift/Xcode tests could not run in this worker: `swift: command not found` and `xcodebuild: command not found`.
- Expected CI coverage: XcodeGen project generation plus the Swift Testing suite, including the new `ArrayPreludeModelsTests`.

## Asset/proof gaps
- No new bitmap assets were added; the packing arrays are project-owned SwiftUI drawings, so no external provenance is required.
- Follow-up proof should add compact/iPad screenshots and richer Flip-mode memory pairing before treating this as the full #767 curriculum.