### PR TITLE
Issue #797 X3: Add card review scheduler

### DIFF
--- a/Domain/CardReviewScheduler.swift
+++ b/Domain/CardReviewScheduler.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+struct CardReviewScheduler {
+    typealias Clock = () -> Date
+
+    struct Configuration: Hashable {
+        var incorrectRetryDelay: TimeInterval
+        var supportedCorrectDelay: TimeInterval
+        var independentCorrectIntervals: [TimeInterval]
+        var interleaveWindow: TimeInterval
+
+        init(
+            incorrectRetryDelay: TimeInterval = 5 * 60,
+            supportedCorrectDelay: TimeInterval = 30 * 60,
+            independentCorrectIntervals: [TimeInterval] = [
+                24 * 60 * 60,
+                3 * 24 * 60 * 60,
+                7 * 24 * 60 * 60,
+                14 * 24 * 60 * 60,
+            ],
+            interleaveWindow: TimeInterval = 30 * 60
+        ) {
+            self.incorrectRetryDelay = incorrectRetryDelay
+            self.supportedCorrectDelay = supportedCorrectDelay
+            self.independentCorrectIntervals = independentCorrectIntervals
+            self.interleaveWindow = interleaveWindow
+        }
+    }
+
+    private let clock: Clock
+    private let configuration: Configuration
+
+    init(now: Date = Date(), configuration: Configuration = Configuration()) {
+        self.clock = { now }
+        self.configuration = configuration
+    }
+
+    init(clock: @escaping Clock, configuration: Configuration = Configuration()) {
+        self.clock = clock
+        self.configuration = configuration
+    }
+
+    func progress(after result: CardReviewResult, from progress: CardProgress) -> CardProgress {
+        var updated = progress
+        let now = clock()
+        updated.timesSeen += 1
+        updated.lastReviewedAt = now
+        updated.lastReviewResult = result
+
+        switch result {
+        case .correct:
+            updated.correctCount += 1
+            updated.currentCorrectStreak += 1
+        case .supportedCorrect:
+            updated.correctCount += 1
+            updated.currentCorrectStreak = 0
+        case .incorrect:
+            updated.incorrectCount += 1
+            updated.currentCorrectStreak = 0
+        }
+
+        return updated
+    }
+
+    func card(_ card: LearningCard, after result: CardReviewResult) -> LearningCard {
+        var updated = card
+        updated.progress = progress(after: result, from: card.progress)
+        return updated
+    }
+
+    func nextReviewDate(for progress: CardProgress) -> Date {
+        nextReviewDate(for: progress, at: clock())
+    }
+
+    private func nextReviewDate(for progress: CardProgress, at now: Date) -> Date {
+        guard let lastReviewedAt = progress.lastReviewedAt else {
+            return now
+        }
+
+        switch progress.lastReviewResult {
+        case .incorrect:
+            return lastReviewedAt.addingTimeInterval(configuration.incorrectRetryDelay)
+        case .supportedCorrect:
+            return lastReviewedAt.addingTimeInterval(configuration.supportedCorrectDelay)
+        case .correct:
+            return lastReviewedAt.addingTimeInterval(independentCorrectInterval(for: progress.currentCorrectStreak))
+        case nil:
+            return lastReviewedAt.addingTimeInterval(independentCorrectInterval(for: progress.currentCorrectStreak))
+        }
+    }
+
+    func isDue(_ card: LearningCard) -> Bool {
+        let now = clock()
+        return nextReviewDate(for: card.progress, at: now) <= now
+    }
+
+    func reviewQueue(from cards: [LearningCard], limit: Int, includeFutureCards: Bool = false) -> [LearningCard] {
+        guard limit > 0 else { return [] }
+
+        let now = clock()
+        var remaining = cards
+            .map { ScheduledCard(card: $0, dueAt: nextReviewDate(for: $0.progress, at: now)) }
+            .filter { includeFutureCards || $0.dueAt <= now }
+            .sorted()
+
+        var selected: [ScheduledCard] = []
+        selected.reserveCapacity(min(limit, remaining.count))
+
+        while selected.count < limit, !remaining.isEmpty {
+            let selectedIndex = nextSelectionIndex(in: remaining, after: selected.last)
+            selected.append(remaining.remove(at: selectedIndex))
+        }
+
+        return selected.map(\.card)
+    }
+
+    private func independentCorrectInterval(for streak: Int) -> TimeInterval {
+        guard !configuration.independentCorrectIntervals.isEmpty else { return 0 }
+        let index = max(0, min(streak - 1, configuration.independentCorrectIntervals.count - 1))
+        return configuration.independentCorrectIntervals[index]
+    }
+
+    private func nextSelectionIndex(in remaining: [ScheduledCard], after previous: ScheduledCard?) -> Int {
+        guard let previous else { return 0 }
+
+        let windowEnd = remaining[0].dueAt.addingTimeInterval(configuration.interleaveWindow)
+        let pool = remaining.enumerated().filter { $0.element.dueAt <= windowEnd }
+
+        if let match = pool.first(where: {
+            $0.element.card.laneID != previous.card.laneID
+                && $0.element.card.conceptID != previous.card.conceptID
+        }) {
+            return match.offset
+        }
+
+        if let match = pool.first(where: { $0.element.card.laneID != previous.card.laneID }) {
+            return match.offset
+        }
+
+        return 0
+    }
+}
+
+private struct ScheduledCard: Comparable {
+    let card: LearningCard
+    let dueAt: Date
+
+    static func < (lhs: ScheduledCard, rhs: ScheduledCard) -> Bool {
+        if lhs.dueAt != rhs.dueAt {
+            return lhs.dueAt < rhs.dueAt
+        }
+        if lhs.card.laneID.rawValue != rhs.card.laneID.rawValue {
+            return lhs.card.laneID.rawValue < rhs.card.laneID.rawValue
+        }
+        if lhs.card.conceptID.rawValue != rhs.card.conceptID.rawValue {
+            return lhs.card.conceptID.rawValue < rhs.card.conceptID.rawValue
+        }
+        return lhs.card.id < rhs.card.id
+    }
+}

