### PR TITLE
Issue #797: Add sensor capability service

### DIFF
--- a/Services/SensorCapabilityService.swift
+++ b/Services/SensorCapabilityService.swift
@@ -1,0 +1,145 @@
+import AVFoundation
+import CoreHaptics
+import CoreLocation
+import CoreMotion
+
+enum SensorPermissionState: Equatable, Sendable {
+    case notRequired
+    case notDetermined
+    case restricted
+    case denied
+    case authorized
+    case unknown
+
+    var allowsUse: Bool {
+        switch self {
+        case .notRequired, .authorized:
+            true
+        case .notDetermined, .restricted, .denied, .unknown:
+            false
+        }
+    }
+}
+
+struct DeviceSensorCapability: Equatable, Sendable {
+    let hardwareAvailable: Bool
+    let permission: SensorPermissionState
+
+    var isReady: Bool {
+        hardwareAvailable && permission.allowsUse
+    }
+
+    static func available(permission: SensorPermissionState = .notRequired) -> DeviceSensorCapability {
+        DeviceSensorCapability(hardwareAvailable: true, permission: permission)
+    }
+
+    static func unavailable(permission: SensorPermissionState = .notRequired) -> DeviceSensorCapability {
+        DeviceSensorCapability(hardwareAvailable: false, permission: permission)
+    }
+}
+
+struct DeviceSensorCapabilities: Equatable, Sendable {
+    let motion: DeviceSensorCapability
+    let heading: DeviceSensorCapability
+    let camera: DeviceSensorCapability
+    let lidar: DeviceSensorCapability
+    let barometer: DeviceSensorCapability
+    let microphone: DeviceSensorCapability
+    let haptics: DeviceSensorCapability
+    let pencil: DeviceSensorCapability
+
+    static let allUnavailable = DeviceSensorCapabilities(
+        motion: .unavailable(),
+        heading: .unavailable(),
+        camera: .unavailable(permission: .notDetermined),
+        lidar: .unavailable(permission: .notDetermined),
+        barometer: .unavailable(),
+        microphone: .unavailable(permission: .notDetermined),
+        haptics: .unavailable(),
+        pencil: .unavailable()
+    )
+}
+
+protocol SensorCapabilityProviding {
+    var capabilities: DeviceSensorCapabilities { get }
+}
+
+/// Simulator-safe capability snapshot for sensor-driven lanes.
+///
+/// Inspection is intentionally read-only: this service never starts a capture
+/// session, starts motion/location updates, or requests permissions.
+final class SensorCapabilityService: SensorCapabilityProviding {
+    var capabilities: DeviceSensorCapabilities {
+        DeviceSensorCapabilities(
+            motion: DeviceSensorCapability(
+                hardwareAvailable: CMMotionManager().isDeviceMotionAvailable,
+                permission: .notRequired
+            ),
+            heading: DeviceSensorCapability(
+                hardwareAvailable: CLLocationManager.headingAvailable(),
+                permission: .notRequired
+            ),
+            camera: DeviceSensorCapability(
+                hardwareAvailable: AVCaptureDevice.default(for: .video) != nil,
+                permission: Self.capturePermission(for: .video)
+            ),
+            lidar: DeviceSensorCapability(
+                hardwareAvailable: Self.hasLiDARCamera(),
+                permission: Self.capturePermission(for: .video)
+            ),
+            barometer: DeviceSensorCapability(
+                hardwareAvailable: CMAltimeter.isRelativeAltitudeAvailable(),
+                permission: .notRequired
+            ),
+            microphone: DeviceSensorCapability(
+                hardwareAvailable: AVCaptureDevice.default(for: .audio) != nil,
+                permission: Self.capturePermission(for: .audio)
+            ),
+            haptics: DeviceSensorCapability(
+                hardwareAvailable: CHHapticEngine.capabilitiesForHardware().supportsHaptics,
+                permission: .notRequired
+            ),
+            pencil: DeviceSensorCapability(
+                hardwareAvailable: Self.hasPencilSupportPlaceholder(),
+                permission: .notRequired
+            )
+        )
+    }
+
+    private static func capturePermission(for mediaType: AVMediaType) -> SensorPermissionState {
+        switch AVCaptureDevice.authorizationStatus(for: mediaType) {
+        case .notDetermined:
+            .notDetermined
+        case .restricted:
+            .restricted
+        case .denied:
+            .denied
+        case .authorized:
+            .authorized
+        @unknown default:
+            .unknown
+        }
+    }
+
+    private static func hasLiDARCamera() -> Bool {
+#if targetEnvironment(simulator)
+        false
+#else
+        AVCaptureDevice.default(.builtInLiDARDepthCamera, for: .video, position: .back) != nil
+#endif
+    }
+
+    private static func hasPencilSupportPlaceholder() -> Bool {
+        // iOS exposes Pencil interactions, not a reliable passive hardware
+        // capability query. Keep this conservative until PencilKit work needs it.
+        false
+    }
+}
+
+struct FixedSensorCapabilityService: SensorCapabilityProviding {
+    let capabilities: DeviceSensorCapabilities
+
+    init(capabilities: DeviceSensorCapabilities) {
+        self.capabilities = capabilities
+    }
+}

