### PR TITLE
Show Mix-Match readiness in Explorer Lab lanes

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -102,6 +102,22 @@ struct CapabilityLane: Identifiable, Equatable {
         Self.starterMixMatchCardsByLane[id, default: []]
     }
 
+    var starterMixMatchCount: Int { starterMixMatchCards.count }
+
+    var starterMixMatchConceptPreview: String {
+        var seen: Set<String> = []
+        let concepts = starterMixMatchCards.compactMap { card -> String? in
+            guard !seen.contains(card.concept) else { return nil }
+            seen.insert(card.concept)
+            return card.concept
+        }
+        return concepts.prefix(3).joined(separator: " • ")
+    }
+
+    var recallReadinessLabel: String {
+        "\(starterMixMatchCount) Mix-Match cards ready"
+    }
+
     static let defaultExplorerLanes: [CapabilityLane] = [
         CapabilityLane(
             id: .numbers,

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -84,6 +84,7 @@ struct LabView: View {
             }
 
             modeChips(lane.modes, tint: laneColor(lane.id))
+            recallPreview(lane, tint: laneColor(lane.id))
 
             if lane.isReady {
                 VStack(spacing: 8) {
@@ -114,6 +115,25 @@ struct LabView: View {
         )
         .accessibilityElement(children: .contain)
         .accessibilityLabel(lane.title)
+    }
+
+    private func recallPreview(_ lane: CapabilityLane, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label(lane.recallReadinessLabel, systemImage: "rectangle.on.rectangle.angled")
+                .font(.caption.weight(.black))
+                .foregroundStyle(tint)
+            if !lane.starterMixMatchConceptPreview.isEmpty {
+                Text(lane.starterMixMatchConceptPreview)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(lane.title) \(lane.recallReadinessLabel)")
     }
 
     private func modeChips(_ modes: [PlayMode], tint: Color) -> some View {

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -36,6 +36,15 @@ final class LabModelsTests: XCTestCase {
         XCTAssertTrue(modesByLane[.mapWorld, default: []].contains(.challenge))
         XCTAssertTrue(modesByLane[.discoveryCards, default: []].contains(.review))
     }
+
+    func testLaneRecallReadinessSummariesExposeCardCountsAndConcepts() throws {
+        let numbers = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .numbers })
+
+        XCTAssertEqual(numbers.starterMixMatchCount, 8)
+        XCTAssertEqual(numbers.recallReadinessLabel, "8 Mix-Match cards ready")
+        XCTAssertTrue(numbers.starterMixMatchConceptPreview.contains("number-bond"))
+    }
+
 }
 
 extension LabModelsTests {


### PR DESCRIPTION
## Summary
- add lane-level recall readiness helpers for starter Mix-Match counts and concept previews
- show a small “Mix-Match cards ready” panel on every Explorer Lab capability lane
- add unit coverage for the recall summary values

## Scope
This wires the #797 starter-card substrate into the Explorer Lab shell without building the full Review/Mix-Match play loop yet.

## Validation
- `git diff --check`
- Local iOS build/test not available in this Linux workspace (`xcodebuild`, `xcodegen`, and `swift` are not installed); CI should run on macOS.

Refs #797
