### PR TITLE
Add staged progress model for Explorer Lab lanes

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -124,6 +124,57 @@ struct LabActivity: Identifiable, Equatable {
     }
 }
 
+
+struct CapabilityLaneProgress: Equatable {
+    let laneID: CapabilityLaneID
+    let availableModes: [PlayMode]
+    var completedModes: Set<PlayMode>
+    var reviewedCardIDs: Set<String>
+
+    init(
+        laneID: CapabilityLaneID,
+        availableModes: [PlayMode],
+        completedModes: Set<PlayMode> = [],
+        reviewedCardIDs: Set<String> = []
+    ) {
+        self.laneID = laneID
+        self.availableModes = availableModes
+        self.completedModes = completedModes
+        self.reviewedCardIDs = reviewedCardIDs
+    }
+
+    var completedModeCount: Int {
+        availableModes.filter { completedModes.contains($0) }.count
+    }
+
+    var progressLabel: String {
+        "\(completedModeCount) / \(availableModes.count) modes"
+    }
+
+    var masteryFraction: Double {
+        guard !availableModes.isEmpty else { return 0 }
+        return Double(completedModeCount) / Double(availableModes.count)
+    }
+
+    var masteryPercentLabel: String {
+        "\(Int((masteryFraction * 100).rounded()))% ready"
+    }
+
+    var nextRecommendedMode: PlayMode? {
+        availableModes.first { !completedModes.contains($0) } ?? availableModes.last
+    }
+
+    mutating func markCompleted(_ mode: PlayMode) {
+        guard availableModes.contains(mode) else { return }
+        completedModes.insert(mode)
+    }
+
+    mutating func markReviewed(_ card: MixMatchCard) {
+        guard card.laneID == laneID else { return }
+        reviewedCardIDs.insert(card.id)
+    }
+}
+
 struct CapabilityLane: Identifiable, Equatable {
     let id: CapabilityLaneID
     let emoji: String
@@ -157,6 +208,10 @@ struct CapabilityLane: Identifiable, Equatable {
 
     var starterMixMatchSampler: MixMatchReviewSampler {
         MixMatchReviewSampler(laneID: id, cards: starterMixMatchCards)
+    }
+
+    var emptyProgress: CapabilityLaneProgress {
+        CapabilityLaneProgress(laneID: id, availableModes: modes)
     }
 
     static let defaultExplorerLanes: [CapabilityLane] = [

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -75,6 +75,34 @@ extension LabModelsTests {
         XCTAssertEqual(sampler.progressLabel, "1 / 8")
     }
 
+
+    func testCapabilityLaneProgressTracksModesAndRecommendation() throws {
+        let numbers = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .numbers })
+        var progress = numbers.emptyProgress
+
+        XCTAssertEqual(progress.progressLabel, "0 / 4 modes")
+        XCTAssertEqual(progress.masteryPercentLabel, "0% ready")
+        XCTAssertEqual(progress.nextRecommendedMode, .learn)
+
+        progress.markCompleted(.learn)
+        progress.markCompleted(.timed)
+
+        XCTAssertEqual(progress.progressLabel, "2 / 4 modes")
+        XCTAssertEqual(progress.masteryPercentLabel, "50% ready")
+        XCTAssertEqual(progress.nextRecommendedMode, .challenge)
+    }
+
+    func testCapabilityLaneProgressTracksReviewedCardsOnlyForItsLane() throws {
+        let numbers = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .numbers })
+        let geometry = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .geometry })
+        var progress = numbers.emptyProgress
+
+        progress.markReviewed(try XCTUnwrap(numbers.starterMixMatchCards.first))
+        progress.markReviewed(try XCTUnwrap(geometry.starterMixMatchCards.first))
+
+        XCTAssertEqual(progress.reviewedCardIDs.count, 1)
+    }
+
     func testStarterMixMatchCardsHaveChildReadablePromptsAndMatches() {
         let allCards = CapabilityLane.defaultExplorerLanes.flatMap(\.starterMixMatchCards)
 


### PR DESCRIPTION
## Summary
- add `CapabilityLaneProgress` for deterministic staged lane progress
- track completed play modes, reviewed Mix-Match card IDs, progress labels, mastery percentage, and next recommended mode
- expose `CapabilityLane.emptyProgress` as a lane-level hook
- add unit coverage for progress/recommendation and lane-scoped reviewed-card tracking

## Scope
This is a small #797 model/test substrate slice. It does not add persistence or full profile-level mastery tracking yet.

## Validation
- `git diff --check`
- Local iOS build/test not available in this Linux workspace (`xcodebuild`, `xcodegen`, and `swift` are not installed); CI should run on macOS.

Refs #797
