### PR TITLE
Open Explorer Lab lanes as game-card screens

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -88,6 +88,8 @@ struct RootView: View {
                     CompassAnglesView(appModel: appModel)
                 case .lab:
                     LabView(appModel: appModel)
+                case .labLane(let laneID):
+                    LabLaneDetailView(appModel: appModel, laneID: laneID)
                 case .memory:
                     MemoryView(appModel: appModel)
                 case .waterCycle:

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -18,6 +18,7 @@ enum AppRoute: Hashable {
     case gravityArtist
     case compassAngles
     case lab
+    case labLane(CapabilityLaneID)
     case memory
     case waterCycle
 }
@@ -128,6 +129,7 @@ final class VerticalSliceEngine {
     func showGravityArtist() { route = .gravityArtist }
     func showCompassAngles() { route = .compassAngles }
     func showLab() { route = .lab }
+    func showLabLane(_ laneID: CapabilityLaneID) { route = .labLane(laneID) }
     func showMemory() { route = .memory }
     func showWaterCycle() { route = .waterCycle }
 

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -1,0 +1,601 @@
+import SwiftUI
+
+struct LabLaneDetailView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Bindable var appModel: AppModel
+    let laneID: CapabilityLaneID
+
+    @State private var expandedReview = false
+    @State private var sensorCapabilities = DeviceSensorCapabilities.unavailable
+
+    private var lane: CapabilityLane {
+        CapabilityLane.defaultExplorerLanes.first { $0.id == laneID } ?? CapabilityLane.defaultExplorerLanes[0]
+    }
+
+    var body: some View {
+        let selectedLane = lane
+        let tint = laneColor(selectedLane.id)
+        let progress = progress(for: selectedLane)
+        let presentation = LabLaneDetailPresentation(lane: selectedLane)
+
+        ZStack {
+            MatherTheme.background.ignoresSafeArea()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header(selectedLane, presentation: presentation, progress: progress, tint: tint)
+                    supportPanel(selectedLane, progress: progress, tint: tint)
+                    gamesSection(selectedLane, tint: tint)
+                    recallSection(selectedLane, tint: tint)
+                }
+                .padding(24)
+            }
+        }
+        .onAppear {
+            sensorCapabilities = SensorCapabilityService().currentCapabilities()
+        }
+    }
+
+    private func header(
+        _ lane: CapabilityLane,
+        presentation: LabLaneDetailPresentation,
+        progress: CapabilityLaneProgress,
+        tint: Color
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 14) {
+                Button {
+                    appModel.engine.showLab()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.title3.weight(.black))
+                        .foregroundStyle(tint)
+                        .frame(width: 56, height: 56)
+                        .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Back to Explorer Lab lanes")
+
+                laneHeroVisual(lane, tint: tint)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(presentation.title)
+                        .font(.system(size: 34, weight: .black, design: .rounded))
+                        .foregroundStyle(MatherTheme.ink)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
+                    Text(lane.promise)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Label(presentation.activityCountLabel, systemImage: lane.isReady ? "gamecontroller.fill" : "sparkles")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(tint)
+                }
+
+                Spacer(minLength: 0)
+
+                Button {
+                    appModel.engine.showHome()
+                } label: {
+                    Image(systemName: "house.fill")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(MatherTheme.accent)
+                        .frame(width: 56, height: 56)
+                }
+                .accessibilityLabel("Home")
+            }
+
+            progressBar(progress, tint: tint)
+        }
+        .padding(16)
+        .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(tint.opacity(0.18), lineWidth: 1)
+        )
+        .shadow(color: colorScheme == .dark ? .black.opacity(0.3) : .black.opacity(0.08), radius: 8, y: 4)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(lane.title). \(lane.promise). \(progress.progressSummaryLabel).")
+    }
+
+    private func supportPanel(_ lane: CapabilityLane, progress: CapabilityLaneProgress, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            modeChips(lane.modes, tint: tint)
+            modeChoicePreview(lane, tint: tint)
+            ageEntryPreview(lane, tint: tint)
+            progressPreview(progress, tint: tint)
+        }
+        .padding(14)
+        .background(MatherTheme.card.opacity(0.82), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .accessibilityElement(children: .contain)
+    }
+
+    private func gamesSection(_ lane: CapabilityLane, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Games")
+                .font(.title3.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+
+            if lane.isReady {
+                ForEach(lane.activities) { activity in
+                    activityCard(activity, lane: lane, tint: tint)
+                }
+            } else {
+                Label("Games coming soon", systemImage: "sparkles")
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .frame(maxWidth: .infinity, minHeight: 96, alignment: .leading)
+                    .padding(16)
+                    .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .accessibilityLabel("\(lane.title) games coming soon")
+            }
+        }
+    }
+
+    private func activityCard(_ activity: LabActivity, lane: CapabilityLane, tint: Color) -> some View {
+        Button {
+            launch(activity.id)
+        } label: {
+            HStack(alignment: .center, spacing: 14) {
+                activityVisual(activity, tint: tint)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(activity.title)
+                        .font(.title3.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                    Text(activity.tagline)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                    modeChips(activity.modes, tint: tint)
+                    sensorAffordanceRow(activity, tint: tint)
+                }
+
+                Spacer(minLength: 6)
+
+                Image(systemName: "play.circle.fill")
+                    .font(.system(size: 34, weight: .black))
+                    .foregroundStyle(tint)
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, minHeight: 128, alignment: .leading)
+            .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(tint.opacity(0.16), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Launch \(activity.title). \(activity.tagline)")
+        .accessibilityHint("Starts this \(lane.title) game. Modes: \(activity.modes.map(\.rawValue).joined(separator: ", ")).")
+    }
+
+    private func recallSection(_ lane: CapabilityLane, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Label(lane.recallReadinessLabel, systemImage: "rectangle.on.rectangle.angled")
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(tint)
+                Spacer()
+                Button {
+                    withAnimation(.spring(response: 0.28, dampingFraction: 0.9)) {
+                        expandedReview.toggle()
+                    }
+                } label: {
+                    Text(expandedReview ? "Hide review" : "Review cards")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(tint)
+                        .frame(minWidth: 120, minHeight: 56)
+                        .background(tint.opacity(0.10), in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(expandedReview ? "Hide \(lane.title) review cards" : "Open \(lane.title) review cards")
+            }
+
+            if !lane.starterMixMatchConceptPreview.isEmpty {
+                Text(lane.starterMixMatchConceptPreview)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
+
+            if expandedReview {
+                recallReviewPanel(lane, tint: tint)
+            }
+        }
+        .padding(14)
+        .background(MatherTheme.card.opacity(0.82), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(lane.recallAccessibilityLabel)
+    }
+
+    private func modeChoicePreview(_ lane: CapabilityLane, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label("Choose your play style", systemImage: "slider.horizontal.3")
+                .font(.caption.weight(.black))
+                .foregroundStyle(tint)
+            ForEach(lane.modeChoiceCards.prefix(3)) { card in
+                HStack(spacing: 6) {
+                    Text(card.title)
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text(card.flavor)
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                    Spacer(minLength: 0)
+                    if card.policy.usesTimer {
+                        Text("opt-in timer")
+                            .font(.caption2.weight(.black))
+                            .foregroundStyle(tint)
+                    }
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(card.accessibilityLabel)
+                .accessibilityHint(card.policy.usesTimer ? "Timer starts only after this mode is chosen." : "No timer in this mode.")
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(MatherTheme.panel.opacity(0.58), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(lane.title) play styles: \(lane.modeChoicePreviewLabel)")
+    }
+
+    private func ageEntryPreview(_ lane: CapabilityLane, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label("Age entry points", systemImage: "person.2.fill")
+                .font(.caption.weight(.black))
+                .foregroundStyle(tint)
+            Text(lane.ageEntryPreview)
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .lineLimit(2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(10)
+        .background(tint.opacity(0.07), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(lane.title) age entry points: \(lane.ageEntryPreview)")
+    }
+
+    private func progress(for lane: CapabilityLane) -> CapabilityLaneProgress {
+        guard let masteryState = appModel.explorerLabMasteryProfile[lane.id] else {
+            return lane.emptyProgress
+        }
+        return CapabilityLaneProgress(masteryState: masteryState)
+    }
+
+    private func progressPreview(_ progress: CapabilityLaneProgress, tint: Color) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: "chart.bar.fill")
+                .font(.caption.weight(.black))
+                .foregroundStyle(tint)
+                .frame(width: 24, height: 24)
+                .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(progress.progressSummaryLabel)
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text(progress.nextRecommendedModeLabel)
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(MatherTheme.panel.opacity(0.58), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Lane progress \(progress.progressSummaryLabel). \(progress.nextRecommendedModeLabel)")
+    }
+
+    private func progressBar(_ progress: CapabilityLaneProgress, tint: Color) -> some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(MatherTheme.panel.opacity(0.8))
+                Capsule()
+                    .fill(tint.opacity(0.72))
+                    .frame(width: max(12, proxy.size.width * progress.masteryFraction))
+            }
+        }
+        .frame(height: 10)
+        .accessibilityLabel("Lane mastery \(progress.masteryPercentLabel)")
+    }
+
+    private func recallReviewPanel(_ lane: CapabilityLane, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let entry = lane.firstRecallEntry {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(entry.title)
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    LabDetailFlowLayout(spacing: 6) {
+                        ForEach(entry.card.choices) { choice in
+                            Button {
+                                recordReviewAction(
+                                    LaneRecallReviewAction(
+                                        laneID: entry.laneID,
+                                        cardID: entry.card.id,
+                                        choiceID: choice.id,
+                                        isCorrect: choice.isCorrect
+                                    )
+                                )
+                            } label: {
+                                Text(choice.answer.displayText ?? choice.answer.speechText)
+                                    .font(.caption2.weight(.black))
+                                    .foregroundStyle(tint)
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 7)
+                                    .background(MatherTheme.card.opacity(0.86), in: Capsule())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Review \(lane.title): \(choice.answer.speechText)")
+                        }
+                    }
+                }
+                .padding(8)
+                .background(MatherTheme.card.opacity(0.72), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            }
+
+            ForEach(Array(lane.starterMixMatchCards.prefix(4))) { card in
+                HStack(spacing: 8) {
+                    Text(card.prompt)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(MatherTheme.ink)
+                    Image(systemName: "arrow.right")
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(tint)
+                    Text(card.match)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(MatherTheme.ink)
+                    Spacer(minLength: 0)
+                }
+                .padding(8)
+                .background(MatherTheme.card.opacity(0.72), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(card.accessibilityLabel)
+            }
+        }
+        .padding(10)
+        .background(tint.opacity(0.10), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(lane.title) recall review sample")
+    }
+
+    private func modeChips(_ modes: [PlayMode], tint: Color) -> some View {
+        LabDetailFlowLayout(spacing: 6) {
+            ForEach(modes, id: \.self) { mode in
+                Text(mode.rawValue)
+                    .font(.caption2.weight(.heavy))
+                    .foregroundStyle(tint)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(tint.opacity(0.10), in: Capsule())
+            }
+        }
+    }
+
+    private func sensorAffordanceRow(_ activity: LabActivity, tint: Color) -> some View {
+        LabDetailFlowLayout(spacing: 4) {
+            ForEach(activity.id.sensorAffordances(with: sensorCapabilities)) { affordance in
+                Label {
+                    Text(affordance.displayLabel)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
+                } icon: {
+                    Image(systemName: sensorIcon(for: affordance.need, isAvailable: affordance.isAvailable))
+                }
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(affordance.isAvailable ? tint : MatherTheme.cardSubtitle)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 4)
+                .background(
+                    (affordance.isAvailable ? tint.opacity(0.10) : MatherTheme.panel.opacity(0.72)),
+                    in: Capsule()
+                )
+                .accessibilityLabel(affordance.accessibilityLabel)
+                .accessibilityHint(affordance.accessibilityHint)
+            }
+        }
+    }
+
+    private func laneHeroVisual(_ lane: CapabilityLane, tint: Color) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(tint.opacity(0.14))
+            Circle()
+                .fill(tint.opacity(0.18))
+                .frame(width: 54, height: 54)
+                .offset(x: 22, y: -18)
+            Text(lane.emoji)
+                .font(.system(size: 42))
+        }
+        .frame(width: 76, height: 76)
+    }
+
+    private func activityVisual(_ activity: LabActivity, tint: Color) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(tint.opacity(0.12))
+            visualMotif(for: activity.id, tint: tint)
+            Text(activity.emoji)
+                .font(.system(size: 38))
+                .offset(x: -18, y: -14)
+        }
+        .frame(width: 104, height: 96)
+        .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private func visualMotif(for activityID: LabActivityID, tint: Color) -> some View {
+        switch activityID {
+        case .sumSprint:
+            HStack(spacing: 4) {
+                ForEach(0..<4, id: \.self) { index in
+                    Capsule()
+                        .fill(tint.opacity(0.18 + Double(index) * 0.08))
+                        .frame(width: 8, height: CGFloat(24 + index * 10))
+                }
+            }
+            .offset(x: 18, y: 12)
+        case .roomQuest, .compassAngles:
+            Image(systemName: "location.north.line.fill")
+                .font(.system(size: 46, weight: .bold))
+                .foregroundStyle(tint.opacity(0.35))
+                .offset(x: 20, y: 12)
+        case .symmetryFold, .twoFingerProtractor:
+            Image(systemName: "angle")
+                .font(.system(size: 52, weight: .bold))
+                .foregroundStyle(tint.opacity(0.35))
+                .offset(x: 18, y: 12)
+        case .rectangleFactory, .factoryCards:
+            Grid(horizontalSpacing: 3, verticalSpacing: 3) {
+                ForEach(0..<2, id: \.self) { _ in
+                    GridRow {
+                        ForEach(0..<3, id: \.self) { _ in
+                            RoundedRectangle(cornerRadius: 3)
+                                .fill(tint.opacity(0.28))
+                                .frame(width: 16, height: 16)
+                        }
+                    }
+                }
+            }
+            .offset(x: 20, y: 12)
+        case .angleCannon, .gravityArtist:
+            Image(systemName: "circle.dotted")
+                .font(.system(size: 52, weight: .bold))
+                .foregroundStyle(tint.opacity(0.35))
+                .offset(x: 20, y: 12)
+        case .waterCycle:
+            Image(systemName: "cloud.rain.fill")
+                .font(.system(size: 48, weight: .bold))
+                .foregroundStyle(tint.opacity(0.35))
+                .offset(x: 20, y: 12)
+        case .memoryMatch:
+            Image(systemName: "rectangle.on.rectangle.angled")
+                .font(.system(size: 48, weight: .bold))
+                .foregroundStyle(tint.opacity(0.35))
+                .offset(x: 20, y: 12)
+        }
+    }
+
+    private func sensorIcon(for need: LabSensorNeed, isAvailable: Bool) -> String {
+        if !isAvailable {
+            return "exclamationmark.triangle.fill"
+        }
+
+        switch need {
+        case .noSpecialSensor:
+            return "hand.tap.fill"
+        case .motion:
+            return "gyroscope"
+        case .compass:
+            return "location.north.line.fill"
+        case .cameraMarkerMode:
+            return "camera.viewfinder"
+        case .haptics:
+            return "waveform"
+        }
+    }
+
+    private func launch(_ activityID: LabActivityID) {
+        appModel.pickProfileThenRun {
+            appModel.engine.show(activityID.appRoute)
+            switch activityID {
+            case .sumSprint:
+                appModel.sumSprintEngine.showDifficultyPick()
+            case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
+                 .twoFingerProtractor, .gravityArtist, .compassAngles, .waterCycle, .memoryMatch:
+                break
+            }
+        }
+    }
+
+    private func recordReviewAction(_ action: LaneRecallReviewAction) {
+        appModel.markExplorerLabReviewedCard(laneID: action.laneID, cardID: action.cardID)
+        appModel.markExplorerLabModeCompleted(laneID: action.laneID, mode: .review)
+
+        if action.isCorrect,
+           let card = CapabilityLane.defaultExplorerLanes
+            .first(where: { $0.id == action.laneID })?
+            .recallEntries
+            .first(where: { $0.card.id == action.cardID })?
+            .card {
+            appModel.setExplorerLabConceptConfidence(.steady, for: card.conceptID, laneID: action.laneID)
+        }
+    }
+
+    private func laneColor(_ laneID: CapabilityLaneID) -> Color {
+        switch laneID {
+        case .numbers:
+            return MatherTheme.warm
+        case .geometry:
+            return MatherTheme.coral
+        case .physics:
+            return MatherTheme.panelDeep
+        case .mapWorld:
+            return MatherTheme.softBlue
+        case .discoveryCards:
+            return MatherTheme.accent
+        case .chemistry:
+            return MatherTheme.warm
+        case .electronics:
+            return MatherTheme.accent
+        }
+    }
+}
+
+private struct LabDetailFlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = proposal.width ?? 300
+        let rows = rows(in: width, subviews: subviews)
+        return CGSize(width: width, height: rows.reduce(0) { $0 + $1.height } + CGFloat(max(0, rows.count - 1)) * spacing)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX, x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+
+    private func rows(in width: CGFloat, subviews: Subviews) -> [CGSize] {
+        var rows: [CGSize] = []
+        var currentWidth: CGFloat = 0
+        var currentHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            let nextWidth = currentWidth == 0 ? size.width : currentWidth + spacing + size.width
+            if currentWidth > 0, nextWidth > width {
+                rows.append(CGSize(width: currentWidth, height: currentHeight))
+                currentWidth = size.width
+                currentHeight = size.height
+            } else {
+                currentWidth = nextWidth
+                currentHeight = max(currentHeight, size.height)
+            }
+        }
+
+        if currentWidth > 0 {
+            rows.append(CGSize(width: currentWidth, height: currentHeight))
+        }
+        return rows
+    }
+}

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -174,7 +174,7 @@ struct LabActivity: Identifiable, Equatable {
     }
 
     var accessibilityHint: String {
-        "Opens \(title). Modes: \(modes.map(\.rawValue).joined(separator: ", "))."
+        "Launches \(title). Modes: \(modes.map(\.rawValue).joined(separator: ", "))."
     }
 }
 
