### PR TITLE
Replace Water Cycle flip recall with open matching

### DIFF
--- a/Features/MixMatchRecall/MixMatchRecallView.swift
+++ b/Features/MixMatchRecall/MixMatchRecallView.swift
@@ -67,6 +67,36 @@ struct MixMatchRecallChoiceEvaluator: Equatable {
     }
 }
 
+struct MixMatchRecallFeedbackState: Equatable {
+    private(set) var selectedChoiceID: String?
+    private(set) var matchedChoiceID: String?
+    private(set) var incorrectChoiceID: String?
+    private(set) var isResolving = false
+
+    var hasActiveFeedback: Bool {
+        selectedChoiceID != nil || matchedChoiceID != nil || incorrectChoiceID != nil || isResolving
+    }
+
+    mutating func markAttempt(_ attempt: MixMatchRecallAttempt) {
+        selectedChoiceID = attempt.choiceID
+        isResolving = true
+        if attempt.isCorrect {
+            matchedChoiceID = attempt.choiceID
+            incorrectChoiceID = nil
+        } else {
+            matchedChoiceID = nil
+            incorrectChoiceID = attempt.choiceID
+        }
+    }
+
+    mutating func clear() {
+        selectedChoiceID = nil
+        matchedChoiceID = nil
+        incorrectChoiceID = nil
+        isResolving = false
+    }
+}
+
 extension LearningCard {
     var mixMatchPromptCard: LearningCardViewModel {
         let display: LearningCardDisplay
@@ -208,12 +238,16 @@ struct LearningCardView: View {
 
 @MainActor
 struct MixMatchRecallView: View {
+    private static let correctFeedbackDuration: Duration = .milliseconds(520)
+    private static let incorrectFeedbackDuration: Duration = .milliseconds(420)
+
     let prompt: LearningCardViewModel?
     let choices: [MixMatchRecallChoice]
     private let evaluator: MixMatchRecallChoiceEvaluator
     let onCorrect: (MixMatchRecallAttempt) -> Void
     let onIncorrect: (MixMatchRecallAttempt) -> Void
-    @State private var latestAttempt: MixMatchRecallAttempt?
+    @State private var feedback = MixMatchRecallFeedbackState()
+    @State private var feedbackTask: Task<Void, Never>?
 
     init(
         prompt: LearningCardViewModel? = nil,
@@ -251,36 +285,60 @@ struct MixMatchRecallView: View {
 
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 112), spacing: 12)], spacing: 12) {
                 ForEach(choices) { choice in
-                    let attempt = latestAttempt
-                    let feedbackCard = LearningCardViewModel(
-                        id: choice.card.id,
-                        display: choice.card.display,
-                        accessibilityLabel: choice.card.accessibilityLabel,
-                        accessibilityHint: choice.card.accessibilityHint,
-                        isFaceDown: choice.card.isFaceDown,
-                        isSelected: attempt?.choiceID == choice.id,
-                        isMatched: attempt?.choiceID == choice.id && attempt?.isCorrect == true,
-                        isIncorrect: attempt?.choiceID == choice.id && attempt?.isCorrect == false
-                    )
-
                     Button {
-                        let attempt = evaluator.attempt(choiceID: choice.id)
-                        withAnimation(.spring(response: 0.25, dampingFraction: 0.58)) {
-                            latestAttempt = attempt
-                        }
-                        if attempt.isCorrect {
-                            onCorrect(attempt)
-                        } else {
-                            onIncorrect(attempt)
-                        }
+                        handleChoice(choice)
                     } label: {
-                        LearningCardView(model: feedbackCard, minTouchSize: 80)
+                        LearningCardView(model: feedbackCard(for: choice), minTouchSize: 80)
                             .frame(minHeight: 96)
                     }
                     .buttonStyle(.plain)
+                    .disabled(feedback.isResolving)
                     .accessibilityIdentifier("mix-match-choice-\(choice.id)")
                     .accessibilityAddTraits(.isButton)
                 }
+            }
+        }
+        .onDisappear {
+            feedbackTask?.cancel()
+        }
+    }
+
+    private func feedbackCard(for choice: MixMatchRecallChoice) -> LearningCardViewModel {
+        var card = choice.card
+        card.isSelected = feedback.selectedChoiceID == choice.id
+        card.isMatched = feedback.matchedChoiceID == choice.id
+        card.isIncorrect = feedback.incorrectChoiceID == choice.id
+        return card
+    }
+
+    private func handleChoice(_ choice: MixMatchRecallChoice) {
+        guard !feedback.isResolving else { return }
+        let attempt = evaluator.attempt(choiceID: choice.id)
+        feedbackTask?.cancel()
+
+        withAnimation(.spring(response: 0.25, dampingFraction: 0.62)) {
+            feedback.markAttempt(attempt)
+        }
+
+        let feedbackDuration = attempt.isCorrect
+            ? Self.correctFeedbackDuration
+            : Self.incorrectFeedbackDuration
+
+        feedbackTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: feedbackDuration)
+            } catch {
+                return
+            }
+
+            if attempt.isCorrect {
+                onCorrect(attempt)
+            } else {
+                onIncorrect(attempt)
+            }
+
+            withAnimation(.easeOut(duration: 0.12)) {
+                feedback.clear()
             }
         }
     }

