### PR TITLE
Issue #797 I5: Add Smart Play provider stub

### DIFF
--- a/Services/SmartPlayProvider.swift
+++ b/Services/SmartPlayProvider.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+enum SmartPlayPromptKind: String, Equatable, Sendable {
+    case hint
+    case story
+    case review
+}
+
+enum SmartPlayPromptSource: Equatable, Sendable {
+    case curatedFallback
+}
+
+struct SmartPlayPrompt: Equatable, Sendable {
+    let kind: SmartPlayPromptKind
+    let spokenText: String
+    let source: SmartPlayPromptSource
+}
+
+struct SmartPlayActivityContext: Equatable, Sendable {
+    let laneID: String
+    let activityID: String
+    let stageID: String?
+    let goal: String
+    let problemText: String?
+    let themeID: String?
+
+    init(
+        laneID: String,
+        activityID: String,
+        stageID: String? = nil,
+        goal: String,
+        problemText: String? = nil,
+        themeID: String? = nil
+    ) {
+        self.laneID = laneID
+        self.activityID = activityID
+        self.stageID = stageID
+        self.goal = goal
+        self.problemText = problemText
+        self.themeID = themeID
+    }
+}
+
+struct SmartPlayHintRequest: Equatable, Sendable {
+    let context: SmartPlayActivityContext
+    let attemptSummary: String?
+
+    init(context: SmartPlayActivityContext, attemptSummary: String? = nil) {
+        self.context = context
+        self.attemptSummary = attemptSummary
+    }
+}
+
+struct SmartPlayStoryRequest: Equatable, Sendable {
+    let context: SmartPlayActivityContext
+    let storySeed: String?
+
+    init(context: SmartPlayActivityContext, storySeed: String? = nil) {
+        self.context = context
+        self.storySeed = storySeed
+    }
+}
+
+struct SmartPlayReviewPromptRequest: Equatable, Sendable {
+    let context: SmartPlayActivityContext
+    let completedSkillSummary: String?
+
+    init(context: SmartPlayActivityContext, completedSkillSummary: String? = nil) {
+        self.context = context
+        self.completedSkillSummary = completedSkillSummary
+    }
+}
+
+enum SmartPlayRequest: Equatable, Sendable {
+    case hint(SmartPlayHintRequest)
+    case story(SmartPlayStoryRequest)
+    case reviewPrompt(SmartPlayReviewPromptRequest)
+}
+
+protocol SmartPlayProvider: Sendable {
+    func prompt(for request: SmartPlayRequest) async -> SmartPlayPrompt
+}
+
+struct CuratedSmartPlayProvider: SmartPlayProvider {
+    func prompt(for request: SmartPlayRequest) async -> SmartPlayPrompt {
+        switch request {
+        case let .hint(request):
+            SmartPlayPrompt(
+                kind: .hint,
+                spokenText: hintText(for: request),
+                source: .curatedFallback
+            )
+        case let .story(request):
+            SmartPlayPrompt(
+                kind: .story,
+                spokenText: storyText(for: request),
+                source: .curatedFallback
+            )
+        case let .reviewPrompt(request):
+            SmartPlayPrompt(
+                kind: .review,
+                spokenText: reviewText(for: request),
+                source: .curatedFallback
+            )
+        }
+    }
+
+    private func hintText(for request: SmartPlayHintRequest) -> String {
+        let goal = clean(request.context.goal)
+        if let problemText = cleanOptional(request.context.problemText) {
+            return "Try one careful move for \(problemText). Then check how it helps with \(goal)."
+        }
+        return "Try one careful move. Then check how it helps with \(goal)."
+    }
+
+    private func storyText(for request: SmartPlayStoryRequest) -> String {
+        let goal = clean(request.context.goal)
+        if let theme = cleanOptional(request.context.themeID) {
+            return "Here is a \(theme) story. We are exploring \(goal) with calm, careful choices."
+        }
+        return "Here is a learning story. We are exploring \(goal) with calm, careful choices."
+    }
+
+    private func reviewText(for request: SmartPlayReviewPromptRequest) -> String {
+        if let summary = cleanOptional(request.completedSkillSummary) {
+            return "Show that idea one more way: \(summary). Say what stayed the same."
+        }
+        let goal = clean(request.context.goal)
+        return "Show \(goal) one more way. Say what stayed the same."
+    }
+
+    private func cleanOptional(_ text: String?) -> String? {
+        guard let cleaned = text.map(clean), !cleaned.isEmpty else { return nil }
+        return cleaned
+    }
+
+    private func clean(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Tests/MatherTests/SmartPlayProviderTests.swift
+++ b/Tests/MatherTests/SmartPlayProviderTests.swift
@@ -1,0 +1,121 @@
+import Testing
+@testable import Mather
+
+struct SmartPlayProviderTests {
+    @Test
+    func curatedProviderReturnsDeterministicHint() async {
+        let provider: any SmartPlayProvider = CuratedSmartPlayProvider()
+        let request = SmartPlayRequest.hint(SmartPlayHintRequest(
+            context: SmartPlayActivityContext(
+                laneID: "numbers",
+                activityID: "make-break",
+                stageID: "concrete",
+                goal: "making 10",
+                problemText: "6 and 4"
+            ),
+            attemptSummary: "moved six counters"
+        ))
+
+        let first = await provider.prompt(for: request)
+        let second = await provider.prompt(for: request)
+
+        #expect(first == second)
+        #expect(first.kind == .hint)
+        #expect(first.source == .curatedFallback)
+        #expect(first.spokenText == "Try one careful move for 6 and 4. Then check how it helps with making 10.")
+    }
+
+    @Test
+    func curatedProviderSupportsStoryRequests() async {
+        let provider = CuratedSmartPlayProvider()
+        let request = SmartPlayRequest.story(SmartPlayStoryRequest(
+            context: SmartPlayActivityContext(
+                laneID: "geometry",
+                activityID: "symmetry-fold",
+                goal: "matching two equal halves",
+                themeID: "paper garden"
+            ),
+            storySeed: "butterfly"
+        ))
+
+        let prompt = await provider.prompt(for: request)
+
+        #expect(prompt.kind == .story)
+        #expect(prompt.source == .curatedFallback)
+        #expect(prompt.spokenText == "Here is a paper garden story. We are exploring matching two equal halves with calm, careful choices.")
+    }
+
+    @Test
+    func curatedProviderSupportsReviewPromptRequests() async {
+        let provider = CuratedSmartPlayProvider()
+        let request = SmartPlayRequest.reviewPrompt(SmartPlayReviewPromptRequest(
+            context: SmartPlayActivityContext(
+                laneID: "physics",
+                activityID: "gravity-artist",
+                goal: "predicting tilt direction"
+            ),
+            completedSkillSummary: "tilt changed the path"
+        ))
+
+        let prompt = await provider.prompt(for: request)
+
+        #expect(prompt.kind == .review)
+        #expect(prompt.source == .curatedFallback)
+        #expect(prompt.spokenText == "Show that idea one more way: tilt changed the path. Say what stayed the same.")
+    }
+
+    @Test
+    func curatedProviderCleansRequestTextWithoutChangingPrivacyBoundary() async {
+        let provider = CuratedSmartPlayProvider()
+        let request = SmartPlayRequest.hint(SmartPlayHintRequest(
+            context: SmartPlayActivityContext(
+                laneID: "numbers",
+                activityID: "bond-blast",
+                goal: "finding partners\nfor 10",
+                problemText: "  7   and   3  "
+            )
+        ))
+
+        let prompt = await provider.prompt(for: request)
+
+        #expect(prompt.spokenText == "Try one careful move for 7 and 3. Then check how it helps with finding partners for 10.")
+    }
+
+    @Test
+    func curatedProviderTextAvoidsPressureAndNetworkClaims() async {
+        let provider = CuratedSmartPlayProvider()
+        let context = SmartPlayActivityContext(
+            laneID: "numbers",
+            activityID: "make-break",
+            goal: "making 10",
+            problemText: "8 and 2",
+            themeID: "space"
+        )
+        let prompts = [
+            await provider.prompt(for: .hint(SmartPlayHintRequest(context: context))),
+            await provider.prompt(for: .story(SmartPlayStoryRequest(context: context))),
+            await provider.prompt(for: .reviewPrompt(SmartPlayReviewPromptRequest(context: context)))
+        ]
+        let bannedTerms = [
+            "ai",
+            "chatgpt",
+            "network",
+            "internet",
+            "timer",
+            "hurry",
+            "race",
+            "wrong",
+            "lose",
+            "lost",
+            "scary",
+            "danger"
+        ]
+
+        for prompt in prompts {
+            let text = prompt.spokenText.lowercased()
+            for term in bannedTerms {
+                #expect(!text.contains(term))
+            }
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -26,6 +26,7 @@ targets:
       - path: Domain
       - path: Features
       - path: Persistence
+      # Directory source includes SmartPlayProvider.swift.
       - path: Services
       - path: Shared
     settings:
@@ -58,6 +59,7 @@ targets:
     type: bundle.unit-test
     platform: iOS
     sources:
+      # Directory source includes SmartPlayProviderTests.swift.
       - path: Tests/MatherTests
     dependencies:
       - target: Mather


### PR DESCRIPTION
## Scope
- Add a `SmartPlayProvider` protocol for hint, story, and review prompt requests.
- Add `SmartPlayActivityContext` plus specific request/response models for those prompt types.
- Add `CuratedSmartPlayProvider` as a deterministic, local fallback with safe spoken text.
- Add Swift Testing coverage proving deterministic fallback behavior through the protocol.

## Checks
- `git diff --check`
- `git diff --cached --check`
- Not run: `xcodegen generate` and `xcodebuild test` because neither `xcodegen` nor `xcodebuild` is installed in this Linux worktree.

## Future Extension Points
- Add a gated on-device FoundationModels adapter in a separate PR without changing lane call sites.
- Inject lane/card-specific context models once the Explorer Lab lane architecture lands.
- Keep deterministic curated output as the fallback and source of truth for child-facing flows.

Part of #797