### PR TITLE
Stabilize water cycle screenshot completion check

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -279,7 +279,11 @@ final class ScreenshotTests: XCTestCase {
             tapWhenReachable(primaryAction, in: app, scrollDirection: .up)
         }
 
-        XCTAssertTrue(app.staticTexts["Cycle complete"].waitForExistence(timeout: 5))
+        let completedPrimaryAction = app.buttons
+            .matching(identifier: "water-cycle-primary-action")
+            .matching(NSPredicate(format: "label CONTAINS[c] %@", "Try the cycle again"))
+            .firstMatch
+        XCTAssertTrue(completedPrimaryAction.waitForExistence(timeout: 5))
         XCTAssertTrue(scrollUntilExists(app.buttons["water-cycle-replay-prompt"], in: app, direction: .up, maxSwipes: 4))
         XCTAssertTrue(scrollUntilExists(app.buttons["water-cycle-reset"], in: app, direction: .up, maxSwipes: 4))
         snapshot(app, "WaterCycle-Complete-Compact")


### PR DESCRIPTION
## Summary
- Make the water cycle compact screenshot test wait for the visible completion action state instead of an offscreen stage label
- Keeps replay/reset control checks intact for the final compact screenshot

## Validation
- git diff --check
- Investigated failed iOS UI Review run 25197526300; both iPhone/iPad jobs failed at ScreenshotTests.testScreenshot_WaterCycleCompactCompletion waiting for the Cycle complete static text