### PR TITLE
Run iOS UI review without runner sudo

### DIFF
--- a/.github/workflows/ios-ui-review-main.yml
+++ b/.github/workflows/ios-ui-review-main.yml
@@ -25,85 +25,24 @@ jobs:
         device-family: [iphone, ipad]
     env:
       DEVICE_FAMILY: ${{ matrix.device-family }}
-      SANDBOX_USER_PREFIX: mathergha
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
-      - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode.app
-
-      - name: Install XcodeGen
-        run: |
-          if ! command -v xcodegen >/dev/null 2>&1; then
-            brew install xcodegen
-          fi
-
-      - name: Prepare isolated macOS user
-        shell: bash
+      - name: Show constrained runner toolchain versions
         run: |
           set -euo pipefail
-
-          SANDBOX_USER="${SANDBOX_USER_PREFIX}${DEVICE_FAMILY:0:2}${GITHUB_RUN_ATTEMPT}${GITHUB_RUN_ID}"
-          SANDBOX_USER="${SANDBOX_USER:0:31}"
-          SANDBOX_HOME="${RUNNER_TEMP}/sandbox-home-${SANDBOX_USER}"
-          SANDBOX_WORKSPACE="${RUNNER_TEMP}/sandbox-workspace-${SANDBOX_USER}"
-          RUN_AS_SANDBOX="${RUNNER_TEMP}/run-as-${SANDBOX_USER}"
-
-          mkdir -p "$SANDBOX_WORKSPACE"
-          sudo /usr/local/sbin/mather-gha-sandbox add \
-            "$SANDBOX_USER" "$SANDBOX_HOME" "$SANDBOX_WORKSPACE"
-          rsync -a --delete --exclude .git "$GITHUB_WORKSPACE/" "$SANDBOX_WORKSPACE/"
-          sudo /usr/local/sbin/mather-gha-sandbox chown "$SANDBOX_USER" "$SANDBOX_WORKSPACE"
-
-          cat > "$RUN_AS_SANDBOX" <<'EOF'
-          #!/usr/bin/env bash
-          set -euo pipefail
-          exec sudo -H -u "$SANDBOX_USER" env \
-            HOME="$SANDBOX_HOME" \
-            USER="$SANDBOX_USER" \
-            LOGNAME="$SANDBOX_USER" \
-            DEVICE_FAMILY="${DEVICE_FAMILY:-}" \
-            SANDBOX_WORKSPACE="$SANDBOX_WORKSPACE" \
-            PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-            XCODE_XCCONFIG_FILE= \
-            "$@"
-          EOF
-          chmod 700 "$RUN_AS_SANDBOX"
-
-          {
-            echo "SANDBOX_USER=$SANDBOX_USER"
-            echo "SANDBOX_HOME=$SANDBOX_HOME"
-            echo "SANDBOX_WORKSPACE=$SANDBOX_WORKSPACE"
-            echo "RUN_AS_SANDBOX=$RUN_AS_SANDBOX"
-          } >> "$GITHUB_ENV"
-
-      - name: Show sandbox toolchain versions
-        run: |
-          "$RUN_AS_SANDBOX" bash -euo pipefail <<SANDBOX_SCRIPT
-          cd "$SANDBOX_WORKSPACE"
           xcodebuild -version
           swift --version
           xcodegen --version
-          if command -v xbox >/dev/null 2>&1; then
-            xbox --version 2>/dev/null || xbox version 2>/dev/null || true
-          else
-            echo "xbox utility not found on PATH; continuing because it is optional"
-          fi
-          SANDBOX_SCRIPT
 
       - name: Generate project
-        run: |
-          "$RUN_AS_SANDBOX" bash -euo pipefail <<SANDBOX_SCRIPT
-          cd "$SANDBOX_WORKSPACE"
-          xcodegen generate
-          SANDBOX_SCRIPT
+        run: xcodegen generate
 
       - name: Choose simulator destination
         run: |
           set -euo pipefail
-          cd "$SANDBOX_WORKSPACE"
 
           if [[ "$DEVICE_FAMILY" == "ipad" ]]; then
             preferred=("iPad Pro 11-inch (M4)" "iPad Air 11-inch (M2)" "iPad (10th generation)" "iPad Pro (11-inch) (4th generation)")
@@ -114,7 +53,7 @@ jobs:
           fi
 
           for name in "${preferred[@]}"; do