--- a/Tests/MatherTests/SensorCapabilityServiceTests.swift
+++ b/Tests/MatherTests/SensorCapabilityServiceTests.swift
@@ -1,0 +1,83 @@
+import AVFoundation
+import Testing
+@testable import Mather
+
+struct SensorCapabilityServiceTests {
+
+    @Test
+    func readinessRequiresHardwareAndUsablePermission() {
+        #expect(DeviceSensorCapability.available().isReady)
+        #expect(DeviceSensorCapability.available(permission: .authorized).isReady)
+        #expect(!DeviceSensorCapability.available(permission: .notDetermined).isReady)
+        #expect(!DeviceSensorCapability.available(permission: .denied).isReady)
+        #expect(!DeviceSensorCapability.unavailable().isReady)
+    }
+
+    @Test
+    func fixedServiceReturnsInjectedCapabilities() {
+        let expected = DeviceSensorCapabilities(
+            motion: .available(),
+            heading: .available(),
+            camera: .available(permission: .authorized),
+            lidar: .unavailable(permission: .authorized),
+            barometer: .available(),
+            microphone: .available(permission: .denied),
+            haptics: .unavailable(),
+            pencil: .unavailable()
+        )
+
+        let service = FixedSensorCapabilityService(capabilities: expected)
+
+        #expect(service.capabilities == expected)
+        #expect(service.capabilities.motion.isReady)
+        #expect(!service.capabilities.lidar.isReady)
+        #expect(!service.capabilities.microphone.isReady)
+    }
+
+    @Test
+    func allUnavailableFixtureCoversEverySensorField() {
+        let capabilities = DeviceSensorCapabilities.allUnavailable
+
+        #expect(!capabilities.motion.isReady)
+        #expect(!capabilities.heading.isReady)
+        #expect(!capabilities.camera.isReady)
+        #expect(!capabilities.lidar.isReady)
+        #expect(!capabilities.barometer.isReady)
+        #expect(!capabilities.microphone.isReady)
+        #expect(!capabilities.haptics.isReady)
+        #expect(!capabilities.pencil.isReady)
+    }
+
+    @Test
+    func platformServiceSnapshotDoesNotRequestCapturePermissions() {
+        let cameraBefore = AVCaptureDevice.authorizationStatus(for: .video)
+        let microphoneBefore = AVCaptureDevice.authorizationStatus(for: .audio)
+
+        let capabilities = SensorCapabilityService().capabilities
+
+        let cameraAfter = AVCaptureDevice.authorizationStatus(for: .video)
+        let microphoneAfter = AVCaptureDevice.authorizationStatus(for: .audio)
+
+        #expect(cameraAfter == cameraBefore)
+        #expect(microphoneAfter == microphoneBefore)
+        #expect(capabilities.camera.permission == SensorPermissionState(captureAuthorizationStatus: cameraAfter))
+        #expect(capabilities.microphone.permission == SensorPermissionState(captureAuthorizationStatus: microphoneAfter))
+    }
+}
+
+private extension SensorPermissionState {
+    init(captureAuthorizationStatus status: AVAuthorizationStatus) {
+        switch status {
+        case .notDetermined:
+            self = .notDetermined
+        case .restricted:
+            self = .restricted
+        case .denied:
+            self = .denied
+        case .authorized:
+            self = .authorized
+        @unknown default:
+            self = .unknown
+        }
+    }
+}


