### PR TITLE
Add Mix-Match review sampler to Explorer Lab lanes

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -57,6 +57,43 @@ struct MixMatchCard: Identifiable, Equatable {
     }
 }
 
+
+struct MixMatchReviewSampler: Equatable {
+    let laneID: CapabilityLaneID
+    let cards: [MixMatchCard]
+    private(set) var currentIndex: Int
+
+    init(laneID: CapabilityLaneID, cards: [MixMatchCard], currentIndex: Int = 0) {
+        self.laneID = laneID
+        self.cards = cards
+        if cards.isEmpty {
+            self.currentIndex = 0
+        } else {
+            self.currentIndex = min(max(currentIndex, 0), cards.count - 1)
+        }
+    }
+
+    var currentCard: MixMatchCard? {
+        guard cards.indices.contains(currentIndex) else { return nil }
+        return cards[currentIndex]
+    }
+
+    var progressLabel: String {
+        guard !cards.isEmpty else { return "0 / 0" }
+        return "\(currentIndex + 1) / \(cards.count)"
+    }
+
+    mutating func advance() {
+        guard !cards.isEmpty else { return }
+        currentIndex = (currentIndex + 1) % cards.count
+    }
+
+    mutating func rewind() {
+        guard !cards.isEmpty else { return }
+        currentIndex = (currentIndex - 1 + cards.count) % cards.count
+    }
+}
+
 enum LabActivityID: String, CaseIterable, Hashable {
     case sumSprint
     case roomQuest
@@ -116,6 +153,10 @@ struct CapabilityLane: Identifiable, Equatable {
 
     var recallReadinessLabel: String {
         "\(starterMixMatchCount) Mix-Match cards ready"
+    }
+
+    var starterMixMatchSampler: MixMatchReviewSampler {
+        MixMatchReviewSampler(laneID: id, cards: starterMixMatchCards)
     }
 
     static let defaultExplorerLanes: [CapabilityLane] = [

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct LabView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Bindable var appModel: AppModel
+    @State private var expandedReviewLaneID: CapabilityLaneID?
 
     private let lanes = CapabilityLane.defaultExplorerLanes
 
@@ -85,6 +86,9 @@ struct LabView: View {
 
             modeChips(lane.modes, tint: laneColor(lane.id))
             recallPreview(lane, tint: laneColor(lane.id))
+            if expandedReviewLaneID == lane.id {
+                mixMatchSampler(lane, tint: laneColor(lane.id))
+            }
 
             if lane.isReady {
                 VStack(spacing: 8) {
@@ -118,7 +122,7 @@ struct LabView: View {
     }
 
     private func recallPreview(_ lane: CapabilityLane, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 8) {
             Label(lane.recallReadinessLabel, systemImage: "rectangle.on.rectangle.angled")
                 .font(.caption.weight(.black))
                 .foregroundStyle(tint)
@@ -128,12 +132,59 @@ struct LabView: View {
                     .foregroundStyle(MatherTheme.cardSubtitle)
                     .lineLimit(1)
             }
+            Button {
+                withAnimation(.spring(response: 0.28, dampingFraction: 0.9)) {
+                    expandedReviewLaneID = expandedReviewLaneID == lane.id ? nil : lane.id
+                }
+            } label: {
+                Text(expandedReviewLaneID == lane.id ? "Hide review cards" : "Review cards")
+                    .font(.caption2.weight(.black))
+                    .foregroundStyle(tint)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(MatherTheme.card.opacity(0.8), in: Capsule())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Review \(lane.title) Mix-Match cards")
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(10)
         .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(lane.title) \(lane.recallReadinessLabel)")
+    }
+
+    private func mixMatchSampler(_ lane: CapabilityLane, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Review sample")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Spacer()
+                Text(lane.starterMixMatchSampler.progressLabel)
+                    .font(.caption2.weight(.heavy))
+                    .foregroundStyle(tint)
+            }
+
+            ForEach(Array(lane.starterMixMatchCards.prefix(3))) { card in
+                HStack(spacing: 8) {
+                    Text(card.prompt)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(MatherTheme.ink)
+                    Image(systemName: "arrow.right")
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(tint)
+                    Text(card.match)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(MatherTheme.ink)
+                    Spacer(minLength: 0)
+                }
+                .padding(8)
+                .background(MatherTheme.card.opacity(0.72), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            }
+        }
+        .padding(10)
+        .background(tint.opacity(0.10), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(lane.title) Mix-Match review sample")
     }
 
     private func modeChips(_ modes: [PlayMode], tint: Color) -> some View {

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -59,6 +59,22 @@ extension LabModelsTests {
         }
     }
 
+
+    func testStarterMixMatchSamplerCyclesThroughCards() throws {
+        let geometry = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .geometry })
+        var sampler = geometry.starterMixMatchSampler
+
+        XCTAssertEqual(sampler.progressLabel, "1 / 8")
+        XCTAssertEqual(sampler.currentCard?.prompt, "3 sides")
+
+        sampler.advance()
+        XCTAssertEqual(sampler.progressLabel, "2 / 8")
+        XCTAssertEqual(sampler.currentCard?.prompt, "4 equal sides")
+
+        sampler.rewind()
+        XCTAssertEqual(sampler.progressLabel, "1 / 8")
+    }
+
     func testStarterMixMatchCardsHaveChildReadablePromptsAndMatches() {
         let allCards = CapabilityLane.defaultExplorerLanes.flatMap(\.starterMixMatchCards)
 


### PR DESCRIPTION
## Summary
- add a deterministic `MixMatchReviewSampler` for lane starter cards
- expose a lightweight “Review cards” toggle on Explorer Lab capability lanes
- show an inline Mix-Match prompt → match sample for each lane
- add unit coverage for sampler progress, advance, and rewind behavior

## Scope
This is a small #797 interaction slice. It introduces an in-lane review sampler over the existing starter-card substrate, but does not implement the full spaced-repetition scheduler or mastery tracking yet.

## Validation
- `git diff --check`
- Local iOS build/test not available in this Linux workspace (`xcodebuild`, `xcodegen`, and `swift` are not installed); CI should run on macOS.

Refs #797
