### PR TITLE
Add Explorer Lab mastery mutation helpers

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -43,6 +43,26 @@ final class AppModel {
         action?()
     }
 
+    func markExplorerLabModeCompleted(laneID: CapabilityLaneID, mode: PlayMode) {
+        explorerLabMasteryProfile = explorerLabMasteryStore.markCompleted(laneID: laneID, mode: mode)
+    }
+
+    func markExplorerLabReviewedCard(laneID: CapabilityLaneID, cardID: String) {
+        explorerLabMasteryProfile = explorerLabMasteryStore.markReviewedCard(laneID: laneID, cardID: cardID)
+    }
+
+    func setExplorerLabConceptConfidence(
+        _ confidence: ConceptConfidence,
+        for conceptID: ConceptId,
+        laneID: CapabilityLaneID
+    ) {
+        explorerLabMasteryProfile = explorerLabMasteryStore.setConfidence(
+            confidence,
+            for: conceptID,
+            laneID: laneID
+        )
+    }
+
     init(modelContext: ModelContext) {
         let profileStore = KidProfileStore(modelContext: modelContext)
         let featureFlags = FeatureFlagService()

--- a/Persistence/ExplorerLabMasteryStore.swift
+++ b/Persistence/ExplorerLabMasteryStore.swift
@@ -51,12 +51,63 @@ final class ExplorerLabMasteryStore {
         storage.set(data, forKey: storageKey)
     }
 
+    @discardableResult
+    func update(_ mutation: (inout ExplorerLabMasteryProfile) -> Void) -> ExplorerLabMasteryProfile {
+        var profile = load()
+        mutation(&profile)
+        profile = profile.withSeededExplorerLanes()
+        try? save(profile)
+        return profile
+    }
+
+    @discardableResult
+    func markCompleted(laneID: CapabilityLaneID, mode: PlayMode) -> ExplorerLabMasteryProfile {
+        update { profile in
+            profile.updateLane(laneID) { lane in
+                lane.markCompleted(mode)
+            }
+        }
+    }
+
+    @discardableResult
+    func markReviewedCard(laneID: CapabilityLaneID, cardID: String) -> ExplorerLabMasteryProfile {
+        update { profile in
+            profile.updateLane(laneID) { lane in
+                lane.markReviewedCard(id: cardID)
+            }
+        }
+    }
+
+    @discardableResult
+    func setConfidence(
+        _ confidence: ConceptConfidence,
+        for conceptID: ConceptId,
+        laneID: CapabilityLaneID
+    ) -> ExplorerLabMasteryProfile {
+        update { profile in
+            profile.updateLane(laneID) { lane in
+                lane.setConfidence(confidence, for: conceptID)
+            }
+        }
+    }
+
     func reset() {
         storage.removeObject(forKey: storageKey)
     }
 }
 
 extension ExplorerLabMasteryProfile {
+    mutating func updateLane(_ laneID: CapabilityLaneID, _ mutation: (inout LaneMasteryState) -> Void) {
+        guard let descriptor = CapabilityLaneRegistry.all.first(where: { $0.id == laneID }) else { return }
+        var lane = lanes[laneID] ?? LaneMasteryState(
+            laneID: descriptor.id,
+            availableModes: descriptor.supportedPlayModes,
+            conceptConfidence: Dictionary(uniqueKeysWithValues: descriptor.starterConcepts.map { ($0, .introduced) })
+        )
+        mutation(&lane)
+        lanes[laneID] = lane
+    }
+
     func withSeededExplorerLanes() -> ExplorerLabMasteryProfile {
         var profile = self
         for descriptor in CapabilityLaneRegistry.all {

--- a/Tests/MatherTests/ExplorerLabMasteryStoreTests.swift
+++ b/Tests/MatherTests/ExplorerLabMasteryStoreTests.swift
@@ -52,6 +52,32 @@ struct ExplorerLabMasteryStoreTests {
     }
 
     @Test
+    func mutationHelpersPersistLaneMasteryUpdates() throws {
+        let storage = InMemoryMasteryDefaults()
+        let store = ExplorerLabMasteryStore(storage: storage, storageKey: "test.mastery")
+
+        store.markCompleted(laneID: .numbers, mode: .learn)
+        store.markReviewedCard(laneID: .numbers, cardID: "numbers-number-bond-five-and-five")
+        store.setConfidence(.steady, for: "number-bond", laneID: .numbers)
+
+        let numbers = try #require(store.load()[.numbers])
+        #expect(numbers.completedModes == [.learn])
+        #expect(numbers.reviewedCardIDs == ["numbers-number-bond-five-and-five"])
+        #expect(numbers.conceptConfidence["number-bond"] == .steady)
+    }
+
+    @Test
+    func mutationHelpersIgnoreModesOutsideLane() throws {
+        let storage = InMemoryMasteryDefaults()
+        let store = ExplorerLabMasteryStore(storage: storage, storageKey: "test.mastery")
+
+        store.markCompleted(laneID: .physics, mode: .timed)
+
+        let physics = try #require(store.load()[.physics])
+        #expect(physics.completedModes.isEmpty)
+    }
+
+    @Test
     func corruptDataFallsBackToSeededProfile() throws {
         let storage = InMemoryMasteryDefaults()
         storage.set(Data("not json".utf8), forKey: "test.mastery")


### PR DESCRIPTION
## Summary
- add safe Explorer Lab mastery mutation helpers on `ExplorerLabMasteryStore`
- expose AppModel APIs for completed modes, reviewed cards, and concept confidence updates
- cover persisted mutation helpers and invalid-mode guarding in unit tests

## Validation
- `git diff --check`
- Not run locally: Swift/Xcode toolchain is unavailable on this host (`swift`, `xcodebuild`, and `xcodegen` not found). CI will run Build & Test.

Part of #797
