### PR TITLE
[codex] Bypass profile picker in screenshot launches

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -421,7 +421,8 @@ final class ScreenshotTests: XCTestCase {
         launchApp(with: [
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
-            "-feature.testModeEnabled", "YES"
+            "-feature.testModeEnabled", "YES",
+            "-feature.skipProfilePicker", "YES"
         ])
     }
 


### PR DESCRIPTION
## Summary

- Add `-feature.skipProfilePicker YES` to the generic screenshot test launch arguments.
- Keeps the Water Cycle screenshot route from stopping on the profile picker after tapping the Explorer Lab tile.

## Root Cause

`ScreenshotTests.launch()` enabled test mode but did not bypass the profile picker. Lab tiles route through `AppModel.pickProfileThenRun`, so tapping `Water Cycle Lab` could open the picker instead of navigating to `WaterCycleLabView`. On iPad, the Explorer Lab tile text could still satisfy the `Water Cycle Lab` title assertion while `water-cycle-primary-action` was absent.

## Validation

- `git diff --check`

macOS/Xcode validation will be run separately over SSH on `ganesh@mba`.