### PR TITLE
Issue #797: Add Explorer Lab capability foundation models

### DIFF
--- a/Domain/CapabilityLane.swift
+++ b/Domain/CapabilityLane.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// Stable identifiers for Explorer Lab capability lanes.
+enum CapabilityLaneID: String, CaseIterable, Codable, Hashable, Sendable {
+    case numbers
+    case geometry
+    case physics
+    case mapWorld
+    case discoveryCards
+    case chemistry
+    case electronics
+
+    var title: String {
+        switch self {
+        case .numbers:
+            return "Numbers Lab"
+        case .geometry:
+            return "Geometry Lab"
+        case .physics:
+            return "Physics Lab"
+        case .mapWorld:
+            return "Map & World Lab"
+        case .discoveryCards:
+            return "Discovery Cards"
+        case .chemistry:
+            return "Chemistry Lab"
+        case .electronics:
+            return "Electronics Lab"
+        }
+    }
+
+    var shortTitle: String {
+        switch self {
+        case .numbers:
+            return "Numbers"
+        case .geometry:
+            return "Geometry"
+        case .physics:
+            return "Physics"
+        case .mapWorld:
+            return "Map & World"
+        case .discoveryCards:
+            return "Discovery"
+        case .chemistry:
+            return "Chemistry"
+        case .electronics:
+            return "Electronics"
+        }
+    }
+}
+
+enum PlayMode: String, CaseIterable, Codable, Hashable, Sendable {
+    case learn = "Learn"
+    case explore = "Explore"
+    case challenge = "Challenge"
+    case timed = "Timed"
+    case review = "Review"
+}
+
+enum LaneStage: String, CaseIterable, Codable, Hashable, Sendable {
+    case concrete
+    case pictorial
+    case abstract
+    case recall
+    case quiz
+    case transfer
+    case summary
+
+    var displayName: String {
+        switch self {
+        case .concrete:
+            return "Concrete"
+        case .pictorial:
+            return "Pictorial"
+        case .abstract:
+            return "Abstract"
+        case .recall:
+            return "Recall"
+        case .quiz:
+            return "Quiz"
+        case .transfer:
+            return "Transfer"
+        case .summary:
+            return "Summary"
+        }
+    }
+}
+
+enum AgeBand: String, CaseIterable, Codable, Hashable, Sendable {
+    case preschool
+    case earlyElementary
+    case elementary
+    case mixed
+    case future
+
+    var displayName: String {
+        switch self {
+        case .preschool:
+            return "Ages 2-5"
+        case .earlyElementary:
+            return "Ages 4-7"
+        case .elementary:
+            return "Ages 6-12"
+        case .mixed:
+            return "Ages 4-12"
+        case .future:
+            return "Future lane"
+        }
+    }
+}
+
+/// Open-ended concept identifier for lane-specific content.
+///
+/// Keep this as a string wrapper so new concepts can be added in each lane
+/// without changing a central enum.
+struct ConceptId: RawRepresentable, Codable, Hashable, Sendable, ExpressibleByStringLiteral {
+    let rawValue: String
+
+    init(rawValue: String) {
+        precondition(!rawValue.isEmpty, "ConceptId should not be empty.")
+        self.rawValue = rawValue
+    }
+
+    init(stringLiteral value: StringLiteralType) {
+        self.init(rawValue: value)
+    }
+}
+
+extension ConceptId {
+    static func laneSpecific(_ lane: CapabilityLaneID, _ localID: String) -> ConceptId {
+        ConceptId(rawValue: "\(lane.rawValue).\(localID)")
+    }
+}

