### PR TITLE
Issue #797: Add fallback Smart Play provider

### DIFF
--- a/Services/CuratedSmartPlayProvider.swift
+++ b/Services/CuratedSmartPlayProvider.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+@MainActor
+struct CuratedSmartPlayProvider: SmartPlayProvider {
+    func hint(for request: SmartPlayHintRequest) async -> SmartPlayHintResponse {
+        SmartPlayHintResponse(
+            spokenText: hintText(for: request),
+            source: .curatedFallback
+        )
+    }
+
+    func story(for request: SmartPlayStoryRequest) async -> SmartPlayStoryResponse {
+        SmartPlayStoryResponse(
+            spokenText: storyText(for: request),
+            source: .curatedFallback
+        )
+    }
+
+    func reviewPrompt(for request: SmartPlayReviewPromptRequest) async -> SmartPlayReviewPromptResponse {
+        SmartPlayReviewPromptResponse(
+            spokenText: reviewText(for: request),
+            source: .curatedFallback
+        )
+    }
+
+    private func hintText(for request: SmartPlayHintRequest) -> String {
+        let context = request.context.normalizedTokens
+        if context.contains("make-break-10") || context.contains("vs1") {
+            if request.attemptCount >= 2 {
+                return "Try making one group smaller and the other group bigger. Count both groups together."
+            }
+            return "Try moving one counter, then count each group."
+        }
+
+        if context.contains("sum-sprint") {
+            return "Look for the number that joins with this one. Then say the whole amount."
+        }
+
+        if context.contains("room-quest") {
+            return "Look carefully at the place, then try the closest matching spot."
+        }
+
+        return "Try one small move, then check what changed."
+    }
+
+    private func storyText(for request: SmartPlayStoryRequest) -> String {
+        let context = request.context.normalizedTokens
+        if context.contains("make-break-10") || context.contains("vs1") {
+            let target = request.targetNumber ?? 10
+            return "The builders are sharing \(target) blocks between two trucks. Move the blocks until both trucks match your plan."
+        }
+
+        if context.contains("sum-sprint") {
+            return "The cards are racing to find their partner. Match the numbers and keep the race moving."
+        }
+
+        if context.contains("room-quest") {
+            return "The room has a secret math spot. Find the matching place and check it like a detective."
+        }
+
+        let theme = request.theme.flatMap { $0.trimmedNonEmpty } ?? "math"
+        return "This \(theme) challenge needs careful looking. Try a move, then check your answer."
+    }
+
+    private func reviewText(for request: SmartPlayReviewPromptRequest) -> String {
+        let context = request.context.normalizedTokens
+        if context.contains("make-break-10") || context.contains("vs1") {
+            return "Show how you made the number two ways. Tell which parts stayed the same."
+        }
+
+        if request.retryCount > request.successCount {
+            return "Show one tricky part again. Tell what you will try first next time."
+        }
+
+        if request.successCount > 0 {
+            return "Show your favorite answer from today. Tell how you knew it worked."
+        }
+
+        return "Show one thing you tried. Tell what changed when you tried it."
+    }
+}
+
+private extension SmartPlayRequestContext {
+    var normalizedTokens: Set<String> {
+        Set(
+            [laneID, stageID, activityID, learningGoal]
+                .compactMap { $0.flatMap { value in value.trimmedNonEmpty }?.lowercased() }
+        )
+    }
+}
+
+private extension String {
+    var trimmedNonEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Services/SmartPlayProvider.swift
+++ b/Services/SmartPlayProvider.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+enum SmartPlayResponseSource: String, Equatable, Sendable {
+    case curatedFallback
+}
+
+struct SmartPlayRequestContext: Equatable, Sendable {
+    var laneID: String
+    var stageID: String?
+    var activityID: String?
+    var learningGoal: String?
+    var localeIdentifier: String
+    var knownFacts: [String]
+
+    init(
+        laneID: String,
+        stageID: String? = nil,
+        activityID: String? = nil,
+        learningGoal: String? = nil,
+        localeIdentifier: String = Locale.current.identifier,
+        knownFacts: [String] = []
+    ) {
+        self.laneID = laneID
+        self.stageID = stageID
+        self.activityID = activityID
+        self.learningGoal = learningGoal
+        self.localeIdentifier = localeIdentifier
+        self.knownFacts = knownFacts
+    }
+}
+
+struct SmartPlayHintRequest: Equatable, Sendable {
+    var context: SmartPlayRequestContext
+    var currentProblem: String?
+    var attemptCount: Int
+    var availableTools: [String]
+
+    init(
+        context: SmartPlayRequestContext,
+        currentProblem: String? = nil,
+        attemptCount: Int = 0,
+        availableTools: [String] = []
+    ) {
+        self.context = context
+        self.currentProblem = currentProblem
+        self.attemptCount = attemptCount
+        self.availableTools = availableTools
+    }
+}
+
+struct SmartPlayHintResponse: Equatable, Sendable {
+    var spokenText: String
+    var source: SmartPlayResponseSource
+}
+
+struct SmartPlayStoryRequest: Equatable, Sendable {
+    var context: SmartPlayRequestContext
+    var theme: String?
+    var targetNumber: Int?
+
+    init(
+        context: SmartPlayRequestContext,
+        theme: String? = nil,
+        targetNumber: Int? = nil
+    ) {
+        self.context = context
+        self.theme = theme
+        self.targetNumber = targetNumber
+    }
+}
+
+struct SmartPlayStoryResponse: Equatable, Sendable {
+    var spokenText: String
+    var source: SmartPlayResponseSource
+}
+
+struct SmartPlayReviewPromptRequest: Equatable, Sendable {
+    var context: SmartPlayRequestContext
+    var completedActivities: [String]
+    var successCount: Int
+    var retryCount: Int
+
+    init(
+        context: SmartPlayRequestContext,
+        completedActivities: [String] = [],
+        successCount: Int = 0,
+        retryCount: Int = 0
+    ) {
+        self.context = context
+        self.completedActivities = completedActivities
+        self.successCount = successCount
+        self.retryCount = retryCount
+    }
+}
+
+struct SmartPlayReviewPromptResponse: Equatable, Sendable {
+    var spokenText: String
+    var source: SmartPlayResponseSource
+}
+
+@MainActor
+protocol SmartPlayProvider {
+    func hint(for request: SmartPlayHintRequest) async -> SmartPlayHintResponse
+    func story(for request: SmartPlayStoryRequest) async -> SmartPlayStoryResponse
+    func reviewPrompt(for request: SmartPlayReviewPromptRequest) async -> SmartPlayReviewPromptResponse
+}

--- a/Tests/MatherTests/SmartPlayProviderTests.swift
+++ b/Tests/MatherTests/SmartPlayProviderTests.swift
@@ -1,0 +1,81 @@
+import Testing
+@testable import Mather
+
+@Suite("SmartPlayProvider")
+struct SmartPlayProviderTests {
+    @MainActor
+    @Test func curatedFallbackReturnsDeterministicHint() async {
+        let provider = CuratedSmartPlayProvider()
+        let request = SmartPlayHintRequest(
+            context: SmartPlayRequestContext(
+                laneID: "make-break-10",
+                stageID: "concrete",
+                learningGoal: "Make and break to 10"
+            ),
+            currentProblem: "Split 10 into two groups",
+            attemptCount: 0,
+            availableTools: ["counters"]
+        )
+
+        let first = await provider.hint(for: request)
+        let second = await provider.hint(for: request)
+
+        #expect(first == second)
+        #expect(first.source == .curatedFallback)
+        #expect(first.spokenText == "Try moving one counter, then count each group.")
+    }
+
+    @MainActor
+    @Test func curatedFallbackReturnsDeterministicStory() async {
+        let provider = CuratedSmartPlayProvider()
+        let request = SmartPlayStoryRequest(
+            context: SmartPlayRequestContext(laneID: "vs1", stageID: "story"),
+            theme: "vehicles",
+            targetNumber: 10
+        )
+
+        let response = await provider.story(for: request)
+
+        #expect(response.source == .curatedFallback)
+        #expect(response.spokenText == "The builders are sharing 10 blocks between two trucks. Move the blocks until both trucks match your plan.")
+    }
+
+    @MainActor
+    @Test func curatedFallbackReturnsDeterministicReviewPrompt() async {
+        let provider = CuratedSmartPlayProvider()
+        let request = SmartPlayReviewPromptRequest(
+            context: SmartPlayRequestContext(laneID: "make-break-10", stageID: "review"),
+            completedActivities: ["concrete", "pictorial", "abstract"],
+            successCount: 3,
+            retryCount: 1
+        )
+
+        let response = await provider.reviewPrompt(for: request)
+
+        #expect(response.source == .curatedFallback)
+        #expect(response.spokenText == "Show how you made the number two ways. Tell which parts stayed the same.")
+    }
+
+    @MainActor
+    @Test func unknownContextUsesGenericSafeFallbacks() async {
+        let provider = CuratedSmartPlayProvider()
+        let context = SmartPlayRequestContext(laneID: "future-lane", stageID: "unknown")
+
+        let hint = await provider.hint(for: SmartPlayHintRequest(context: context, attemptCount: 4))
+        let story = await provider.story(for: SmartPlayStoryRequest(context: context, theme: ""))
+        let review = await provider.reviewPrompt(for: SmartPlayReviewPromptRequest(context: context))
+
+        #expect(hint == SmartPlayHintResponse(
+            spokenText: "Try one small move, then check what changed.",
+            source: .curatedFallback
+        ))
+        #expect(story == SmartPlayStoryResponse(
+            spokenText: "This math challenge needs careful looking. Try a move, then check your answer.",
+            source: .curatedFallback
+        ))
+        #expect(review == SmartPlayReviewPromptResponse(
+            spokenText: "Show one thing you tried. Tell what changed when you tried it.",
+            source: .curatedFallback
+        ))
+    }
+}


