### PR TITLE
Restore hosted macOS for iOS UI review

### DIFF
--- a/.github/workflows/ios-ui-review-main.yml
+++ b/.github/workflows/ios-ui-review-main.yml
@@ -2,8 +2,9 @@ name: iOS UI Review (main)
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
+  schedule:
+    # Run artifact-producing UI review twice daily without blocking main/release.
+    - cron: '17 */12 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/ios-ui-review-main.yml
+++ b/.github/workflows/ios-ui-review-main.yml
@@ -11,13 +11,7 @@ permissions:
 jobs:
   ui-review:
     name: UI Screenshot Review (${{ matrix.device-family }})
-    # Public-repo hardening: only the canonical main branch may run this
-    # workflow on the self-hosted Mac. Do not run untrusted fork code here.
-    if: >-
-      github.repository == 'ganesh47/mather' &&
-      github.ref == 'refs/heads/main' &&
-      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-    runs-on: [self-hosted, macOS, ganesh-mba]
+    runs-on: macos-15
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -30,12 +24,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Show constrained runner toolchain versions
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Show toolchain versions
         run: |
           set -euo pipefail
           xcodebuild -version
           swift --version
-          xcodegen --version
+
+      - name: Install XcodeGen
+        run: |
+          if ! command -v xcodegen >/dev/null 2>&1; then
+            brew install xcodegen
+          fi
 
       - name: Generate project
         run: xcodegen generate


### PR DESCRIPTION
## Summary
- move `ios-ui-review-main` back to hosted `macos-15`
- remove the `push` trigger so UI review no longer runs on main changes or blocks release flow
- run UI review on a 12-hour schedule plus manual `workflow_dispatch`
- keep checkout credential persistence disabled

## Rationale
The current MacBook Air self-hosted runner runs the iPhone/iPad matrix serially and failed the no-sudo trial, so it does not improve time/reliability. UI review is artifact-producing and should be decoupled from the main/release critical path.

## Security notes
- no `pull_request` trigger, so fork code still does not run this workflow
- no secrets are referenced or exported
- no self-hosted runner is exposed to public-repo workflow code
- scheduled workflows run from the default branch

## Validation
- YAML parse
- static check for hosted `macos-15`, no `push`, 12-hour `schedule`, manual dispatch, no `pull_request`, no secrets, no self-hosted labels
- `git diff --check`