### PR TITLE
Issue #797 I3: Add sensor affordance fallbacks

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -104,6 +104,106 @@ struct LabActivity: Identifiable, Equatable {
     }
 }
 
+enum LabSensorNeed: CaseIterable, Equatable {
+    case noSpecialSensor
+    case motion
+    case compass
+    case cameraMarkerMode
+    case haptics
+
+    func isAvailable(with capabilities: DeviceSensorCapabilities) -> Bool {
+        switch self {
+        case .noSpecialSensor:
+            return true
+        case .motion:
+            return capabilities.supportsMotion
+        case .compass:
+            return capabilities.supportsHeading
+        case .cameraMarkerMode:
+            return capabilities.supportsCamera
+        case .haptics:
+            return capabilities.supportsHaptics
+        }
+    }
+
+    func copy(with capabilities: DeviceSensorCapabilities) -> LabSensorAffordance {
+        let available = isAvailable(with: capabilities)
+        switch self {
+        case .noSpecialSensor:
+            return LabSensorAffordance(
+                need: self,
+                isAvailable: true,
+                label: "No special sensor needed",
+                fallback: nil
+            )
+        case .motion:
+            return LabSensorAffordance(
+                need: self,
+                isAvailable: available,
+                label: available ? "Motion ready" : "Motion unavailable",
+                fallback: available ? nil : "Touch fallback available"
+            )
+        case .compass:
+            return LabSensorAffordance(
+                need: self,
+                isAvailable: available,
+                label: available ? "Compass ready" : "Compass unavailable",
+                fallback: available ? nil : "Use on-screen turns"
+            )
+        case .cameraMarkerMode:
+            return LabSensorAffordance(
+                need: self,
+                isAvailable: available,
+                label: available ? "Camera marker mode ready" : "Camera marker mode unavailable",
+                fallback: available ? nil : "Use tap-to-place stations"
+            )
+        case .haptics:
+            return LabSensorAffordance(
+                need: self,
+                isAvailable: available,
+                label: available ? "Haptics ready" : "Haptics unavailable",
+                fallback: available ? nil : "Visual feedback stays available"
+            )
+        }
+    }
+}
+
+struct LabSensorAffordance: Identifiable, Equatable {
+    var id: LabSensorNeed { need }
+    let need: LabSensorNeed
+    let isAvailable: Bool
+    let label: String
+    let fallback: String?
+
+    var displayLabel: String {
+        guard let fallback else { return label }
+        return "\(label): \(fallback)"
+    }
+
+    var accessibilityLabel: String {
+        displayLabel
+    }
+}
+
+extension LabActivityID {
+    var sensorNeeds: [LabSensorNeed] {
+        switch self {
+        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .waterCycle, .memoryMatch:
+            return [.noSpecialSensor]
+        case .symmetryFold, .angleCannon, .gravityArtist:
+            return [.motion]
+        case .roomQuest:
+            return [.cameraMarkerMode, .haptics]
+        case .compassAngles:
+            return [.compass]
+        }
+    }
+
+    func sensorAffordances(with capabilities: DeviceSensorCapabilities) -> [LabSensorAffordance] {
+        sensorNeeds.map { $0.copy(with: capabilities) }
+    }
+}
+
 
 struct CapabilityLaneProgress: Equatable {
     let laneID: CapabilityLaneID

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -5,6 +5,7 @@ struct LabView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Bindable var appModel: AppModel
     @State private var expandedReviewLaneID: CapabilityLaneID?
+    @State private var sensorCapabilities = DeviceSensorCapabilities.unavailable
 
     private let lanes = CapabilityLane.defaultExplorerLanes
 
@@ -25,6 +26,9 @@ struct LabView: View {
                     .padding(24)
                 }
             }
+        }
+        .onAppear {
+            sensorCapabilities = SensorCapabilityService().currentCapabilities()
         }
     }
 
@@ -297,6 +301,7 @@ struct LabView: View {
                         .font(.caption2.weight(.medium))
                         .foregroundStyle(MatherTheme.cardSubtitle)
                         .lineLimit(2)
+                    sensorAffordanceRow(activity, tint: tint)
                 }
                 Spacer(minLength: 6)
                 Image(systemName: "chevron.right")