@@ -276,7 +276,6 @@ enum LabLaneCardSection: Equatable {
     case visualSummary
     case promise
     case progressStatus
-    case detailAffordance
     case modes
     case playStyles
     case ageEntries
@@ -287,43 +286,54 @@ enum LabLaneCardSection: Equatable {
 
 struct LabLaneCardPresentation: Equatable {
     let laneID: CapabilityLaneID
-    let isExpanded: Bool
     let title: String
     let promiseLine: String
     let progressMicrocopy: String
-    let detailAffordanceLabel: String
+    let openAffordanceLabel: String
+    let accessibilityLabel: String
+    let accessibilityHint: String
     let sections: [LabLaneCardSection]
 
-    init(lane: CapabilityLane, progress: CapabilityLaneProgress, isExpanded: Bool) {
+    init(lane: CapabilityLane, progress: CapabilityLaneProgress) {
         self.laneID = lane.id
-        self.isExpanded = isExpanded
         title = lane.title
         promiseLine = lane.promise
         progressMicrocopy = "\(progress.progressSummaryLabel) • \(progress.nextRecommendedModeLabel)"
-        detailAffordanceLabel = isExpanded ? "Hide details" : "Show details"
-
-        var visibleSections: [LabLaneCardSection] = [
+        openAffordanceLabel = "Open lane"
+        accessibilityLabel = "\(lane.title). \(lane.ageBandHint). \(lane.promise)"
+        accessibilityHint = "Opens \(lane.title) to choose games, review cards, play styles, and sensor options."
+        sections = [
             .visualSummary,
             .promise,
             .progressStatus,
-            .detailAffordance,
         ]
-
-        if isExpanded {
-            visibleSections += [
-                .modes,
-                .playStyles,
-                .ageEntries,
-                .recall,
-                lane.isReady ? .activities : .comingSoon,
-            ]
-        }
-
-        sections = visibleSections
     }
 
     var showsDetails: Bool {
         sections.contains(.activities) || sections.contains(.comingSoon)
+    }
+}
+
+struct LabLaneDetailPresentation: Equatable {
+    let laneID: CapabilityLaneID
+    let title: String
+    let activityCountLabel: String
+    let sections: [LabLaneCardSection]
+
+    init(lane: CapabilityLane) {
+        laneID = lane.id
+        title = lane.title
+        activityCountLabel = lane.activities.isEmpty
+            ? "Games coming soon"
+            : "\(lane.activities.count) game\(lane.activities.count == 1 ? "" : "s") ready"
+        sections = [
+            .visualSummary,
+            .modes,
+            .playStyles,
+            .ageEntries,
+            .recall,
+            lane.isReady ? .activities : .comingSoon,
+        ]
     }
 }
 

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -4,9 +4,6 @@ import SwiftUI
 struct LabView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Bindable var appModel: AppModel
-    @State private var expandedLaneIDs: Set<CapabilityLaneID> = []
-    @State private var expandedReviewLaneID: CapabilityLaneID?
-    @State private var sensorCapabilities = DeviceSensorCapabilities.unavailable
 
     private let lanes = CapabilityLane.defaultExplorerLanes
 
@@ -18,20 +15,15 @@ struct LabView: View {
                     VStack(alignment: .leading, spacing: 20) {
                         header
 
-                        let isCompact = Self.usesCollapsedLaneCards(for: proxy.size.width)
-
                         LazyVGrid(columns: labColumns(for: proxy.size.width), spacing: 16) {
                             ForEach(lanes) { lane in
-                                laneCard(lane, isCompact: isCompact)
+                                laneCard(lane)
                             }
                         }
                     }
                     .padding(24)
                 }
             }
-        }
-        .onAppear {
-            sensorCapabilities = SensorCapabilityService().currentCapabilities()
         }
     }
 
@@ -41,10 +33,10 @@ struct LabView: View {
                 Text("Explorer Lab")
                     .font(.system(size: 36, weight: .black, design: .rounded))
                     .foregroundStyle(MatherTheme.ink)
-                Text("Pick a capability, then choose how you want to play")
+                Text("Pick a capability lane")
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(MatherTheme.cardSubtitle)
-                Text("Learn • Explore • Challenge • Timed • Review")
+                Text("Games, review cards, play styles, and sensors live inside each lane")
                     .font(.caption.weight(.bold))
                     .foregroundStyle(MatherTheme.accent)
             }
@@ -61,184 +53,88 @@ struct LabView: View {
         }
     }
 
