### PR TITLE
Issue #797 Q2: Add Lab route regression coverage

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Observation
 
-enum AppRoute {
+enum AppRoute: Hashable {
     case home
     case sessionConfig
     case session
@@ -113,6 +113,7 @@ final class VerticalSliceEngine {
     var concreteCount: Int { concreteWarmCount + concreteAccentCount }
     var sumSprintStageCardCount: Int { sumSprintBurstState?.totalPairs ?? 0 }
 
+    func show(_ route: AppRoute) { self.route = route }
     func showSettings() { route = .settings }
     func showHome() { route = .home }
     func showParentSummary() { route = .parentSummary }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -88,6 +88,35 @@ enum LabActivityID: String, CaseIterable, Hashable {
     case memoryMatch
 }
 
+extension LabActivityID {
+    var appRoute: AppRoute {
+        switch self {
+        case .sumSprint:
+            return .sumSprint
+        case .roomQuest:
+            return .roomQuest
+        case .symmetryFold:
+            return .symmetryFold
+        case .rectangleFactory:
+            return .rectangleFactory
+        case .factoryCards:
+            return .factoryCards
+        case .angleCannon:
+            return .angleCannon
+        case .twoFingerProtractor:
+            return .twoFingerProtractor
+        case .gravityArtist:
+            return .gravityArtist
+        case .compassAngles:
+            return .compassAngles
+        case .waterCycle:
+            return .waterCycle
+        case .memoryMatch:
+            return .memory
+        }
+    }
+}
+
 struct LabActivity: Identifiable, Equatable {
     let id: LabActivityID
     let emoji: String

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -313,30 +313,13 @@ struct LabView: View {
 
     private func launch(_ activityID: LabActivityID) {
         appModel.pickProfileThenRun {
+            appModel.engine.show(activityID.appRoute)
             switch activityID {
             case .sumSprint:
-                appModel.engine.showSumSprint()
                 appModel.sumSprintEngine.showDifficultyPick()
-            case .roomQuest:
-                appModel.engine.showRoomQuest()
-            case .symmetryFold:
-                appModel.engine.showSymmetryFold()
-            case .rectangleFactory:
-                appModel.engine.showRectangleFactory()
-            case .factoryCards:
-                appModel.engine.showFactoryCards()
-            case .angleCannon:
-                appModel.engine.showAngleCannon()
-            case .twoFingerProtractor:
-                appModel.engine.showTwoFingerProtractor()
-            case .gravityArtist:
-                appModel.engine.showGravityArtist()
-            case .compassAngles:
-                appModel.engine.showCompassAngles()
-            case .waterCycle:
-                appModel.engine.showWaterCycle()
-            case .memoryMatch:
-                appModel.engine.showMemory()
+            case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
+                 .twoFingerProtractor, .gravityArtist, .compassAngles, .waterCycle, .memoryMatch:
+                break
             }
         }
     }

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import Mather
+
+@MainActor
+struct LabRouteRegressionTests {
+    @Test
+    func everyExplorerLabActivityIsReachableFromExactlyOneCapabilityLane() {
+        let activitiesByLane = CapabilityLane.defaultExplorerLanes.flatMap { lane in
+            lane.activities.map { (laneID: lane.id, activityID: $0.id) }
+        }
+        let activityIDs = activitiesByLane.map(\.activityID)
+
+        #expect(Set(activityIDs) == Set(LabActivityID.allCases))
+        #expect(activityIDs.count == LabActivityID.allCases.count)
+
+        for activityID in LabActivityID.allCases {
+            let hostLanes = activitiesByLane.filter { $0.activityID == activityID }.map(\.laneID)
+            #expect(hostLanes.count == 1, "\(activityID.rawValue) should be exposed by exactly one lane")
+        }
+    }
+
+    @Test
+    func explorerLabActivitiesMapToCurrentAppRoutes() throws {
+        let expectedRoutes: [LabActivityID: AppRoute] = [
+            .sumSprint: .sumSprint,
+            .roomQuest: .roomQuest,
+            .symmetryFold: .symmetryFold,
+            .rectangleFactory: .rectangleFactory,
+            .factoryCards: .factoryCards,
+            .angleCannon: .angleCannon,
+            .twoFingerProtractor: .twoFingerProtractor,
+            .gravityArtist: .gravityArtist,
+            .compassAngles: .compassAngles,
+            .waterCycle: .waterCycle,
+            .memoryMatch: .memory,
+        ]
+
+        #expect(Set(expectedRoutes.keys) == Set(LabActivityID.allCases))
+        for activityID in LabActivityID.allCases {
+            let expectedRoute = try #require(expectedRoutes[activityID])
+            #expect(activityID.appRoute == expectedRoute)
+        }
+    }
+
+    @Test
+    func labGameRoutesCanReturnHomeThroughSharedRouteAPI() {
+        let engine = makeEngine()
+        let labRoutes = Set(LabActivityID.allCases.map(\.appRoute))
+
+        for route in labRoutes {
+            engine.show(route)
+            #expect(engine.route == route)
+
+            engine.showHome()
+            #expect(engine.route == .home)
+        }
+    }
+
+    @Test
+    func discoveryChemistryAndElectronicsShellsStayRegistered() throws {
+        let lanes = CapabilityLane.defaultExplorerLanes
+        let discovery = try #require(lanes.first { $0.id == .discoveryCards })
+        let chemistry = try #require(lanes.first { $0.id == .chemistry })
+        let electronics = try #require(lanes.first { $0.id == .electronics })
+
+        #expect(discovery.activities.map(\.id) == [.memoryMatch])
+        #expect(discovery.starterMixMatchCards.count >= 8)
+        #expect(discovery.modeChoiceCards.count == discovery.modes.count)
+
+        for futureShell in [chemistry, electronics] {
+            #expect(futureShell.activities.isEmpty)
+            #expect(!futureShell.promise.isEmpty)
+            #expect(futureShell.ageBandHint == "Future lane")
+            #expect(futureShell.starterMixMatchCards.count >= 8)
+            #expect(futureShell.modeChoiceCards.count == futureShell.modes.count)
+        }
+    }
+
+    private func makeEngine() -> VerticalSliceEngine {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: "LabRouteRegressionTests")!)
+        flags.testModeEnabled = true
+        flags.audioEnabled = false
+        return VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add Lab route regression tests proving every current Explorer Lab activity is present in exactly one capability lane.
- Centralize `LabActivityID` to `AppRoute` mapping and route Lab launches through that mapping.
- Cover route-to-home behavior through the shared route API and keep Discovery/Chemistry/Electronics shell registration under test.

Refs #797

## Validation

- `git diff --cached --check` before commit: passed.
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' -only-testing:MatherTests/LabRouteRegressionTests CODE_SIGNING_ALLOWED=NO`: not run locally because `xcodebuild` is not installed in this worker environment.
- `swift` and `xcodegen` are also unavailable in this worker environment.