### PR TITLE
Add Explorer Lab capability lane shell

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+/// Top-level capability lanes used by Explorer Lab.
+///
+/// The lab intentionally groups activities by the capability a child is growing,
+/// instead of presenting every mini-game as an unrelated destination.
+enum CapabilityLaneID: String, CaseIterable, Hashable {
+    case numbers
+    case geometry
+    case physics
+    case mapWorld
+    case discoveryCards
+    case chemistry
+    case electronics
+
+    var title: String {
+        switch self {
+        case .numbers:
+            return "Numbers Lab"
+        case .geometry:
+            return "Geometry Lab"
+        case .physics:
+            return "Physics Lab"
+        case .mapWorld:
+            return "Map & World Lab"
+        case .discoveryCards:
+            return "Discovery Cards"
+        case .chemistry:
+            return "Chemistry Lab"
+        case .electronics:
+            return "Electronics Lab"
+        }
+    }
+}
+
+enum PlayMode: String, CaseIterable, Hashable {
+    case learn = "Learn"
+    case explore = "Explore"
+    case challenge = "Challenge"
+    case timed = "Timed"
+    case review = "Review"
+}
+
+enum LabActivityID: String, CaseIterable, Hashable {
+    case sumSprint
+    case roomQuest
+    case symmetryFold
+    case rectangleFactory
+    case factoryCards
+    case angleCannon
+    case twoFingerProtractor
+    case gravityArtist
+    case compassAngles
+    case waterCycle
+    case memoryMatch
+}
+
+struct LabActivity: Identifiable, Equatable {
+    let id: LabActivityID
+    let emoji: String
+    let title: String
+    let tagline: String
+    let modes: [PlayMode]
+
+    init(id: LabActivityID, emoji: String, title: String, tagline: String, modes: [PlayMode]) {
+        self.id = id
+        self.emoji = emoji
+        self.title = title
+        self.tagline = tagline
+        self.modes = modes
+    }
+}
+
+struct CapabilityLane: Identifiable, Equatable {
+    let id: CapabilityLaneID
+    let emoji: String
+    let promise: String
+    let ageBandHint: String
+    let modes: [PlayMode]
+    let activities: [LabActivity]
+
+    var title: String { id.title }
+    var isReady: Bool { !activities.isEmpty }
+
+    static let defaultExplorerLanes: [CapabilityLane] = [
+        CapabilityLane(
+            id: .numbers,
+            emoji: "🔢",
+            promise: "Build number bonds, fast facts, arrays, and whole-part thinking.",
+            ageBandHint: "Ages 4–12",
+            modes: [.learn, .challenge, .timed, .review],
+            activities: [
+                LabActivity(
+                    id: .sumSprint,
+                    emoji: "⚡",
+                    title: "Sum Sprint",
+                    tagline: "Race through sums 11–20",
+                    modes: [.challenge, .timed, .review]
+                ),
+                LabActivity(
+                    id: .rectangleFactory,
+                    emoji: "🏭",
+                    title: "Rectangle Factory",
+                    tagline: "Drag frames to find factors",
+                    modes: [.learn, .explore, .challenge]
+                ),
+                LabActivity(
+                    id: .factoryCards,
+                    emoji: "📦",
+                    title: "Packing Cards",
+                    tagline: "Practice equal rows first",
+                    modes: [.learn, .review]
+                ),
+            ]
+        ),
+        CapabilityLane(
+            id: .geometry,
+            emoji: "📐",
+            promise: "Fold, measure, aim, and transform shapes with touch and motion.",
+            ageBandHint: "Ages 4–12",
+            modes: [.learn, .explore, .challenge, .review],
+            activities: [
+                LabActivity(
+                    id: .symmetryFold,
+                    emoji: "🪞",
+                    title: "Symmetry Fold",
+                    tagline: "Tilt to fold shapes in half",
+                    modes: [.explore, .challenge]
+                ),
+                LabActivity(
+                    id: .angleCannon,
+                    emoji: "💥",
+                    title: "Angle Cannon",
+                    tagline: "Tilt to aim — hit the target",
+                    modes: [.explore, .challenge, .timed]
+                ),
+                LabActivity(
+                    id: .twoFingerProtractor,
+                    emoji: "📐",
+                    title: "Protractor",
+                    tagline: "Spread two fingers to measure angles",
+                    modes: [.learn, .explore]
+                ),
+            ]
+        ),
+        CapabilityLane(
+            id: .physics,
+            emoji: "🧪",
+            promise: "Predict motion, gravity, water, and cause-and-effect systems.",
+            ageBandHint: "Ages 2–12",
+            modes: [.explore, .challenge, .review],
+            activities: [
+                LabActivity(
+                    id: .gravityArtist,
+                    emoji: "🎨",
+                    title: "Gravity Artist",
+                    tagline: "Predict where the ball lands",
+                    modes: [.explore, .challenge]
+                ),
+                LabActivity(
+                    id: .waterCycle,
+                    emoji: "💧",
+                    title: "Water Cycle Lab",
+                    tagline: "Predict, make clouds, then rain",
+                    modes: [.learn, .explore, .review]
+                ),
+            ]
+        ),
+        CapabilityLane(
+            id: .mapWorld,
+            emoji: "🗺️",
+            promise: "Use rooms, compass turns, direction words, and route clues.",
+            ageBandHint: "Ages 4–12",
+            modes: [.explore, .challenge, .timed],
+            activities: [
+                LabActivity(
+                    id: .roomQuest,
+                    emoji: "🗺️",
+                    title: "Room Quest",
+                    tagline: "Collect tokens around the room",
+                    modes: [.explore, .challenge]
+                ),
+                LabActivity(
+                    id: .compassAngles,
+                    emoji: "🧭",
+                    title: "Compass Walk",
+                    tagline: "Turn your body to match the angle",
+                    modes: [.explore, .challenge, .timed]
+                ),
+            ]
+        ),
+        CapabilityLane(
+            id: .discoveryCards,
+            emoji: "🃏",
+            promise: "Practice names, pictures, categories, and Mix-Match recall.",
+            ageBandHint: "Ages 2–12",
+            modes: [.learn, .review, .challenge],
+            activities: [
+                LabActivity(
+                    id: .memoryMatch,
+                    emoji: "🃏",
+                    title: "Memory Match",
+                    tagline: "Match pictures and words",
+                    modes: [.learn, .review, .challenge]
+                ),
+            ]
+        ),
+        CapabilityLane(
+            id: .chemistry,
+            emoji: "⚗️",
+            promise: "Future: sort materials, mix safely, and predict properties.",
+            ageBandHint: "Future lane",
+            modes: [.explore, .challenge, .review],
+            activities: []
+        ),
+        CapabilityLane(
+            id: .electronics,
+            emoji: "💡",
+            promise: "Future: switches, circuits, sensors, and input/output systems.",
+            ageBandHint: "Future lane",
+            modes: [.explore, .challenge, .review],
+            activities: []
+        ),
+    ]
+}

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -1,80 +1,11 @@
 import SwiftUI
 