--- a/Domain/CapabilityModels.swift
+++ b/Domain/CapabilityModels.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+struct CapabilityLaneDescriptor: Identifiable, Equatable, Sendable {
+    let id: CapabilityLaneID
+    let symbolName: String
+    let ageBand: AgeBand
+    let promise: String
+    let defaultModes: [PlayMode]
+    let stages: [LaneStage]
+    let featuredConcepts: [ConceptId]
+    let isAvailable: Bool
+
+    var title: String { id.title }
+    var shortTitle: String { id.shortTitle }
+    var ageBandLabel: String { ageBand.displayName }
+
+    init(
+        id: CapabilityLaneID,
+        symbolName: String,
+        ageBand: AgeBand,
+        promise: String,
+        defaultModes: [PlayMode],
+        stages: [LaneStage],
+        featuredConcepts: [ConceptId],
+        isAvailable: Bool
+    ) {
+        self.id = id
+        self.symbolName = symbolName
+        self.ageBand = ageBand
+        self.promise = promise
+        self.defaultModes = defaultModes
+        self.stages = stages
+        self.featuredConcepts = featuredConcepts
+        self.isAvailable = isAvailable
+    }
+}
+
+struct CapabilityLaneRegistry: Equatable, Sendable {
+    let descriptors: [CapabilityLaneDescriptor]
+
+    init(descriptors: [CapabilityLaneDescriptor]) {
+        self.descriptors = descriptors
+    }
+
+    func descriptor(for laneID: CapabilityLaneID) -> CapabilityLaneDescriptor? {
+        descriptors.first { $0.id == laneID }
+    }
+}
+
+extension CapabilityLaneRegistry {
+    static let explorerLab = CapabilityLaneRegistry(descriptors: [
+        CapabilityLaneDescriptor(
+            id: .numbers,
+            symbolName: "number",
+            ageBand: .mixed,
+            promise: "Build number bonds, fast facts, arrays, and whole-part thinking.",
+            defaultModes: [.learn, .challenge, .timed, .review],
+            stages: [.concrete, .pictorial, .abstract, .recall, .quiz, .transfer, .summary],
+            featuredConcepts: [
+                .laneSpecific(.numbers, "number-bond"),
+                .laneSpecific(.numbers, "dot-pattern"),
+                .laneSpecific(.numbers, "array")
+            ],
+            isAvailable: true
+        ),
+        CapabilityLaneDescriptor(
+            id: .geometry,
+            symbolName: "ruler",
+            ageBand: .mixed,
+            promise: "Fold, measure, aim, and transform shapes with touch and motion.",
+            defaultModes: [.learn, .explore, .challenge, .review],
+            stages: [.concrete, .pictorial, .abstract, .recall, .quiz, .transfer, .summary],
+            featuredConcepts: [
+                .laneSpecific(.geometry, "shape"),
+                .laneSpecific(.geometry, "symmetry"),
+                .laneSpecific(.geometry, "angle")
+            ],
+            isAvailable: true
+        ),
+        CapabilityLaneDescriptor(
+            id: .physics,
+            symbolName: "atom",
+            ageBand: .mixed,
+            promise: "Predict motion, gravity, water, and cause-and-effect systems.",
+            defaultModes: [.explore, .challenge, .review],
+            stages: [.concrete, .pictorial, .recall, .quiz, .transfer, .summary],
+            featuredConcepts: [
+                .laneSpecific(.physics, "motion"),
+                .laneSpecific(.physics, "gravity"),
+                .laneSpecific(.physics, "water-cycle")
+            ],
+            isAvailable: true
+        ),
+        CapabilityLaneDescriptor(
+            id: .mapWorld,
+            symbolName: "map",
+            ageBand: .mixed,
+            promise: "Use rooms, compass turns, direction words, and route clues.",
+            defaultModes: [.explore, .challenge, .timed],
+            stages: [.concrete, .pictorial, .abstract, .recall, .quiz, .transfer, .summary],
+            featuredConcepts: [
+                .laneSpecific(.mapWorld, "direction"),
+                .laneSpecific(.mapWorld, "turn"),
+                .laneSpecific(.mapWorld, "route")
+            ],
+            isAvailable: true
+        ),
+        CapabilityLaneDescriptor(
+            id: .discoveryCards,
+            symbolName: "rectangle.on.rectangle",
+            ageBand: .mixed,
+            promise: "Practice names, pictures, categories, and Mix-Match recall.",
+            defaultModes: [.learn, .review, .challenge],
+            stages: [.pictorial, .recall, .quiz, .summary],
+            featuredConcepts: [
+                .laneSpecific(.discoveryCards, "category"),
+                .laneSpecific(.discoveryCards, "vocabulary"),
+                .laneSpecific(.discoveryCards, "world")
+            ],
+            isAvailable: true
+        ),
+        CapabilityLaneDescriptor(
+            id: .chemistry,
+            symbolName: "flask",
+            ageBand: .future,
+            promise: "Future: sort materials, mix safely, and predict properties.",
+            defaultModes: [.explore, .challenge, .review],
+            stages: [.concrete, .pictorial, .recall, .quiz, .summary],
+            featuredConcepts: [
+                .laneSpecific(.chemistry, "state"),
+                .laneSpecific(.chemistry, "property"),
+                .laneSpecific(.chemistry, "mixture")
+            ],
+            isAvailable: false
+        ),
+        CapabilityLaneDescriptor(
+            id: .electronics,
+            symbolName: "lightbulb",
+            ageBand: .future,
+            promise: "Future: switches, circuits, sensors, and input/output systems.",
+            defaultModes: [.explore, .challenge, .review],
+            stages: [.concrete, .pictorial, .abstract, .recall, .quiz, .summary],
+            featuredConcepts: [
+                .laneSpecific(.electronics, "component"),
+                .laneSpecific(.electronics, "circuit"),
+                .laneSpecific(.electronics, "sensor")
+            ],
+            isAvailable: false
+        ),
+    ])
+}

