### PR TITLE
Add age-band entry points to Explorer Lab lanes

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -33,6 +33,28 @@ enum CapabilityLaneID: String, CaseIterable, Hashable {
     }
 }
 
+
+enum ChildAgeBand: String, CaseIterable, Hashable {
+    case toddler = "2–3"
+    case preschool = "4–5"
+    case earlyElementary = "6–7"
+    case upperElementary = "8–10"
+    case preteen = "11–12"
+
+    var label: String { "Ages \(rawValue)" }
+}
+
+struct CapabilityAgeEntry: Identifiable, Equatable {
+    var id: ChildAgeBand { ageBand }
+    let ageBand: ChildAgeBand
+    let posture: String
+    let entryPlay: String
+
+    var summaryLabel: String {
+        "\(ageBand.label): \(entryPlay)"
+    }
+}
+
 enum PlayMode: String, CaseIterable, Hashable {
     case learn = "Learn"
     case explore = "Explore"
@@ -190,10 +212,15 @@ struct CapabilityLane: Identifiable, Equatable {
     let promise: String
     let ageBandHint: String
     let modes: [PlayMode]
+    let ageEntries: [CapabilityAgeEntry]
     let activities: [LabActivity]
 
     var title: String { id.title }
     var isReady: Bool { !activities.isEmpty }
+
+    var ageEntryPreview: String {
+        ageEntries.prefix(2).map(\.summaryLabel).joined(separator: " • ")
+    }
 
     var starterMixMatchCards: [MixMatchCard] {
         Self.starterMixMatchCardsByLane[id, default: []]
@@ -230,6 +257,12 @@ struct CapabilityLane: Identifiable, Equatable {
             promise: "Build number bonds, fast facts, arrays, and whole-part thinking.",
             ageBandHint: "Ages 4–12",
             modes: [.learn, .challenge, .timed, .review],
+            ageEntries: [
+                CapabilityAgeEntry(ageBand: .preschool, posture: "count and pair", entryPlay: "Bond Blast pairs"),
+                CapabilityAgeEntry(ageBand: .earlyElementary, posture: "CPA number bonds", entryPlay: "Make & Break"),
+                CapabilityAgeEntry(ageBand: .upperElementary, posture: "strategy and factors", entryPlay: "arrays and races"),
+                CapabilityAgeEntry(ageBand: .preteen, posture: "mastery and mental math", entryPlay: "personal-best challenges"),
+            ],
             activities: [
                 LabActivity(
                     id: .sumSprint,
@@ -260,6 +293,12 @@ struct CapabilityLane: Identifiable, Equatable {
             promise: "Fold, measure, aim, and transform shapes with touch and motion.",
             ageBandHint: "Ages 4–12",
             modes: [.learn, .explore, .challenge, .review],
+            ageEntries: [
+                CapabilityAgeEntry(ageBand: .preschool, posture: "shape discovery", entryPlay: "shape sort"),
+                CapabilityAgeEntry(ageBand: .earlyElementary, posture: "fold and compare", entryPlay: "symmetry play"),
+                CapabilityAgeEntry(ageBand: .upperElementary, posture: "measure and transform", entryPlay: "angles and arrays"),
+                CapabilityAgeEntry(ageBand: .preteen, posture: "systems and coordinates", entryPlay: "puzzle challenges"),
+            ],
             activities: [
                 LabActivity(
                     id: .symmetryFold,
@@ -290,6 +329,12 @@ struct CapabilityLane: Identifiable, Equatable {
             promise: "Predict motion, gravity, water, and cause-and-effect systems.",
             ageBandHint: "Ages 2–12",
             modes: [.explore, .challenge, .review],
+            ageEntries: [
+                CapabilityAgeEntry(ageBand: .toddler, posture: "cause and effect", entryPlay: "tap, drop, splash"),
+                CapabilityAgeEntry(ageBand: .preschool, posture: "predict and observe", entryPlay: "roll and rain"),
+                CapabilityAgeEntry(ageBand: .upperElementary, posture: "forces and systems", entryPlay: "cannon strategy"),
+                CapabilityAgeEntry(ageBand: .preteen, posture: "model and explain", entryPlay: "energy puzzles"),
+            ],
             activities: [
                 LabActivity(
                     id: .gravityArtist,
@@ -313,6 +358,12 @@ struct CapabilityLane: Identifiable, Equatable {
             promise: "Use rooms, compass turns, direction words, and route clues.",
             ageBandHint: "Ages 4–12",
             modes: [.explore, .challenge, .timed],
+            ageEntries: [
+                CapabilityAgeEntry(ageBand: .preschool, posture: "left/right and finding", entryPlay: "room clues"),
+                CapabilityAgeEntry(ageBand: .earlyElementary, posture: "directions and turns", entryPlay: "compass walk"),
+                CapabilityAgeEntry(ageBand: .upperElementary, posture: "maps and scale", entryPlay: "route planning"),
+                CapabilityAgeEntry(ageBand: .preteen, posture: "coordinates and strategy", entryPlay: "map challenges"),
+            ],
             activities: [
                 LabActivity(
                     id: .roomQuest,
@@ -336,6 +387,12 @@ struct CapabilityLane: Identifiable, Equatable {
             promise: "Practice names, pictures, categories, and Mix-Match recall.",
             ageBandHint: "Ages 2–12",
             modes: [.learn, .review, .challenge],
+            ageEntries: [
+                CapabilityAgeEntry(ageBand: .toddler, posture: "name and notice", entryPlay: "big picture cards"),
+                CapabilityAgeEntry(ageBand: .preschool, posture: "sort and match", entryPlay: "Mix-Match"),
+                CapabilityAgeEntry(ageBand: .earlyElementary, posture: "facts and categories", entryPlay: "choice cards"),
+                CapabilityAgeEntry(ageBand: .preteen, posture: "explain and connect", entryPlay: "systems cards"),
+            ],
             activities: [
                 LabActivity(
                     id: .memoryMatch,
@@ -352,6 +409,12 @@ struct CapabilityLane: Identifiable, Equatable {
             promise: "Future: sort materials, mix safely, and predict properties.",
             ageBandHint: "Future lane",
             modes: [.explore, .challenge, .review],
+            ageEntries: [
+                CapabilityAgeEntry(ageBand: .preschool, posture: "material sorting", entryPlay: "color and texture"),
+                CapabilityAgeEntry(ageBand: .earlyElementary, posture: "states and mixtures", entryPlay: "mix and separate"),
+                CapabilityAgeEntry(ageBand: .upperElementary, posture: "properties and prediction", entryPlay: "safe reaction cards"),
+                CapabilityAgeEntry(ageBand: .preteen, posture: "families and systems", entryPlay: "property puzzles"),
+            ],
             activities: []
         ),
         CapabilityLane(
@@ -360,6 +423,12 @@ struct CapabilityLane: Identifiable, Equatable {
             promise: "Future: switches, circuits, sensors, and input/output systems.",
             ageBandHint: "Future lane",
             modes: [.explore, .challenge, .review],
+            ageEntries: [
+                CapabilityAgeEntry(ageBand: .preschool, posture: "switch and output", entryPlay: "light on/off"),
+                CapabilityAgeEntry(ageBand: .earlyElementary, posture: "circuits and components", entryPlay: "wire paths"),
+                CapabilityAgeEntry(ageBand: .upperElementary, posture: "debug and sensors", entryPlay: "input/output"),
+                CapabilityAgeEntry(ageBand: .preteen, posture: "logic and systems", entryPlay: "gate puzzles"),
+            ],
             activities: []
         ),
     ]

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -85,6 +85,7 @@ struct LabView: View {
             }
 
             modeChips(lane.modes, tint: laneColor(lane.id))
+            ageEntryPreview(lane, tint: laneColor(lane.id))
             progressPreview(lane.emptyProgress, tint: laneColor(lane.id))
             recallPreview(lane, tint: laneColor(lane.id))
             if expandedReviewLaneID == lane.id {
@@ -120,6 +121,23 @@ struct LabView: View {
         )
         .accessibilityElement(children: .contain)
         .accessibilityLabel(lane.title)
+    }
+
+    private func ageEntryPreview(_ lane: CapabilityLane, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label("Age entry points", systemImage: "person.2.fill")
+                .font(.caption.weight(.black))
+                .foregroundStyle(tint)
+            Text(lane.ageEntryPreview)
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(tint.opacity(0.07), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(lane.title) age entry points: \(lane.ageEntryPreview)")
     }
 
     private func progressPreview(_ progress: CapabilityLaneProgress, tint: Color) -> some View {

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -25,6 +25,18 @@ final class LabModelsTests: XCTestCase {
         XCTAssertFalse(CapabilityLaneID.allCases.contains { $0.title == "Memory Match" })
     }
 
+
+    func testCapabilityLanesExposeAgeBandEntryPoints() throws {
+        for lane in CapabilityLane.defaultExplorerLanes {
+            XCTAssertGreaterThanOrEqual(lane.ageEntries.count, 4, "\(lane.title) should define multiple age entry points")
+            XCTAssertFalse(lane.ageEntryPreview.isEmpty)
+        }
+
+        let physics = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .physics })
+        XCTAssertTrue(physics.ageEntries.contains { $0.ageBand == .toddler })
+        XCTAssertTrue(physics.ageEntryPreview.contains("Ages 2–3"))
+    }
+
     func testCapabilityLanesIncludeChoiceBasedPlayModes() {
         let modesByLane = Dictionary(
             uniqueKeysWithValues: CapabilityLane.defaultExplorerLanes.map { ($0.id, Set($0.modes)) }


### PR DESCRIPTION
## Summary
- add deterministic `ChildAgeBand` / `CapabilityAgeEntry` metadata for Explorer Lab capability lanes
- surface age-entry previews on lane cards so each capability can show child-friendly 2–12 entry play
- cover age-band metadata and toddler physics entry with model tests

## Scope
Small #797 substrate/UI slice. This adds lane-level age entry metadata and card copy only; it does not add onboarding/profile selection or persistence yet.

## Validation
- `git diff --check`
- Local iOS build/test not available in this Linux workspace (`swift`, `xcodebuild`, and `xcodegen` are not installed); CI should run on macOS.

Refs #797