@@ -309,6 +314,48 @@ struct LabView: View {
         .buttonStyle(.plain)
         .accessibilityLabel(activity.title)
         .accessibilityHint(activity.modes.map(\.rawValue).joined(separator: ", "))
+    }
+
+    private func sensorAffordanceRow(_ activity: LabActivity, tint: Color) -> some View {
+        FlowLayout(spacing: 4) {
+            ForEach(activity.id.sensorAffordances(with: sensorCapabilities)) { affordance in
+                Label {
+                    Text(affordance.displayLabel)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
+                } icon: {
+                    Image(systemName: sensorIcon(for: affordance.need, isAvailable: affordance.isAvailable))
+                }
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(affordance.isAvailable ? tint : MatherTheme.cardSubtitle)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 4)
+                .background(
+                    (affordance.isAvailable ? tint.opacity(0.10) : MatherTheme.panel.opacity(0.72)),
+                    in: Capsule()
+                )
+                .accessibilityLabel(affordance.accessibilityLabel)
+            }
+        }
+    }
+
+    private func sensorIcon(for need: LabSensorNeed, isAvailable: Bool) -> String {
+        if !isAvailable {
+            return "exclamationmark.triangle.fill"
+        }
+
+        switch need {
+        case .noSpecialSensor:
+            return "hand.tap.fill"
+        case .motion:
+            return "gyroscope"
+        case .compass:
+            return "location.north.line.fill"
+        case .cameraMarkerMode:
+            return "camera.viewfinder"
+        case .haptics:
+            return "waveform"
+        }
     }
 
     private func launch(_ activityID: LabActivityID) {

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -152,4 +152,56 @@ extension LabModelsTests {
         XCTAssertTrue(allCards.allSatisfy { !$0.match.isEmpty })
         XCTAssertEqual(Set(allCards.map(\.id)).count, allCards.count)
     }
+
+    func testActivitySensorNeedsMapToHonestLaneAffordances() {
+        XCTAssertEqual(LabActivityID.sumSprint.sensorNeeds, [.noSpecialSensor])
+        XCTAssertEqual(LabActivityID.angleCannon.sensorNeeds, [.motion])
+        XCTAssertEqual(LabActivityID.gravityArtist.sensorNeeds, [.motion])
+        XCTAssertEqual(LabActivityID.compassAngles.sensorNeeds, [.compass])
+        XCTAssertEqual(LabActivityID.roomQuest.sensorNeeds, [.cameraMarkerMode, .haptics])
+        XCTAssertEqual(LabActivityID.memoryMatch.sensorNeeds, [.noSpecialSensor])
+    }
+
+    func testUnavailableSensorAffordancesExposeVisibleFallbackCopy() {
+        let affordances = LabActivityID.roomQuest.sensorAffordances(with: .unavailable)
+
+        XCTAssertEqual(
+            affordances.map(\.displayLabel),
+            [
+                "Camera marker mode unavailable: Use tap-to-place stations",
+                "Haptics unavailable: Visual feedback stays available",
+            ]
+        )
+        XCTAssertTrue(affordances.allSatisfy { !$0.isAvailable })
+    }
+
+    func testAvailableCapabilitiesUseReadyCopyWithoutFallbacks() {
+        let capabilities = DeviceSensorCapabilities(
+            supportsMotion: true,
+            supportsHeading: true,
+            supportsCamera: true,
+            supportsMicrophone: false,
+            supportsHaptics: true,
+            supportsBarometer: false,
+            supportsLiDAR: false,
+            supportsApplePencil: false
+        )
+
+        XCTAssertEqual(
+            LabActivityID.angleCannon.sensorAffordances(with: capabilities).map(\.displayLabel),
+            ["Motion ready"]
+        )
+        XCTAssertEqual(
+            LabActivityID.compassAngles.sensorAffordances(with: capabilities).map(\.displayLabel),
+            ["Compass ready"]
+        )
+        XCTAssertEqual(
+            LabActivityID.roomQuest.sensorAffordances(with: capabilities).map(\.displayLabel),
+            ["Camera marker mode ready", "Haptics ready"]
+        )
+        XCTAssertEqual(
+            LabActivityID.twoFingerProtractor.sensorAffordances(with: capabilities).map(\.displayLabel),
+            ["No special sensor needed"]
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Add Lab sensor affordance models that map activities to motion, compass, camera marker mode, haptics, or no special sensor needed.
- Render passive sensor/fallback chips on Lab activity cards using the existing `SensorCapabilityService` capability snapshot.
- Add model tests covering capability mapping and fallback wording.

Refs #797

## Validation
- `git diff --check` passed.
- `xcodegen generate` not run: `xcodegen` is unavailable in this Linux worktree.
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO` not run: `xcodebuild` is unavailable in this Linux worktree.
- `swift test` not run: `swift` is unavailable in this Linux worktree.