### PR TITLE
Issue #797 F1: Add capability spine models

### DIFF
--- a/Domain/CapabilityLane.swift
+++ b/Domain/CapabilityLane.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Top-level capability lanes used by Explorer Lab.
+///
+/// The lab groups activities by the capability a child is growing instead of
+/// presenting every mini-game as an unrelated destination.
+enum CapabilityLaneID: String, CaseIterable, Codable, Hashable, Identifiable {
+    case numbers
+    case geometry
+    case physics
+    case mapWorld
+    case discoveryCards
+    case chemistry
+    case electronics
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .numbers:
+            return "Numbers Lab"
+        case .geometry:
+            return "Geometry Lab"
+        case .physics:
+            return "Physics Lab"
+        case .mapWorld:
+            return "Map & World Lab"
+        case .discoveryCards:
+            return "Discovery Cards"
+        case .chemistry:
+            return "Chemistry Lab"
+        case .electronics:
+            return "Electronics Lab"
+        }
+    }
+}
+
+enum PlayMode: String, CaseIterable, Codable, Hashable, Identifiable {
+    case learn = "Learn"
+    case explore = "Explore"
+    case challenge = "Challenge"
+    case timed = "Timed"
+    case review = "Review"
+
+    var id: String { rawValue }
+}
+
+enum LaneStage: String, CaseIterable, Codable, Hashable, Identifiable {
+    case concrete
+    case pictorial
+    case abstract
+    case transfer
+    case review
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .concrete:
+            return "Concrete"
+        case .pictorial:
+            return "Pictorial"
+        case .abstract:
+            return "Abstract"
+        case .transfer:
+            return "Transfer"
+        case .review:
+            return "Review"
+        }
+    }
+}
+
+enum AgeBand: String, CaseIterable, Codable, Hashable, Identifiable {
+    case ages2To12
+    case ages4To12
+    case future
+
+    var id: String { rawValue }
+
+    var displayLabel: String {
+        switch self {
+        case .ages2To12:
+            return "Ages 2-12"
+        case .ages4To12:
+            return "Ages 4-12"
+        case .future:
+            return "Future lane"
+        }
+    }
+}
+
+struct ConceptId: RawRepresentable, ExpressibleByStringLiteral, Codable, Hashable, Identifiable {
+    let rawValue: String
+
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    init(stringLiteral value: String) {
+        self.init(rawValue: value)
+    }
+
+    var id: String { rawValue }
+}
+

--- a/Domain/CapabilityModels.swift
+++ b/Domain/CapabilityModels.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+struct CapabilityLaneDescriptor: Identifiable, Equatable {
+    let id: CapabilityLaneID
+    let emoji: String
+    let promise: String
+    let ageBand: AgeBand
+    let stages: [LaneStage]
+    let supportedPlayModes: [PlayMode]
+    let starterConcepts: [ConceptId]
+
+    var title: String { id.title }
+    var ageBandHint: String { ageBand.displayLabel }
+}
+
+enum CapabilityLaneRegistry {
+    static let all: [CapabilityLaneDescriptor] = [
+        CapabilityLaneDescriptor(
+            id: .numbers,
+            emoji: "🔢",
+            promise: "Build number bonds, fast facts, arrays, and whole-part thinking.",
+            ageBand: .ages4To12,
+            stages: [.concrete, .pictorial, .abstract, .transfer, .review],
+            supportedPlayModes: [.learn, .challenge, .timed, .review],
+            starterConcepts: ["number-bond", "dot-pattern", "array", "factor-pair", "story-equation"]
+        ),
+        CapabilityLaneDescriptor(
+            id: .geometry,
+            emoji: "📐",
+            promise: "Fold, measure, aim, and transform shapes with touch and motion.",
+            ageBand: .ages4To12,
+            stages: [.concrete, .pictorial, .abstract, .transfer, .review],
+            supportedPlayModes: [.learn, .explore, .challenge, .review],
+            starterConcepts: ["shape", "symmetry", "angle", "array-shape", "transformation"]
+        ),
+        CapabilityLaneDescriptor(
+            id: .physics,
+            emoji: "🧪",
+            promise: "Predict motion, gravity, water, and cause-and-effect systems.",
+            ageBand: .ages2To12,
+            stages: [.concrete, .pictorial, .transfer, .review],
+            supportedPlayModes: [.explore, .challenge, .review],
+            starterConcepts: ["motion", "gravity", "prediction", "water-cycle", "float-sink", "balance"]
+        ),
+        CapabilityLaneDescriptor(
+            id: .mapWorld,
+            emoji: "🗺️",
+            promise: "Use rooms, compass turns, direction words, and route clues.",
+            ageBand: .ages4To12,
+            stages: [.concrete, .pictorial, .abstract, .transfer],
+            supportedPlayModes: [.explore, .challenge, .timed],
+            starterConcepts: ["direction", "turn", "route", "map-symbol", "scale", "compass"]
+        ),
+        CapabilityLaneDescriptor(
+            id: .discoveryCards,
+            emoji: "🃏",
+            promise: "Practice names, pictures, categories, and Mix-Match recall.",
+            ageBand: .ages2To12,
+            stages: [.pictorial, .abstract, .review],
+            supportedPlayModes: [.learn, .review, .challenge],
+            starterConcepts: ["animal", "habitat", "category", "body", "world", "vocabulary"]
+        ),
+        CapabilityLaneDescriptor(
+            id: .chemistry,
+            emoji: "⚗️",
+            promise: "Future: sort materials, mix safely, and predict properties.",
+            ageBand: .future,
+            stages: [.concrete, .pictorial, .transfer, .review],
+            supportedPlayModes: [.explore, .challenge, .review],
+            starterConcepts: ["state", "property", "mixture", "safety"]
+        ),
+        CapabilityLaneDescriptor(
+            id: .electronics,
+            emoji: "💡",
+            promise: "Future: switches, circuits, sensors, and input/output systems.",
+            ageBand: .future,
+            stages: [.concrete, .pictorial, .abstract, .transfer, .review],
+            supportedPlayModes: [.explore, .challenge, .review],
+            starterConcepts: ["component", "output", "circuit", "sensor", "logic"]
+        ),
+    ]
+
+    static func descriptor(for laneID: CapabilityLaneID) -> CapabilityLaneDescriptor? {
+        all.first { $0.id == laneID }
+    }
+}
+

