### PR TITLE
Add lane mastery state models

### DIFF
--- a/Domain/LaneMasteryState.swift
+++ b/Domain/LaneMasteryState.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+enum ConceptConfidence: String, CaseIterable, Codable, Hashable, Comparable {
+    case introduced
+    case practicing
+    case steady
+    case mastered
+
+    var score: Double {
+        switch self {
+        case .introduced: return 0.25
+        case .practicing: return 0.5
+        case .steady: return 0.75
+        case .mastered: return 1
+        }
+    }
+
+    static func < (lhs: ConceptConfidence, rhs: ConceptConfidence) -> Bool {
+        lhs.score < rhs.score
+    }
+}
+
+struct LaneMasteryState: Equatable, Codable, Identifiable {
+    let id: CapabilityLaneID
+    var availableModes: [PlayMode]
+    var completedModes: Set<PlayMode>
+    var reviewedCardIDs: Set<String>
+    var conceptConfidence: [ConceptId: ConceptConfidence]
+
+    init(
+        laneID: CapabilityLaneID,
+        availableModes: [PlayMode],
+        completedModes: Set<PlayMode> = [],
+        reviewedCardIDs: Set<String> = [],
+        conceptConfidence: [ConceptId: ConceptConfidence] = [:]
+    ) {
+        self.id = laneID
+        self.availableModes = availableModes
+        self.completedModes = completedModes
+        self.reviewedCardIDs = reviewedCardIDs
+        self.conceptConfidence = conceptConfidence
+    }
+
+    var completedModeCount: Int {
+        availableModes.filter { completedModes.contains($0) }.count
+    }
+
+    var masteryFraction: Double {
+        let modeFraction: Double
+        if availableModes.isEmpty {
+            modeFraction = 0
+        } else {
+            modeFraction = Double(completedModeCount) / Double(availableModes.count)
+        }
+
+        guard !conceptConfidence.isEmpty else { return modeFraction }
+        let conceptAverage = conceptConfidence.values.map(\.score).reduce(0, +) / Double(conceptConfidence.count)
+        return (modeFraction + conceptAverage) / 2
+    }
+
+    var progressLabel: String {
+        "\(completedModeCount) / \(availableModes.count) modes"
+    }
+
+    var masteryPercentLabel: String {
+        "\(Int((masteryFraction * 100).rounded()))% ready"
+    }
+
+    var nextRecommendedMode: PlayMode? {
+        availableModes.first { !completedModes.contains($0) } ?? availableModes.last
+    }
+
+    mutating func markCompleted(_ mode: PlayMode) {
+        guard availableModes.contains(mode) else { return }
+        completedModes.insert(mode)
+    }
+
+    mutating func markReviewedCard(id cardID: String) {
+        reviewedCardIDs.insert(cardID)
+    }
+
+    mutating func setConfidence(_ confidence: ConceptConfidence, for conceptID: ConceptId) {
+        conceptConfidence[conceptID] = confidence
+    }
+}
+
+struct ExplorerLabMasteryProfile: Equatable, Codable {
+    var lanes: [CapabilityLaneID: LaneMasteryState]
+
+    init(lanes: [CapabilityLaneID: LaneMasteryState] = [:]) {
+        self.lanes = lanes
+    }
+
+    subscript(laneID: CapabilityLaneID) -> LaneMasteryState? {
+        get { lanes[laneID] }
+        set { lanes[laneID] = newValue }
+    }
+
+    mutating func ensureLane(_ descriptor: CapabilityLaneDescriptor) -> LaneMasteryState {
+        if let existing = lanes[descriptor.id] {
+            return existing
+        }
+
+        let state = LaneMasteryState(
+            laneID: descriptor.id,
+            availableModes: descriptor.supportedPlayModes,
+            conceptConfidence: Dictionary(uniqueKeysWithValues: descriptor.starterConcepts.map { ($0, .introduced) })
+        )
+        lanes[descriptor.id] = state
+        return state
+    }
+
+    static func emptyExplorerProfile() -> ExplorerLabMasteryProfile {
+        var profile = ExplorerLabMasteryProfile()
+        for descriptor in CapabilityLaneRegistry.all {
+            _ = profile.ensureLane(descriptor)
+        }
+        return profile
+    }
+}

--- a/Tests/MatherTests/LaneMasteryStateTests.swift
+++ b/Tests/MatherTests/LaneMasteryStateTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import Mather
+
+struct LaneMasteryStateTests {
+    @Test
+    func laneStateTracksModesCardsAndConceptConfidence() {
+        var state = LaneMasteryState(
+            laneID: .numbers,
+            availableModes: [.learn, .challenge, .timed, .review],
+            conceptConfidence: ["number-bond": .introduced, "array": .introduced]
+        )
+
+        #expect(state.progressLabel == "0 / 4 modes")
+        #expect(state.masteryPercentLabel == "13% ready")
+        #expect(state.nextRecommendedMode == .learn)
+
+        state.markCompleted(.learn)
+        state.markReviewedCard(id: "numbers-number-bond-five-and-five")
+        state.setConfidence(.mastered, for: "number-bond")
+
+        #expect(state.completedModeCount == 1)
+        #expect(state.reviewedCardIDs == ["numbers-number-bond-five-and-five"])
+        #expect(state.conceptConfidence["number-bond"] == .mastered)
+        #expect(state.nextRecommendedMode == .challenge)
+        #expect(state.masteryPercentLabel == "44% ready")
+    }
+
+    @Test
+    func unsupportedModeDoesNotAffectProgress() {
+        var state = LaneMasteryState(laneID: .physics, availableModes: [.explore, .challenge])
+
+        state.markCompleted(.timed)
+
+        #expect(state.completedModes.isEmpty)
+        #expect(state.progressLabel == "0 / 2 modes")
+    }
+
+    @Test
+    func emptyExplorerProfileSeedsEveryCapabilityLane() throws {
+        let profile = ExplorerLabMasteryProfile.emptyExplorerProfile()
+
+        #expect(profile.lanes.keys.count == CapabilityLaneID.allCases.count)
+        let numbers = try #require(profile[.numbers])
+        #expect(numbers.availableModes == [.learn, .challenge, .timed, .review])
+        #expect(numbers.conceptConfidence["number-bond"] == .introduced)
+    }
+}


### PR DESCRIPTION
## Summary
- add `LaneMasteryState` for per-lane mode completion, reviewed cards, and concept confidence
- add `ConceptConfidence` readiness ladder and `ExplorerLabMasteryProfile` seeding for all Explorer Lab lanes
- add tests for updates, recommendations, unsupported mode handling, and default profile seeding

## Scope
Small #797 substrate slice. This introduces deterministic value types only; it does not add persistence/storage migration or profile UI yet.

## Validation
- `git diff --cached --check`
- Local iOS build/test not available in this Linux workspace (`swift`, `xcodebuild`, and `xcodegen` are not installed); CI should run on macOS.

Refs #797
