### PR TITLE
Launch Water Cycle screenshot test directly

### DIFF
--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -19,6 +19,7 @@ struct MatherApp: App {
             let appModel = AppModel(modelContext: container.mainContext)
             Self.seedSessionHistoryIfRequested(using: appModel)
             Self.seedGameHistoryIfRequested(using: appModel)
+            Self.applyUITestStartRouteIfRequested(using: appModel)
             _appModel = State(initialValue: appModel)
         } catch {
             fatalError("Failed to create model container: \(error)")
@@ -44,6 +45,21 @@ private extension MatherApp {
         case "light": return .light
         case "dark": return .dark
         default: return nil
+        }
+    }
+
+    static func applyUITestStartRouteIfRequested(using appModel: AppModel) {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard let flagIndex = arguments.firstIndex(of: "-uiTest.startRoute"),
+              arguments.indices.contains(flagIndex + 1) else { return }
+
+        switch arguments[flagIndex + 1].lowercased() {
+        case "lab", "explorerlab", "explorer-lab":
+            appModel.engine.showLab()
+        case "watercycle", "water-cycle", "watercyclelab", "water-cycle-lab":
+            appModel.engine.showWaterCycle()
+        default:
+            break
         }
     }
 

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -270,12 +270,7 @@ final class ScreenshotTests: XCTestCase {
     }
 
     func testScreenshot_WaterCycleCompactCompletion() {
-        let app = launch()
-        _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
-
-        app.buttons["ExplorerLab"].tap()
-        _ = app.staticTexts["Explorer Lab"].waitForExistence(timeout: 5)
-        tapWhenReachable(app.buttons["Water Cycle Lab"], in: app, scrollDirection: .up)
+        let app = launchWaterCycleLab()
         XCTAssertTrue(app.staticTexts["Water Cycle Lab"].waitForExistence(timeout: 10))
 
         let primaryAction = app.buttons["water-cycle-primary-action"]
@@ -415,6 +410,16 @@ final class ScreenshotTests: XCTestCase {
                 app.swipeDown()
             }
         }
+    }
+
+    private func launchWaterCycleLab() -> XCUIApplication {
+        launchApp(with: [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.testModeEnabled", "YES",
+            "-feature.skipProfilePicker", "YES",
+            "-uiTest.startRoute", "waterCycle"
+        ])
     }
 
     private func launch() -> XCUIApplication {


### PR DESCRIPTION
## Summary\n- Add a small UI-test-only start-route launch argument so screenshot tests can open Explorer Lab or Water Cycle directly.\n- Use the direct Water Cycle route for the compact completion screenshot test, avoiding brittle Explorer Lab tile scrolling while keeping the scroll-aware assertions for in-view controls.\n\n## Validation\n- git diff --check\n- Main UI Review run 25127881093 still failed on the iPad screenshot job after PR #784; artifacts/log access is limited until the whole run finishes, but the direct route removes the remaining navigation variable.\n\nGitHub macOS checks will validate the full XCTest path.