### PR TITLE
Make xbox optional in iOS UI review

### DIFF
--- a/.github/workflows/ios-ui-review-main.yml
+++ b/.github/workflows/ios-ui-review-main.yml
@@ -98,8 +98,7 @@ jobs:
           if command -v xbox >/dev/null 2>&1; then
             xbox --version 2>/dev/null || xbox version 2>/dev/null || true
           else
-            echo "xbox utility not found on PATH" >&2
-            exit 1
+            echo "xbox utility not found on PATH; continuing because it is optional"
           fi
           SANDBOX_SCRIPT
 


### PR DESCRIPTION
## Summary
- make `xbox` optional in `ios-ui-review-main`
- keep PATH access so the runner can use it later if installed
- avoid failing the secure main-only UI review workflow on a missing optional utility

## Validation
- YAML parse
- `git diff --check`