-/// The Explorer Lab — a game picker for maths, physics, geometry, and science inquiry activities.
+/// The Explorer Lab — a capability playground for maths, physics, geometry, and science inquiry.
 struct LabView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Bindable var appModel: AppModel
 
-    private struct GameTile {
-        let emoji: String
-        let name: String
-        let tagline: String
-        let fill: Color
-        let action: () -> Void
-    }
-
-    private var tiles: [GameTile] {
-        [
-            GameTile(emoji: "⚡", name: "Sum Sprint",
-                     tagline: "Race through sums 11–20",
-                     fill: MatherTheme.warm) {
-                appModel.pickProfileThenRun {
-                    appModel.engine.showSumSprint()
-                    appModel.sumSprintEngine.showDifficultyPick()
-                }
-            },
-            GameTile(emoji: "🗺️", name: "Room Quest",
-                     tagline: "Collect tokens around the room",
-                     fill: MatherTheme.accent) {
-                appModel.pickProfileThenRun { appModel.engine.showRoomQuest() }
-            },
-            GameTile(emoji: "🪞", name: "Symmetry Fold",
-                     tagline: "Tilt to fold shapes in half",
-                     fill: MatherTheme.coral) {
-                appModel.pickProfileThenRun { appModel.engine.showSymmetryFold() }
-            },
-            GameTile(emoji: "🏭", name: "Rectangle Factory",
-                     tagline: "Drag frames to find factors",
-                     fill: MatherTheme.softBlue) {
-                appModel.pickProfileThenRun { appModel.engine.showRectangleFactory() }
-            },
-            GameTile(emoji: "📦", name: "Packing Cards",
-                     tagline: "Practice equal rows first",
-                     fill: MatherTheme.panelDeep) {
-                appModel.pickProfileThenRun { appModel.engine.showFactoryCards() }
-            },
-            GameTile(emoji: "💥", name: "Angle Cannon",
-                     tagline: "Tilt to aim — hit the target",
-                     fill: MatherTheme.warm) {
-                appModel.pickProfileThenRun { appModel.engine.showAngleCannon() }
-            },
-            GameTile(emoji: "📐", name: "Protractor",
-                     tagline: "Spread two fingers to measure angles",
-                     fill: MatherTheme.accent) {
-                appModel.pickProfileThenRun { appModel.engine.showTwoFingerProtractor() }
-            },
-            GameTile(emoji: "🎨", name: "Gravity Artist",
-                     tagline: "Predict where the ball lands",
-                     fill: MatherTheme.panelDeep) {
-                appModel.pickProfileThenRun { appModel.engine.showGravityArtist() }
-            },
-            GameTile(emoji: "🧭", name: "Compass Walk",
-                     tagline: "Turn your body to match the angle",
-                     fill: MatherTheme.softBlue) {
-                appModel.pickProfileThenRun { appModel.engine.showCompassAngles() }
-            },
-            GameTile(emoji: "💧", name: "Water Cycle Lab",
-                     tagline: "Predict, make clouds, then rain",
-                     fill: MatherTheme.accent) {
-                appModel.pickProfileThenRun { appModel.engine.showWaterCycle() }
-            },
-            GameTile(emoji: "🃏", name: "Memory Match",
-                     tagline: "Match pictures and words",
-                     fill: MatherTheme.coral) {
-                appModel.pickProfileThenRun { appModel.engine.showMemory() }
-            },
-        ]
-    }
+    private let lanes = CapabilityLane.defaultExplorerLanes
 
     var body: some View {
         ZStack {
@@ -82,30 +13,11 @@ struct LabView: View {
             GeometryReader { proxy in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 20) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Explorer Lab")
-                                    .font(.system(size: 36, weight: .black, design: .rounded))
-                                    .foregroundStyle(MatherTheme.ink)
-                                Text("Pick a game and discover maths and science")
-                                    .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(MatherTheme.cardSubtitle)
-                            }
-                            Spacer()
-                            Button {
-                                appModel.engine.showHome()
-                            } label: {
-                                Image(systemName: "house.fill")
-                                    .font(.title2.weight(.semibold))
-                                    .foregroundStyle(MatherTheme.accent)
-                                    .frame(width: 44, height: 44)
-                            }
-                            .accessibilityLabel("Home")
-                        }
+                        header
 
                         LazyVGrid(columns: ResponsiveLayout.labColumns(for: proxy.size.width), spacing: 16) {
-                            ForEach(Array(tiles.enumerated()), id: \.offset) { _, tile in
-                                gameTileButton(tile)
+                            ForEach(lanes) { lane in
+                                laneCard(lane)
                             }
                         }
                     }
@@ -115,54 +27,238 @@ struct LabView: View {
         }
     }
 
