### PR TITLE
Issue #797 X1: Add reusable Mix-Match recall component

### DIFF
--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -1044,33 +1044,7 @@ struct MemoryView: View {
 
     @ViewBuilder
     private func cardView(_ card: MemoryCard) -> some View {
-        GeometryReader { proxy in
-            let cardHeight = proxy.size.height
-            let isMismatch = mismatchIds.contains(card.id)
-            let isFlipped = difficulty.faceDown && !card.isSelected && !card.isMatched
-
-            ZStack {
-                if isFlipped {
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .fill(LinearGradient(colors: [MatherTheme.accent.opacity(0.7), MatherTheme.softBlue.opacity(0.7)], startPoint: .topLeading, endPoint: .bottomTrailing))
-                    Text("?")
-                        .font(.system(size: min(44, max(32, cardHeight * 0.34)), weight: .black, design: .rounded))
-                        .foregroundStyle(.white.opacity(0.6))
-                } else {
-                    cardFace(card, cardHeight: cardHeight)
-                }
-            }
-            .overlay(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .strokeBorder(card.isSelected ? MatherTheme.accent : (card.isMatched ? Color.green : Color.clear), lineWidth: card.isSelected ? 3 : 2)
-            )
-            .scaleEffect(card.isMatched ? 0.92 : 1.0)
-            .opacity(card.isMatched ? 0.68 : 1.0)
-            .rotationEffect(isMismatch ? .degrees(-3) : .zero)
-            .animation(.spring(response: 0.25, dampingFraction: 0.6), value: card.isSelected)
-            .animation(.easeOut(duration: 0.3), value: card.isMatched)
-            .animation(isMismatch ? .easeInOut(duration: 0.08).repeatCount(3, autoreverses: true) : .default, value: isMismatch)
-        }
+        LearningCardView(model: Self.learningCardModel(for: card, difficulty: difficulty, isIncorrect: mismatchIds.contains(card.id)))
     }
 
     @ViewBuilder
@@ -1604,6 +1578,38 @@ struct MemoryView: View {
             return "Tap to turn this card over."
         }
         return "Tap to choose this card."
+    }
+
+    static func learningCardModel(for card: MemoryCard, difficulty: MemoryDifficulty, isIncorrect: Bool) -> LearningCardViewModel {
+        let display: LearningCardDisplay
+        switch card.content {
+        case .picture(let pictureAnimal):
+            display = Self.learningCardDisplay(for: pictureAnimal.picture)
+        case .label(let labelAnimal):
+            display = .text(labelAnimal.name)
+        }
+
+        return LearningCardViewModel(
+            id: card.id.uuidString,
+            display: display,
+            accessibilityLabel: accessibilityLabel(for: card),
+            accessibilityHint: accessibilityHint(for: card, difficulty: difficulty),
+            isFaceDown: difficulty.faceDown && !card.isSelected && !card.isMatched,
+            isSelected: card.isSelected,
+            isMatched: card.isMatched,
+            isIncorrect: isIncorrect
+        )
+    }
+
+    private static func learningCardDisplay(for picture: MemoryPicture) -> LearningCardDisplay {
+        switch picture {
+        case .emoji(let emoji):
+            return .emoji(emoji)
+        case .asset(let assetName):
+            return .asset(assetName)
+        case .text(let value):
+            return .text(value)
+        }
     }
 
     private static func learningSourceBadge(for deckSelection: DeckSelection, source: MemoryCardDescriptionSource) -> String {

--- a/Features/MixMatchRecall/MixMatchRecallView.swift
+++ b/Features/MixMatchRecall/MixMatchRecallView.swift
@@ -1,0 +1,271 @@
+import SwiftUI
+
+enum LearningCardDisplay: Equatable, Hashable {
+    case emoji(String)
+    case asset(String)
+    case text(String)
+    case choice(String)
+}
+
+struct LearningCardViewModel: Identifiable, Equatable, Hashable {
+    let id: String
+    let display: LearningCardDisplay
+    let accessibilityLabel: String
+    let accessibilityHint: String?
+    var isFaceDown: Bool
+    var isSelected: Bool
+    var isMatched: Bool
+    var isIncorrect: Bool
+
+    init(
+        id: String,
+        display: LearningCardDisplay,
+        accessibilityLabel: String,
+        accessibilityHint: String? = nil,
+        isFaceDown: Bool = false,
+        isSelected: Bool = false,
+        isMatched: Bool = false,
+        isIncorrect: Bool = false
+    ) {
+        self.id = id
+        self.display = display
+        self.accessibilityLabel = accessibilityLabel
+        self.accessibilityHint = accessibilityHint
+        self.isFaceDown = isFaceDown
+        self.isSelected = isSelected
+        self.isMatched = isMatched
+        self.isIncorrect = isIncorrect
+    }
+}
+
+struct MixMatchRecallChoice: Identifiable, Equatable, Hashable {
+    let id: String
+    let card: LearningCardViewModel
+    let isCorrect: Bool
+
+    init(id: String, card: LearningCardViewModel, isCorrect: Bool) {
+        self.id = id
+        self.card = card
+        self.isCorrect = isCorrect
+    }
+}
+
+struct MixMatchRecallAttempt: Equatable {
+    let choiceID: String
+    let isCorrect: Bool
+}
+
+struct MixMatchRecallChoiceEvaluator: Equatable {
+    let correctChoiceIDs: Set<String>
+
+    init(correctChoiceIDs: Set<String>) {
+        self.correctChoiceIDs = correctChoiceIDs
+    }
+
+    func attempt(choiceID: String) -> MixMatchRecallAttempt {
+        MixMatchRecallAttempt(choiceID: choiceID, isCorrect: correctChoiceIDs.contains(choiceID))
+    }
+}
+
+extension LearningCard {
+    var mixMatchPromptCard: LearningCardViewModel {
+        let display: LearningCardDisplay
+        if let assetName = prompt.assetName {
+            display = .asset(assetName)
+        } else if let displayText = prompt.displayText {
+            display = .text(displayText)
+        } else {
+            display = .text(prompt.speechText)
+        }
+
+        return LearningCardViewModel(
+            id: "\(id).prompt",
+            display: display,
+            accessibilityLabel: prompt.speechText,
+            accessibilityHint: "Choose the matching answer."
+        )
+    }
+
+    var mixMatchChoices: [MixMatchRecallChoice] {
+        choices.map { choice in
+            MixMatchRecallChoice(
+                id: choice.id,
+                card: LearningCardViewModel(
+                    id: choice.id,
+                    display: .choice(choice.answer.displayText ?? choice.answer.speechText),
+                    accessibilityLabel: choice.answer.speechText,
+                    accessibilityHint: "Answer choice."
+                ),
+                isCorrect: choice.isCorrect
+            )
+        }
+    }
+}
+
+@MainActor
+struct LearningCardView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let model: LearningCardViewModel
+    var minTouchSize: CGFloat = 80
+
+    var body: some View {
+        GeometryReader { proxy in
+            let cardHeight = max(proxy.size.height, minTouchSize)
+
+            ZStack {
+                if model.isFaceDown {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(LinearGradient(colors: [MatherTheme.accent.opacity(0.72), MatherTheme.softBlue.opacity(0.70)], startPoint: .topLeading, endPoint: .bottomTrailing))
+                    Text("?")
+                        .font(.system(size: min(48, max(34, cardHeight * 0.34)), weight: .black, design: .rounded))
+                        .foregroundStyle(.white.opacity(0.72))
+                } else {
+                    cardFace(cardHeight: cardHeight)
+                }
+            }
+            .frame(minWidth: minTouchSize, minHeight: minTouchSize)
+            .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(borderColor, lineWidth: model.isSelected || model.isIncorrect ? 3 : 2)
+            )
+            .scaleEffect(model.isMatched ? 0.92 : 1.0)
+            .opacity(model.isMatched ? 0.68 : 1.0)
+            .rotationEffect(model.isIncorrect ? .degrees(-3) : .zero)
+            .animation(.spring(response: 0.25, dampingFraction: 0.6), value: model.isSelected)
+            .animation(.easeOut(duration: 0.3), value: model.isMatched)
+            .animation(model.isIncorrect ? .easeInOut(duration: 0.08).repeatCount(3, autoreverses: true) : .default, value: model.isIncorrect)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(model.accessibilityLabel))
+        .accessibilityHint(Text(model.accessibilityHint ?? ""))
+    }
+
+    private var borderColor: Color {
+        if model.isIncorrect { return MatherTheme.danger }
+        if model.isSelected { return MatherTheme.accent }
+        if model.isMatched { return .green }
+        return .clear
+    }
+
+    @ViewBuilder
+    private func cardFace(cardHeight: CGFloat) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(backgroundGradient)
+
+            Circle()
+                .fill(Color.white.opacity(colorScheme == .dark ? 0.08 : 0.24))
+                .frame(width: cardHeight * 0.72, height: cardHeight * 0.72)
+                .offset(x: cardHeight * 0.16, y: -cardHeight * 0.18)
+
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.white.opacity(colorScheme == .dark ? 0.08 : 0.16))
+                .frame(width: cardHeight * 0.52, height: cardHeight * 0.16)
+                .offset(x: -cardHeight * 0.14, y: cardHeight * 0.24)
+                .rotationEffect(.degrees(-10))
+
+            displayContent(cardHeight: cardHeight)
+                .padding(8)
+        }
+    }
+
+    private var backgroundGradient: LinearGradient {
+        let colors: [Color]
+        if model.isMatched {
+            colors = [Color.green.opacity(0.24), Color.green.opacity(0.10)]
+        } else {
+            colors = [MatherTheme.panel.opacity(0.28), MatherTheme.softBlue.opacity(0.18)]
+        }
+        return LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
+    }
+
+    @ViewBuilder
+    private func displayContent(cardHeight: CGFloat) -> some View {
+        switch model.display {
+        case .emoji(let emoji):
+            Text(emoji)
+                .font(.system(size: min(58, max(34, cardHeight * 0.42))))
+                .shadow(color: .black.opacity(0.10), radius: 3, y: 2)
+        case .asset(let assetName):
+            Image(assetName)
+                .resizable()
+                .scaledToFit()
+                .shadow(color: .black.opacity(0.08), radius: 3, y: 2)
+                .padding(4)
+        case .text(let value), .choice(let value):
+            Text(value)
+                .font(.system(size: min(24, max(16, cardHeight * 0.18)), weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+                .multilineTextAlignment(.center)
+                .lineLimit(3)
+                .minimumScaleFactor(0.55)
+                .allowsTightening(true)
+                .padding(10)
+        }
+    }
+}
+
+@MainActor
+struct MixMatchRecallView: View {
+    let prompt: LearningCardViewModel?
+    let choices: [MixMatchRecallChoice]
+    private let evaluator: MixMatchRecallChoiceEvaluator
+    let onCorrect: (MixMatchRecallAttempt) -> Void
+    let onIncorrect: (MixMatchRecallAttempt) -> Void
+
+    init(
+        prompt: LearningCardViewModel? = nil,
+        choices: [MixMatchRecallChoice],
+        onCorrect: @escaping (MixMatchRecallAttempt) -> Void,
+        onIncorrect: @escaping (MixMatchRecallAttempt) -> Void
+    ) {
+        self.prompt = prompt
+        self.choices = choices
+        self.evaluator = MixMatchRecallChoiceEvaluator(correctChoiceIDs: Set(choices.filter(\.isCorrect).map(\.id)))
+        self.onCorrect = onCorrect
+        self.onIncorrect = onIncorrect
+    }
+
+    init(
+        learningCard: LearningCard,
+        onCorrect: @escaping (MixMatchRecallAttempt) -> Void,
+        onIncorrect: @escaping (MixMatchRecallAttempt) -> Void
+    ) {
+        self.init(
+            prompt: learningCard.mixMatchPromptCard,
+            choices: learningCard.mixMatchChoices,
+            onCorrect: onCorrect,
+            onIncorrect: onIncorrect
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if let prompt {
+                LearningCardView(model: prompt)
+                    .frame(minHeight: 112)
+                    .accessibilityIdentifier("mix-match-prompt-card")
+            }
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 112), spacing: 12)], spacing: 12) {
+                ForEach(choices) { choice in
+                    Button {
+                        let attempt = evaluator.attempt(choiceID: choice.id)
+                        if attempt.isCorrect {
+                            onCorrect(attempt)
+                        } else {
+                            onIncorrect(attempt)
+                        }
+                    } label: {
+                        LearningCardView(model: choice.card, minTouchSize: 80)
+                            .frame(minHeight: 96)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("mix-match-choice-\(choice.id)")
+                    .accessibilityAddTraits(.isButton)
+                }
+            }
+        }
+    }
+}

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -162,7 +162,7 @@ extension LabModelsTests {
         XCTAssertTrue(numbers.accessibilityLabel.contains("Numbers Lab"))
         XCTAssertTrue(numbers.accessibilityLabel.contains("Ages 4–12"))
         XCTAssertEqual(numbers.accessibilityHint, "Choose an activity or review cards.")
-        XCTAssertTrue(numbers.recallAccessibilityLabel.contains("8 Mix-Match cards ready"))
+        XCTAssertTrue(numbers.recallAccessibilityLabel.contains("1 recall card + 8 Mix-Match ready"))
         XCTAssertTrue(numbers.recallAccessibilityLabel.contains("number-bond"))
         XCTAssertEqual(sumSprint.accessibilityLabel, "Sum Sprint. Race through sums 11–20")
         XCTAssertTrue(sumSprint.accessibilityHint.contains("Modes: Challenge, Timed, Review"))

--- a/Tests/MatherTests/MixMatchRecallViewTests.swift
+++ b/Tests/MatherTests/MixMatchRecallViewTests.swift
@@ -1,0 +1,58 @@
+import Testing
+@testable import Mather
+
+struct MixMatchRecallViewTests {
+    @Test
+    func evaluatorMarksCorrectAndIncorrectChoices() {
+        let evaluator = MixMatchRecallChoiceEvaluator(correctChoiceIDs: ["ten"])
+
+        #expect(evaluator.attempt(choiceID: "ten") == MixMatchRecallAttempt(choiceID: "ten", isCorrect: true))
+        #expect(evaluator.attempt(choiceID: "nine") == MixMatchRecallAttempt(choiceID: "nine", isCorrect: false))
+    }
+
+    @Test
+    func learningCardAdapterCreatesPromptAndChoiceCards() {
+        let correct = CardAnswer(id: "triangle", speechText: "triangle", displayText: "Triangle")
+        let card = LearningCard(
+            laneID: .geometry,
+            conceptID: "shape",
+            stage: .pictorial,
+            ageBand: .ages4To12,
+            prompt: CardPrompt(id: "three-sides", speechText: "Which shape has three sides?", displayText: "Three sides"),
+            answer: correct,
+            choices: [
+                CardChoice(answer: correct, isCorrect: true),
+                CardChoice(answer: CardAnswer(id: "circle", speechText: "circle", displayText: "Circle"))
+            ]
+        )
+
+        #expect(card.mixMatchPromptCard.display == .text("Three sides"))
+        #expect(card.mixMatchPromptCard.accessibilityLabel == "Which shape has three sides?")
+        #expect(card.mixMatchChoices.map(\.id) == ["triangle", "circle"])
+        #expect(card.mixMatchChoices.map(\.isCorrect) == [true, false])
+        #expect(card.mixMatchChoices.first?.card.display == .choice("Triangle"))
+        #expect(card.mixMatchChoices.last?.card.accessibilityLabel == "circle")
+    }
+
+    @Test
+    func memoryAdapterPreservesCardStateAndAccessibleLabels() throws {
+        let animal = try #require(MemoryDeck.countryFlags.first)
+        var pictureCard = MemoryCard(pairId: animal.id, content: .picture(animal))
+        pictureCard.isSelected = true
+        let model = MemoryView.learningCardModel(for: pictureCard, difficulty: .hard, isIncorrect: true)
+
+        #expect(model.display == .asset("MemoryFlagIndia"))
+        #expect(model.accessibilityLabel == "Flag of India")
+        #expect(model.accessibilityHint == "Tap to choose this card.")
+        #expect(model.isFaceDown == false)
+        #expect(model.isSelected == true)
+        #expect(model.isIncorrect == true)
+
+        let hiddenLabelCard = MemoryCard(pairId: animal.id, content: .label(animal))
+        let hiddenModel = MemoryView.learningCardModel(for: hiddenLabelCard, difficulty: .hard, isIncorrect: false)
+
+        #expect(hiddenModel.display == .text("India"))
+        #expect(hiddenModel.accessibilityLabel == "India")
+        #expect(hiddenModel.isFaceDown == true)
+    }
+}

--- a/Tests/MatherTests/MixMatchRecallViewTests.swift
+++ b/Tests/MatherTests/MixMatchRecallViewTests.swift
@@ -35,6 +35,7 @@ struct MixMatchRecallViewTests {
     }
 
     @Test
+    @MainActor
     func memoryAdapterPreservesCardStateAndAccessibleLabels() throws {
         let animal = try #require(MemoryDeck.countryFlags.first)
         var pictureCard = MemoryCard(pairId: animal.id, content: .picture(animal))


### PR DESCRIPTION
## Summary

Refs #797

- Add a reusable lane-agnostic `LearningCardView` / `MixMatchRecallView` surface for picture, text, and choice-style recall cards.
- Add `LearningCard` adapters plus callback/evaluation plumbing for correct and incorrect choice attempts.
- Wire Memory card rendering through a tiny adapter while leaving its existing tap, match, mismatch, round, and learning detail behavior intact.
- Add focused Swift Testing coverage for evaluator logic, `LearningCard` conversion, and Memory adapter state/VoiceOver labels.

## Validation

- `git diff --check` passed.
- `xcodegen generate` could not run in this worker: `xcodegen: command not found`.
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO` could not run in this worker: `xcodebuild: command not found`.