### PR TITLE
Fix build 59 compact fullscreen feedback

### DIFF
--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -79,8 +79,22 @@ struct GravitySplitView: View {
     // MARK: - Header
 
     private var headerRow: some View {
-        HStack(alignment: .top) {
-            VStack(alignment: .leading, spacing: 4) {
+        ViewThatFits(in: .horizontal) {
+            HStack(alignment: .top, spacing: 10) {
+                headerText
+                Spacer(minLength: 8)
+                compactActionRail
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                headerText
+                compactActionRail
+            }
+        }
+    }
+
+    private var headerText: some View {
+        VStack(alignment: .leading, spacing: 4) {
                 Text(vocabulary.title)
                     .font(.title2.weight(.black))
                     .foregroundStyle(MatherTheme.coral)
@@ -96,12 +110,7 @@ struct GravitySplitView: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
 
-                liveCountRow
-            }
-
-            Spacer()
-
-            compactActionRail
+            liveCountRow
         }
     }
 
@@ -167,21 +176,40 @@ struct GravitySplitView: View {
         VStack(spacing: 10) {
             sourceTray
 
-            HStack(alignment: .top, spacing: 10) {
-                destinationZone(
-                    label: vocabulary.leftLabel,
-                    count: state.leftCount,
-                    target: state.decompositionA,
-                    fill: MatherTheme.warm,
-                    side: .left
-                )
-                destinationZone(
-                    label: vocabulary.rightLabel,
-                    count: state.rightCount,
-                    target: state.decompositionB,
-                    fill: MatherTheme.accent,
-                    side: .right
-                )
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .top, spacing: 10) {
+                    destinationZone(
+                        label: vocabulary.leftLabel,
+                        count: state.leftCount,
+                        target: state.decompositionA,
+                        fill: MatherTheme.warm,
+                        side: .left
+                    )
+                    destinationZone(
+                        label: vocabulary.rightLabel,
+                        count: state.rightCount,
+                        target: state.decompositionB,
+                        fill: MatherTheme.accent,
+                        side: .right
+                    )
+                }
+
+                VStack(spacing: 10) {
+                    destinationZone(
+                        label: vocabulary.leftLabel,
+                        count: state.leftCount,
+                        target: state.decompositionA,
+                        fill: MatherTheme.warm,
+                        side: .left
+                    )
+                    destinationZone(
+                        label: vocabulary.rightLabel,
+                        count: state.rightCount,
+                        target: state.decompositionB,
+                        fill: MatherTheme.accent,
+                        side: .right
+                    )
+                }
             }
         }
         .accessibilityIdentifier("gravity-direct-token-board")
@@ -448,11 +476,12 @@ struct GravitySplitView: View {
             Image(systemName: "hand.tap.fill")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MatherTheme.coral.opacity(0.8))
-            Text("Choose which side each token belongs on. Keep \(state.leftCount) + \(state.rightCount) = \(state.target) in view.")
+            Text("Tap Add on each side until the equation is complete: \(state.leftCount) + \(state.rightCount) = \(state.target). Use Clear to try again.")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MatherTheme.cardSubtitle)
-                .lineLimit(2)
-                .minimumScaleFactor(0.8)
+                .lineLimit(3)
+                .minimumScaleFactor(0.82)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .center)
     }

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -17,27 +17,31 @@ struct SliceSessionView: View {
             )
             .ignoresSafeArea()
 
