### PR TITLE
Show staged progress on Explorer Lab lanes

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -160,6 +160,15 @@ struct CapabilityLaneProgress: Equatable {
         "\(Int((masteryFraction * 100).rounded()))% ready"
     }
 
+    var progressSummaryLabel: String {
+        "\(progressLabel) • \(masteryPercentLabel)"
+    }
+
+    var nextRecommendedModeLabel: String {
+        guard let nextRecommendedMode else { return "Choose any mode" }
+        return "Try \(nextRecommendedMode.rawValue) next"
+    }
+
     var nextRecommendedMode: PlayMode? {
         availableModes.first { !completedModes.contains($0) } ?? availableModes.last
     }

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -85,6 +85,7 @@ struct LabView: View {
             }
 
             modeChips(lane.modes, tint: laneColor(lane.id))
+            progressPreview(lane.emptyProgress, tint: laneColor(lane.id))
             recallPreview(lane, tint: laneColor(lane.id))
             if expandedReviewLaneID == lane.id {
                 mixMatchSampler(lane, tint: laneColor(lane.id))
@@ -119,6 +120,29 @@ struct LabView: View {
         )
         .accessibilityElement(children: .contain)
         .accessibilityLabel(lane.title)
+    }
+
+    private func progressPreview(_ progress: CapabilityLaneProgress, tint: Color) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "chart.bar.fill")
+                .font(.caption.weight(.black))
+                .foregroundStyle(tint)
+                .frame(width: 24, height: 24)
+                .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(progress.progressSummaryLabel)
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text(progress.nextRecommendedModeLabel)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(MatherTheme.panel.opacity(0.58), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Lane progress \(progress.progressSummaryLabel). \(progress.nextRecommendedModeLabel)")
     }
 
     private func recallPreview(_ lane: CapabilityLane, tint: Color) -> some View {

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -82,14 +82,18 @@ extension LabModelsTests {
 
         XCTAssertEqual(progress.progressLabel, "0 / 4 modes")
         XCTAssertEqual(progress.masteryPercentLabel, "0% ready")
+        XCTAssertEqual(progress.progressSummaryLabel, "0 / 4 modes • 0% ready")
         XCTAssertEqual(progress.nextRecommendedMode, .learn)
+        XCTAssertEqual(progress.nextRecommendedModeLabel, "Try Learn next")
 
         progress.markCompleted(.learn)
         progress.markCompleted(.timed)
 
         XCTAssertEqual(progress.progressLabel, "2 / 4 modes")
         XCTAssertEqual(progress.masteryPercentLabel, "50% ready")
+        XCTAssertEqual(progress.progressSummaryLabel, "2 / 4 modes • 50% ready")
         XCTAssertEqual(progress.nextRecommendedMode, .challenge)
+        XCTAssertEqual(progress.nextRecommendedModeLabel, "Try Challenge next")
     }
 
     func testCapabilityLaneProgressTracksReviewedCardsOnlyForItsLane() throws {


### PR DESCRIPTION
## Summary
- add progress summary and next-mode labels to `CapabilityLaneProgress`
- show staged progress/readiness on Explorer Lab capability lane cards
- extend model tests for progress summary and next recommendation copy

## Scope
This is a small #797 UI/model slice. It surfaces the existing staged progress substrate with default progress state, but does not add persistence/profile wiring yet.

## Validation
- `git diff --check`
- Local iOS build/test not available in this Linux workspace (`xcodebuild`, `xcodegen`, and `swift` are not installed); CI should run on macOS.

Refs #797
