### PR TITLE
Issue #797 I1: Wire lane recall integration

### DIFF
--- a/Domain/CapabilityModels.swift
+++ b/Domain/CapabilityModels.swift
@@ -47,8 +47,8 @@ enum CapabilityLaneRegistry {
             emoji: "🗺️",
             promise: "Use rooms, compass turns, direction words, and route clues.",
             ageBand: .ages4To12,
-            stages: [.concrete, .pictorial, .abstract, .transfer],
-            supportedPlayModes: [.explore, .challenge, .timed],
+            stages: [.concrete, .pictorial, .abstract, .transfer, .review],
+            supportedPlayModes: [.explore, .challenge, .timed, .review],
             starterConcepts: ["direction", "turn", "route", "map-symbol", "scale", "compass"]
         ),
         CapabilityLaneDescriptor(
@@ -84,4 +84,3 @@ enum CapabilityLaneRegistry {
         all.first { $0.id == laneID }
     }
 }
-

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -74,6 +74,39 @@ struct MixMatchReviewSampler: Equatable {
     }
 }
 
+struct LaneRecallEntry: Identifiable, Equatable {
+    let laneID: CapabilityLaneID
+    let card: LearningCard
+
+    var id: String { card.id }
+
+    var title: String {
+        card.prompt.displayText ?? card.prompt.speechText
+    }
+
+    var answerLabel: String {
+        card.answer.displayText ?? card.answer.speechText
+    }
+
+    var choiceActions: [LaneRecallReviewAction] {
+        card.choices.map { choice in
+            LaneRecallReviewAction(
+                laneID: laneID,
+                cardID: card.id,
+                choiceID: choice.id,
+                isCorrect: choice.isCorrect
+            )
+        }
+    }
+}
+
+struct LaneRecallReviewAction: Equatable {
+    let laneID: CapabilityLaneID
+    let cardID: String
+    let choiceID: String
+    let isCorrect: Bool
+}
+
 enum LabActivityID: String, CaseIterable, Hashable {
     case sumSprint
     case roomQuest
@@ -330,6 +363,16 @@ struct CapabilityLane: Identifiable, Equatable {
         Self.starterMixMatchCardsByLane[id, default: []]
     }
 
+    var recallEntries: [LaneRecallEntry] {
+        Self.starterLearningCardProvider
+            .starterCards(for: id)
+            .map { LaneRecallEntry(laneID: id, card: $0) }
+    }
+
+    var firstRecallEntry: LaneRecallEntry? {
+        recallEntries.first
+    }
+
     var starterMixMatchCount: Int { starterMixMatchCards.count }
 
     var starterMixMatchConceptPreview: String {
@@ -343,7 +386,11 @@ struct CapabilityLane: Identifiable, Equatable {
     }
 
     var recallReadinessLabel: String {
-        "\(starterMixMatchCount) Mix-Match cards ready"
+        let learningCardCount = recallEntries.count
+        guard learningCardCount > 0 else {
+            return "\(starterMixMatchCount) Mix-Match cards ready"
+        }
+        return "\(learningCardCount) recall card + \(starterMixMatchCount) Mix-Match ready"
     }
 
     var starterMixMatchSampler: MixMatchReviewSampler {
@@ -461,7 +508,7 @@ struct CapabilityLane: Identifiable, Equatable {
             emoji: "🗺️",
             promise: "Use rooms, compass turns, direction words, and route clues.",
             ageBandHint: "Ages 4–12",
-            modes: [.explore, .challenge, .timed],
+            modes: [.explore, .challenge, .timed, .review],
             ageEntries: [
                 CapabilityAgeEntry(ageBand: .preschool, posture: "left/right and finding", entryPlay: "room clues"),
                 CapabilityAgeEntry(ageBand: .earlyElementary, posture: "directions and turns", entryPlay: "compass walk"),
@@ -536,6 +583,8 @@ struct CapabilityLane: Identifiable, Equatable {
             activities: []
         ),
     ]
+
+    static let starterLearningCardProvider = DeterministicStarterLearningCardProvider()
 
     static let starterMixMatchCardsByLane: [CapabilityLaneID: [MixMatchCard]] = [
         .numbers: [

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -94,7 +94,7 @@ struct LabView: View {
             progressPreview(progress(for: lane), tint: laneColor(lane.id))
             recallPreview(lane, tint: laneColor(lane.id))
             if expandedReviewLaneID == lane.id {
-                mixMatchSampler(lane, tint: laneColor(lane.id))
+                recallReviewPanel(lane, tint: laneColor(lane.id))
             }
 
             if lane.isReady {
@@ -235,7 +235,7 @@ struct LabView: View {
         .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
-    private func mixMatchSampler(_ lane: CapabilityLane, tint: Color) -> some View {
+    private func recallReviewPanel(_ lane: CapabilityLane, tint: Color) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
                 Text("Review sample")
@@ -245,6 +245,41 @@ struct LabView: View {
                 Text(lane.starterMixMatchSampler.progressLabel)
                     .font(.caption2.weight(.heavy))
                     .foregroundStyle(tint)
+            }
+
+            if let entry = lane.firstRecallEntry {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(entry.title)
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    FlowLayout(spacing: 6) {
+                        ForEach(entry.card.choices) { choice in
+                            Button {
+                                recordReviewAction(
+                                    LaneRecallReviewAction(
+                                        laneID: entry.laneID,
+                                        cardID: entry.card.id,
+                                        choiceID: choice.id,
+                                        isCorrect: choice.isCorrect
+                                    )
+                                )
+                            } label: {
+                                Text(choice.answer.displayText ?? choice.answer.speechText)
+                                    .font(.caption2.weight(.black))
+                                    .foregroundStyle(tint)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 7)
+                                    .background(MatherTheme.card.opacity(0.86), in: Capsule())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Review \(lane.title): \(choice.answer.speechText)")
+                        }
+                    }
+                }
+                .padding(8)
+                .background(MatherTheme.card.opacity(0.72), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
             }
 
             ForEach(Array(lane.starterMixMatchCards.prefix(3))) { card in
@@ -267,7 +302,7 @@ struct LabView: View {
         .padding(10)
         .background(tint.opacity(0.10), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(lane.title) Mix-Match review sample")
+        .accessibilityLabel("\(lane.title) recall review sample")
     }
 
     private func modeChips(_ modes: [PlayMode], tint: Color) -> some View {
@@ -368,6 +403,20 @@ struct LabView: View {
                  .twoFingerProtractor, .gravityArtist, .compassAngles, .waterCycle, .memoryMatch:
                 break
             }
+        }
+    }
+
+    private func recordReviewAction(_ action: LaneRecallReviewAction) {
+        appModel.markExplorerLabReviewedCard(laneID: action.laneID, cardID: action.cardID)
+        appModel.markExplorerLabModeCompleted(laneID: action.laneID, mode: .review)
+
+        if action.isCorrect,
+           let card = CapabilityLane.defaultExplorerLanes
+            .first(where: { $0.id == action.laneID })?
+            .recallEntries
+            .first(where: { $0.card.id == action.cardID })?
+            .card {
+            appModel.setExplorerLabConceptConfidence(.steady, for: card.conceptID, laneID: action.laneID)
         }
     }
 

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -61,7 +61,8 @@ final class LabModelsTests: XCTestCase {
         let numbers = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .numbers })
 
         XCTAssertEqual(numbers.starterMixMatchCount, 8)
-        XCTAssertEqual(numbers.recallReadinessLabel, "8 Mix-Match cards ready")
+        XCTAssertEqual(numbers.recallReadinessLabel, "1 recall card + 8 Mix-Match ready")
+        XCTAssertEqual(numbers.recallEntries.count, 1)
         XCTAssertTrue(numbers.starterMixMatchConceptPreview.contains("number-bond"))
     }
 

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -77,6 +77,33 @@ struct LabRouteRegressionTests {
         }
     }
 
+    @Test
+    func everyCapabilityLaneExposesRecallEntries() {
+        let lanes = CapabilityLane.defaultExplorerLanes
+
+        #expect(Set(lanes.map(\.id)) == Set(CapabilityLaneID.allCases))
+
+        for lane in lanes {
+            #expect(!lane.recallEntries.isEmpty, "\(lane.id.rawValue) should expose recall cards")
+            #expect(lane.recallEntries.allSatisfy { $0.laneID == lane.id })
+            #expect(lane.modes.contains(.review), "\(lane.id.rawValue) should expose Review mode")
+        }
+    }
+
+    @Test
+    func recallReviewActionsMapBackToOwningLane() throws {
+        for lane in CapabilityLane.defaultExplorerLanes {
+            let entry = try #require(lane.firstRecallEntry)
+            let actions = entry.choiceActions
+
+            #expect(!actions.isEmpty)
+            #expect(actions.allSatisfy { $0.laneID == lane.id })
+            #expect(actions.allSatisfy { $0.cardID == entry.card.id })
+            #expect(Set(actions.map(\.choiceID)) == Set(entry.card.choices.map(\.id)))
+            #expect(actions.filter(\.isCorrect).map(\.choiceID) == entry.card.correctChoices.map(\.id))
+        }
+    }
+
     private func makeEngine() -> VerticalSliceEngine {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: "LabRouteRegressionTests")!)
         flags.testModeEnabled = true


### PR DESCRIPTION
## Summary
- add lane-scoped recall entries backed by starter `LearningCard`s for every Explorer Lab lane
- surface starter recall choices in the existing Lab review expansion and record reviewed card IDs through the existing Explorer Lab mastery hooks
- add Review mode coverage for Map & World so every lane has a recall/review entry point
- add regression tests that every lane exposes recall entries and that review actions map back to their owning lane

Refs #797

## Validation
- `git diff --check`
- `xcodegen generate` not run: `xcodegen` is not installed in this worker
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO` not run: `xcodebuild` is not installed in this worker
- `swift --version` not run: `swift` is not installed in this worker