### PR TITLE
Add Explorer Lab mastery persistence

### DIFF
--- a/Persistence/ExplorerLabMasteryStore.swift
+++ b/Persistence/ExplorerLabMasteryStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+protocol ExplorerLabMasteryKeyValueStore: AnyObject {
+    func data(forKey defaultName: String) -> Data?
+    func set(_ value: Data?, forKey defaultName: String)
+    func removeObject(forKey defaultName: String)
+}
+
+extension UserDefaults: ExplorerLabMasteryKeyValueStore {
+    func set(_ value: Data?, forKey defaultName: String) {
+        if let value {
+            set(value as Any, forKey: defaultName)
+        } else {
+            removeObject(forKey: defaultName)
+        }
+    }
+}
+
+final class ExplorerLabMasteryStore {
+    static let defaultStorageKey = "explorerLabMasteryProfile.v1"
+
+    private let storage: ExplorerLabMasteryKeyValueStore
+    private let storageKey: String
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(
+        storage: ExplorerLabMasteryKeyValueStore = UserDefaults.standard,
+        storageKey: String = ExplorerLabMasteryStore.defaultStorageKey,
+        encoder: JSONEncoder = JSONEncoder(),
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.storage = storage
+        self.storageKey = storageKey
+        self.encoder = encoder
+        self.decoder = decoder
+    }
+
+    func load() -> ExplorerLabMasteryProfile {
+        guard let data = storage.data(forKey: storageKey),
+              let profile = try? decoder.decode(ExplorerLabMasteryProfile.self, from: data)
+        else {
+            return .emptyExplorerProfile()
+        }
+
+        return profile.withSeededExplorerLanes()
+    }
+
+    func save(_ profile: ExplorerLabMasteryProfile) throws {
+        let data = try encoder.encode(profile.withSeededExplorerLanes())
+        storage.set(data, forKey: storageKey)
+    }
+
+    func reset() {
+        storage.removeObject(forKey: storageKey)
+    }
+}
+
+extension ExplorerLabMasteryProfile {
+    func withSeededExplorerLanes() -> ExplorerLabMasteryProfile {
+        var profile = self
+        for descriptor in CapabilityLaneRegistry.all {
+            _ = profile.ensureLane(descriptor)
+        }
+        return profile
+    }
+}

--- a/Tests/MatherTests/ExplorerLabMasteryStoreTests.swift
+++ b/Tests/MatherTests/ExplorerLabMasteryStoreTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import Mather
+
+private final class InMemoryMasteryDefaults: ExplorerLabMasteryKeyValueStore {
+    var values: [String: Data] = [:]
+
+    func data(forKey defaultName: String) -> Data? {
+        values[defaultName]
+    }
+
+    func set(_ value: Data?, forKey defaultName: String) {
+        values[defaultName] = value
+    }
+
+    func removeObject(forKey defaultName: String) {
+        values.removeValue(forKey: defaultName)
+    }
+}
+
+struct ExplorerLabMasteryStoreTests {
+    @Test
+    func missingDataLoadsSeededProfile() throws {
+        let storage = InMemoryMasteryDefaults()
+        let store = ExplorerLabMasteryStore(storage: storage, storageKey: "test.mastery")
+
+        let profile = store.load()
+
+        #expect(profile.lanes.keys.count == CapabilityLaneID.allCases.count)
+        let numbers = try #require(profile[.numbers])
+        #expect(numbers.conceptConfidence["number-bond"] == .introduced)
+    }
+
+    @Test
+    func savedProfileRoundTripsMasteryState() throws {
+        let storage = InMemoryMasteryDefaults()
+        let store = ExplorerLabMasteryStore(storage: storage, storageKey: "test.mastery")
+        var profile = ExplorerLabMasteryProfile.emptyExplorerProfile()
+        var numbers = try #require(profile[.numbers])
+        numbers.markCompleted(.learn)
+        numbers.markReviewedCard(id: "numbers-number-bond-five-and-five")
+        numbers.setConfidence(.mastered, for: "number-bond")
+        profile[.numbers] = numbers
+
+        try store.save(profile)
+        let reloaded = store.load()
+
+        let reloadedNumbers = try #require(reloaded[.numbers])
+        #expect(reloadedNumbers.completedModes == [.learn])
+        #expect(reloadedNumbers.reviewedCardIDs == ["numbers-number-bond-five-and-five"])
+        #expect(reloadedNumbers.conceptConfidence["number-bond"] == .mastered)
+    }
+
+    @Test
+    func corruptDataFallsBackToSeededProfile() throws {
+        let storage = InMemoryMasteryDefaults()
+        storage.set(Data("not json".utf8), forKey: "test.mastery")
+        let store = ExplorerLabMasteryStore(storage: storage, storageKey: "test.mastery")
+
+        let profile = store.load()
+
+        #expect(profile.lanes.keys.count == CapabilityLaneID.allCases.count)
+    }
+
+    @Test
+    func resetRemovesSavedProfile() throws {
+        let storage = InMemoryMasteryDefaults()
+        let store = ExplorerLabMasteryStore(storage: storage, storageKey: "test.mastery")
+        try store.save(.emptyExplorerProfile())
+
+        store.reset()
+
+        #expect(storage.values["test.mastery"] == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- add `ExplorerLabMasteryStore` for encoding/decoding `ExplorerLabMasteryProfile` behind injectable key-value storage
- seed missing/older/corrupt loaded profiles with every Explorer Lab lane
- cover missing data, corrupt data, reset, and mastery state round-trip in tests

## Scope
Small #797 persistence substrate slice. This adds a store/service only; it does not yet wire gameplay UI to persist updates.

## Validation
- `git diff --cached --check`
- Local iOS build/test not available in this Linux workspace (`swift`, `xcodebuild`, and `xcodegen` are not installed); CI should run on macOS.

Refs #797
