### PR TITLE
Animate Mix-Match attempt feedback

### DIFF
--- a/Features/MixMatchRecall/MixMatchRecallView.swift
+++ b/Features/MixMatchRecall/MixMatchRecallView.swift
@@ -67,6 +67,36 @@ struct MixMatchRecallChoiceEvaluator: Equatable {
     }
 }
 
+struct MixMatchRecallFeedbackState: Equatable {
+    private(set) var selectedChoiceID: String?
+    private(set) var matchedChoiceID: String?
+    private(set) var incorrectChoiceID: String?
+    private(set) var isResolving = false
+
+    var hasActiveFeedback: Bool {
+        selectedChoiceID != nil || matchedChoiceID != nil || incorrectChoiceID != nil || isResolving
+    }
+
+    mutating func markAttempt(_ attempt: MixMatchRecallAttempt) {
+        selectedChoiceID = attempt.choiceID
+        isResolving = true
+        if attempt.isCorrect {
+            matchedChoiceID = attempt.choiceID
+            incorrectChoiceID = nil
+        } else {
+            matchedChoiceID = nil
+            incorrectChoiceID = attempt.choiceID
+        }
+    }
+
+    mutating func clear() {
+        selectedChoiceID = nil
+        matchedChoiceID = nil
+        incorrectChoiceID = nil
+        isResolving = false
+    }
+}
+
 extension LearningCard {
     var mixMatchPromptCard: LearningCardViewModel {
         let display: LearningCardDisplay
@@ -208,11 +238,16 @@ struct LearningCardView: View {
 
 @MainActor
 struct MixMatchRecallView: View {
+    private static let correctFeedbackDuration: Duration = .milliseconds(520)
+    private static let incorrectFeedbackDuration: Duration = .milliseconds(420)
+
     let prompt: LearningCardViewModel?
     let choices: [MixMatchRecallChoice]
     private let evaluator: MixMatchRecallChoiceEvaluator
     let onCorrect: (MixMatchRecallAttempt) -> Void
     let onIncorrect: (MixMatchRecallAttempt) -> Void
+    @State private var feedback = MixMatchRecallFeedbackState()
+    @State private var feedbackTask: Task<Void, Never>?
 
     init(
         prompt: LearningCardViewModel? = nil,
@@ -251,20 +286,59 @@ struct MixMatchRecallView: View {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 112), spacing: 12)], spacing: 12) {
                 ForEach(choices) { choice in
                     Button {
-                        let attempt = evaluator.attempt(choiceID: choice.id)
-                        if attempt.isCorrect {
-                            onCorrect(attempt)
-                        } else {
-                            onIncorrect(attempt)
-                        }
+                        handleChoice(choice)
                     } label: {
-                        LearningCardView(model: choice.card, minTouchSize: 80)
+                        LearningCardView(model: feedbackCard(for: choice), minTouchSize: 80)
                             .frame(minHeight: 96)
                     }
                     .buttonStyle(.plain)
+                    .disabled(feedback.isResolving)
                     .accessibilityIdentifier("mix-match-choice-\(choice.id)")
                     .accessibilityAddTraits(.isButton)
                 }
+            }
+        }
+        .onDisappear {
+            feedbackTask?.cancel()
+        }
+    }
+
+    private func feedbackCard(for choice: MixMatchRecallChoice) -> LearningCardViewModel {
+        var card = choice.card
+        card.isSelected = feedback.selectedChoiceID == choice.id
+        card.isMatched = feedback.matchedChoiceID == choice.id
+        card.isIncorrect = feedback.incorrectChoiceID == choice.id
+        return card
+    }
+
+    private func handleChoice(_ choice: MixMatchRecallChoice) {
+        guard !feedback.isResolving else { return }
+        let attempt = evaluator.attempt(choiceID: choice.id)
+        feedbackTask?.cancel()
+
+        withAnimation(.spring(response: 0.25, dampingFraction: 0.62)) {
+            feedback.markAttempt(attempt)
+        }
+
+        let feedbackDuration = attempt.isCorrect
+            ? Self.correctFeedbackDuration
+            : Self.incorrectFeedbackDuration
+
+        feedbackTask = Task { @MainActor in
+            do {
+                try await Task.sleep(for: feedbackDuration)
+            } catch {
+                return
+            }
+
+            if attempt.isCorrect {
+                onCorrect(attempt)
+            } else {
+                onIncorrect(attempt)
+            }
+
+            withAnimation(.easeOut(duration: 0.12)) {
+                feedback.clear()
             }
         }
     }

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -250,7 +250,12 @@ struct WaterCycleLabState: Equatable {
     }
 
     mutating func recordMixMatchAttempt(_ attempt: MixMatchRecallAttempt) {
-        guard stage == .complete, lessonThread.activeStage.kind == .mixMatchFinale, attempt.isCorrect else { return }
+        guard
+            stage == .complete,
+            lessonThread.activeStage.kind == .mixMatchFinale,
+            attempt.isCorrect,
+            attempt.choiceID == currentMixMatchCard.answer.id
+        else { return }
         mixMatchCorrectCardIDs.insert(currentMixMatchCard.answer.id)
         if mixMatchCorrectCardIDs.count == WaterCycleLessonThread.mixMatchCards.count {
             lessonThread.completeActiveStage()

--- a/Tests/MatherTests/MixMatchRecallViewTests.swift
+++ b/Tests/MatherTests/MixMatchRecallViewTests.swift
@@ -11,6 +11,26 @@ struct MixMatchRecallViewTests {
     }
 
     @Test
+    func feedbackStateMarksCorrectAndIncorrectAttempts() {
+        var feedback = MixMatchRecallFeedbackState()
+
+        feedback.markAttempt(MixMatchRecallAttempt(choiceID: "ten", isCorrect: true))
+        #expect(feedback.selectedChoiceID == "ten")
+        #expect(feedback.matchedChoiceID == "ten")
+        #expect(feedback.incorrectChoiceID == nil)
+        #expect(feedback.isResolving)
+
+        feedback.clear()
+        #expect(feedback.hasActiveFeedback == false)
+
+        feedback.markAttempt(MixMatchRecallAttempt(choiceID: "nine", isCorrect: false))
+        #expect(feedback.selectedChoiceID == "nine")
+        #expect(feedback.matchedChoiceID == nil)
+        #expect(feedback.incorrectChoiceID == "nine")
+        #expect(feedback.isResolving)
+    }
+
+    @Test
     func learningCardAdapterCreatesPromptAndChoiceCards() {
         let correct = CardAnswer(id: "triangle", speechText: "triangle", displayText: "Triangle")
         let card = LearningCard(

--- a/Tests/MatherTests/WaterCycleLabTests.swift
+++ b/Tests/MatherTests/WaterCycleLabTests.swift
@@ -219,4 +219,30 @@ extension WaterCycleLabTests {
         #expect(state.activeLessonPrimaryActionTitle == "Try the cycle again")
         #expect(state.cyclesCompleted == 1)
     }
+
+    @Test func mixMatchFinaleIgnoresIncorrectAttemptsAndAdvancesOnCurrentCorrectMatch() {
+        var state = WaterCycleLabState()
+        for _ in 0..<5 { state.advance() }
+        state.completeCurrentLessonStage()
+        state.completeCurrentLessonStage()
+        state.completeCurrentLessonStage()
+
+        #expect(state.lessonThread.activeStage.kind == .mixMatchFinale)
+        #expect(state.currentMixMatchCard.answer.id == "sun-heat")
+
+        state.recordMixMatchAttempt(MixMatchRecallAttempt(choiceID: "evaporation", isCorrect: false))
+        #expect(state.currentMixMatchCard.answer.id == "sun-heat")
+        #expect(state.mixMatchCorrectCardIDs.isEmpty)
+        #expect(state.mixMatchProgressLabel == "Match 0 of 5")
+        #expect(state.lessonThread.isComplete == false)
+
+        state.recordMixMatchAttempt(MixMatchRecallAttempt(choiceID: "evaporation", isCorrect: true))
+        #expect(state.currentMixMatchCard.answer.id == "sun-heat")
+        #expect(state.mixMatchCorrectCardIDs.isEmpty)
+
+        state.recordMixMatchAttempt(MixMatchRecallAttempt(choiceID: "sun-heat", isCorrect: true))
+        #expect(state.mixMatchCorrectCardIDs == Set(["sun-heat"]))
+        #expect(state.currentMixMatchCard.answer.id == "evaporation")
+        #expect(state.mixMatchProgressLabel == "Match 1 of 5")
+    }
 }


### PR DESCRIPTION
## Summary
- Drive Mix-Match choice cards through selected, matched, and incorrect visual states during user attempts.
- Delay correct progress long enough for matched feedback to be visible before Water Cycle advances to the next card.
- Keep incorrect attempts local to feedback and prevent non-current answers from advancing Water Cycle mastery.

## Tests
- git diff --check
- Not run: xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO -only-testing:MatherTests/MixMatchRecallViewTests -only-testing:MatherTests/WaterCycleLabTests (xcodebuild is not installed in this container)

Fixes #836