-            line="$("$RUN_AS_SANDBOX" xcrun simctl list devices available | grep -F "$name (" | grep -v "26\." | head -n 1 || true)"
+            line="$(xcrun simctl list devices available | grep -F "$name (" | grep -v "26\." | head -n 1 || true)"
             if [[ -n "$line" ]]; then
               id="$(sed -E "s/.*\(([A-F0-9-]+)\).*/\1/" <<<"$line")"
               echo "SIM_DESTINATION=id=$id" >> "$GITHUB_ENV"
@@ -124,7 +63,7 @@ jobs:
           done
 
           for name in "${fallback[@]}"; do
-            line="$("$RUN_AS_SANDBOX" xcrun simctl list devices available | grep -F "$name" | head -n 1 || true)"
+            line="$(xcrun simctl list devices available | grep -F "$name" | head -n 1 || true)"
             if [[ -n "$line" ]]; then
               id="$(sed -E "s/.*\(([A-F0-9-]+)\).*/\1/" <<<"$line")"
               echo "SIM_DESTINATION=id=$id" >> "$GITHUB_ENV"
@@ -134,35 +73,27 @@ jobs:
           done
 
           echo "No preferred $DEVICE_FAMILY simulator found" >&2
-          "$RUN_AS_SANDBOX" xcrun simctl list devices available
+          xcrun simctl list devices available
           exit 1
 
       - name: Resolve dependencies
-        run: |
-          "$RUN_AS_SANDBOX" bash -euo pipefail <<SANDBOX_SCRIPT
-          cd "$SANDBOX_WORKSPACE"
-          xcodebuild -project Mather.xcodeproj -resolvePackageDependencies -scheme Mather
-          SANDBOX_SCRIPT
+        run: xcodebuild -project Mather.xcodeproj -resolvePackageDependencies -scheme Mather
 
       - name: Build for testing
         run: |
-          "$RUN_AS_SANDBOX" bash -euo pipefail <<SANDBOX_SCRIPT
-          cd "$SANDBOX_WORKSPACE"
           xcodebuild build-for-testing \
             -project Mather.xcodeproj \
             -scheme Mather \
             -destination "generic/platform=iOS Simulator" \
             CODE_SIGNING_ALLOWED=NO
-          SANDBOX_SCRIPT
 
       - name: Boot simulator
         timeout-minutes: 8
         run: |
-          cd "$SANDBOX_WORKSPACE"
           SIM_ID="${SIM_DESTINATION#id=}"
-          "$RUN_AS_SANDBOX" xcrun simctl boot "$SIM_ID" 2>/dev/null || true
+          xcrun simctl boot "$SIM_ID" 2>/dev/null || true
           for i in $(seq 1 40); do
-            STATE=$("$RUN_AS_SANDBOX" xcrun simctl list devices | grep -F "$SIM_ID" \
+            STATE=$(xcrun simctl list devices | grep -F "$SIM_ID" \
               | grep -oE 'Booted|Shutdown|Booting' | head -1 || echo "Unknown")
             echo "[$i/40] $STATE"
             [[ "$STATE" == "Booted" ]] && {
@@ -173,7 +104,7 @@ jobs:
             sleep 5
           done
           echo "Simulator did not reach Booted state after 200s" >&2
-          "$RUN_AS_SANDBOX" xcrun simctl list devices | grep -F "$SIM_ID" >&2
+          xcrun simctl list devices | grep -F "$SIM_ID" >&2
           exit 1
 
       - name: Run UI screenshot tests
@@ -183,17 +114,16 @@ jobs:
         # upload review artifacts instead of being killed mid-run.
         timeout-minutes: 25
         run: |
-          cd "$SANDBOX_WORKSPACE"
           mkdir -p ci-videos
           SIM_ID="${SIM_DESTINATION#id=}"
 
-          "$RUN_AS_SANDBOX" xcrun simctl io "$SIM_ID" recordVideo --codec hevc \
+          xcrun simctl io "$SIM_ID" recordVideo --codec hevc \
             "ci-videos/ui-tests-${DEVICE_FAMILY}.mp4" &
           VIDEO_PID=$!
 
           # Keep screenshot review focused on artifact-producing flows.
           # Slower behavioral UI assertions belong in the main test lane.
-          "$RUN_AS_SANDBOX" xcodebuild test-without-building \
+          xcodebuild test-without-building \
             -project Mather.xcodeproj \
             -scheme Mather \
             -destination "$SIM_DESTINATION" \
@@ -211,11 +141,9 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          cd "$SANDBOX_WORKSPACE"
           mkdir -p ci-screenshots
 
-          EXTRACT_SCRIPT="${RUNNER_TEMP}/extract_screenshots.py"
-          cat > "$EXTRACT_SCRIPT" << 'PYEOF'
+          cat > "$RUNNER_TEMP/extract_screenshots.py" << 'PYEOF'
           import sys, json, subprocess, pathlib, shutil, plistlib
 
           bundle = pathlib.Path(f"UITestResults-{__import__('os').environ.get('DEVICE_FAMILY', 'device')}.xcresult")
@@ -295,32 +223,21 @@ jobs:
                           idx += 1
           PYEOF
 
-          "$RUN_AS_SANDBOX" python3 "$EXTRACT_SCRIPT"
+          python3 "$RUNNER_TEMP/extract_screenshots.py"
 
-          SIM_ID=$("$RUN_AS_SANDBOX" xcrun simctl list devices booted \
+          SIM_ID=$(xcrun simctl list devices booted \
             | grep -E '\([-A-F0-9]+\)' | head -1 \
             | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
           if [[ -n "$SIM_ID" ]]; then
-            "$RUN_AS_SANDBOX" xcrun simctl io "$SIM_ID" screenshot \
+            xcrun simctl io "$SIM_ID" screenshot \
               "ci-screenshots/simulator-final-state-${DEVICE_FAMILY}.png" 2>/dev/null || true
           fi
 
-      - name: Stage review artifacts for upload
+      - name: Shutdown simulator
         if: always()
         run: |
-          set -euo pipefail
-          rm -rf ci-upload
-          mkdir -p ci-upload
-          if [[ -n "${SANDBOX_WORKSPACE:-}" ]]; then
-            if [[ -d "${SANDBOX_WORKSPACE}/UITestResults-${DEVICE_FAMILY}.xcresult" ]]; then
-              cp -R "${SANDBOX_WORKSPACE}/UITestResults-${DEVICE_FAMILY}.xcresult" ci-upload/
-            fi
-            if [[ -d "${SANDBOX_WORKSPACE}/ci-screenshots" ]]; then
-              cp -R "${SANDBOX_WORKSPACE}/ci-screenshots" ci-upload/
-            fi
-            if [[ -d "${SANDBOX_WORKSPACE}/ci-videos" ]]; then
-              cp -R "${SANDBOX_WORKSPACE}/ci-videos" ci-upload/
-            fi
+          if [[ -n "${SIM_DESTINATION:-}" ]]; then
+            xcrun simctl shutdown "${SIM_DESTINATION#id=}" 2>/dev/null || true
           fi
 
       - name: Upload UI result bundle
@@ -328,7 +245,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ui-review-results-${{ matrix.device-family }}-${{ github.run_number }}
-          path: ci-upload/UITestResults-${{ matrix.device-family }}.xcresult
+          path: UITestResults-${{ matrix.device-family }}.xcresult
           if-no-files-found: ignore
           retention-days: 30
 
@@ -337,7 +254,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ui-review-screenshots-${{ matrix.device-family }}-${{ github.run_number }}
-          path: ci-upload/ci-screenshots/
+          path: ci-screenshots/
           if-no-files-found: ignore
           retention-days: 30
 
@@ -346,25 +263,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: ui-review-video-${{ matrix.device-family }}-${{ github.run_number }}
-          path: ci-upload/ci-videos/
+          path: ci-videos/
           if-no-files-found: ignore
           retention-days: 30
-
-
-      - name: Remove isolated macOS user
-        if: always()
-        run: |
-          set -euo pipefail
-          if [[ -n "${SIM_DESTINATION:-}" && -n "${RUN_AS_SANDBOX:-}" ]]; then
-            SIM_ID="${SIM_DESTINATION#id=}"
-            "$RUN_AS_SANDBOX" xcrun simctl shutdown "$SIM_ID" 2>/dev/null || true
-          fi
-          if [[ -n "${SANDBOX_WORKSPACE:-}" ]]; then
-            sudo /usr/local/sbin/mather-gha-sandbox cleanup "$SANDBOX_USER" "$SANDBOX_WORKSPACE"
-          fi
-          if [[ -n "${SANDBOX_USER:-}" ]]; then
-            sudo /usr/local/sbin/mather-gha-sandbox delete "$SANDBOX_USER"
-          fi
-          if [[ -n "${SANDBOX_HOME:-}" ]]; then
-            sudo /usr/local/sbin/mather-gha-sandbox cleanup "$SANDBOX_USER" "$SANDBOX_HOME"
-          fi


### PR DESCRIPTION
## Summary
- remove all `sudo` usage from `ios-ui-review-main`
- remove dynamic macOS user creation/deletion from the public-repo workflow
- run UI review directly as the constrained self-hosted runner account
- keep main-only / manual-dispatch-only gating and disabled checkout credential persistence

## Security model
The self-hosted runner should be installed under a dedicated low-privilege macOS user such as `mather-runner` with **no sudo access**. That account is the sandbox boundary. Repo-controlled code should not be able to create users, delete files outside its workspace, or invoke privileged helpers.

## Mac prep required
- create/register the GitHub runner as `mather-runner`, not `ganesh`
- label it `ganesh-mba`
- preselect Xcode globally/admin-side before starting the runner
- preinstall `xcodegen` so the workflow does not need Homebrew install permissions

## Validation
- YAML parse
- static check: no `sudo`, `sysadminctl`, sandbox helper, or dynamic sandbox wrapper tokens remain
- `git diff --check`