-    private func gameTileButton(_ tile: GameTile) -> some View {
-        Button(action: tile.action) {
-            VStack(alignment: .leading, spacing: 0) {
-                ZStack {
-                    tile.fill.opacity(0.85)
-                    Text(tile.emoji)
-                        .font(.system(size: 52))
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, 20)
-                }
-                .clipShape(
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: 16, bottomLeadingRadius: 0,
-                        bottomTrailingRadius: 0, topTrailingRadius: 16,
-                        style: .continuous
-                    )
-                )
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Explorer Lab")
+                    .font(.system(size: 36, weight: .black, design: .rounded))
+                    .foregroundStyle(MatherTheme.ink)
+                Text("Pick a capability, then choose how you want to play")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                Text("Learn • Explore • Challenge • Timed • Review")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(MatherTheme.accent)
+            }
+            Spacer()
+            Button {
+                appModel.engine.showHome()
+            } label: {
+                Image(systemName: "house.fill")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(MatherTheme.accent)
+                    .frame(width: 44, height: 44)
+            }
+            .accessibilityLabel("Home")
+        }
+    }
+
+    private func laneCard(_ lane: CapabilityLane) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                Text(lane.emoji)
+                    .font(.system(size: 42))
+                    .frame(width: 56, height: 56)
+                    .background(laneColor(lane.id).opacity(0.18), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(tile.name)
-                        .font(.headline.weight(.black))
-                        .foregroundStyle(MatherTheme.ink)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.8)
-                    Text(tile.tagline)
+                    HStack(spacing: 8) {
+                        Text(lane.title)
+                            .font(.headline.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                        Text(lane.ageBandHint)
+                            .font(.caption2.weight(.black))
+                            .foregroundStyle(laneColor(lane.id))
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 4)
+                            .background(laneColor(lane.id).opacity(0.12), in: Capsule())
+                    }
+                    Text(lane.promise)
                         .font(.caption.weight(.medium))
                         .foregroundStyle(MatherTheme.cardSubtitle)
