### PR TITLE
Issue #797 F3: Add sensor capability service

### DIFF
--- a/Services/SensorCapabilityService.swift
+++ b/Services/SensorCapabilityService.swift
@@ -1,0 +1,74 @@
+import ARKit
+import AVFoundation
+import CoreHaptics
+import CoreLocation
+import CoreMotion
+import UIKit
+
+/// Immutable snapshot of device sensors that Explorer Lab activities may depend on.
+///
+/// These values are hardware capability checks only. They do not represent permission
+/// authorization and must be safe to inspect before an activity starts.
+struct DeviceSensorCapabilities: Equatable, Sendable {
+    let supportsMotion: Bool
+    let supportsHeading: Bool
+    let supportsCamera: Bool
+    let supportsMicrophone: Bool
+    let supportsHaptics: Bool
+    let supportsBarometer: Bool
+
+    /// LiDAR is currently only a readiness signal for future Explorer Lab lanes.
+    let supportsLiDAR: Bool
+
+    /// Apple Pencil capability cannot be reliably detected without interaction.
+    /// Keep this conservative until a Pencil-specific lane defines its runtime needs.
+    let supportsApplePencil: Bool
+
+    static let unavailable = DeviceSensorCapabilities(
+        supportsMotion: false,
+        supportsHeading: false,
+        supportsCamera: false,
+        supportsMicrophone: false,
+        supportsHaptics: false,
+        supportsBarometer: false,
+        supportsLiDAR: false,
+        supportsApplePencil: false
+    )
+}
+
+@MainActor
+protocol DeviceSensorCapabilityInspecting {
+    func currentCapabilities() -> DeviceSensorCapabilities
+}
+
+/// Reads device hardware availability without starting sensors or asking for permissions.
+@MainActor
+final class SensorCapabilityService {
+    private let inspector: any DeviceSensorCapabilityInspecting
+
+    init(inspector: any DeviceSensorCapabilityInspecting = SystemDeviceSensorCapabilityInspector()) {
+        self.inspector = inspector
+    }
+
+    func currentCapabilities() -> DeviceSensorCapabilities {
+        inspector.currentCapabilities()
+    }
+}
+
+@MainActor
+struct SystemDeviceSensorCapabilityInspector: DeviceSensorCapabilityInspecting {
+    func currentCapabilities() -> DeviceSensorCapabilities {
+        let motionManager = CMMotionManager()
+
+        return DeviceSensorCapabilities(
+            supportsMotion: motionManager.isDeviceMotionAvailable || motionManager.isAccelerometerAvailable,
+            supportsHeading: CLLocationManager.headingAvailable(),
+            supportsCamera: UIImagePickerController.isSourceTypeAvailable(.camera),
+            supportsMicrophone: AVAudioSession.sharedInstance().isInputAvailable,
+            supportsHaptics: CHHapticEngine.capabilitiesForHardware().supportsHaptics,
+            supportsBarometer: CMAltimeter.isRelativeAltitudeAvailable(),
+            supportsLiDAR: ARWorldTrackingConfiguration.supportsSceneReconstruction(.mesh),
+            supportsApplePencil: false
+        )
+    }
+}

--- a/Tests/MatherTests/SensorCapabilityServiceTests.swift
+++ b/Tests/MatherTests/SensorCapabilityServiceTests.swift
@@ -1,0 +1,73 @@
+import Testing
+@testable import Mather
+
+@MainActor
+struct SensorCapabilityServiceTests {
+
+    @Test
+    func fixedInspectorReturnsInjectedCapabilities() {
+        let expected = DeviceSensorCapabilities(
+            supportsMotion: true,
+            supportsHeading: false,
+            supportsCamera: true,
+            supportsMicrophone: false,
+            supportsHaptics: true,
+            supportsBarometer: false,
+            supportsLiDAR: false,
+            supportsApplePencil: false
+        )
+        let service = SensorCapabilityService(inspector: FixedSensorCapabilityInspector(capabilities: expected))
+
+        #expect(service.currentCapabilities() == expected)
+    }
+
+    @Test
+    func unavailableFixtureReportsEveryCapabilityAsUnavailable() {
+        let service = SensorCapabilityService(inspector: FixedSensorCapabilityInspector(capabilities: .unavailable))
+
+        #expect(service.currentCapabilities() == .unavailable)
+    }
+
+    @Test
+    func currentCapabilitiesAsksInspectorOncePerRead() {
+        let inspector = CountingSensorCapabilityInspector(capabilities: .unavailable)
+        let service = SensorCapabilityService(inspector: inspector)
+
+        _ = service.currentCapabilities()
+        _ = service.currentCapabilities()
+
+        #expect(inspector.readCount == 2)
+    }
+
+    @Test
+    func systemInspectorIsCallableWithoutPermissionPrompts() {
+        let service = SensorCapabilityService()
+        let capabilities = service.currentCapabilities()
+
+        #expect(capabilities.supportsApplePencil == false)
+    }
+}
+
+@MainActor
+private struct FixedSensorCapabilityInspector: DeviceSensorCapabilityInspecting {
+    let capabilities: DeviceSensorCapabilities
+
+    func currentCapabilities() -> DeviceSensorCapabilities {
+        capabilities
+    }
+}
+
+@MainActor
+private final class CountingSensorCapabilityInspector: DeviceSensorCapabilityInspecting {
+    private(set) var readCount = 0
+    private let capabilities: DeviceSensorCapabilities
+
+    init(capabilities: DeviceSensorCapabilities) {
+        self.capabilities = capabilities
+    }
+
+    func currentCapabilities() -> DeviceSensorCapabilities {
+        readCount += 1
+        return capabilities
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -27,6 +27,8 @@ targets:
       - path: Features
       - path: Persistence
       - path: Services
+        includes:
+          - "**/*.swift"
       - path: Shared
     settings:
       base:
@@ -59,6 +61,8 @@ targets:
     platform: iOS
     sources:
       - path: Tests/MatherTests
+        includes:
+          - "**/*.swift"
     dependencies:
       - target: Mather
     settings:


### PR DESCRIPTION
## Scope
- Add `DeviceSensorCapabilities` as an immutable hardware capability snapshot for Explorer Lab sensor readiness.
- Add `SensorCapabilityService` with a default system inspector that checks motion, heading, camera, microphone, haptics, barometer, LiDAR readiness, and a conservative Apple Pencil placeholder.
- Add fixed/counting test inspectors and Swift Testing coverage for deterministic capability injection.
- Update `project.yml` source entries for the affected Swift source directories.

## Checks
- `git diff --check` passed.
- `xcodegen generate` could not run in this worker: `xcodegen: command not found`.
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO` could not run in this worker: `xcodebuild: command not found`.

## Simulator-Safety Notes
- Capability inspection only calls non-authorizing availability APIs.
- The service does not start motion, location, camera, microphone, scanner, or Room Quest flows.
- Apple Pencil support is reported conservatively as unavailable until a future lane defines runtime detection needs.

Part of #797