-    private static func usesCollapsedLaneCards(for availableWidth: CGFloat) -> Bool {
-        availableWidth < 700
-    }
-
     private func labColumns(for availableWidth: CGFloat) -> [GridItem] {
-        Self.usesCollapsedLaneCards(for: availableWidth)
+        availableWidth < 700
             ? [GridItem(.flexible(), spacing: 16)]
             : ResponsiveLayout.labColumns(for: availableWidth)
     }
 
-    private func laneCard(_ lane: CapabilityLane, isCompact: Bool) -> some View {
-        let isExpanded = !isCompact || expandedLaneIDs.contains(lane.id)
+    private func laneCard(_ lane: CapabilityLane) -> some View {
         let progress = progress(for: lane)
-        let presentation = LabLaneCardPresentation(lane: lane, progress: progress, isExpanded: isExpanded)
+        let presentation = LabLaneCardPresentation(lane: lane, progress: progress)
         let tint = laneColor(lane.id)
 
-        return VStack(alignment: .leading, spacing: 14) {
-            laneSummaryHeader(lane, presentation: presentation, tint: tint, isCompact: isCompact)
+        return Button {
+            appModel.engine.showLabLane(lane.id)
+        } label: {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top, spacing: 14) {
+                    laneVisual(lane, tint: tint)
 
-            if isExpanded {
-                modeChips(lane.modes, tint: tint)
-                modeChoicePreview(lane, tint: tint)
-                ageEntryPreview(lane, tint: tint)
-                progressPreview(progress, tint: tint)
-                recallPreview(lane, tint: tint)
-                if expandedReviewLaneID == lane.id {
-                    recallReviewPanel(lane, tint: tint)
-                }
-
-                if lane.isReady {
-                    VStack(spacing: 8) {
-                        ForEach(lane.activities) { activity in
-                            activityButton(activity, tint: tint)
+                    VStack(alignment: .leading, spacing: 7) {
+                        HStack(spacing: 8) {
+                            Text(presentation.title)
+                                .font(.headline.weight(.black))
+                                .foregroundStyle(MatherTheme.ink)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.75)
+                            Text(lane.ageBandHint)
+                                .font(.caption2.weight(.black))
+                                .foregroundStyle(tint)
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 4)
+                                .background(tint.opacity(0.12), in: Capsule())
                         }
+                        Text(presentation.promiseLine)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .lineLimit(3)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
-                } else {
-                    Label("Coming soon", systemImage: "sparkles")
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(10)
-                        .background(MatherTheme.panel.opacity(0.7), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-                        .accessibilityLabel("\(lane.title) coming soon")
-                }
-            }
-        }
-        .padding(isCompact ? 16 : 14)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
-        .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(tint.opacity(isExpanded ? 0.22 : 0.16), lineWidth: 1)
-        )
-        .shadow(
-            color: colorScheme == .dark ? .black.opacity(0.3) : .black.opacity(0.08),
-            radius: 8, y: 4
-        )
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(lane.accessibilityLabel)
-        .accessibilityHint(isCompact && !isExpanded ? "Show details to choose activities, review cards, and sensor options." : lane.accessibilityHint)
-    }
-
-    private func laneSummaryHeader(
-        _ lane: CapabilityLane,
-        presentation: LabLaneCardPresentation,
-        tint: Color,
-        isCompact: Bool
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .center, spacing: 14) {
-                Text(lane.emoji)
-                    .font(.system(size: isCompact ? 58 : 42))
-                    .frame(width: isCompact ? 84 : 56, height: isCompact ? 84 : 56)
-                    .background(tint.opacity(0.18), in: RoundedRectangle(cornerRadius: isCompact ? 18 : 16, style: .continuous))
-
-                VStack(alignment: .leading, spacing: 5) {
-                    HStack(spacing: 8) {
-                        Text(presentation.title)
-                            .font(.headline.weight(.black))
-                            .foregroundStyle(MatherTheme.ink)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.75)
-                        Text(lane.ageBandHint)
-                            .font(.caption2.weight(.black))
-                            .foregroundStyle(tint)
-                            .padding(.horizontal, 7)
-                            .padding(.vertical, 4)
-                            .background(tint.opacity(0.12), in: Capsule())
-                    }
-                    Text(presentation.promiseLine)
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .lineLimit(isCompact ? 1 : 3)
-                        .minimumScaleFactor(0.82)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-            .contentShape(Rectangle())
-            .onTapGesture {
-                guard isCompact else { return }
-                toggleLaneDetails(lane.id)
-            }
-
-            if isCompact {
-                HStack(spacing: 10) {
-                    Label(presentation.progressMicrocopy, systemImage: "chart.bar.fill")
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.72)
-
-                    Spacer(minLength: 8)
-
-                    Button {
-                        toggleLaneDetails(lane.id)
-                    } label: {
-                        Label(presentation.detailAffordanceLabel, systemImage: presentation.isExpanded ? "chevron.up" : "chevron.down")
-                            .font(.caption.weight(.black))
-                            .foregroundStyle(tint)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .frame(minHeight: 56)
-                            .background(tint.opacity(0.10), in: Capsule())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("\(presentation.detailAffordanceLabel) for \(lane.title)")
-                }
-            }
-        }
-    }
-
-    private func modeChoicePreview(_ lane: CapabilityLane, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Label("Choose your play style", systemImage: "slider.horizontal.3")
-                .font(.caption.weight(.black))
-                .foregroundStyle(tint)
-            ForEach(lane.modeChoiceCards.prefix(3)) { card in
-                HStack(spacing: 6) {
-                    Text(card.title)
-                        .font(.caption2.weight(.black))
-                        .foregroundStyle(MatherTheme.ink)
-                    Text(card.flavor)
-                        .font(.caption2.weight(.medium))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
                     Spacer(minLength: 0)
-                    if card.policy.usesTimer {
-                        Text("opt-in timer")
-                            .font(.caption2.weight(.black))
-                            .foregroundStyle(tint)
-                    }
                 }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel(card.accessibilityLabel)
-                .accessibilityHint(card.policy.usesTimer ? "Timer starts only after this mode is chosen." : "No timer in this mode.")
+
+                progressPreview(progress, tint: tint)
+
+                HStack(spacing: 10) {
+                    Label(lane.isReady ? "\(lane.activities.count) game\(lane.activities.count == 1 ? "" : "s")" : "Games coming soon", systemImage: lane.isReady ? "gamecontroller.fill" : "sparkles")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(tint)
+                    Spacer(minLength: 8)
+                    Label(presentation.openAffordanceLabel, systemImage: "chevron.right.circle.fill")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(tint)
+                }
             }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(tint.opacity(0.18), lineWidth: 1)
+            )
+            .shadow(
+                color: colorScheme == .dark ? .black.opacity(0.3) : .black.opacity(0.08),
+                radius: 8, y: 4
+            )
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(10)
-        .background(MatherTheme.panel.opacity(0.58), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(lane.title) play styles: \(lane.modeChoicePreviewLabel)")
+        .buttonStyle(.plain)
+        .accessibilityLabel(presentation.accessibilityLabel)
+        .accessibilityHint(presentation.accessibilityHint)
     }
 
-    private func ageEntryPreview(_ lane: CapabilityLane, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Label("Age entry points", systemImage: "person.2.fill")
-                .font(.caption.weight(.black))
-                .foregroundStyle(tint)
-            Text(lane.ageEntryPreview)
-                .font(.caption2.weight(.medium))
-                .foregroundStyle(MatherTheme.cardSubtitle)
-                .lineLimit(2)
+    private func laneVisual(_ lane: CapabilityLane, tint: Color) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(tint.opacity(0.14))
+            Circle()
+                .fill(tint.opacity(0.18))
+                .frame(width: 48, height: 48)
+                .offset(x: 18, y: -18)
+            Text(lane.emoji)
+                .font(.system(size: 46))
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(10)
-        .background(tint.opacity(0.07), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(lane.title) age entry points: \(lane.ageEntryPreview)")
+        .frame(width: 84, height: 84)
     }
 
     private func progress(for lane: CapabilityLane) -> CapabilityLaneProgress {
@@ -271,243 +167,6 @@ struct LabView: View {
         .accessibilityLabel("Lane progress \(progress.progressSummaryLabel). \(progress.nextRecommendedModeLabel)")
     }
 
-    private func recallPreview(_ lane: CapabilityLane, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Label(lane.recallReadinessLabel, systemImage: "rectangle.on.rectangle.angled")
-                .font(.caption.weight(.black))
-                .foregroundStyle(tint)
-            if !lane.starterMixMatchConceptPreview.isEmpty {
-                Text(lane.starterMixMatchConceptPreview)
-                    .font(.caption2.weight(.medium))
-                    .foregroundStyle(MatherTheme.cardSubtitle)
-                    .lineLimit(1)
-            }
-            Button {
-                withAnimation(.spring(response: 0.28, dampingFraction: 0.9)) {
-                    expandedReviewLaneID = expandedReviewLaneID == lane.id ? nil : lane.id
-                }
-            } label: {
-                Text(expandedReviewLaneID == lane.id ? "Hide review cards" : "Review cards")
-                    .font(.caption2.weight(.black))
-                    .foregroundStyle(tint)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 8)
-                    .frame(minWidth: 120, minHeight: 56)
-                    .background(MatherTheme.card.opacity(0.8), in: Capsule())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Review \(lane.title) Mix-Match cards")
-            .accessibilityHint(expandedReviewLaneID == lane.id ? "Hides the sample review cards." : "Shows sample cards for quick recall practice.")
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(10)
-        .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(lane.recallAccessibilityLabel)
-    }
-
-    private func recallReviewPanel(_ lane: CapabilityLane, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("Review sample")
-                    .font(.caption.weight(.black))
-                    .foregroundStyle(MatherTheme.ink)
-                Spacer()
-                Text(lane.starterMixMatchSampler.progressLabel)
-                    .font(.caption2.weight(.heavy))
-                    .foregroundStyle(tint)
-            }
-
-            if let entry = lane.firstRecallEntry {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(entry.title)
-                        .font(.caption.weight(.black))
-                        .foregroundStyle(MatherTheme.ink)
-                        .fixedSize(horizontal: false, vertical: true)
-
-                    FlowLayout(spacing: 6) {
-                        ForEach(entry.card.choices) { choice in
-                            Button {
-                                recordReviewAction(
-                                    LaneRecallReviewAction(
-                                        laneID: entry.laneID,
-                                        cardID: entry.card.id,
-                                        choiceID: choice.id,
-                                        isCorrect: choice.isCorrect
-                                    )
-                                )
-                            } label: {
-                                Text(choice.answer.displayText ?? choice.answer.speechText)
-                                    .font(.caption2.weight(.black))
-                                    .foregroundStyle(tint)
-                                    .padding(.horizontal, 10)
-                                    .padding(.vertical, 7)
-                                    .background(MatherTheme.card.opacity(0.86), in: Capsule())
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("Review \(lane.title): \(choice.answer.speechText)")
-                        }
-                    }
-                }
-                .padding(8)
-                .background(MatherTheme.card.opacity(0.72), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-            }
-
-            ForEach(Array(lane.starterMixMatchCards.prefix(3))) { card in
-                HStack(spacing: 8) {
-                    Text(card.prompt)
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(MatherTheme.ink)
-                    Image(systemName: "arrow.right")
-                        .font(.caption2.weight(.black))
-                        .foregroundStyle(tint)
-                    Text(card.match)
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(MatherTheme.ink)
-                    Spacer(minLength: 0)
-                }
-                .padding(8)
-                .background(MatherTheme.card.opacity(0.72), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel(card.accessibilityLabel)
-            }
-        }
-        .padding(10)
-        .background(tint.opacity(0.10), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(lane.title) recall review sample")
-    }
-
-    private func modeChips(_ modes: [PlayMode], tint: Color) -> some View {
-        FlowLayout(spacing: 6) {
-            ForEach(modes, id: \.self) { mode in
-                Text(mode.rawValue)
-                    .font(.caption2.weight(.heavy))
-                    .foregroundStyle(tint)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 5)
-                    .background(tint.opacity(0.10), in: Capsule())
-            }
-        }
-    }
-
-    private func activityButton(_ activity: LabActivity, tint: Color) -> some View {
-        Button {
-            launch(activity.id)
-        } label: {
-            HStack(spacing: 10) {
-                Text(activity.emoji)
-                    .font(.title3)
-                    .frame(width: 32, height: 32)
-                    .background(tint.opacity(0.13), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(activity.title)
-                        .font(.subheadline.weight(.black))
-                        .foregroundStyle(MatherTheme.ink)
-                        .lineLimit(1)
-                    Text(activity.tagline)
-                        .font(.caption2.weight(.medium))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .lineLimit(2)
-                    sensorAffordanceRow(activity, tint: tint)
-                }
-                Spacer(minLength: 6)
-                Image(systemName: "chevron.right")
-                    .font(.caption.weight(.black))
-                    .foregroundStyle(tint)
-            }
-            .padding(10)
-            .frame(maxWidth: .infinity, minHeight: 80)
-            .background(MatherTheme.panel.opacity(0.72), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(activity.accessibilityLabel)
-        .accessibilityHint(activity.accessibilityHint)
-    }
-
-    private func sensorAffordanceRow(_ activity: LabActivity, tint: Color) -> some View {
-        FlowLayout(spacing: 4) {
-            ForEach(activity.id.sensorAffordances(with: sensorCapabilities)) { affordance in
-                Label {
-                    Text(affordance.displayLabel)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.72)
-                } icon: {
-                    Image(systemName: sensorIcon(for: affordance.need, isAvailable: affordance.isAvailable))
-                }
-                .font(.caption2.weight(.bold))
-                .foregroundStyle(affordance.isAvailable ? tint : MatherTheme.cardSubtitle)
-                .padding(.horizontal, 7)
-                .padding(.vertical, 4)
-                .background(
-                    (affordance.isAvailable ? tint.opacity(0.10) : MatherTheme.panel.opacity(0.72)),
-                    in: Capsule()
-                )
-                .accessibilityLabel(affordance.accessibilityLabel)
-                .accessibilityHint(affordance.accessibilityHint)
-            }
-        }
-    }
-
-    private func sensorIcon(for need: LabSensorNeed, isAvailable: Bool) -> String {
-        if !isAvailable {
-            return "exclamationmark.triangle.fill"
-        }
-
-        switch need {
-        case .noSpecialSensor:
-            return "hand.tap.fill"
-        case .motion:
-            return "gyroscope"
-        case .compass:
-            return "location.north.line.fill"
-        case .cameraMarkerMode:
-            return "camera.viewfinder"
-        case .haptics:
-            return "waveform"
-        }
-    }
-
-    private func launch(_ activityID: LabActivityID) {
-        appModel.pickProfileThenRun {
-            appModel.engine.show(activityID.appRoute)
-            switch activityID {
-            case .sumSprint:
-                appModel.sumSprintEngine.showDifficultyPick()
-            case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
-                 .twoFingerProtractor, .gravityArtist, .compassAngles, .waterCycle, .memoryMatch:
-                break
-            }
-        }
-    }
-
-    private func toggleLaneDetails(_ laneID: CapabilityLaneID) {
-        withAnimation(.spring(response: 0.28, dampingFraction: 0.9)) {
-            if expandedLaneIDs.contains(laneID) {
-                expandedLaneIDs.remove(laneID)
-                if expandedReviewLaneID == laneID {
-                    expandedReviewLaneID = nil
-                }
-            } else {
-                expandedLaneIDs.insert(laneID)
-            }
-        }
-    }
-
-    private func recordReviewAction(_ action: LaneRecallReviewAction) {
-        appModel.markExplorerLabReviewedCard(laneID: action.laneID, cardID: action.cardID)
-        appModel.markExplorerLabModeCompleted(laneID: action.laneID, mode: .review)
-
-        if action.isCorrect,
-           let card = CapabilityLane.defaultExplorerLanes
-            .first(where: { $0.id == action.laneID })?
-            .recallEntries
-            .first(where: { $0.card.id == action.cardID })?
-            .card {
-            appModel.setExplorerLabConceptConfidence(.steady, for: card.conceptID, laneID: action.laneID)
-        }
-    }
-
     private func laneColor(_ laneID: CapabilityLaneID) -> Color {
         switch laneID {
         case .numbers:
@@ -525,57 +184,5 @@ struct LabView: View {
         case .electronics:
             return MatherTheme.accent
         }
-    }
-}
-
-private struct FlowLayout: Layout {
-    var spacing: CGFloat = 8
-
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        let width = proposal.width ?? 300
-        let rows = rows(in: width, subviews: subviews)
-        return CGSize(width: width, height: rows.reduce(0) { $0 + $1.height } + CGFloat(max(0, rows.count - 1)) * spacing)
-    }
-
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        var x = bounds.minX
-        var y = bounds.minY
-        var rowHeight: CGFloat = 0
-
-        for subview in subviews {
-            let size = subview.sizeThatFits(.unspecified)
-            if x > bounds.minX, x + size.width > bounds.maxX {
-                x = bounds.minX
-                y += rowHeight + spacing
-                rowHeight = 0
-            }
-            subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
-            x += size.width + spacing
-            rowHeight = max(rowHeight, size.height)
-        }
-    }
-
-    private func rows(in width: CGFloat, subviews: Subviews) -> [CGSize] {
-        var rows: [CGSize] = []
-        var currentWidth: CGFloat = 0
-        var currentHeight: CGFloat = 0
-
-        for subview in subviews {
-            let size = subview.sizeThatFits(.unspecified)
-            let nextWidth = currentWidth == 0 ? size.width : currentWidth + spacing + size.width
-            if currentWidth > 0, nextWidth > width {
-                rows.append(CGSize(width: currentWidth, height: currentHeight))
-                currentWidth = size.width
-                currentHeight = size.height
-            } else {
-                currentWidth = nextWidth
-                currentHeight = max(currentHeight, size.height)
-            }
-        }
-
-        if currentWidth > 0 {
-            rows.append(CGSize(width: currentWidth, height: currentHeight))
-        }
-        return rows
     }
 }

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -66,43 +66,46 @@ final class LabModelsTests: XCTestCase {
         XCTAssertTrue(numbers.starterMixMatchConceptPreview.contains("number-bond"))
     }
 
-    func testCollapsedLaneCardPresentationKeepsFirstPaintSparse() throws {
+    func testRootLaneCardPresentationStaysSparseAndOpensDetailScreen() throws {
         let numbers = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .numbers })
         let presentation = LabLaneCardPresentation(
             lane: numbers,
-            progress: numbers.emptyProgress,
-            isExpanded: false
+            progress: numbers.emptyProgress
         )
 
         XCTAssertEqual(presentation.title, "Numbers Lab")
-        XCTAssertEqual(presentation.detailAffordanceLabel, "Show details")
+        XCTAssertEqual(presentation.openAffordanceLabel, "Open lane")
         XCTAssertEqual(
             presentation.sections,
-            [.visualSummary, .promise, .progressStatus, .detailAffordance]
+            [.visualSummary, .promise, .progressStatus]
         )
         XCTAssertFalse(presentation.showsDetails)
         XCTAssertFalse(presentation.sections.contains(.modes))
         XCTAssertFalse(presentation.sections.contains(.ageEntries))
         XCTAssertFalse(presentation.sections.contains(.recall))
         XCTAssertFalse(presentation.sections.contains(.activities))
+        XCTAssertTrue(presentation.accessibilityHint.contains("Opens Numbers Lab"))
     }
 
-    func testExpandedLaneCardPresentationRestoresDetailsWithoutDroppingLaunches() throws {
+    func testLaneDetailPresentationRestoresDetailsWithoutDroppingLaunches() throws {
         let numbers = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .numbers })
-        let presentation = LabLaneCardPresentation(
-            lane: numbers,
-            progress: numbers.emptyProgress,
-            isExpanded: true
-        )
+        let presentation = LabLaneDetailPresentation(lane: numbers)
 
-        XCTAssertEqual(presentation.detailAffordanceLabel, "Hide details")
-        XCTAssertTrue(presentation.showsDetails)
+        XCTAssertEqual(presentation.activityCountLabel, "3 games ready")
         XCTAssertTrue(presentation.sections.contains(.modes))
         XCTAssertTrue(presentation.sections.contains(.playStyles))
         XCTAssertTrue(presentation.sections.contains(.ageEntries))
         XCTAssertTrue(presentation.sections.contains(.recall))
         XCTAssertTrue(presentation.sections.contains(.activities))
         XCTAssertEqual(numbers.activities.map(\.id), [.sumSprint, .rectangleFactory, .factoryCards])
+    }
+
+    func testLabLaneRouteCarriesSelectedLaneWithoutChangingGameRoutes() throws {
+        XCTAssertEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.geometry))
+        XCTAssertNotEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.numbers))
+        XCTAssertEqual(LabActivityID.sumSprint.appRoute, .sumSprint)
+        XCTAssertEqual(LabActivityID.waterCycle.appRoute, .waterCycle)
+        XCTAssertEqual(LabActivityID.memoryMatch.appRoute, .memory)
     }
 
 }