### PR DESCRIPTION
## Scope

Adds a simulator-safe sensor capability service for Issue #797 lane work:

- `SensorCapabilityService` reports a read-only `DeviceSensorCapabilities` snapshot.
- `DeviceSensorCapability` separates hardware availability from permission state and exposes derived `isReady`.
- Fields cover motion, heading, camera, LiDAR, barometer, microphone, haptics, and Pencil.
- `FixedSensorCapabilityService` provides an injectable fixture/stub for tests and future lane PRs.

The service only inspects passive capability/authorization APIs. It does not start motion/location updates, capture sessions, audio engines, or permission requests.

## Tests

Added `SensorCapabilityServiceTests` covering:

- readiness derivation from hardware plus permission state
- injected fixed capabilities
- all-unavailable fixture coverage for every sensor field
- camera/microphone authorization status remains unchanged after platform capability inspection

Validation attempted locally:

- `git diff --cached --check` passed
- `xcodegen generate` blocked: `/bin/bash: line 1: xcodegen: command not found`
- `xcodebuild -version` blocked: `/bin/bash: line 1: xcodebuild: command not found`
- `xcrun --version` blocked: `/bin/bash: line 1: xcrun: command not found`

## Dependencies

None. This PR does not reference F1 lane models or change existing sensor services.

## Coordinator update

## Codex update — Issue #797 / Issue #797: Add sensor capability service

**Branch:** `issue-797-f3-20260430092417`
**PR:** this PR
**Scope completed:**
- Added simulator-safe sensor capability snapshot service.
- Added hardware/permission/ready model for sensor checks.
- Added fixed stub provider for tests and future injection.

**Files touched:**
- `Services/SensorCapabilityService.swift` — new capability model, provider protocol, platform service, fixed stub.
- `Tests/MatherTests/SensorCapabilityServiceTests.swift` — unit coverage for readiness, injection, fixture completeness, and no capture permission mutation.

**Assumptions made:**
- LiDAR can be passively detected via AVFoundation on devices and conservatively reports false in simulator.
- Pencil hardware availability has no reliable passive public query here, so it is an explicit conservative placeholder reporting unavailable.
- Heading is treated as hardware capability with no app permission readiness gate at this layer.

**Interfaces added/changed:**
- `SensorPermissionState`
- `DeviceSensorCapability`
- `DeviceSensorCapabilities`
- `SensorCapabilityProviding`
- `SensorCapabilityService`
- `FixedSensorCapabilityService`

**Dependencies:**
- Depends on: none
- Blocks: sensor affordance/lane PRs that need a central capability query

**Blockers:**
- Local Xcode validation unavailable in this worker image because `xcodegen`, `xcodebuild`, and `xcrun` are not installed.

**Integration notes:**
- Capability inspection is read-only and does not trigger permission prompts.
- Camera, microphone, and LiDAR readiness are permission-gated through existing AVFoundation authorization status.
- Motion, heading, barometer, haptics, and Pencil use `.notRequired` permission state.

**Tests run:**
- `git diff --cached --check` — passed
- `xcodegen generate` — blocked, command missing
- `xcodebuild -version` — blocked, command missing
- `xcrun --version` — blocked, command missing

**Screenshots / media:**
- not applicable; no UI changed
