### PR TITLE
Add Water Cycle lesson play thread

### DIFF
--- a/Domain/LessonPlayThread.swift
+++ b/Domain/LessonPlayThread.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+enum LessonPlayStageKind: String, Codable, CaseIterable, Equatable, Hashable {
+    case lookLearnFlashcards
+    case invertedRecall
+    case contextualAsk
+    case mixMatchFinale
+}
+
+struct LessonPlayCard: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let title: String
+    let prompt: String
+    let answer: String
+    let detail: String
+    let assetName: String?
+}
+
+struct LessonSafeAskTurn: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let question: String
+    let answer: String
+}
+
+struct LessonSafeAskResponse: Equatable {
+    enum Kind: Equatable {
+        case answer
+        case refusal
+    }
+
+    let kind: Kind
+    let spokenText: String
+}
+
+enum LessonSafeAskTurnRequest: Equatable {
+    case suggestedTurn(id: String)
+    case unsupportedTopic
+}
+
+struct LessonSafeAskSession: Equatable {
+    static let allowsMicrophoneInput = false
+    static let allowsFreeformTextInput = false
+
+    let cardID: String
+    let suggestedTurns: [LessonSafeAskTurn]
+    private(set) var selectedTurnIDs: [String] = []
+
+    mutating func respond(to request: LessonSafeAskTurnRequest) -> LessonSafeAskResponse {
+        switch request {
+        case .unsupportedTopic:
+            return Self.offScopeResponse
+        case .suggestedTurn(let id):
+            guard let turn = suggestedTurns.first(where: { $0.id == id }) else {
+                return Self.offScopeResponse
+            }
+            selectedTurnIDs.append(id)
+            return LessonSafeAskResponse(kind: .answer, spokenText: turn.answer)
+        }
+    }
+
+    private static var offScopeResponse: LessonSafeAskResponse {
+        LessonSafeAskResponse(
+            kind: .refusal,
+            spokenText: "I can only talk about this card. Pick one of the card questions."
+        )
+    }
+}
+
+struct LessonPlayStage: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let kind: LessonPlayStageKind
+    let title: String
+    let prompt: String
+}
+
+struct LessonPlayThread: Identifiable, Codable, Equatable {
+    let id: String
+    let title: String
+    let stages: [LessonPlayStage]
+    let cards: [LessonPlayCard]
+    private(set) var activeStageIndex: Int
+    private(set) var completedStageIDs: Set<String>
+
+    init(
+        id: String,
+        title: String,
+        stages: [LessonPlayStage],
+        cards: [LessonPlayCard],
+        activeStageIndex: Int = 0,
+        completedStageIDs: Set<String> = []
+    ) {
+        self.id = id
+        self.title = title
+        self.stages = stages
+        self.cards = cards
+        self.activeStageIndex = min(max(activeStageIndex, 0), max(stages.count - 1, 0))
+        self.completedStageIDs = completedStageIDs
+    }
+
+    var activeStage: LessonPlayStage {
+        stages[activeStageIndex]
+    }
+
+    var isComplete: Bool {
+        completedStageIDs.count == stages.count
+    }
+
+    var progressLabel: String {
+        "Level \(activeStageIndex + 1) of \(stages.count)"
+    }
+
+    var progress: Double {
+        guard !stages.isEmpty else { return 1 }
+        return Double(completedStageIDs.count) / Double(stages.count)
+    }
+
+    mutating func completeActiveStage() {
+        completedStageIDs.insert(activeStage.id)
+        guard activeStageIndex < stages.count - 1 else { return }
+        activeStageIndex += 1
+    }
+
+    mutating func resetProgress() {
+        activeStageIndex = 0
+        completedStageIDs.removeAll()
+    }
+}

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -76,13 +76,36 @@ struct WaterCycleLabState: Equatable {
     private(set) var cyclesCompleted = 0
     private(set) var flashcardIndex = 0
     private(set) var isFlashcardAnswerRevealed = false
+    private(set) var lessonThread = WaterCycleLessonThread.thread
+    private(set) var lessonCardIndex = 0
+    private(set) var isRecallCardRevealed = false
+    private(set) var askSession = WaterCycleLessonThread.askSession(for: WaterCycleLessonThread.cards[0])
+    private(set) var latestAskResponse: LessonSafeAskResponse?
+    private(set) var mixMatchIndex = 0
+    private(set) var mixMatchCorrectCardIDs: Set<String> = []
 
     var currentFlashcard: WaterCycleConceptFlashcard {
         WaterCycleConceptFlashcard.reviewDeck[flashcardIndex % WaterCycleConceptFlashcard.reviewDeck.count]
     }
 
+    var currentLessonCard: LessonPlayCard {
+        lessonThread.cards[lessonCardIndex % lessonThread.cards.count]
+    }
+
+    var currentMixMatchCard: LearningCard {
+        WaterCycleLessonThread.mixMatchCards[mixMatchIndex % WaterCycleLessonThread.mixMatchCards.count]
+    }
+
     var flashcardProgressLabel: String {
         "Card \(flashcardIndex + 1) of \(WaterCycleConceptFlashcard.reviewDeck.count)"
+    }
+
+    var lessonCardProgressLabel: String {
+        "Card \(lessonCardIndex + 1) of \(lessonThread.cards.count)"
+    }
+
+    var mixMatchProgressLabel: String {
+        "Match \(mixMatchCorrectCardIDs.count) of \(WaterCycleLessonThread.mixMatchCards.count)"
     }
 
     var progress: Double {
@@ -145,6 +168,7 @@ struct WaterCycleLabState: Equatable {
             cyclesCompleted += 1
             flashcardIndex = 0
             isFlashcardAnswerRevealed = false
+            resetLessonThread()
             stage = .complete
         case .complete:
             reset()
@@ -162,6 +186,55 @@ struct WaterCycleLabState: Equatable {
         isFlashcardAnswerRevealed = false
     }
 
+    mutating func advanceLessonCard() {
+        guard stage == .complete else { return }
+        lessonCardIndex = (lessonCardIndex + 1) % lessonThread.cards.count
+        isRecallCardRevealed = false
+        askSession = WaterCycleLessonThread.askSession(for: currentLessonCard)
+        latestAskResponse = nil
+    }
+
+    mutating func revealRecallCard() {
+        guard stage == .complete, lessonThread.activeStage.kind == .invertedRecall else { return }
+        isRecallCardRevealed = true
+    }
+
+    mutating func selectAskTurn(id: String) -> LessonSafeAskResponse? {
+        guard stage == .complete, lessonThread.activeStage.kind == .contextualAsk else { return nil }
+        var session = askSession
+        let response = session.respond(to: .suggestedTurn(id: id))
+        askSession = session
+        latestAskResponse = response
+        return response
+    }
+
+    mutating func completeCurrentLessonStage() {
+        guard stage == .complete else { return }
+        lessonThread.completeActiveStage()
+        lessonCardIndex = 0
+        isRecallCardRevealed = false
+        askSession = WaterCycleLessonThread.askSession(for: currentLessonCard)
+        latestAskResponse = nil
+    }
+
+    mutating func recordMixMatchAttempt(_ attempt: MixMatchRecallAttempt) {
+        guard stage == .complete, lessonThread.activeStage.kind == .mixMatchFinale, attempt.isCorrect else { return }
+        mixMatchCorrectCardIDs.insert(currentMixMatchCard.answer.id)
+        if mixMatchCorrectCardIDs.count == WaterCycleLessonThread.mixMatchCards.count {
+            lessonThread.completeActiveStage()
+        } else {
+            mixMatchIndex = nextUnmatchedMixMatchIndex()
+        }
+    }
+
+    private func nextUnmatchedMixMatchIndex() -> Int {
+        let cards = WaterCycleLessonThread.mixMatchCards
+        guard let next = cards.indices.first(where: { !mixMatchCorrectCardIDs.contains(cards[$0].answer.id) }) else {
+            return mixMatchIndex
+        }
+        return next
+    }
+
     mutating func reset() {
         stage = .wonder
         vaporDrops = 0
@@ -170,6 +243,17 @@ struct WaterCycleLabState: Equatable {
         pondDrops = 4
         flashcardIndex = 0
         isFlashcardAnswerRevealed = false
+        resetLessonThread()
+    }
+
+    private mutating func resetLessonThread() {
+        lessonThread.resetProgress()
+        lessonCardIndex = 0
+        isRecallCardRevealed = false
+        askSession = WaterCycleLessonThread.askSession(for: currentLessonCard)
+        latestAskResponse = nil
+        mixMatchIndex = 0
+        mixMatchCorrectCardIDs = []
     }
 }
 
@@ -235,7 +319,7 @@ struct WaterCycleLabView: View {
                         inquiryCard
                         waterCycleScene(width: contentWidth, height: sceneHeight)
                         if state.stage == .complete {
-                            flashcardReviewCard
+                            lessonPlayThreadCard
                         }
                         actionControls(availableWidth: contentWidth)
                     }
@@ -470,6 +554,211 @@ struct WaterCycleLabView: View {
         }
     }
 
+    private var lessonPlayThreadCard: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .firstTextBaseline) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Label(state.lessonThread.activeStage.title, systemImage: lessonStageIcon)
+                            .font(.headline.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text(state.lessonThread.progressLabel)
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                    }
+                    Spacer()
+                    Text(state.lessonCardProgressLabel)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                }
+
+                Text(state.lessonThread.activeStage.prompt)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                ProgressView(value: state.lessonThread.progress)
+                    .tint(MatherTheme.accent)
+                    .accessibilityLabel("Lesson thread progress")
+
+                switch state.lessonThread.activeStage.kind {
+                case .lookLearnFlashcards:
+                    lookLearnLevel
+                case .invertedRecall:
+                    invertedRecallLevel
+                case .contextualAsk:
+                    safeAskLevel
+                case .mixMatchFinale:
+                    mixMatchFinaleLevel
+                }
+            }
+        }
+        .accessibilityIdentifier("water-cycle-lesson-thread")
+    }
+
+    private var lessonStageIcon: String {
+        switch state.lessonThread.activeStage.kind {
+        case .lookLearnFlashcards: "photo.stack.fill"
+        case .invertedRecall: "rectangle.on.rectangle.angled.fill"
+        case .contextualAsk: "bubble.left.and.text.bubble.right.fill"
+        case .mixMatchFinale: "rectangle.2.swap"
+        }
+    }
+
+    private var lookLearnLevel: some View {
+        let card = state.currentLessonCard
+
+        return VStack(alignment: .leading, spacing: 12) {
+            if let assetName = card.assetName {
+                Image(assetName)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxHeight: 180)
+                    .frame(maxWidth: .infinity)
+                    .accessibilityHidden(true)
+            }
+
+            Text(card.title)
+                .font(.system(size: 24, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.accent)
+
+            Text(card.prompt)
+                .font(.system(size: 19, weight: .semibold, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(card.answer)
+                    .font(.system(size: 18, weight: .bold, design: .rounded))
+                    .foregroundStyle(MatherTheme.ink)
+                Text(card.detail)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
+
+            lessonNavigationButtons(nextTitle: "Next card", completeTitle: "Start flip recall")
+        }
+    }
+
+    private var invertedRecallLevel: some View {
+        let card = state.currentLessonCard
+        let model = LearningCardViewModel(
+            id: card.id,
+            display: card.assetName.map(LearningCardDisplay.asset) ?? .text(card.title),
+            accessibilityLabel: card.title,
+            accessibilityHint: "Flip to recall this water cycle idea.",
+            isFaceDown: !state.isRecallCardRevealed,
+            isSelected: state.isRecallCardRevealed,
+            isMatched: false,
+            isIncorrect: false
+        )
+
+        return VStack(alignment: .leading, spacing: 12) {
+            Button {
+                state.revealRecallCard()
+                speakLessonCard()
+            } label: {
+                LearningCardView(model: model)
+                    .frame(minHeight: 150)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("water-cycle-recall-card")
+
+            Text(state.isRecallCardRevealed ? card.answer : "Say the idea before you flip.")
+                .font(.system(size: 18, weight: .bold, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if state.isRecallCardRevealed {
+                Text(card.detail)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            lessonNavigationButtons(nextTitle: "Next recall", completeTitle: "Ask this card")
+        }
+    }
+
+    private var safeAskLevel: some View {
+        let card = state.currentLessonCard
+
+        return VStack(alignment: .leading, spacing: 12) {
+            Text(card.title)
+                .font(.system(size: 22, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.accent)
+
+            ForEach(state.askSession.suggestedTurns) { turn in
+                Button {
+                    if let response = state.selectAskTurn(id: turn.id) {
+                        appModel.speechService.speak(response.spokenText, enabled: appModel.featureFlags.audioEnabled)
+                    }
+                } label: {
+                    Label(turn.question, systemImage: "questionmark.bubble.fill")
+                }
+                .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.panelDeep.opacity(0.28)))
+                .accessibilityIdentifier("water-cycle-safe-ask-\(turn.id)")
+            }
+
+            if let latestAskResponse = state.latestAskResponse {
+                Text(latestAskResponse.spokenText)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.ink)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("water-cycle-safe-ask-response")
+            }
+
+            lessonNavigationButtons(nextTitle: "Next card", completeTitle: "Start mix-match")
+        }
+    }
+
+    private var mixMatchFinaleLevel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(state.mixMatchProgressLabel)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+
+            if state.lessonThread.isComplete {
+                Label("Lesson thread complete", systemImage: "checkmark.seal.fill")
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+            } else {
+                MixMatchRecallView(
+                    learningCard: state.currentMixMatchCard,
+                    onCorrect: { attempt in
+                        state.recordMixMatchAttempt(attempt)
+                        speakLessonText(attempt.isCorrect ? "Correct match." : "Try another match.")
+                    },
+                    onIncorrect: { attempt in
+                        state.recordMixMatchAttempt(attempt)
+                        speakLessonText("Try another match.")
+                    }
+                )
+                .accessibilityIdentifier("water-cycle-mix-match-finale")
+            }
+        }
+    }
+
+    private func lessonNavigationButtons(nextTitle: String, completeTitle: String) -> some View {
+        HStack(spacing: 12) {
+            Button {
+                state.advanceLessonCard()
+                speakLessonCard()
+            } label: {
+                Label(nextTitle, systemImage: "arrow.right.circle.fill")
+            }
+            .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.panelDeep.opacity(0.28)))
+
+            Button {
+                state.completeCurrentLessonStage()
+                speakLessonStage()
+            } label: {
+                Label(completeTitle, systemImage: "play.fill")
+            }
+            .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.32)))
+        }
+    }
+
     private var flashcardReviewCard: some View {
         let flashcard = state.currentFlashcard
 
@@ -605,6 +894,20 @@ struct WaterCycleLabView: View {
             ? "\(flashcard.question) \(flashcard.answer) \(flashcard.connection)"
             : flashcard.question
         appModel.speechService.speak(spokenText, enabled: appModel.featureFlags.audioEnabled)
+    }
+
+    private func speakLessonStage() {
+        let stage = state.lessonThread.activeStage
+        appModel.speechService.speak("\(stage.title). \(stage.prompt)", enabled: appModel.featureFlags.audioEnabled)
+    }
+
+    private func speakLessonCard() {
+        let card = state.currentLessonCard
+        appModel.speechService.speak("\(card.title). \(card.prompt) \(card.answer) \(card.detail)", enabled: appModel.featureFlags.audioEnabled)
+    }
+
+    private func speakLessonText(_ text: String) {
+        appModel.speechService.speak(text, enabled: appModel.featureFlags.audioEnabled)
     }
 
     private func saveIfCompleted() {

--- a/Features/WaterCycle/WaterCycleLessonThread.swift
+++ b/Features/WaterCycle/WaterCycleLessonThread.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+enum WaterCycleLessonThread {
+    static let thread = LessonPlayThread(
+        id: "water-cycle-thread",
+        title: "Water Cycle Play Thread",
+        stages: [
+            LessonPlayStage(
+                id: "look-learn",
+                kind: .lookLearnFlashcards,
+                title: "Look & Learn",
+                prompt: "Look at each picture and hear what the water is doing."
+            ),
+            LessonPlayStage(
+                id: "flip-recall",
+                kind: .invertedRecall,
+                title: "Flip Recall",
+                prompt: "Flip the hidden card, say the idea, then check the picture."
+            ),
+            LessonPlayStage(
+                id: "safe-ask",
+                kind: .contextualAsk,
+                title: "Ask This Card",
+                prompt: "Pick a card question. Answers stay about this water cycle card."
+            ),
+            LessonPlayStage(
+                id: "mix-match",
+                kind: .mixMatchFinale,
+                title: "Mix-Match Finale",
+                prompt: "Match each picture to the water cycle idea."
+            )
+        ],
+        cards: cards
+    )
+
+    static let cards: [LessonPlayCard] = [
+        LessonPlayCard(
+            id: "sun-heat",
+            title: "Sun Heat",
+            prompt: "What gives pond water the energy to start moving?",
+            answer: "The sun warms the water.",
+            detail: "Warm water can change into vapor and rise.",
+            assetName: "MemoryWaterCycleSunHeat"
+        ),
+        LessonPlayCard(
+            id: "evaporation",
+            title: "Evaporation",
+            prompt: "What do we call water going up as tiny vapor?",
+            answer: "Evaporation.",
+            detail: "The vapor leaves the pond and travels into the air.",
+            assetName: "MemoryWaterCycleEvaporation"
+        ),
+        LessonPlayCard(
+            id: "condensation",
+            title: "Condensation",
+            prompt: "What happens when tiny vapor drops gather together?",
+            answer: "They make a cloud.",
+            detail: "This gathering step is condensation.",
+            assetName: "MemoryWaterCycleCondensation"
+        ),
+        LessonPlayCard(
+            id: "precipitation",
+            title: "Precipitation",
+            prompt: "What happens when a cloud gets heavy with drops?",
+            answer: "Rain falls down.",
+            detail: "Rain, snow, sleet, and hail are precipitation.",
+            assetName: "MemoryWaterCyclePrecipitation"
+        ),
+        LessonPlayCard(
+            id: "collection",
+            title: "Collection",
+            prompt: "Where does rainwater wait after it falls?",
+            answer: "It gathers in ponds, lakes, rivers, puddles, and the ground.",
+            detail: "Then the sun can warm it and the cycle begins again.",
+            assetName: "MemoryWaterCycleCollection"
+        )
+    ]
+
+    static func askTurns(for card: LessonPlayCard) -> [LessonSafeAskTurn] {
+        [
+            LessonSafeAskTurn(
+                id: "\(card.id)-what",
+                question: "What is \(card.title)?",
+                answer: "\(card.title): \(card.answer) \(card.detail)"
+            ),
+            LessonSafeAskTurn(
+                id: "\(card.id)-look",
+                question: "What should I look for?",
+                answer: "Look at the picture for \(card.title.lowercased()). \(card.detail)"
+            )
+        ]
+    }
+
+    static func askSession(for card: LessonPlayCard) -> LessonSafeAskSession {
+        LessonSafeAskSession(cardID: card.id, suggestedTurns: askTurns(for: card))
+    }
+
+    static let mixMatchCards: [LearningCard] = cards.map { card in
+        LearningCard(
+            id: "water-cycle.\(card.id).mix-match",
+            laneID: .physics,
+            conceptID: ConceptId(rawValue: "water-cycle-\(card.id)"),
+            stage: .review,
+            ageBand: .ages4To12,
+            prompt: CardPrompt(
+                id: card.id,
+                speechText: card.prompt,
+                displayText: card.title,
+                assetName: card.assetName
+            ),
+            answer: CardAnswer(
+                id: card.id,
+                speechText: card.title,
+                displayText: card.title
+            ),
+            choices: cards.map { choiceCard in
+                CardChoice(
+                    answer: CardAnswer(
+                        id: choiceCard.id,
+                        speechText: choiceCard.title,
+                        displayText: choiceCard.title
+                    ),
+                    isCorrect: choiceCard.id == card.id
+                )
+            }
+        )
+    }
+}

--- a/Tests/MatherTests/LessonPlayThreadTests.swift
+++ b/Tests/MatherTests/LessonPlayThreadTests.swift
@@ -1,0 +1,69 @@
+import Testing
+@testable import Mather
+
+struct LessonPlayThreadTests {
+    @Test func advancesDeterministicStagesAndReportsProgress() {
+        var thread = LessonPlayThread(
+            id: "sample-thread",
+            title: "Sample",
+            stages: [
+                LessonPlayStage(id: "look", kind: .lookLearnFlashcards, title: "Look", prompt: "Look."),
+                LessonPlayStage(id: "recall", kind: .invertedRecall, title: "Recall", prompt: "Recall."),
+                LessonPlayStage(id: "ask", kind: .contextualAsk, title: "Ask", prompt: "Ask."),
+                LessonPlayStage(id: "match", kind: .mixMatchFinale, title: "Match", prompt: "Match.")
+            ],
+            cards: [
+                LessonPlayCard(id: "card-1", title: "Card", prompt: "Prompt", answer: "Answer", detail: "Detail", assetName: nil)
+            ]
+        )
+
+        #expect(thread.activeStage.kind == .lookLearnFlashcards)
+        #expect(thread.progressLabel == "Level 1 of 4")
+        #expect(thread.progress == 0)
+
+        thread.completeActiveStage()
+        #expect(thread.activeStage.kind == .invertedRecall)
+        #expect(thread.progressLabel == "Level 2 of 4")
+        #expect(thread.progress == 0.25)
+
+        thread.completeActiveStage()
+        thread.completeActiveStage()
+        thread.completeActiveStage()
+        #expect(thread.activeStage.kind == .mixMatchFinale)
+        #expect(thread.isComplete)
+        #expect(thread.progress == 1)
+
+        thread.resetProgress()
+        #expect(thread.activeStage.kind == .lookLearnFlashcards)
+        #expect(!thread.isComplete)
+        #expect(thread.progress == 0)
+    }
+
+    @Test func safeAskOnlyAnswersSuggestedCardScopedTurns() {
+        var session = LessonSafeAskSession(
+            cardID: "evaporation",
+            suggestedTurns: [
+                LessonSafeAskTurn(
+                    id: "evaporation-what",
+                    question: "What is evaporation?",
+                    answer: "Evaporation is water vapor going up."
+                )
+            ]
+        )
+
+        #expect(LessonSafeAskSession.allowsMicrophoneInput == false)
+        #expect(LessonSafeAskSession.allowsFreeformTextInput == false)
+
+        let answer = session.respond(to: .suggestedTurn(id: "evaporation-what"))
+        #expect(answer.kind == .answer)
+        #expect(answer.spokenText.contains("water vapor"))
+        #expect(session.selectedTurnIDs == ["evaporation-what"])
+
+        let missing = session.respond(to: .suggestedTurn(id: "off-card"))
+        #expect(missing.kind == .refusal)
+        #expect(missing.spokenText.contains("only talk about this card"))
+
+        let unsupported = session.respond(to: .unsupportedTopic)
+        #expect(unsupported.kind == .refusal)
+    }
+}

--- a/Tests/MatherTests/WaterCycleLabTests.swift
+++ b/Tests/MatherTests/WaterCycleLabTests.swift
@@ -106,9 +106,57 @@ extension WaterCycleLabTests {
         #expect(state.currentFlashcard.concept == "Sun Heat")
 
         state.revealFlashcardAnswer()
+        state.completeCurrentLessonStage()
+        #expect(state.lessonThread.activeStage.kind == .invertedRecall)
+
         state.reset()
         #expect(state.stage == .wonder)
         #expect(state.flashcardIndex == 0)
         #expect(state.isFlashcardAnswerRevealed == false)
+        #expect(state.lessonThread.activeStage.kind == .lookLearnFlashcards)
+        #expect(state.mixMatchCorrectCardIDs.isEmpty)
+    }
+
+    @Test func completedCycleUnlocksStagedLessonThread() {
+        var state = WaterCycleLabState()
+        for _ in 0..<5 { state.advance() }
+
+        #expect(state.stage == .complete)
+        #expect(state.lessonThread.stages.map(\.kind) == [
+            .lookLearnFlashcards,
+            .invertedRecall,
+            .contextualAsk,
+            .mixMatchFinale
+        ])
+        #expect(state.currentLessonCard.title == "Sun Heat")
+        #expect(state.currentLessonCard.assetName == "MemoryWaterCycleSunHeat")
+
+        state.completeCurrentLessonStage()
+        #expect(state.lessonThread.activeStage.kind == .invertedRecall)
+        #expect(state.isRecallCardRevealed == false)
+
+        state.revealRecallCard()
+        #expect(state.isRecallCardRevealed)
+
+        state.completeCurrentLessonStage()
+        #expect(state.lessonThread.activeStage.kind == .contextualAsk)
+        #expect(state.askSession.cardID == "sun-heat")
+        #expect(state.askSession.suggestedTurns.count == 2)
+
+        let response = state.selectAskTurn(id: "sun-heat-what")
+        #expect(response?.kind == .answer)
+        #expect(response?.spokenText.contains("Sun Heat") == true)
+
+        state.completeCurrentLessonStage()
+        #expect(state.lessonThread.activeStage.kind == .mixMatchFinale)
+        #expect(state.currentMixMatchCard.answer.id == "sun-heat")
+
+        for card in WaterCycleLessonThread.mixMatchCards {
+            let attempt = MixMatchRecallAttempt(choiceID: card.answer.id, isCorrect: true)
+            state.recordMixMatchAttempt(attempt)
+        }
+
+        #expect(state.lessonThread.isComplete)
+        #expect(state.mixMatchProgressLabel == "Match 5 of 5")
     }
 }


### PR DESCRIPTION
## Summary
- Adds a reusable `LessonPlayThread` foundation with deterministic stages and card-scoped safe ask sessions.
- Pilots the staged thread in Water Cycle after cycle completion: Look & Learn image flashcards, Flip Recall inverted cards, suggested-turn safe ask, and Mix-Match finale.
- Adds unit coverage for lesson stage progression, safe ask boundaries, and Water Cycle thread state progression.

Fixes #826

## Validation
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- Local `xcodegen generate` could not run because `xcodegen` is not installed in this Linux worker.
- Local `xcodebuild test` could not run because this worker is Linux and does not have `xcodebuild`/Swift installed.