@@ -204,6 +207,7 @@ extension LabModelsTests {
         XCTAssertTrue(numbers.recallAccessibilityLabel.contains("1 recall card + 8 Mix-Match ready"))
         XCTAssertTrue(numbers.recallAccessibilityLabel.contains("number-bond"))
         XCTAssertEqual(sumSprint.accessibilityLabel, "Sum Sprint. Race through sums 11–20")
+        XCTAssertTrue(sumSprint.accessibilityHint.contains("Launches Sum Sprint"))
         XCTAssertTrue(sumSprint.accessibilityHint.contains("Modes: Challenge, Timed, Review"))
     }
 


### PR DESCRIPTION
## Summary
- Replace the compact Explorer Lab accordion behavior with root lane cards that open a dedicated lane detail route.
- Add `LabLaneDetailView` with stacked game cards, code-generated SwiftUI/SF Symbol/emoji thumbnails, progress, play-style, age-entry, review, and sensor affordances.
- Keep existing activity launch routes intact, including Sum Sprint difficulty handoff.

Fixes #829

## Validation
- `git diff --check`
- Not run: `xcodegen generate` because `xcodegen` is not installed in this worker environment.
- Not run: `xcodebuild test` because this worker has no Swift/Xcode toolchain (`swift` and `xcodebuild` are unavailable).