--- a/Domain/TimerChallengePolicy.swift
+++ b/Domain/TimerChallengePolicy.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+struct TimerChallengePolicy: Equatable {
+    let playMode: PlayMode
+    let timerSeconds: Int?
+    let startPrompt: String
+    let activeTimerLabel: String?
+    let completionMessage: String
+    let timeExpiredMessage: String?
+
+    var usesTimer: Bool {
+        timerSeconds != nil
+    }
+
+    static func policy(for playMode: PlayMode) -> TimerChallengePolicy {
+        switch playMode {
+        case .learn:
+            return TimerChallengePolicy(
+                playMode: playMode,
+                timerSeconds: nil,
+                startPrompt: "Build at your own pace.",
+                activeTimerLabel: nil,
+                completionMessage: "Nice thinking.",
+                timeExpiredMessage: nil
+            )
+        case .explore:
+            return TimerChallengePolicy(
+                playMode: playMode,
+                timerSeconds: nil,
+                startPrompt: "Try ideas and see what happens.",
+                activeTimerLabel: nil,
+                completionMessage: "You explored the pattern.",
+                timeExpiredMessage: nil
+            )
+        case .challenge:
+            return TimerChallengePolicy(
+                playMode: playMode,
+                timerSeconds: nil,
+                startPrompt: "Try the challenge when you are ready.",
+                activeTimerLabel: nil,
+                completionMessage: "Challenge complete.",
+                timeExpiredMessage: nil
+            )
+        case .timed:
+            return TimerChallengePolicy(
+                playMode: playMode,
+                timerSeconds: 60,
+                startPrompt: "Tap when ready. The clock starts after your tap.",
+                activeTimerLabel: "Time left",
+                completionMessage: "Round complete.",
+                timeExpiredMessage: "Time is up. Take a breath and try another round."
+            )
+        case .review:
+            return TimerChallengePolicy(
+                playMode: playMode,
+                timerSeconds: nil,
+                startPrompt: "Review a few cards.",
+                activeTimerLabel: nil,
+                completionMessage: "Review complete.",
+                timeExpiredMessage: nil
+            )
+        }
+    }
+}
+

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -1,47 +1,5 @@
 import Foundation
 