--- a/Domain/TimerChallengePolicy.swift
+++ b/Domain/TimerChallengePolicy.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+struct TimerChallengePolicy: Equatable, Sendable {
+    struct ChallengeGoal: Equatable, Sendable {
+        let targetCount: Int
+        let label: String
+
+        init(targetCount: Int, label: String) {
+            precondition(targetCount > 0, "Challenge goals should have a positive target.")
+            precondition(!label.isEmpty, "Challenge goals should have a label.")
+            self.targetCount = targetCount
+            self.label = label
+        }
+    }
+
+    let playMode: PlayMode
+    let timeLimitSeconds: Int?
+    let challengeGoal: ChallengeGoal?
+    let allowsPause: Bool
+    let childFacingLabel: String
+
+    var isTimed: Bool { timeLimitSeconds != nil }
+    var isChallenge: Bool { challengeGoal != nil }
+
+    init(
+        playMode: PlayMode,
+        timeLimitSeconds: Int? = nil,
+        challengeGoal: ChallengeGoal? = nil,
+        allowsPause: Bool = true,
+        childFacingLabel: String
+    ) {
+        if let timeLimitSeconds {
+            precondition(timeLimitSeconds > 0, "Timed policies should have a positive duration.")
+        }
+        precondition(!childFacingLabel.isEmpty, "Timer policy labels should not be empty.")
+
+        self.playMode = playMode
+        self.timeLimitSeconds = timeLimitSeconds
+        self.challengeGoal = challengeGoal
+        self.allowsPause = allowsPause
+        self.childFacingLabel = childFacingLabel
+    }
+}
+
+extension TimerChallengePolicy {
+    static let relaxed = TimerChallengePolicy(
+        playMode: .learn,
+        childFacingLabel: "Take your time"
+    )
+
+    static func challenge(targetCount: Int, label: String = "Try the set") -> TimerChallengePolicy {
+        TimerChallengePolicy(
+            playMode: .challenge,
+            challengeGoal: ChallengeGoal(targetCount: targetCount, label: label),
+            childFacingLabel: label
+        )
+    }
+
+    static func timed(seconds: Int, label: String = "Beat the clock") -> TimerChallengePolicy {
+        TimerChallengePolicy(
+            playMode: .timed,
+            timeLimitSeconds: seconds,
+            childFacingLabel: label
+        )
+    }
+
+    static func timedChallenge(
+        seconds: Int,
+        targetCount: Int,
+        label: String = "Try the sprint"
+    ) -> TimerChallengePolicy {
+        TimerChallengePolicy(
+            playMode: .timed,
+            timeLimitSeconds: seconds,
+            challengeGoal: ChallengeGoal(targetCount: targetCount, label: label),
+            childFacingLabel: label
+        )
+    }
+}

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -1,46 +1,5 @@
 import Foundation
 
