### PR TITLE
Wire Explorer Lab progress to persisted mastery

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -21,7 +21,9 @@ final class AppModel {
     let factStore: FactRecordStore
     let sumSprintEngine: SumSprintEngine
     let gameSessionStore: GameSessionStore
+    let explorerLabMasteryStore: ExplorerLabMasteryStore
 
+    var explorerLabMasteryProfile: ExplorerLabMasteryProfile
     var showingProfilePicker = false
     private var pendingGameAction: (() -> Void)?
 
@@ -108,6 +110,8 @@ final class AppModel {
 
         let factStore = FactRecordStore(modelContext: modelContext, activeProfileIdProvider: { profileStore.activeProfileId })
         let gameSessionStore = GameSessionStore(modelContext: modelContext, activeProfileIdProvider: { profileStore.activeProfileId })
+        let explorerLabMasteryStore = ExplorerLabMasteryStore()
+        let explorerLabMasteryProfile = explorerLabMasteryStore.load()
         let sumSprintEngine = SumSprintEngine(
             featureFlags: featureFlags,
             telemetryWriter: telemetryWriter,
@@ -117,6 +121,8 @@ final class AppModel {
         )
         self.factStore = factStore
         self.gameSessionStore = gameSessionStore
+        self.explorerLabMasteryStore = explorerLabMasteryStore
+        self.explorerLabMasteryProfile = explorerLabMasteryProfile
         self.sumSprintEngine = sumSprintEngine
         sumSprintEngine.onExitToHome = { [weak vsEngine] in vsEngine?.showHome() }
         sumSprintEngine.onSessionComplete = { [weak gameSessionStore] summary in

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -123,6 +123,15 @@ struct CapabilityLaneProgress: Equatable {
         self.reviewedCardIDs = reviewedCardIDs
     }
 
+    init(masteryState: LaneMasteryState) {
+        self.init(
+            laneID: masteryState.laneID,
+            availableModes: masteryState.availableModes,
+            completedModes: masteryState.completedModes,
+            reviewedCardIDs: masteryState.reviewedCardIDs
+        )
+    }
+
     var completedModeCount: Int {
         availableModes.filter { completedModes.contains($0) }.count
     }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -125,7 +125,7 @@ struct CapabilityLaneProgress: Equatable {
 
     init(masteryState: LaneMasteryState) {
         self.init(
-            laneID: masteryState.laneID,
+            laneID: masteryState.id,
             availableModes: masteryState.availableModes,
             completedModes: masteryState.completedModes,
             reviewedCardIDs: masteryState.reviewedCardIDs

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -87,7 +87,7 @@ struct LabView: View {
             modeChips(lane.modes, tint: laneColor(lane.id))
             modeChoicePreview(lane, tint: laneColor(lane.id))
             ageEntryPreview(lane, tint: laneColor(lane.id))
-            progressPreview(lane.emptyProgress, tint: laneColor(lane.id))
+            progressPreview(progress(for: lane), tint: laneColor(lane.id))
             recallPreview(lane, tint: laneColor(lane.id))
             if expandedReviewLaneID == lane.id {
                 mixMatchSampler(lane, tint: laneColor(lane.id))
@@ -168,6 +168,13 @@ struct LabView: View {
         .background(tint.opacity(0.07), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(lane.title) age entry points: \(lane.ageEntryPreview)")
+    }
+
+    private func progress(for lane: CapabilityLane) -> CapabilityLaneProgress {
+        guard let masteryState = appModel.explorerLabMasteryProfile[lane.id] else {
+            return lane.emptyProgress
+        }
+        return CapabilityLaneProgress(masteryState: masteryState)
     }
 
     private func progressPreview(_ progress: CapabilityLaneProgress, tint: Color) -> some View {

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -127,6 +127,22 @@ extension LabModelsTests {
         XCTAssertEqual(progress.reviewedCardIDs.count, 1)
     }
 
+    func testCapabilityLaneProgressCanRenderPersistedMasteryState() {
+        var masteryState = LaneMasteryState(
+            laneID: .numbers,
+            availableModes: [.learn, .challenge, .timed, .review]
+        )
+        masteryState.markCompleted(.learn)
+        masteryState.markCompleted(.timed)
+        masteryState.markReviewedCard(id: "numbers-number-bond-five-and-five")
+
+        let progress = CapabilityLaneProgress(masteryState: masteryState)
+
+        XCTAssertEqual(progress.progressSummaryLabel, "2 / 4 modes • 50% ready")
+        XCTAssertEqual(progress.nextRecommendedModeLabel, "Try Challenge next")
+        XCTAssertEqual(progress.reviewedCardIDs, ["numbers-number-bond-five-and-five"])
+    }
+
     func testStarterMixMatchCardsHaveChildReadablePromptsAndMatches() {
         let allCards = CapabilityLane.defaultExplorerLanes.flatMap(\.starterMixMatchCards)
 


### PR DESCRIPTION
## Summary
- load Explorer Lab mastery profile into AppModel at startup
- render Lab lane progress from persisted LaneMasteryState with safe empty-progress fallback
- add model coverage for converting persisted mastery into progress labels/recommendations

## Validation
- Not run locally: Swift/Xcode toolchain is unavailable on this host (, , and  not found). CI will run Build & Test.

Part of #797