--- a/Features/MixMatchRecall/MixMatchRecallView.swift
+++ b/Features/MixMatchRecall/MixMatchRecallView.swift
@@ -213,6 +213,7 @@ struct MixMatchRecallView: View {
     private let evaluator: MixMatchRecallChoiceEvaluator
     let onCorrect: (MixMatchRecallAttempt) -> Void
     let onIncorrect: (MixMatchRecallAttempt) -> Void
+    @State private var latestAttempt: MixMatchRecallAttempt?
 
     init(
         prompt: LearningCardViewModel? = nil,
@@ -250,15 +251,30 @@ struct MixMatchRecallView: View {
 
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 112), spacing: 12)], spacing: 12) {
                 ForEach(choices) { choice in
+                    let attempt = latestAttempt
+                    let feedbackCard = LearningCardViewModel(
+                        id: choice.card.id,
+                        display: choice.card.display,
+                        accessibilityLabel: choice.card.accessibilityLabel,
+                        accessibilityHint: choice.card.accessibilityHint,
+                        isFaceDown: choice.card.isFaceDown,
+                        isSelected: attempt?.choiceID == choice.id,
+                        isMatched: attempt?.choiceID == choice.id && attempt?.isCorrect == true,
+                        isIncorrect: attempt?.choiceID == choice.id && attempt?.isCorrect == false
+                    )
+
                     Button {
                         let attempt = evaluator.attempt(choiceID: choice.id)
+                        withAnimation(.spring(response: 0.25, dampingFraction: 0.58)) {
+                            latestAttempt = attempt
+                        }
                         if attempt.isCorrect {
                             onCorrect(attempt)
                         } else {
                             onIncorrect(attempt)
                         }
                     } label: {
-                        LearningCardView(model: choice.card, minTouchSize: 80)
+                        LearningCardView(model: feedbackCard, minTouchSize: 80)
                             .frame(minHeight: 96)
                     }
                     .buttonStyle(.plain)

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -67,6 +67,39 @@ struct WaterCycleConceptFlashcard: Equatable, Identifiable {
     ]
 }
 
+struct WaterCycleInterestingFact: Equatable, Identifiable {
+    let id: String
+    let title: String
+    let detail: String
+
+    var accessibilityText: String {
+        "Interesting water fact: \(title). \(detail)"
+    }
+
+    static let completionFacts: [WaterCycleInterestingFact] = [
+        WaterCycleInterestingFact(
+            id: "rainiest-place",
+            title: "Rainiest place",
+            detail: "Mawsynram, India is famous for some of the highest average yearly rainfall on Earth."
+        ),
+        WaterCycleInterestingFact(
+            id: "driest-desert",
+            title: "Driest desert",
+            detail: "Parts of the Atacama Desert can go years with almost no rain."
+        ),
+        WaterCycleInterestingFact(
+            id: "ocean-evaporation",
+            title: "Ocean engine",
+            detail: "Most water vapor that becomes rain starts by evaporating from the ocean."
+        ),
+        WaterCycleInterestingFact(
+            id: "tiny-freshwater",
+            title: "Freshwater is rare",
+            detail: "Only a tiny part of Earth’s water is fresh water we can easily use."
+        )
+    ]
+}
+
 struct WaterCycleLabState: Equatable {
     private(set) var stage: WaterCycleStage = .wonder
     private(set) var vaporDrops = 0
@@ -83,6 +116,7 @@ struct WaterCycleLabState: Equatable {
     private(set) var latestAskResponse: LessonSafeAskResponse?
     private(set) var mixMatchIndex = 0
     private(set) var mixMatchCorrectCardIDs: Set<String> = []
+    private(set) var interestingFactIndex = 0
 
     var currentFlashcard: WaterCycleConceptFlashcard {
         WaterCycleConceptFlashcard.reviewDeck[flashcardIndex % WaterCycleConceptFlashcard.reviewDeck.count]
@@ -94,6 +128,14 @@ struct WaterCycleLabState: Equatable {
 
     var currentMixMatchCard: LearningCard {
         WaterCycleLessonThread.mixMatchCards[mixMatchIndex % WaterCycleLessonThread.mixMatchCards.count]
+    }
+
+    var currentInterestingFact: WaterCycleInterestingFact {
+        WaterCycleInterestingFact.completionFacts[interestingFactIndex % WaterCycleInterestingFact.completionFacts.count]
+    }
+
+    var interestingFactProgressLabel: String {
+        "Fact \(interestingFactIndex + 1) of \(WaterCycleInterestingFact.completionFacts.count)"
     }
 
     var flashcardProgressLabel: String {
@@ -201,6 +243,7 @@ struct WaterCycleLabState: Equatable {
             flashcardIndex = 0
             isFlashcardAnswerRevealed = false
             resetLessonThread()
+            interestingFactIndex = max(cyclesCompleted - 1, 0) % WaterCycleInterestingFact.completionFacts.count
             stage = .complete
         case .complete:
             reset()
@@ -216,6 +259,11 @@ struct WaterCycleLabState: Equatable {
         guard stage == .complete else { return }
         flashcardIndex = (flashcardIndex + 1) % WaterCycleConceptFlashcard.reviewDeck.count
         isFlashcardAnswerRevealed = false
+    }
+
+    mutating func advanceInterestingFact() {
+        guard stage == .complete, lessonThread.isComplete else { return }
+        interestingFactIndex = (interestingFactIndex + 1) % WaterCycleInterestingFact.completionFacts.count
     }
 
     mutating func advanceLessonCard() {
@@ -286,6 +334,7 @@ struct WaterCycleLabState: Equatable {
         latestAskResponse = nil
         mixMatchIndex = 0
         mixMatchCorrectCardIDs = []
+        interestingFactIndex = 0
     }
 }
 
@@ -798,6 +847,8 @@ struct WaterCycleLabView: View {
                 Label("Lesson thread complete", systemImage: "checkmark.seal.fill")
                     .font(.headline.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
+
+                completionFactCard
             } else {
                 MixMatchRecallView(
                     learningCard: state.currentMixMatchCard,
@@ -813,6 +864,45 @@ struct WaterCycleLabView: View {
                 .accessibilityIdentifier("water-cycle-mix-match-finale")
             }
         }
+    }
+
+    private var completionFactCard: some View {
+        let fact = state.currentInterestingFact
+
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                Label("Interesting fact", systemImage: "sparkles")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.accent)
+                Spacer()
+                Text(state.interestingFactProgressLabel)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
+
+            Text(fact.title)
+                .font(.system(size: 21, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+
+            Text(fact.detail)
+                .font(.system(size: 17, weight: .semibold, design: .rounded))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button {
+                state.advanceInterestingFact()
+                speakLessonText(state.currentInterestingFact.accessibilityText)
+            } label: {
+                Label("Next fact", systemImage: "sparkles")
+            }
+            .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.panelDeep.opacity(0.28)))
+            .accessibilityIdentifier("water-cycle-next-interesting-fact")
+        }
+        .padding(14)
+        .background(MatherTheme.warm.opacity(0.18), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(fact.accessibilityText)
+        .accessibilityIdentifier("water-cycle-interesting-fact-card")
     }
 
     private func lessonPlayActionBar(availableWidth: CGFloat) -> some View {

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -284,7 +284,11 @@ struct WaterCycleLabState: Equatable {
     }
 
     mutating func recordMixMatchAttempt(_ attempt: MixMatchRecallAttempt) {
-        guard stage == .complete, lessonThread.activeStage.kind == .mixMatchFinale, attempt.isCorrect else { return }
+        guard stage == .complete,
+              lessonThread.activeStage.kind == .mixMatchFinale,
+              attempt.isCorrect,
+              attempt.choiceID == currentMixMatchCard.answer.id
+        else { return }
         mixMatchCorrectCardIDs.insert(currentMixMatchCard.answer.id)
         if mixMatchCorrectCardIDs.count == WaterCycleLessonThread.mixMatchCards.count {
             lessonThread.completeActiveStage()

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -1,5 +1,22 @@
 import SwiftUI
 
+
+enum WaterCycleOpenMatchFeedback: Equatable {
+    case correct(choiceID: String)
+    case incorrect(choiceID: String)
+
+    var choiceID: String {
+        switch self {
+        case .correct(let choiceID), .incorrect(let choiceID): choiceID
+        }
+    }
+
+    var isCorrect: Bool {
+        if case .correct = self { return true }
+        return false
+    }
+}
+
 enum WaterCycleStage: String, CaseIterable, Equatable {
     case wonder
     case evaporation
@@ -79,6 +96,8 @@ struct WaterCycleLabState: Equatable {
     private(set) var lessonThread = WaterCycleLessonThread.thread
     private(set) var lessonCardIndex = 0
     private(set) var isRecallCardRevealed = false
+    private(set) var openMatchFeedback: WaterCycleOpenMatchFeedback?
+    private(set) var openMatchedCardIDs: Set<String> = []
     private(set) var askSession = WaterCycleLessonThread.askSession(for: WaterCycleLessonThread.cards[0])
     private(set) var latestAskResponse: LessonSafeAskResponse?
     private(set) var mixMatchIndex = 0
@@ -119,10 +138,10 @@ struct WaterCycleLabState: Equatable {
     var activeLessonPrimaryActionTitle: String {
         switch lessonThread.activeStage.kind {
         case .lookLearnFlashcards:
-            return isOnLastLessonCard ? "Start flip recall" : "Next look card"
+            return isOnLastLessonCard ? "Start picture match" : "Next look card"
         case .invertedRecall:
-            if !isRecallCardRevealed { return "Flip recall card" }
-            return isOnLastLessonCard ? "Ask this card" : "Next recall"
+            if !isRecallCardRevealed { return "Pick the matching name" }
+            return isOnLastLessonCard ? "Ask this card" : "Next picture"
         case .contextualAsk:
             if latestAskResponse == nil { return "Ask suggested question" }
             return isOnLastLessonCard ? "Start mix-match" : "Next ask card"
@@ -134,7 +153,7 @@ struct WaterCycleLabState: Equatable {
     var activeLessonPrimaryActionIcon: String {
         switch lessonThread.activeStage.kind {
         case .lookLearnFlashcards: "arrow.right.circle.fill"
-        case .invertedRecall: isRecallCardRevealed ? "arrow.right.circle.fill" : "rectangle.on.rectangle.angled.fill"
+        case .invertedRecall: isRecallCardRevealed ? "arrow.right.circle.fill" : "rectangle.2.swap"
         case .contextualAsk: latestAskResponse == nil ? "questionmark.bubble.fill" : "arrow.right.circle.fill"
         case .mixMatchFinale: lessonThread.isComplete ? "arrow.counterclockwise" : "speaker.wave.2.fill"
         }
@@ -222,6 +241,7 @@ struct WaterCycleLabState: Equatable {
         guard stage == .complete else { return }
         lessonCardIndex = (lessonCardIndex + 1) % lessonThread.cards.count
         isRecallCardRevealed = false
+        openMatchFeedback = nil
         askSession = WaterCycleLessonThread.askSession(for: currentLessonCard)
         latestAskResponse = nil
     }
@@ -229,6 +249,19 @@ struct WaterCycleLabState: Equatable {
     mutating func revealRecallCard() {
         guard stage == .complete, lessonThread.activeStage.kind == .invertedRecall else { return }
         isRecallCardRevealed = true
+        openMatchedCardIDs.insert(currentLessonCard.id)
+        openMatchFeedback = .correct(choiceID: currentLessonCard.id)
+    }
+
+    mutating func recordOpenMatchChoice(id choiceID: String) -> MixMatchRecallAttempt? {
+        guard stage == .complete, lessonThread.activeStage.kind == .invertedRecall else { return nil }
+        let isCorrect = choiceID == currentLessonCard.id
+        openMatchFeedback = isCorrect ? .correct(choiceID: choiceID) : .incorrect(choiceID: choiceID)
+        if isCorrect {
+            isRecallCardRevealed = true
+            openMatchedCardIDs.insert(currentLessonCard.id)
+        }
+        return MixMatchRecallAttempt(choiceID: choiceID, isCorrect: isCorrect)
     }
 
     mutating func selectAskTurn(id: String) -> LessonSafeAskResponse? {
@@ -245,6 +278,7 @@ struct WaterCycleLabState: Equatable {
         lessonThread.completeActiveStage()
         lessonCardIndex = 0
         isRecallCardRevealed = false
+        openMatchFeedback = nil
         askSession = WaterCycleLessonThread.askSession(for: currentLessonCard)
         latestAskResponse = nil
     }
@@ -282,6 +316,8 @@ struct WaterCycleLabState: Equatable {
         lessonThread.resetProgress()
         lessonCardIndex = 0
         isRecallCardRevealed = false
+        openMatchFeedback = nil
+        openMatchedCardIDs = []
         askSession = WaterCycleLessonThread.askSession(for: currentLessonCard)
         latestAskResponse = nil
         mixMatchIndex = 0
@@ -594,7 +630,7 @@ struct WaterCycleLabView: View {
     private var lessonStageIcon: String {
         switch state.lessonThread.activeStage.kind {
         case .lookLearnFlashcards: "photo.stack.fill"
-        case .invertedRecall: "rectangle.on.rectangle.angled.fill"
+        case .invertedRecall: "rectangle.2.swap"
         case .contextualAsk: "bubble.left.and.text.bubble.right.fill"
         case .mixMatchFinale: "rectangle.2.swap"
         }
@@ -676,7 +712,7 @@ struct WaterCycleLabView: View {
                 case .lookLearnFlashcards:
                     lookLearnLevel
                 case .invertedRecall:
-                    invertedRecallLevel
+                    openPictureNameMatchLevel
                 case .contextualAsk:
                     safeAskLevel
                 case .mixMatchFinale:
@@ -720,40 +756,57 @@ struct WaterCycleLabView: View {
         }
     }
 
-    private var invertedRecallLevel: some View {
+    private var openPictureNameMatchLevel: some View {
         let card = state.currentLessonCard
-        let model = LearningCardViewModel(
-            id: card.id,
+        let feedback = state.openMatchFeedback
+        let pictureModel = LearningCardViewModel(
+            id: "\(card.id).picture",
             display: card.assetName.map(LearningCardDisplay.asset) ?? .text(card.title),
-            accessibilityLabel: card.title,
-            accessibilityHint: "Flip to recall this water cycle idea.",
-            isFaceDown: !state.isRecallCardRevealed,
+            accessibilityLabel: "Picture for \(card.title)",
+            accessibilityHint: "Choose the matching water cycle name.",
             isSelected: state.isRecallCardRevealed,
-            isMatched: false,
+            isMatched: state.openMatchedCardIDs.contains(card.id),
             isIncorrect: false
         )
+        let choices = WaterCycleLessonThread.cards.map { choice in
+            LearningCardViewModel(
+                id: choice.id,
+                display: .choice(choice.title),
+                accessibilityLabel: choice.title,
+                accessibilityHint: choice.id == card.id ? "Correct name for this picture." : "Name choice.",
+                isSelected: feedback?.choiceID == choice.id,
+                isMatched: state.openMatchedCardIDs.contains(choice.id) && choice.id == card.id,
+                isIncorrect: feedback == .incorrect(choiceID: choice.id)
+            )
+        }
 
         return VStack(alignment: .leading, spacing: 12) {
-            Button {
-                state.revealRecallCard()
-                speakLessonCard()
-            } label: {
-                LearningCardView(model: model)
-                    .frame(minHeight: 150)
-            }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("water-cycle-recall-card")
+            LearningCardView(model: pictureModel)
+                .frame(minHeight: 150)
+                .accessibilityIdentifier("water-cycle-open-picture-card")
 
-            Text(state.isRecallCardRevealed ? card.answer : "Say the idea before you flip.")
+            Text(state.isRecallCardRevealed ? "Matched: \(card.title)" : "Tap the name that matches this picture.")
                 .font(.system(size: 18, weight: .bold, design: .rounded))
                 .foregroundStyle(MatherTheme.ink)
                 .fixedSize(horizontal: false, vertical: true)
+                .accessibilityIdentifier("water-cycle-open-match-feedback")
 
-            if state.isRecallCardRevealed {
-                Text(card.detail)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(MatherTheme.cardSubtitle)
-                    .fixedSize(horizontal: false, vertical: true)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 118), spacing: 12)], spacing: 12) {
+                ForEach(choices) { choice in
+                    Button {
+                        withAnimation(.spring(response: 0.25, dampingFraction: 0.58)) {
+                            if let attempt = state.recordOpenMatchChoice(id: choice.id) {
+                                speakLessonText(attempt.isCorrect ? "Correct match." : "Try another match.")
+                            }
+                        }
+                    } label: {
+                        LearningCardView(model: choice, minTouchSize: 78)
+                            .frame(minHeight: 88)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(state.isRecallCardRevealed)
+                    .accessibilityIdentifier("water-cycle-open-match-choice-\(choice.id)")
+                }
             }
         }
     }
@@ -861,8 +914,7 @@ struct WaterCycleLabView: View {
             }
         case .invertedRecall:
             if !state.isRecallCardRevealed {
-                state.revealRecallCard()
-                speakLessonCard()
+                speakLessonText("Choose the name that matches \(state.currentLessonCard.title).")
             } else if state.isOnLastLessonCard {
                 state.completeCurrentLessonStage()
                 speakLessonStage()

--- a/Features/WaterCycle/WaterCycleLessonThread.swift
+++ b/Features/WaterCycle/WaterCycleLessonThread.swift
@@ -12,10 +12,10 @@ enum WaterCycleLessonThread {
                 prompt: "Look at each picture and hear what the water is doing."
             ),
             LessonPlayStage(
-                id: "flip-recall",
+                id: "picture-name-match",
                 kind: .invertedRecall,
-                title: "Flip Recall",
-                prompt: "Flip the hidden card, say the idea, then check the picture."
+                title: "Picture Match",
+                prompt: "Match the open picture card to its water cycle name."
             ),
             LessonPlayStage(
                 id: "safe-ask",

--- a/Tests/MatherTests/MixMatchRecallViewTests.swift
+++ b/Tests/MatherTests/MixMatchRecallViewTests.swift
@@ -11,6 +11,27 @@ struct MixMatchRecallViewTests {
     }
 
     @Test
+    func feedbackStateMarksCorrectAndIncorrectAttempts() {
+        var feedback = MixMatchRecallFeedbackState()
+        #expect(feedback.hasActiveFeedback == false)
+
+        feedback.markAttempt(MixMatchRecallAttempt(choiceID: "ten", isCorrect: true))
+        #expect(feedback.selectedChoiceID == "ten")
+        #expect(feedback.matchedChoiceID == "ten")
+        #expect(feedback.incorrectChoiceID == nil)
+        #expect(feedback.isResolving)
+
+        feedback.clear()
+        #expect(feedback.hasActiveFeedback == false)
+
+        feedback.markAttempt(MixMatchRecallAttempt(choiceID: "nine", isCorrect: false))
+        #expect(feedback.selectedChoiceID == "nine")
+        #expect(feedback.matchedChoiceID == nil)
+        #expect(feedback.incorrectChoiceID == "nine")
+        #expect(feedback.isResolving)
+    }
+
+    @Test
     func learningCardAdapterCreatesPromptAndChoiceCards() {
         let correct = CardAnswer(id: "triangle", speechText: "triangle", displayText: "Triangle")
         let card = LearningCard(

--- a/Tests/MatherTests/WaterCycleLabTests.swift
+++ b/Tests/MatherTests/WaterCycleLabTests.swift
@@ -135,8 +135,10 @@ extension WaterCycleLabTests {
         #expect(state.lessonThread.activeStage.kind == .invertedRecall)
         #expect(state.isRecallCardRevealed == false)
 
-        state.revealRecallCard()
+        let openMatchAttempt = state.recordOpenMatchChoice(id: "sun-heat")
+        #expect(openMatchAttempt == MixMatchRecallAttempt(choiceID: "sun-heat", isCorrect: true))
         #expect(state.isRecallCardRevealed)
+        #expect(state.openMatchFeedback == .correct(choiceID: "sun-heat"))
 
         state.completeCurrentLessonStage()
         #expect(state.lessonThread.activeStage.kind == .contextualAsk)
@@ -170,17 +172,17 @@ extension WaterCycleLabTests {
 
         for _ in 0..<4 { state.advanceLessonCard() }
         #expect(state.isOnLastLessonCard)
-        #expect(state.activeLessonPrimaryActionTitle == "Start flip recall")
+        #expect(state.activeLessonPrimaryActionTitle == "Start picture match")
 
         state.completeCurrentLessonStage()
         #expect(state.lessonThread.activeStage.kind == .invertedRecall)
-        #expect(state.activeLessonPrimaryActionTitle == "Flip recall card")
+        #expect(state.activeLessonPrimaryActionTitle == "Pick the matching name")
 
-        state.revealRecallCard()
-        #expect(state.activeLessonPrimaryActionTitle == "Next recall")
+        _ = state.recordOpenMatchChoice(id: "sun-heat")
+        #expect(state.activeLessonPrimaryActionTitle == "Next picture")
 
         for _ in 0..<4 { state.advanceLessonCard() }
-        state.revealRecallCard()
+        _ = state.recordOpenMatchChoice(id: state.currentLessonCard.id)
         #expect(state.activeLessonPrimaryActionTitle == "Ask this card")
 
         state.completeCurrentLessonStage()
@@ -218,5 +220,35 @@ extension WaterCycleLabTests {
         #expect(state.lessonThread.isComplete)
         #expect(state.activeLessonPrimaryActionTitle == "Try the cycle again")
         #expect(state.cyclesCompleted == 1)
+    }
+}
+
+
+extension WaterCycleLabTests {
+    @Test func openPictureNameMatchRecordsDeterministicFeedback() {
+        var state = WaterCycleLabState()
+        for _ in 0..<5 { state.advance() }
+        state.completeCurrentLessonStage()
+
+        #expect(state.lessonThread.activeStage.title == "Picture Match")
+        #expect(state.isRecallCardRevealed == false)
+
+        let wrong = state.recordOpenMatchChoice(id: "evaporation")
+        #expect(wrong == MixMatchRecallAttempt(choiceID: "evaporation", isCorrect: false))
+        #expect(state.openMatchFeedback == .incorrect(choiceID: "evaporation"))
+        #expect(state.isRecallCardRevealed == false)
+        #expect(state.openMatchedCardIDs.isEmpty)
+
+        let correct = state.recordOpenMatchChoice(id: "sun-heat")
+        #expect(correct == MixMatchRecallAttempt(choiceID: "sun-heat", isCorrect: true))
+        #expect(state.openMatchFeedback == .correct(choiceID: "sun-heat"))
+        #expect(state.isRecallCardRevealed)
+        #expect(state.openMatchedCardIDs == Set(["sun-heat"]))
+
+        state.advanceLessonCard()
+        #expect(state.currentLessonCard.id == "evaporation")
+        #expect(state.openMatchFeedback == nil)
+        #expect(state.isRecallCardRevealed == false)
+        #expect(state.openMatchedCardIDs == Set(["sun-heat"]))
     }
 }

--- a/Tests/MatherTests/WaterCycleLabTests.swift
+++ b/Tests/MatherTests/WaterCycleLabTests.swift
@@ -221,6 +221,32 @@ extension WaterCycleLabTests {
         #expect(state.activeLessonPrimaryActionTitle == "Try the cycle again")
         #expect(state.cyclesCompleted == 1)
     }
+    @Test func mixMatchFinaleIgnoresIncorrectAttemptsAndAdvancesOnCurrentCorrectMatch() {
+        var state = WaterCycleLabState()
+        for _ in 0..<5 { state.advance() }
+        state.completeCurrentLessonStage()
+        state.completeCurrentLessonStage()
+        state.completeCurrentLessonStage()
+
+        #expect(state.lessonThread.activeStage.kind == .mixMatchFinale)
+        #expect(state.currentMixMatchCard.answer.id == "sun-heat")
+
+        state.recordMixMatchAttempt(MixMatchRecallAttempt(choiceID: "evaporation", isCorrect: false))
+        #expect(state.currentMixMatchCard.answer.id == "sun-heat")
+        #expect(state.mixMatchCorrectCardIDs.isEmpty)
+        #expect(state.mixMatchProgressLabel == "Match 0 of 5")
+        #expect(state.lessonThread.isComplete == false)
+
+        state.recordMixMatchAttempt(MixMatchRecallAttempt(choiceID: "evaporation", isCorrect: true))
+        #expect(state.currentMixMatchCard.answer.id == "sun-heat")
+        #expect(state.mixMatchCorrectCardIDs.isEmpty)
+
+        state.recordMixMatchAttempt(MixMatchRecallAttempt(choiceID: "sun-heat", isCorrect: true))
+        #expect(state.mixMatchCorrectCardIDs == Set(["sun-heat"]))
+        #expect(state.currentMixMatchCard.answer.id == "evaporation")
+        #expect(state.mixMatchProgressLabel == "Match 1 of 5")
+    }
+
 }
 
 

--- a/Tests/MatherTests/WaterCycleLabTests.swift
+++ b/Tests/MatherTests/WaterCycleLabTests.swift
@@ -280,6 +280,12 @@ extension WaterCycleLabTests {
         state.completeCurrentLessonStage()
         state.completeCurrentLessonStage()
         state.advanceInterestingFact()
+        #expect(state.currentInterestingFact.title == "Rainiest place")
+
+        for card in WaterCycleLessonThread.mixMatchCards {
+            state.recordMixMatchAttempt(MixMatchRecallAttempt(choiceID: card.answer.id, isCorrect: true))
+        }
+        state.advanceInterestingFact()
         #expect(state.currentInterestingFact.title == "Driest desert")
 
         state.reset()

--- a/Tests/MatherTests/WaterCycleLabTests.swift
+++ b/Tests/MatherTests/WaterCycleLabTests.swift
@@ -219,4 +219,45 @@ extension WaterCycleLabTests {
         #expect(state.activeLessonPrimaryActionTitle == "Try the cycle again")
         #expect(state.cyclesCompleted == 1)
     }
+
+    @Test func completedLessonThreadExposesDeterministicInterestingFacts() {
+        var state = WaterCycleLabState()
+        for _ in 0..<5 { state.advance() }
+        state.completeCurrentLessonStage()
+        state.completeCurrentLessonStage()
+        state.completeCurrentLessonStage()
+
+        for card in WaterCycleLessonThread.mixMatchCards {
+            state.recordMixMatchAttempt(MixMatchRecallAttempt(choiceID: card.answer.id, isCorrect: true))
+        }
+
+        #expect(state.lessonThread.isComplete)
+        #expect(WaterCycleInterestingFact.completionFacts.count >= 4)
+        #expect(state.currentInterestingFact.title == "Rainiest place")
+        #expect(state.interestingFactProgressLabel == "Fact 1 of 4")
+        #expect(state.currentInterestingFact.detail.contains("Mawsynram"))
+
+        state.advanceInterestingFact()
+        #expect(state.currentInterestingFact.title == "Driest desert")
+        #expect(state.interestingFactProgressLabel == "Fact 2 of 4")
+    }
+
+    @Test func interestingFactsIgnoreEarlyAdvanceAndResetWithReplay() {
+        var state = WaterCycleLabState()
+
+        state.advanceInterestingFact()
+        #expect(state.currentInterestingFact.title == "Rainiest place")
+
+        for _ in 0..<5 { state.advance() }
+        state.completeCurrentLessonStage()
+        state.completeCurrentLessonStage()
+        state.completeCurrentLessonStage()
+        state.advanceInterestingFact()
+        #expect(state.currentInterestingFact.title == "Driest desert")
+
+        state.reset()
+        #expect(state.stage == .wonder)
+        #expect(state.currentInterestingFact.title == "Rainiest place")
+        #expect(state.interestingFactProgressLabel == "Fact 1 of 4")
+    }
 }


### PR DESCRIPTION
## Summary
- Replaces the Water Cycle Flip Recall stage with face-up picture/name matching cards.
- Adds deterministic correct/incorrect feedback state for the Water Cycle open-match flow.
- Applies match/mismatch animation affordances to open-match and Mix-Match choice cards.
- Reconciles with the completion facts branch so this can land after #844.

Fixes #836
Fixes #837

## Validation
- PASS: git diff --check
- BLOCKED: local Swift/Xcode validation is unavailable from the Linux worker; ganesh-mba SSH is currently unreachable, and GitHub macOS Build & Test is queued.