--- a/Domain/LearningCard.swift
+++ b/Domain/LearningCard.swift
@@ -120,19 +120,22 @@ struct CardProgress: Codable, Hashable {
     var incorrectCount: Int
     var currentCorrectStreak: Int
     var lastReviewedAt: Date?
+    var lastReviewResult: CardReviewResult?
 
     init(
         timesSeen: Int = 0,
         correctCount: Int = 0,
         incorrectCount: Int = 0,
         currentCorrectStreak: Int = 0,
-        lastReviewedAt: Date? = nil
+        lastReviewedAt: Date? = nil,
+        lastReviewResult: CardReviewResult? = nil
     ) {
         self.timesSeen = timesSeen
         self.correctCount = correctCount
         self.incorrectCount = incorrectCount
         self.currentCorrectStreak = currentCorrectStreak
         self.lastReviewedAt = lastReviewedAt
+        self.lastReviewResult = lastReviewResult
     }
 
     var totalAttempts: Int {
@@ -143,6 +146,12 @@ struct CardProgress: Codable, Hashable {
         guard totalAttempts > 0 else { return 0 }
         return Double(correctCount) / Double(totalAttempts)
     }
+}
+
+enum CardReviewResult: String, Codable, Hashable {
+    case correct
+    case supportedCorrect
+    case incorrect
 }
 
 protocol StarterLearningCardProviding {

--- a/Tests/MatherTests/CardReviewSchedulerTests.swift
+++ b/Tests/MatherTests/CardReviewSchedulerTests.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Testing
+@testable import Mather
+
+struct CardReviewSchedulerTests {
+    private let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+    @Test
+    func independentCorrectExpandsReviewInterval() {
+        let scheduler = CardReviewScheduler(now: now)
+        let first = scheduler.progress(after: .correct, from: CardProgress())
+        let second = scheduler.progress(after: .correct, from: first)
+
+        #expect(first.timesSeen == 1)
+        #expect(first.correctCount == 1)
+        #expect(first.currentCorrectStreak == 1)
+        #expect(scheduler.nextReviewDate(for: first) == now.addingTimeInterval(24 * 60 * 60))
+
+        #expect(second.timesSeen == 2)
+        #expect(second.correctCount == 2)
+        #expect(second.currentCorrectStreak == 2)
+        #expect(scheduler.nextReviewDate(for: second) == now.addingTimeInterval(3 * 24 * 60 * 60))
+    }
+
+    @Test
+    func supportedCorrectRecordsSuccessButKeepsCardCloser() {
+        let scheduler = CardReviewScheduler(now: now)
+        let supported = scheduler.progress(after: .supportedCorrect, from: CardProgress())
+
+        #expect(supported.timesSeen == 1)
+        #expect(supported.correctCount == 1)
+        #expect(supported.incorrectCount == 0)
+        #expect(supported.currentCorrectStreak == 0)
+        #expect(supported.lastReviewResult == .supportedCorrect)
+        #expect(scheduler.nextReviewDate(for: supported) == now.addingTimeInterval(30 * 60))
+    }
+
+    @Test
+    func incorrectReturnsSoonAndResetsStreak() {
+        let scheduler = CardReviewScheduler(now: now)
+        let prior = CardProgress(timesSeen: 4, correctCount: 4, incorrectCount: 0, currentCorrectStreak: 4)
+        let missed = scheduler.progress(after: .incorrect, from: prior)
+
+        #expect(missed.timesSeen == 5)
+        #expect(missed.correctCount == 4)
+        #expect(missed.incorrectCount == 1)
+        #expect(missed.currentCorrectStreak == 0)
+        #expect(missed.lastReviewResult == .incorrect)
+        #expect(scheduler.nextReviewDate(for: missed) == now.addingTimeInterval(5 * 60))
+    }
+
+    @Test
+    func injectedClockMakesDueDecisionsDeterministic() {
+        let reviewedAt = now.addingTimeInterval(-24 * 60 * 60)
+        let dueCard = makeCard(
+            id: "due",
+            laneID: .numbers,
+            conceptID: "number-bond",
+            progress: CardProgress(
+                timesSeen: 1,
+                correctCount: 1,
+                currentCorrectStreak: 1,
+                lastReviewedAt: reviewedAt,
+                lastReviewResult: .correct
+            )
+        )
+        let futureCard = makeCard(
+            id: "future",
+            laneID: .geometry,
+            conceptID: "shape",
+            progress: CardProgress(
+                timesSeen: 1,
+                correctCount: 1,
+                currentCorrectStreak: 1,
+                lastReviewedAt: now,
+                lastReviewResult: .correct
+            )
+        )
+        let scheduler = CardReviewScheduler(clock: { now })
+
+        #expect(scheduler.isDue(dueCard))
+        #expect(!scheduler.isDue(futureCard))
+        #expect(scheduler.reviewQueue(from: [futureCard, dueCard], limit: 10).map(\.id) == ["due"])
+    }
+
+    @Test
+    func reviewQueueInterleavesByLaneAndConceptWithinDueWindow() {
+        let scheduler = CardReviewScheduler(now: now)
+        let cards = [
+            makeCard(id: "numbers-a-1", laneID: .numbers, conceptID: "a"),
+            makeCard(id: "numbers-a-2", laneID: .numbers, conceptID: "a"),
+            makeCard(id: "geometry-a-1", laneID: .geometry, conceptID: "a"),
+            makeCard(id: "physics-b-1", laneID: .physics, conceptID: "b"),
+        ]
+
+        let queue = scheduler.reviewQueue(from: cards, limit: 4)
+
+        #expect(queue.map(\.id) == [
+            "geometry-a-1",
+            "physics-b-1",
+            "numbers-a-1",
+            "numbers-a-2",
+        ])
+    }
+
+    @Test
+    func reviewQueueHandlesLimitsAndEmptyInputs() {
+        let scheduler = CardReviewScheduler(now: now)
+        let card = makeCard(id: "card", laneID: .numbers, conceptID: "number-bond")
+
+        #expect(scheduler.reviewQueue(from: [], limit: 3).isEmpty)
+        #expect(scheduler.reviewQueue(from: [card], limit: 0).isEmpty)
+        #expect(scheduler.reviewQueue(from: [card], limit: 10).map(\.id) == ["card"])
+    }
+
+    private func makeCard(
+        id: String,
+        laneID: CapabilityLaneID,
+        conceptID: ConceptId,
+        progress: CardProgress = CardProgress()
+    ) -> LearningCard {
+        let answer = CardAnswer(id: "answer-\(id)", speechText: "answer")
+        return LearningCard(
+            id: id,
+            laneID: laneID,
+            conceptID: conceptID,
+            stage: .review,
+            ageBand: .ages4To12,
+            prompt: CardPrompt(id: "prompt-\(id)", speechText: "prompt"),
+            answer: answer,
+            choices: [CardChoice(answer: answer, isCorrect: true)],
+            progress: progress
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add deterministic `CardReviewScheduler` for `LearningCard` / `CardProgress` review timing.
- Track the last review result so independent correct, supported-correct, and incorrect outcomes schedule differently.
- Add deterministic unit coverage for interval expansion, supported-correct close returns, incorrect retries, injected clock behavior, queue limits, and lane/concept interleaving.

Refs #797

## Validation

- `git diff --check`
- Unable to run `xcodegen generate`: `xcodegen` is not installed in this worker image.
- Unable to run `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO`: `xcodebuild` is not installed in this worker image.