### PR TITLE
Issue #797 Q1: Tighten Lab accessibility

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -35,6 +35,10 @@ struct MixMatchCard: Identifiable, Equatable {
         self.prompt = prompt
         self.match = match
     }
+
+    var accessibilityLabel: String {
+        "\(prompt), matches \(match)"
+    }
 }
 
 
@@ -131,6 +135,14 @@ struct LabActivity: Identifiable, Equatable {
         self.tagline = tagline
         self.modes = modes
     }
+
+    var accessibilityLabel: String {
+        "\(title). \(tagline)"
+    }
+
+    var accessibilityHint: String {
+        "Opens \(title). Modes: \(modes.map(\.rawValue).joined(separator: ", "))."
+    }
 }
 
 enum LabSensorNeed: CaseIterable, Equatable {
@@ -211,6 +223,19 @@ struct LabSensorAffordance: Identifiable, Equatable {
 
     var accessibilityLabel: String {
         displayLabel
+    }
+
+    var accessibilityHint: String {
+        if need == .noSpecialSensor {
+            return "Works with touch only."
+        }
+        if isAvailable {
+            return "Sensor is ready for this activity."
+        }
+        guard let fallback else {
+            return "This activity still works without extra setup."
+        }
+        return fallback
     }
 }
 
@@ -314,6 +339,14 @@ struct CapabilityLane: Identifiable, Equatable {
     var title: String { id.title }
     var isReady: Bool { !activities.isEmpty }
 
+    var accessibilityLabel: String {
+        "\(title). \(ageBandHint). \(promise)"
+    }
+
+    var accessibilityHint: String {
+        isReady ? "Choose an activity or review cards." : "Activities are coming soon. Review cards are available."
+    }
+
     var ageEntryPreview: String {
         ageEntries.prefix(2).map(\.summaryLabel).joined(separator: " • ")
     }
@@ -344,6 +377,10 @@ struct CapabilityLane: Identifiable, Equatable {
 
     var recallReadinessLabel: String {
         "\(starterMixMatchCount) Mix-Match cards ready"
+    }
+
+    var recallAccessibilityLabel: String {
+        "\(title) recall. \(recallReadinessLabel). Concepts: \(starterMixMatchConceptPreview)"
     }
 
     var starterMixMatchSampler: MixMatchReviewSampler {

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -52,7 +52,7 @@ struct LabView: View {
                 Image(systemName: "house.fill")
                     .font(.title2.weight(.semibold))
                     .foregroundStyle(MatherTheme.accent)
-                    .frame(width: 44, height: 44)
+                    .frame(width: 56, height: 56)
             }
             .accessibilityLabel("Home")
         }
@@ -125,7 +125,8 @@ struct LabView: View {
             radius: 8, y: 4
         )
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(lane.title)
+        .accessibilityLabel(lane.accessibilityLabel)
+        .accessibilityHint(lane.accessibilityHint)
     }
 
     private func modeChoicePreview(_ lane: CapabilityLane, tint: Color) -> some View {
@@ -148,6 +149,9 @@ struct LabView: View {
                             .foregroundStyle(tint)
                     }
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(card.accessibilityLabel)
+                .accessibilityHint(card.policy.usesTimer ? "Timer starts only after this mode is chosen." : "No timer in this mode.")
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -224,15 +228,19 @@ struct LabView: View {
                     .font(.caption2.weight(.black))
                     .foregroundStyle(tint)
                     .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
+                    .padding(.vertical, 8)
+                    .frame(minWidth: 120, minHeight: 56)
                     .background(MatherTheme.card.opacity(0.8), in: Capsule())
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Review \(lane.title) Mix-Match cards")
+            .accessibilityHint(expandedReviewLaneID == lane.id ? "Hides the sample review cards." : "Shows sample cards for quick recall practice.")
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(10)
         .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(lane.recallAccessibilityLabel)
     }
 
     private func mixMatchSampler(_ lane: CapabilityLane, tint: Color) -> some View {
@@ -262,6 +270,8 @@ struct LabView: View {
                 }
                 .padding(8)
                 .background(MatherTheme.card.opacity(0.72), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(card.accessibilityLabel)
             }
         }
         .padding(10)
@@ -309,11 +319,12 @@ struct LabView: View {
                     .foregroundStyle(tint)
             }
             .padding(10)
+            .frame(maxWidth: .infinity, minHeight: 80)
             .background(MatherTheme.panel.opacity(0.72), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(activity.title)
-        .accessibilityHint(activity.modes.map(\.rawValue).joined(separator: ", "))
+        .accessibilityLabel(activity.accessibilityLabel)
+        .accessibilityHint(activity.accessibilityHint)
     }
 
     private func sensorAffordanceRow(_ activity: LabActivity, tint: Color) -> some View {
@@ -335,6 +346,7 @@ struct LabView: View {
                     in: Capsule()
                 )
                 .accessibilityLabel(affordance.accessibilityLabel)
+                .accessibilityHint(affordance.accessibilityHint)
             }
         }
     }

--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -1028,7 +1028,8 @@ struct MemoryView: View {
                 cardView(card)
                     .aspectRatio(ResponsiveLayout.memoryCardAspectRatio(for: difficulty), contentMode: .fit)
                     .accessibilityIdentifier(Self.accessibilityIdentifier(for: card))
-                    .accessibilityLabel(Self.accessibilityLabel(for: card))
+                    .accessibilityLabel(Self.accessibilityLabel(for: card, difficulty: difficulty))
+                    .accessibilityHint(Self.accessibilityHint(for: card, difficulty: difficulty))
                     .onTapGesture(count: 2) { handleDoubleTap(card) }
                     .onTapGesture { handleTap(card) }
                     .modifier(MemoryLearnMoreAccessibilityModifier(
@@ -1577,6 +1578,32 @@ struct MemoryView: View {
         case .label(let animal):
             return animal.name
         }
+    }
+
+    static func accessibilityLabel(for card: MemoryCard, difficulty: MemoryDifficulty) -> String {
+        if difficulty.faceDown && !card.isSelected && !card.isMatched {
+            return "Face down memory card"
+        }
+
+        let state: String
+        if card.isMatched {
+            state = "matched"
+        } else if card.isSelected {
+            state = "selected"
+        } else {
+            state = "visible"
+        }
+        return "\(accessibilityLabel(for: card)), \(state)"
+    }
+
+    static func accessibilityHint(for card: MemoryCard, difficulty: MemoryDifficulty) -> String {
+        if card.isMatched {
+            return "Matched card."
+        }
+        if difficulty.faceDown && !card.isSelected {
+            return "Tap to turn this card over."
+        }
+        return "Tap to choose this card."
     }
 
     private static func learningSourceBadge(for deckSelection: DeckSelection, source: MemoryCardDescriptionSource) -> String {

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -150,7 +150,21 @@ extension LabModelsTests {
         XCTAssertTrue(allCards.allSatisfy { !$0.concept.isEmpty })
         XCTAssertTrue(allCards.allSatisfy { !$0.prompt.isEmpty })
         XCTAssertTrue(allCards.allSatisfy { !$0.match.isEmpty })
+        XCTAssertTrue(allCards.allSatisfy { $0.accessibilityLabel.contains("matches") })
         XCTAssertEqual(Set(allCards.map(\.id)).count, allCards.count)
+    }
+
+    func testLabLaneActivityAndRecallAccessibilityCopyExposeCriticalContext() throws {
+        let numbers = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .numbers })
+        let sumSprint = try XCTUnwrap(numbers.activities.first { $0.id == .sumSprint })
+
+        XCTAssertTrue(numbers.accessibilityLabel.contains("Numbers Lab"))
+        XCTAssertTrue(numbers.accessibilityLabel.contains("Ages 4–12"))
+        XCTAssertEqual(numbers.accessibilityHint, "Choose an activity or review cards.")
+        XCTAssertTrue(numbers.recallAccessibilityLabel.contains("8 Mix-Match cards ready"))
+        XCTAssertTrue(numbers.recallAccessibilityLabel.contains("number-bond"))
+        XCTAssertEqual(sumSprint.accessibilityLabel, "Sum Sprint. Race through sums 11–20")
+        XCTAssertTrue(sumSprint.accessibilityHint.contains("Modes: Challenge, Timed, Review"))
     }
 
     func testActivitySensorNeedsMapToHonestLaneAffordances() {
@@ -172,6 +186,7 @@ extension LabModelsTests {
                 "Haptics unavailable: Visual feedback stays available",
             ]
         )
+        XCTAssertEqual(affordances.map(\.accessibilityHint), ["Use tap-to-place stations", "Visual feedback stays available"])
         XCTAssertTrue(affordances.allSatisfy { !$0.isAvailable })
     }
 

--- a/Tests/MatherTests/MemoryViewTests.swift
+++ b/Tests/MatherTests/MemoryViewTests.swift
@@ -262,6 +262,18 @@ struct MemoryViewTests {
         }
     }
 