-/// Top-level capability lanes used by Explorer Lab.
-///
-/// The lab intentionally groups activities by the capability a child is growing,
-/// instead of presenting every mini-game as an unrelated destination.
-enum CapabilityLaneID: String, CaseIterable, Hashable {
-    case numbers
-    case geometry
-    case physics
-    case mapWorld
-    case discoveryCards
-    case chemistry
-    case electronics
-
-    var title: String {
-        switch self {
-        case .numbers:
-            return "Numbers Lab"
-        case .geometry:
-            return "Geometry Lab"
-        case .physics:
-            return "Physics Lab"
-        case .mapWorld:
-            return "Map & World Lab"
-        case .discoveryCards:
-            return "Discovery Cards"
-        case .chemistry:
-            return "Chemistry Lab"
-        case .electronics:
-            return "Electronics Lab"
-        }
-    }
-}
-
-enum PlayMode: String, CaseIterable, Hashable {
-    case learn = "Learn"
-    case explore = "Explore"
-    case challenge = "Challenge"
-    case timed = "Timed"
-    case review = "Review"
-}
-
-
 struct MixMatchCard: Identifiable, Equatable {
     var id: String { "\(laneID.rawValue)-\(concept)-\(prompt)" }
     let laneID: CapabilityLaneID

--- a/Tests/MatherTests/CapabilityLaneTests.swift
+++ b/Tests/MatherTests/CapabilityLaneTests.swift
@@ -1,0 +1,51 @@
+import Testing
+@testable import Mather
+
+struct CapabilityLaneTests {
+    @Test
+    func registryContainsEveryExplorerLaneInDisplayOrder() {
+        #expect(CapabilityLaneRegistry.all.map(\.id) == [
+            .numbers,
+            .geometry,
+            .physics,
+            .mapWorld,
+            .discoveryCards,
+            .chemistry,
+            .electronics,
+        ])
+    }
+
+    @Test
+    func everyLaneHasCompleteDisplayMetadata() {
+        #expect(CapabilityLaneRegistry.all.count == CapabilityLaneID.allCases.count)
+
+        for descriptor in CapabilityLaneRegistry.all {
+            #expect(!descriptor.title.isEmpty)
+            #expect(!descriptor.emoji.isEmpty)
+            #expect(!descriptor.promise.isEmpty)
+            #expect(!descriptor.ageBandHint.isEmpty)
+            #expect(!descriptor.stages.isEmpty)
+            #expect(!descriptor.supportedPlayModes.isEmpty)
+            #expect(!descriptor.starterConcepts.isEmpty)
+        }
+    }
+
+    @Test
+    func registryCoversAllPlayModes() {
+        let supportedModes = Set(CapabilityLaneRegistry.all.flatMap(\.supportedPlayModes))
+
+        #expect(supportedModes == Set(PlayMode.allCases))
+    }
+
+    @Test
+    func laneIdentifiersExposeExpectedTitles() {
+        #expect(CapabilityLaneID.numbers.title == "Numbers Lab")
+        #expect(CapabilityLaneID.geometry.title == "Geometry Lab")
+        #expect(CapabilityLaneID.physics.title == "Physics Lab")
+        #expect(CapabilityLaneID.mapWorld.title == "Map & World Lab")
+        #expect(CapabilityLaneID.discoveryCards.title == "Discovery Cards")
+        #expect(CapabilityLaneID.chemistry.title == "Chemistry Lab")
+        #expect(CapabilityLaneID.electronics.title == "Electronics Lab")
+    }
+}
+

--- a/Tests/MatherTests/TimerChallengePolicyTests.swift
+++ b/Tests/MatherTests/TimerChallengePolicyTests.swift
@@ -1,0 +1,60 @@
+import Testing
+@testable import Mather
+
+struct TimerChallengePolicyTests {
+    @Test
+    func timedPolicyUsesOptInCountdown() {
+        let policy = TimerChallengePolicy.policy(for: .timed)
+
+        #expect(policy.usesTimer)
+        #expect(policy.timerSeconds == 60)
+        #expect(policy.startPrompt.contains("Tap when ready"))
+        #expect(policy.activeTimerLabel == "Time left")
+        #expect(policy.timeExpiredMessage != nil)
+    }
+
+    @Test
+    func nonTimedModesDoNotUseCountdowns() {
+        for mode in PlayMode.allCases where mode != .timed {
+            let policy = TimerChallengePolicy.policy(for: mode)
+
+            #expect(!policy.usesTimer)
+            #expect(policy.timerSeconds == nil)
+            #expect(policy.activeTimerLabel == nil)
+            #expect(policy.timeExpiredMessage == nil)
+        }
+    }
+
+    @Test
+    func policyCopyAvoidsShameAndPressureLanguage() {
+        let blockedTerms = [
+            "shame",
+            "fail",
+            "failed",
+            "wrong",
+            "lose",
+            "lost",
+            "hurry",
+            "punish",
+            "punishment",
+        ]
+
+        for mode in PlayMode.allCases {
+            let policy = TimerChallengePolicy.policy(for: mode)
+            let text = [
+                policy.startPrompt,
+                policy.activeTimerLabel,
+                policy.completionMessage,
+                policy.timeExpiredMessage,
+            ]
+            .compactMap { $0 }
+            .joined(separator: " ")
+            .lowercased()
+
+            for term in blockedTerms {
+                #expect(!text.contains(term))
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Scope
- Added shared capability lane identifiers, play modes, lane stages, age bands, and concept identifiers in `Domain`.
- Added metadata-only capability lane descriptors and registry covering all seven Explorer Lab lanes, including chemistry and electronics.
- Added timer/challenge policy copy for each play mode with opt-in timed behavior only for Timed mode.
- Kept existing Lab UI behavior intact by moving shared lane/play mode identifiers out of `Features/Lab/LabModels.swift`.

## Tests/Checks
- Added `CapabilityLaneTests` for lane order, metadata completeness, all play modes, and display titles.
- Added `TimerChallengePolicyTests` for timed/non-timed policy behavior and shame/pressure language guards.
- Ran `git diff --check`.
- Could not run `xcodegen generate` or `xcodebuild test` because this Linux host does not have `xcodegen`, `xcodebuild`, or `swift` on `PATH`.

Part of #797