### PR DESCRIPTION
## Scope

- Adds `SmartPlayProvider` as a fallback-first protocol for hint, story, and review prompt requests.
- Adds deterministic request/response models using string-based context so this PR does not depend on pending capability-lane model work.
- Adds `CuratedSmartPlayProvider` with safe deterministic fallback copy for current/future lanes and generic unknown contexts.
- Adds unit tests for fallback hint, story, review prompt, and unknown context handling.

## Tests

- Not run in this worker: `xcodegen`, `xcodebuild`, `swift`, and `swiftc` are unavailable in the container (`command not found`).
- Static check run: `git diff --cached --check` passed before commit.

## Dependencies

- Depends on: none.
- Blocks: future Smart Play implementations can conform to `SmartPlayProvider` without changing lane UI.
- No `FoundationModels`, ChatGPT, network calls, permission prompts, or child privacy flow changes are introduced.

## Coordinator update

Branch: `issue-797-i5-20260430092417`
Interfaces added: `SmartPlayProvider`, `SmartPlayRequestContext`, `SmartPlayHintRequest/Response`, `SmartPlayStoryRequest/Response`, `SmartPlayReviewPromptRequest/Response`, `CuratedSmartPlayProvider`.
Integration note: context intentionally uses local string IDs until F1 capability-lane models land.