+    @MainActor
+    @Test func faceDownMemoryCardsDoNotExposeHiddenAnswerToAccessibility() {
+        let bird = MemoryDeck.birds[0]
+        let hidden = MemoryCard(pairId: bird.id, content: .picture(bird))
+        let selected = MemoryCard(pairId: bird.id, content: .picture(bird), isSelected: true)
+
+        #expect(MemoryView.accessibilityLabel(for: hidden, difficulty: .hard) == "Face down memory card")
+        #expect(MemoryView.accessibilityHint(for: hidden, difficulty: .hard) == "Tap to turn this card over.")
+        #expect(MemoryView.accessibilityLabel(for: selected, difficulty: .hard).contains(bird.canonicalName))
+        #expect(MemoryView.accessibilityLabel(for: selected, difficulty: .hard).contains("selected"))
+    }
+
     @Test func countryFlagAssetsHaveProvenanceAndCatalogs() {
         let expectedHashes = [
             "MemoryFlagIndia": "532012f66641b8e0ddd64628305810178bd97bb35e13086c00ee2ba597ae45f2",


### PR DESCRIPTION
## Summary
- Add stable accessibility labels/hints for Lab lanes, activities, Mix-Match recall cards, and sensor affordances.
- Increase key Lab touch targets for the home, activity, and recall-card controls while preserving the existing visual structure.
- Prevent face-down Memory Match cards from exposing hidden answers to accessibility, while adding stateful labels/hints for visible cards.

Refs #797

## Validation
- `git diff --check`
- Local iOS checks not run: this worker does not have `xcodegen`, `xcodebuild`, or `swift` on PATH.