-            VStack(spacing: 0) {
-                header
-                    .frame(maxWidth: ResponsiveLayout.childSessionMaxWidth(for: horizontalSizeClass))
-                    .padding(.horizontal, ResponsiveLayout.contentPadding(for: horizontalSizeClass))
-                    .padding(.top, 20)
+            GeometryReader { proxy in
+                let horizontalPadding = childSessionHorizontalPadding(for: proxy.size.width)
 
-                ScrollView {
-                    VStack(spacing: 20) {
-                        FeedbackBannerView(message: childFacingBannerMessage, isCelebrating: appModel.engine.showCelebration)
+                VStack(spacing: 0) {
+                    header
+                        .frame(maxWidth: ResponsiveLayout.childSessionMaxWidth(for: horizontalSizeClass))
+                        .padding(.horizontal, horizontalPadding)
+                        .padding(.top, 14)
 
-                        if let currentProblem = appModel.engine.currentProblem {
-                            stageView(for: currentProblem)
-                        } else {
-                            CardSurface { Text("No problem loaded.") }
+                    ScrollView {
+                        VStack(spacing: 16) {
+                            FeedbackBannerView(message: childFacingBannerMessage, isCelebrating: appModel.engine.showCelebration)
+
+                            if let currentProblem = appModel.engine.currentProblem {
+                                stageView(for: currentProblem)
+                            } else {
+                                CardSurface { Text("No problem loaded.") }
+                            }
                         }
+                        .frame(maxWidth: ResponsiveLayout.childSessionMaxWidth(for: horizontalSizeClass))
+                        .padding(.horizontal, horizontalPadding)
+                        .padding(.top, 10)
+                        .padding(.bottom, 20)
+                        .frame(maxWidth: .infinity)
                     }
-                    .frame(maxWidth: ResponsiveLayout.childSessionMaxWidth(for: horizontalSizeClass))
-                    .padding(.horizontal, ResponsiveLayout.contentPadding(for: horizontalSizeClass))
-                    .padding(.top, 12)
-                    .padding(.bottom, 20)
-                    .frame(maxWidth: .infinity)
                 }
             }
 
@@ -73,6 +77,13 @@ struct SliceSessionView: View {
         .animation(.easeOut(duration: 0.25), value: appModel.engine.showCelebration)
     }
 
+
+    private func childSessionHorizontalPadding(for width: CGFloat) -> CGFloat {
+        guard horizontalSizeClass != .regular else { return ResponsiveLayout.contentPadding(for: horizontalSizeClass) }
+        if width < 360 { return 12 }
+        if width < 430 { return 16 }
+        return 20
+    }
 
     private var childFacingBannerMessage: String {
         if appModel.engine.currentStage == .storyAnchor,
@@ -335,63 +346,82 @@ struct SliceSessionView: View {
     private var header: some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 14) {
-                HStack {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Problem \(appModel.engine.progressLabel)")
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                        Text(appModel.engine.currentStage.title)
-                            .font(.system(size: 28, weight: .black, design: .rounded))
-                            .foregroundStyle(stageColour(appModel.engine.currentStage))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.75)
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .center, spacing: 8) {
+                        headerTitleBlock
+                        Spacer(minLength: 8)
+                        headerActionButtons
                     }
-                    Spacer()
-                    Button {
-                        appModel.engine.playPromptFromSpeakerButton()
-                    } label: {
-                        Image(systemName: appModel.featureFlags.audioEnabled ? "speaker.wave.2.fill" : "speaker.slash.fill")
-                            .font(.title2.weight(.bold))
-                            .foregroundStyle(appModel.featureFlags.audioEnabled ? MatherTheme.softBlue : .secondary)
-                            .frame(width: 50, height: 50)
-                            .background(MatherTheme.softBlue.opacity(colorScheme == .dark ? 0.24 : 0.18))
-                            .overlay(Circle().strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1))
-                            .clipShape(Circle())
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        headerTitleBlock
+                        headerActionButtons
                     }
-                    .accessibilityLabel(appModel.featureFlags.audioEnabled ? "Play prompt" : "Enable audio and play prompt")
-                    .accessibilityHint("Speaks the current instruction aloud.")
-                    Button {
-                        appModel.engine.playPromptFromSpeakerButton()
-                    } label: {
-                        Image(systemName: "arrow.counterclockwise.circle.fill")
-                            .font(.title2.weight(.bold))
-                            .foregroundStyle(MatherTheme.warm)
-                            .frame(width: 50, height: 50)
-                            .background(MatherTheme.warm.opacity(colorScheme == .dark ? 0.24 : 0.18))
-                            .overlay(Circle().strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1))
-                            .clipShape(Circle())
-                    }
-                    .accessibilityLabel("Replay prompt")
-                    .accessibilityHint("Speaks the current instruction aloud.")
-                    // Adult escape hatch — secondary styling so child ignores it
-                    Button {
-                        appModel.engine.showHome()
-                    } label: {
-                        Image(systemName: "house.circle.fill")
-                            .font(.title2.weight(.bold))
-                            .foregroundStyle(.secondary)
-                            .frame(width: 50, height: 50)
-                            .background(Color.secondary.opacity(colorScheme == .dark ? 0.18 : 0.12))
-                            .overlay(Circle().strokeBorder(.white.opacity(colorScheme == .dark ? 0.06 : 0), lineWidth: 1))
-                            .clipShape(Circle())
-                    }
-                    .accessibilityLabel("Go to Home")
                 }
 
                 ProgressView(value: Double(appModel.engine.currentProblemIndex + 1), total: Double(max(appModel.engine.problems.count, 1)))
                     .tint(stageColour(appModel.engine.currentStage))
                     .animation(.easeInOut(duration: 0.4), value: appModel.engine.currentProblemIndex)
             }
+        }
+    }
+
+    private var headerTitleBlock: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Problem \(appModel.engine.progressLabel)")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(appModel.engine.currentStage.title)
+                .font(.system(size: 26, weight: .black, design: .rounded))
+                .foregroundStyle(stageColour(appModel.engine.currentStage))
+                .lineLimit(2)
+                .minimumScaleFactor(0.72)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var headerActionButtons: some View {
+        HStack(spacing: 8) {
+            Button {
+                appModel.engine.playPromptFromSpeakerButton()
+            } label: {
+                Image(systemName: appModel.featureFlags.audioEnabled ? "speaker.wave.2.fill" : "speaker.slash.fill")
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(appModel.featureFlags.audioEnabled ? MatherTheme.softBlue : .secondary)
+                    .frame(width: 44, height: 44)
+                    .background(MatherTheme.softBlue.opacity(colorScheme == .dark ? 0.24 : 0.18))
+                    .overlay(Circle().strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1))
+                    .clipShape(Circle())
+            }
+            .accessibilityLabel(appModel.featureFlags.audioEnabled ? "Play prompt" : "Enable audio and play prompt")
+            .accessibilityHint("Speaks the current instruction aloud.")
+
+            Button {
+                appModel.engine.playPromptFromSpeakerButton()
+            } label: {
+                Image(systemName: "arrow.counterclockwise.circle.fill")
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(MatherTheme.warm)
+                    .frame(width: 44, height: 44)
+                    .background(MatherTheme.warm.opacity(colorScheme == .dark ? 0.24 : 0.18))
+                    .overlay(Circle().strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1))
+                    .clipShape(Circle())
+            }
+            .accessibilityLabel("Replay prompt")
+            .accessibilityHint("Speaks the current instruction aloud.")
+
+            Button {
+                appModel.engine.showHome()
+            } label: {
+                Image(systemName: "house.circle.fill")
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 44, height: 44)
+                    .background(Color.secondary.opacity(colorScheme == .dark ? 0.18 : 0.12))
+                    .overlay(Circle().strokeBorder(.white.opacity(colorScheme == .dark ? 0.06 : 0), lineWidth: 1))
+                    .clipShape(Circle())
+            }
+            .accessibilityLabel("Go to Home")
         }
     }
 

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -41,17 +41,17 @@ struct WaterCycleLabState: Equatable {
     var prompt: String {
         switch stage {
         case .wonder:
-            "What do you think the warm sun will do to the pond?"
+            "First, predict: what will the warm sun do to the pond? Tap Make a prediction."
         case .evaporation:
-            "Warm water goes up as tiny vapor. That is evaporation."
+            "evaporation: warm water rises as tiny vapor. Tap Warm the pond."
         case .condensation:
-            "Tiny drops gather and make a cloud. That is condensation."
+            "condensation: tiny drops gather to make a cloud. Tap Gather the cloud."
         case .precipitation:
-            "The cloud is heavy. Tap it to make rain. That is precipitation."
+            "precipitation: a heavy cloud drops rain. Tap Make rain fall."
         case .collection:
-            "Rain fills the pond again. The cycle can start over."
+            "Collection: rain fills the pond again. Tap Fill the pond."
         case .complete:
-            "You made a full water cycle: up, cloud, rain, pond."
+            "Full cycle complete: water went up, made a cloud, fell as rain, and filled the pond."
         }
     }
 
@@ -151,11 +151,11 @@ struct WaterCycleLabView: View {
         ZStack {
             MatherTheme.background.ignoresSafeArea()
             GeometryReader { proxy in
-                let horizontalPadding = proxy.size.width < 390 ? 16.0 : 24.0
+                let horizontalPadding = waterCycleHorizontalPadding(for: proxy.size.width)
                 let contentWidth = max(proxy.size.width - horizontalPadding * 2, 0)
                 let sceneHeight = contentWidth < 340
-                    ? min(max(proxy.size.height * 0.32, 260), 330)
-                    : min(max(proxy.size.height * 0.46, 320), 520)
+                    ? min(max(proxy.size.height * 0.28, 230), 300)
+                    : min(max(proxy.size.height * 0.42, 300), 480)
 
                 ScrollView {
                     VStack(alignment: .leading, spacing: 18) {
@@ -164,10 +164,10 @@ struct WaterCycleLabView: View {
                         waterCycleScene(width: contentWidth, height: sceneHeight)
                         actionControls(availableWidth: contentWidth)
                     }
-                    .frame(width: contentWidth, alignment: .leading)
+                    .frame(maxWidth: contentWidth, alignment: .leading)
                     .padding(.horizontal, horizontalPadding)
-                    .padding(.vertical, 24)
-                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 18)
+                    .frame(maxWidth: .infinity, alignment: .center)
                 }
             }
         }
@@ -175,6 +175,12 @@ struct WaterCycleLabView: View {
             sessionStartedAt = .now
             speakPrompt()
         }
+    }
+
+    private func waterCycleHorizontalPadding(for width: CGFloat) -> CGFloat {
+        if width < 360 { return 12 }
+        if width < 430 { return 16 }
+        return 24
     }
 
     private func header(availableWidth: CGFloat) -> some View {
@@ -220,8 +226,10 @@ struct WaterCycleLabView: View {
                 }
 
                 Text(state.prompt)
-                    .font(.title3.weight(.semibold))
+                    .font(.system(size: 19, weight: .semibold, design: .rounded))
                     .foregroundStyle(MatherTheme.ink)
+                    .lineLimit(4)
+                    .minimumScaleFactor(0.86)
                     .fixedSize(horizontal: false, vertical: true)
 
                 ProgressView(value: state.progress)
@@ -399,7 +407,7 @@ struct WaterCycleLabView: View {
             .buttonStyle(PrimaryActionButtonStyle())
             .accessibilityIdentifier("water-cycle-primary-action")
 
-            if availableWidth < 280 {
+            if availableWidth < 390 {
                 VStack(spacing: 12) {
                     replayPromptButton(compact: false)
                     resetButton(compact: false)


### PR DESCRIPTION
## Summary
- fixes compact iPhone/fullscreen layout clipping reported in TestFlight build 59 (#787, #788)
- reduces compact Water Cycle padding/scene height and makes completion actions stack earlier
- makes the child session header/action row adaptive and shrinks action buttons so stage content stays visible
- lets Gravity Split header/destination zones wrap vertically on narrow screens and clarifies the direct-token instruction copy

## Validation
- `git diff --check`
- Remote Mac `xcodebuild build -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" CODE_SIGNING_ALLOWED=NO` completed without reported errors
- Targeted remote test attempt: `xcodebuild test ... -only-testing:MatherTests/GravitySplitStateTests -only-testing:MatherTests/FeatureFlagTests` is blocked by existing project/test-target membership issues: many app types are not visible to the test build (`KidProfileStore`, `RoomQuestEngine`, `GroupedNumberRepresentation`, etc.)

Fixes #787
Fixes #788
