### PR TITLE
Add child-choice mode cards to Explorer Lab lanes

### DIFF
--- a/Domain/TimerChallengePolicy.swift
+++ b/Domain/TimerChallengePolicy.swift
@@ -1,5 +1,24 @@
 import Foundation
 
+
+struct PlayModeChoiceCard: Identifiable, Equatable {
+    let mode: PlayMode
+    let title: String
+    let flavor: String
+    let detail: String
+    let policy: TimerChallengePolicy
+
+    var id: PlayMode { mode }
+
+    var summaryLabel: String {
+        "\(title): \(flavor)"
+    }
+
+    var accessibilityLabel: String {
+        "\(title). \(flavor). \(detail)"
+    }
+}
+
 struct TimerChallengePolicy: Equatable {
     let playMode: PlayMode
     let timerSeconds: Int?
@@ -10,6 +29,55 @@ struct TimerChallengePolicy: Equatable {
 
     var usesTimer: Bool {
         timerSeconds != nil
+    }
+
+    var choiceCard: PlayModeChoiceCard {
+        switch playMode {
+        case .learn:
+            return PlayModeChoiceCard(
+                mode: playMode,
+                title: "Learn",
+                flavor: "calm build",
+                detail: "Build at your own pace with hints ready.",
+                policy: self
+            )
+        case .explore:
+            return PlayModeChoiceCard(
+                mode: playMode,
+                title: "Explore",
+                flavor: "try ideas",
+                detail: "Move pieces, sensors, or cards and notice what changes.",
+                policy: self
+            )
+        case .challenge:
+            return PlayModeChoiceCard(
+                mode: playMode,
+                title: "Challenge",
+                flavor: "tricky puzzle",
+                detail: "Pick a goal when you feel ready.",
+                policy: self
+            )
+        case .timed:
+            return PlayModeChoiceCard(
+                mode: playMode,
+                title: "Timed",
+                flavor: "rocket round",
+                detail: "Start the clock only after you choose it.",
+                policy: self
+            )
+        case .review:
+            return PlayModeChoiceCard(
+                mode: playMode,
+                title: "Review",
+                flavor: "memory boost",
+                detail: "Bring back cards and ideas you have seen before.",
+                policy: self
+            )
+        }
+    }
+
+    static func choiceCards(for modes: [PlayMode]) -> [PlayModeChoiceCard] {
+        modes.map { policy(for: $0).choiceCard }
     }
 
     static func policy(for playMode: PlayMode) -> TimerChallengePolicy {

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -180,6 +180,14 @@ struct CapabilityLane: Identifiable, Equatable {
         ageEntries.prefix(2).map(\.summaryLabel).joined(separator: " • ")
     }
 
+    var modeChoiceCards: [PlayModeChoiceCard] {
+        TimerChallengePolicy.choiceCards(for: modes)
+    }
+
+    var modeChoicePreviewLabel: String {
+        modeChoiceCards.prefix(2).map(\.summaryLabel).joined(separator: " • ")
+    }
+
     var starterMixMatchCards: [MixMatchCard] {
         Self.starterMixMatchCardsByLane[id, default: []]
     }

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -85,6 +85,7 @@ struct LabView: View {
             }
 
             modeChips(lane.modes, tint: laneColor(lane.id))
+            modeChoicePreview(lane, tint: laneColor(lane.id))
             ageEntryPreview(lane, tint: laneColor(lane.id))
             progressPreview(lane.emptyProgress, tint: laneColor(lane.id))
             recallPreview(lane, tint: laneColor(lane.id))
@@ -121,6 +122,35 @@ struct LabView: View {
         )
         .accessibilityElement(children: .contain)
         .accessibilityLabel(lane.title)
+    }
+
+    private func modeChoicePreview(_ lane: CapabilityLane, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("Choose your play style", systemImage: "slider.horizontal.3")
+                .font(.caption.weight(.black))
+                .foregroundStyle(tint)
+            ForEach(lane.modeChoiceCards.prefix(3)) { card in
+                HStack(spacing: 6) {
+                    Text(card.title)
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text(card.flavor)
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                    Spacer(minLength: 0)
+                    if card.policy.usesTimer {
+                        Text("opt-in timer")
+                            .font(.caption2.weight(.black))
+                            .foregroundStyle(tint)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(MatherTheme.panel.opacity(0.58), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(lane.title) play styles: \(lane.modeChoicePreviewLabel)")
     }
 
     private func ageEntryPreview(_ lane: CapabilityLane, tint: Color) -> some View {

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -37,6 +37,14 @@ final class LabModelsTests: XCTestCase {
         XCTAssertTrue(physics.ageEntryPreview.contains("Ages 2–3"))
     }
 
+    func testCapabilityLanesExposeChildChoiceModeCards() throws {
+        let numbers = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .numbers })
+
+        XCTAssertEqual(numbers.modeChoiceCards.map(\.mode), numbers.modes)
+        XCTAssertTrue(numbers.modeChoicePreviewLabel.contains("Learn: calm build"))
+        XCTAssertTrue(numbers.modeChoiceCards.contains { $0.mode == .timed && $0.policy.usesTimer })
+    }
+
     func testCapabilityLanesIncludeChoiceBasedPlayModes() {
         let modesByLane = Dictionary(
             uniqueKeysWithValues: CapabilityLane.defaultExplorerLanes.map { ($0.id, Set($0.modes)) }

--- a/Tests/MatherTests/TimerChallengePolicyTests.swift
+++ b/Tests/MatherTests/TimerChallengePolicyTests.swift
@@ -26,6 +26,16 @@ struct TimerChallengePolicyTests {
     }
 
     @Test
+    func choiceCardsExposeChildChoiceCopy() {
+        let cards = TimerChallengePolicy.choiceCards(for: [.learn, .challenge, .timed, .review])
+
+        #expect(cards.map(\.mode) == [.learn, .challenge, .timed, .review])
+        #expect(cards.first?.summaryLabel == "Learn: calm build")
+        #expect(cards.first { $0.mode == .timed }?.policy.usesTimer == true)
+        #expect(cards.first { $0.mode == .timed }?.detail.contains("choose") == true)
+    }
+
+    @Test
     func policyCopyAvoidsShameAndPressureLanguage() {
         let blockedTerms = [
             "shame",
@@ -46,6 +56,9 @@ struct TimerChallengePolicyTests {
                 policy.activeTimerLabel,
                 policy.completionMessage,
                 policy.timeExpiredMessage,
+                policy.choiceCard.title,
+                policy.choiceCard.flavor,
+                policy.choiceCard.detail,
             ]
             .compactMap { $0 }
             .joined(separator: " ")


### PR DESCRIPTION
## Summary
- add deterministic `PlayModeChoiceCard` metadata from `TimerChallengePolicy`
- surface child-choice play-style previews on Explorer Lab lane cards
- mark Timed mode as opt-in in mode-card metadata/UI
- add tests for mode-card copy and lane-level previews

## Scope
Small #797 slice for child agency/play-mode framing. This does not add profile persistence or a full mode-selection flow yet.

## Validation
- `git diff --check`
- Local iOS build/test not available in this Linux workspace (`swift`, `xcodebuild`, and `xcodegen` are not installed); CI should run on macOS.

Refs #797