-/// Top-level capability lanes used by Explorer Lab.
-///
-/// The lab intentionally groups activities by the capability a child is growing,
-/// instead of presenting every mini-game as an unrelated destination.
-enum CapabilityLaneID: String, CaseIterable, Hashable {
-    case numbers
-    case geometry
-    case physics
-    case mapWorld
-    case discoveryCards
-    case chemistry
-    case electronics
-
-    var title: String {
-        switch self {
-        case .numbers:
-            return "Numbers Lab"
-        case .geometry:
-            return "Geometry Lab"
-        case .physics:
-            return "Physics Lab"
-        case .mapWorld:
-            return "Map & World Lab"
-        case .discoveryCards:
-            return "Discovery Cards"
-        case .chemistry:
-            return "Chemistry Lab"
-        case .electronics:
-            return "Electronics Lab"
-        }
-    }
-}
-
-enum PlayMode: String, CaseIterable, Hashable {
-    case learn = "Learn"
-    case explore = "Explore"
-    case challenge = "Challenge"
-    case timed = "Timed"
-    case review = "Review"
-}
-
 
 struct MixMatchCard: Identifiable, Equatable {
     var id: String { "\(laneID.rawValue)-\(concept)-\(prompt)" }

--- a/Tests/MatherTests/CapabilityLaneTests.swift
+++ b/Tests/MatherTests/CapabilityLaneTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import Mather
+
+final class CapabilityLaneTests: XCTestCase {
+    func testAllCapabilityLaneIDsHaveDisplayMetadata() throws {
+        XCTAssertEqual(
+            CapabilityLaneID.allCases,
+            [.numbers, .geometry, .physics, .mapWorld, .discoveryCards, .chemistry, .electronics]
+        )
+
+        let registry = CapabilityLaneRegistry.explorerLab
+        XCTAssertEqual(registry.descriptors.map(\.id), CapabilityLaneID.allCases)
+
+        for laneID in CapabilityLaneID.allCases {
+            let descriptor = try XCTUnwrap(registry.descriptor(for: laneID))
+            XCTAssertFalse(descriptor.title.isEmpty)
+            XCTAssertFalse(descriptor.shortTitle.isEmpty)
+            XCTAssertFalse(descriptor.symbolName.isEmpty)
+            XCTAssertFalse(descriptor.promise.isEmpty)
+            XCTAssertFalse(descriptor.ageBandLabel.isEmpty)
+            XCTAssertFalse(descriptor.defaultModes.isEmpty)
+            XCTAssertFalse(descriptor.stages.isEmpty)
+            XCTAssertFalse(descriptor.featuredConcepts.isEmpty)
+        }
+    }
+
+    func testSharedModeAndStageCasesAreComplete() {
+        XCTAssertEqual(PlayMode.allCases, [.learn, .explore, .challenge, .timed, .review])
+        XCTAssertEqual(
+            LaneStage.allCases,
+            [.concrete, .pictorial, .abstract, .recall, .quiz, .transfer, .summary]
+        )
+    }
+
+    func testConceptIdSupportsLaneSpecificStrings() {
+        let numberBond: ConceptId = .laneSpecific(.numbers, "number-bond")
+        let customElectronicsConcept = ConceptId(rawValue: "electronics.resistor-color")
+
+        XCTAssertEqual(numberBond.rawValue, "numbers.number-bond")
+        XCTAssertEqual(customElectronicsConcept.rawValue, "electronics.resistor-color")
+    }
+
+    func testFutureLanesArePresentInMetadataRegistry() throws {
+        let registry = CapabilityLaneRegistry.explorerLab
+        let chemistry = try XCTUnwrap(registry.descriptor(for: .chemistry))
+        let electronics = try XCTUnwrap(registry.descriptor(for: .electronics))
+
+        XCTAssertEqual(chemistry.ageBand, .future)
+        XCTAssertEqual(electronics.ageBand, .future)
+        XCTAssertFalse(chemistry.isAvailable)
+        XCTAssertFalse(electronics.isAvailable)
+    }
+}

--- a/Tests/MatherTests/TimerChallengePolicyTests.swift
+++ b/Tests/MatherTests/TimerChallengePolicyTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Mather
+
+final class TimerChallengePolicyTests: XCTestCase {
+    func testRelaxedPolicyHasNoTimerOrChallengeGoal() {
+        let policy = TimerChallengePolicy.relaxed
+
+        XCTAssertEqual(policy.playMode, .learn)
+        XCTAssertFalse(policy.isTimed)
+        XCTAssertFalse(policy.isChallenge)
+        XCTAssertNil(policy.timeLimitSeconds)
+        XCTAssertNil(policy.challengeGoal)
+        XCTAssertEqual(policy.childFacingLabel, "Take your time")
+    }
+
+    func testTimedAndChallengePoliciesCanBeOptionalOrCombined() throws {
+        let timed = TimerChallengePolicy.timed(seconds: 60)
+        let challenge = TimerChallengePolicy.challenge(targetCount: 8, label: "Try eight")
+        let combined = TimerChallengePolicy.timedChallenge(seconds: 90, targetCount: 10)
+
+        XCTAssertTrue(timed.isTimed)
+        XCTAssertFalse(timed.isChallenge)
+        XCTAssertEqual(timed.timeLimitSeconds, 60)
+
+        XCTAssertFalse(challenge.isTimed)
+        XCTAssertTrue(challenge.isChallenge)
+        XCTAssertEqual(try XCTUnwrap(challenge.challengeGoal).targetCount, 8)
+
+        XCTAssertTrue(combined.isTimed)
+        XCTAssertTrue(combined.isChallenge)
+        XCTAssertEqual(combined.timeLimitSeconds, 90)
+        XCTAssertEqual(try XCTUnwrap(combined.challengeGoal).targetCount, 10)
+    }
+
+    func testDefaultPolicyLabelsAvoidShameLanguage() {
+        let labels = [
+            TimerChallengePolicy.relaxed.childFacingLabel,
+            TimerChallengePolicy.challenge(targetCount: 5).childFacingLabel,
+            TimerChallengePolicy.timed(seconds: 30).childFacingLabel,
+            TimerChallengePolicy.timedChallenge(seconds: 45, targetCount: 6).childFacingLabel,
+        ]
+        let shameWords = ["fail", "failed", "wrong", "slow", "bad", "mistake", "missed", "lost"]
+
+        for label in labels {
+            let lowercased = label.lowercased()
+            XCTAssertFalse(
+                shameWords.contains { lowercased.contains($0) },
+                "\(label) should avoid shame language"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Scope
- Added shared Explorer Lab lane identifiers, play modes, lane stages, age bands, and open-ended `ConceptId` string wrapper.
- Added metadata-only `CapabilityLaneDescriptor` and `CapabilityLaneRegistry.explorerLab` for all lanes, including Chemistry and Electronics.
- Added `TimerChallengePolicy` for optional relaxed, challenge, timed, and timed challenge modes with positive child-facing labels.
- Moved Lab-specific models to reuse shared `CapabilityLaneID` and `PlayMode` definitions.

## Tests
- Added `CapabilityLaneTests` for lane metadata, mode/stage coverage, future lanes, and lane-specific concept IDs.
- Added `TimerChallengePolicyTests` for optional timed/challenge behavior and shame-language checks.
- `git diff --check` passed.
- Local Swift/Xcode validation blocked: this worker image does not have `xcodegen`, `xcodebuild`, `swift`, or `swiftc` installed (`command not found`).

## Dependencies
- Depends on: none.
- Blocks: F2/F4/F5, lane workers, and timer/challenge integration that need the shared capability spine.

## Coordinator Update
- Issue #797 coordinator update will be posted after PR creation with the standard template.