-                        .lineLimit(2)
+                        .lineLimit(3)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(MatherTheme.card)
-                .clipShape(
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: 0, bottomLeadingRadius: 16,
-                        bottomTrailingRadius: 16, topTrailingRadius: 0,
-                        style: .continuous
-                    )
-                )
             }
-            .shadow(
-                color: colorScheme == .dark ? .black.opacity(0.3) : .black.opacity(0.08),
-                radius: 8, y: 4
-            )
+
+            modeChips(lane.modes, tint: laneColor(lane.id))
+
+            if lane.isReady {
+                VStack(spacing: 8) {
+                    ForEach(lane.activities) { activity in
+                        activityButton(activity, tint: laneColor(lane.id))
+                    }
+                }
+            } else {
+                Label("Coming soon", systemImage: "sparkles")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(10)
+                    .background(MatherTheme.panel.opacity(0.7), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .accessibilityLabel("\(lane.title) coming soon")
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(laneColor(lane.id).opacity(0.18), lineWidth: 1)
+        )
+        .shadow(
+            color: colorScheme == .dark ? .black.opacity(0.3) : .black.opacity(0.08),
+            radius: 8, y: 4
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(lane.title)
+    }
+
+    private func modeChips(_ modes: [PlayMode], tint: Color) -> some View {
+        FlowLayout(spacing: 6) {
+            ForEach(modes, id: \.self) { mode in
+                Text(mode.rawValue)
+                    .font(.caption2.weight(.heavy))
+                    .foregroundStyle(tint)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(tint.opacity(0.10), in: Capsule())
+            }
+        }
+    }
+
+    private func activityButton(_ activity: LabActivity, tint: Color) -> some View {
+        Button {
+            launch(activity.id)
+        } label: {
+            HStack(spacing: 10) {
+                Text(activity.emoji)
+                    .font(.title3)
+                    .frame(width: 32, height: 32)
+                    .background(tint.opacity(0.13), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(activity.title)
+                        .font(.subheadline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                        .lineLimit(1)
+                    Text(activity.tagline)
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .lineLimit(2)
+                }
+                Spacer(minLength: 6)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(tint)
+            }
+            .padding(10)
+            .background(MatherTheme.panel.opacity(0.72), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(tile.name)
+        .accessibilityLabel(activity.title)
+        .accessibilityHint(activity.modes.map(\.rawValue).joined(separator: ", "))
+    }
+
+    private func launch(_ activityID: LabActivityID) {
+        appModel.pickProfileThenRun {
+            switch activityID {
+            case .sumSprint:
+                appModel.engine.showSumSprint()
+                appModel.sumSprintEngine.showDifficultyPick()
+            case .roomQuest:
+                appModel.engine.showRoomQuest()
+            case .symmetryFold:
+                appModel.engine.showSymmetryFold()
+            case .rectangleFactory:
+                appModel.engine.showRectangleFactory()
+            case .factoryCards:
+                appModel.engine.showFactoryCards()
+            case .angleCannon:
+                appModel.engine.showAngleCannon()
+            case .twoFingerProtractor:
+                appModel.engine.showTwoFingerProtractor()
+            case .gravityArtist:
+                appModel.engine.showGravityArtist()
+            case .compassAngles:
+                appModel.engine.showCompassAngles()
+            case .waterCycle:
+                appModel.engine.showWaterCycle()
+            case .memoryMatch:
+                appModel.engine.showMemory()
+            }
+        }
+    }
+
+    private func laneColor(_ laneID: CapabilityLaneID) -> Color {
+        switch laneID {
+        case .numbers:
+            return MatherTheme.warm
+        case .geometry:
+            return MatherTheme.coral
+        case .physics:
+            return MatherTheme.panelDeep
+        case .mapWorld:
+            return MatherTheme.softBlue
+        case .discoveryCards:
+            return MatherTheme.accent
+        case .chemistry:
+            return MatherTheme.warm
+        case .electronics:
+            return MatherTheme.accent
+        }
+    }
+}
+
+private struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = proposal.width ?? 300
+        let rows = rows(in: width, subviews: subviews)
+        return CGSize(width: width, height: rows.reduce(0) { $0 + $1.height } + CGFloat(max(0, rows.count - 1)) * spacing)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX, x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+
+    private func rows(in width: CGFloat, subviews: Subviews) -> [CGSize] {
+        var rows: [CGSize] = []
+        var currentWidth: CGFloat = 0
+        var currentHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            let nextWidth = currentWidth == 0 ? size.width : currentWidth + spacing + size.width
+            if currentWidth > 0, nextWidth > width {
+                rows.append(CGSize(width: currentWidth, height: currentHeight))
+                currentWidth = size.width
+                currentHeight = size.height
+            } else {
+                currentWidth = nextWidth
+                currentHeight = max(currentHeight, size.height)
+            }
+        }
+
+        if currentWidth > 0 {
+            rows.append(CGSize(width: currentWidth, height: currentHeight))
+        }
+        return rows
     }
 }

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import Mather
+
+final class LabModelsTests: XCTestCase {
+    func testDefaultExplorerLanesExposeCapabilityShell() throws {
+        let lanes = CapabilityLane.defaultExplorerLanes
+        let laneIDs = lanes.map(\.id)
+
+        XCTAssertEqual(
+            laneIDs,
+            [.numbers, .geometry, .physics, .mapWorld, .discoveryCards, .chemistry, .electronics]
+        )
+
+        for required in [CapabilityLaneID.numbers, .geometry, .physics, .mapWorld] {
+            let lane = try XCTUnwrap(lanes.first { $0.id == required })
+            XCTAssertFalse(lane.activities.isEmpty, "\(lane.title) should launch at least one pilot activity")
+        }
+    }
+
+    func testMemoryMatchIsEmbeddedInDiscoveryCardsInsteadOfTopLevelLane() throws {
+        let lanes = CapabilityLane.defaultExplorerLanes
+        let discovery = try XCTUnwrap(lanes.first { $0.id == .discoveryCards })
+
+        XCTAssertTrue(discovery.activities.contains { $0.id == .memoryMatch })
+        XCTAssertFalse(CapabilityLaneID.allCases.contains { $0.title == "Memory Match" })
+    }
+
+    func testCapabilityLanesIncludeChoiceBasedPlayModes() {
+        let modesByLane = Dictionary(
+            uniqueKeysWithValues: CapabilityLane.defaultExplorerLanes.map { ($0.id, Set($0.modes)) }
+        )
+
+        XCTAssertTrue(modesByLane[.numbers, default: []].contains(.timed))
+        XCTAssertTrue(modesByLane[.geometry, default: []].contains(.explore))
+        XCTAssertTrue(modesByLane[.physics, default: []].contains(.review))
+        XCTAssertTrue(modesByLane[.mapWorld, default: []].contains(.challenge))
+        XCTAssertTrue(modesByLane[.discoveryCards, default: []].contains(.review))
+    }
+}


### PR DESCRIPTION
## Summary
- replace the flat Explorer Lab game picker with capability lane cards for Numbers, Geometry, Physics, Map & World, Discovery Cards, and future Chemistry/Electronics lanes
- add `CapabilityLane`, `PlayMode`, and `LabActivity` models so #797 has a deterministic shell to build on
- keep all existing activities launchable, with Memory Match embedded under Discovery Cards instead of shown as its own top-level destination
- add unit coverage for lane ordering, pilot activities, Memory Match embedding, and choice-based play modes

## Scope
This is the first architecture/shell PR for #797. It does not attempt the full staged mastery/spaced-repetition system yet.

## Validation
- `git diff --check`
- Local iOS build/test not available in this Linux workspace (`xcodebuild`, `xcodegen`, and `swift` are not installed); CI should run on macOS and generate the project.

Refs #797
