### PR TITLE
Replace Water Cycle flip recall with picture matching

### DIFF
--- a/Domain/LessonPlayThread.swift
+++ b/Domain/LessonPlayThread.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum LessonPlayStageKind: String, Codable, CaseIterable, Equatable, Hashable {
     case lookLearnFlashcards
-    case invertedRecall
+    case pictureNameMatch
     case contextualAsk
     case mixMatchFinale
 }

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -1,22 +1,5 @@
 import SwiftUI
 
-
-enum WaterCycleOpenMatchFeedback: Equatable {
-    case correct(choiceID: String)
-    case incorrect(choiceID: String)
-
-    var choiceID: String {
-        switch self {
-        case .correct(let choiceID), .incorrect(let choiceID): choiceID
-        }
-    }
-
-    var isCorrect: Bool {
-        if case .correct = self { return true }
-        return false
-    }
-}
-
 enum WaterCycleStage: String, CaseIterable, Equatable {
     case wonder
     case evaporation
@@ -123,9 +106,8 @@ struct WaterCycleLabState: Equatable {
     private(set) var isFlashcardAnswerRevealed = false
     private(set) var lessonThread = WaterCycleLessonThread.thread
     private(set) var lessonCardIndex = 0
-    private(set) var isRecallCardRevealed = false
-    private(set) var openMatchFeedback: WaterCycleOpenMatchFeedback?
-    private(set) var openMatchedCardIDs: Set<String> = []
+    private(set) var pictureNameMatchIndex = 0
+    private(set) var pictureNameMatchCorrectCardIDs: Set<String> = []
     private(set) var askSession = WaterCycleLessonThread.askSession(for: WaterCycleLessonThread.cards[0])
     private(set) var latestAskResponse: LessonSafeAskResponse?
     private(set) var mixMatchIndex = 0
@@ -143,6 +125,9 @@ struct WaterCycleLabState: Equatable {
         WaterCycleLessonThread.mixMatchCards[mixMatchIndex % WaterCycleLessonThread.mixMatchCards.count]
     }
 
+    var currentPictureNameMatchCard: LearningCard {
+        WaterCycleLessonThread.mixMatchCards[pictureNameMatchIndex % WaterCycleLessonThread.mixMatchCards.count]
+    }
 
     var flashcardProgressLabel: String {
         "Card \(flashcardIndex + 1) of \(WaterCycleConceptFlashcard.reviewDeck.count)"
@@ -154,6 +139,10 @@ struct WaterCycleLabState: Equatable {
 
     var mixMatchProgressLabel: String {
         "Match \(mixMatchCorrectCardIDs.count) of \(WaterCycleLessonThread.mixMatchCards.count)"
+    }
+
+    var pictureNameMatchProgressLabel: String {
+        "Match \(pictureNameMatchCorrectCardIDs.count) of \(WaterCycleLessonThread.mixMatchCards.count)"
     }
 
     var completionInterestingFacts: [WaterCycleInterestingFact] {
@@ -172,9 +161,8 @@ struct WaterCycleLabState: Equatable {
         switch lessonThread.activeStage.kind {
         case .lookLearnFlashcards:
             return isOnLastLessonCard ? "Start picture match" : "Next look card"
-        case .invertedRecall:
-            if !isRecallCardRevealed { return "Pick the matching name" }
-            return isOnLastLessonCard ? "Ask this card" : "Next picture"
+        case .pictureNameMatch:
+            return "Hear match clue"
         case .contextualAsk:
             if latestAskResponse == nil { return "Ask suggested question" }
             return isOnLastLessonCard ? "Start mix-match" : "Next ask card"
@@ -186,7 +174,7 @@ struct WaterCycleLabState: Equatable {
     var activeLessonPrimaryActionIcon: String {
         switch lessonThread.activeStage.kind {
         case .lookLearnFlashcards: "arrow.right.circle.fill"
-        case .invertedRecall: isRecallCardRevealed ? "arrow.right.circle.fill" : "rectangle.2.swap"
+        case .pictureNameMatch: "speaker.wave.2.fill"
         case .contextualAsk: latestAskResponse == nil ? "questionmark.bubble.fill" : "arrow.right.circle.fill"
         case .mixMatchFinale: lessonThread.isComplete ? "arrow.counterclockwise" : "speaker.wave.2.fill"
         }
@@ -270,32 +258,11 @@ struct WaterCycleLabState: Equatable {
         isFlashcardAnswerRevealed = false
     }
 
-
     mutating func advanceLessonCard() {
         guard stage == .complete else { return }
         lessonCardIndex = (lessonCardIndex + 1) % lessonThread.cards.count
-        isRecallCardRevealed = false
-        openMatchFeedback = nil
         askSession = WaterCycleLessonThread.askSession(for: currentLessonCard)
         latestAskResponse = nil
-    }
-
-    mutating func revealRecallCard() {
-        guard stage == .complete, lessonThread.activeStage.kind == .invertedRecall else { return }
-        isRecallCardRevealed = true
-        openMatchedCardIDs.insert(currentLessonCard.id)
-        openMatchFeedback = .correct(choiceID: currentLessonCard.id)
-    }
-
-    mutating func recordOpenMatchChoice(id choiceID: String) -> MixMatchRecallAttempt? {
-        guard stage == .complete, lessonThread.activeStage.kind == .invertedRecall else { return nil }
-        let isCorrect = choiceID == currentLessonCard.id
-        openMatchFeedback = isCorrect ? .correct(choiceID: choiceID) : .incorrect(choiceID: choiceID)
-        if isCorrect {
-            isRecallCardRevealed = true
-            openMatchedCardIDs.insert(currentLessonCard.id)
-        }
-        return MixMatchRecallAttempt(choiceID: choiceID, isCorrect: isCorrect)
     }
 
     mutating func selectAskTurn(id: String) -> LessonSafeAskResponse? {
@@ -311,10 +278,26 @@ struct WaterCycleLabState: Equatable {
         guard stage == .complete else { return }
         lessonThread.completeActiveStage()
         lessonCardIndex = 0
-        isRecallCardRevealed = false
-        openMatchFeedback = nil
         askSession = WaterCycleLessonThread.askSession(for: currentLessonCard)
         latestAskResponse = nil
+    }
+
+    mutating func recordPictureNameMatchAttempt(_ attempt: MixMatchRecallAttempt) {
+        guard
+            stage == .complete,
+            lessonThread.activeStage.kind == .pictureNameMatch,
+            attempt.isCorrect,
+            attempt.choiceID == currentPictureNameMatchCard.answer.id
+        else { return }
+        pictureNameMatchCorrectCardIDs.insert(currentPictureNameMatchCard.answer.id)
+        if pictureNameMatchCorrectCardIDs.count == WaterCycleLessonThread.mixMatchCards.count {
+            lessonThread.completeActiveStage()
+            lessonCardIndex = 0
+            askSession = WaterCycleLessonThread.askSession(for: currentLessonCard)
+            latestAskResponse = nil
+        } else {
+            pictureNameMatchIndex = nextUnmatchedPictureNameMatchIndex()
+        }
     }
 
     mutating func recordMixMatchAttempt(_ attempt: MixMatchRecallAttempt) {
@@ -340,6 +323,14 @@ struct WaterCycleLabState: Equatable {
         return next
     }
 
+    private func nextUnmatchedPictureNameMatchIndex() -> Int {
+        let cards = WaterCycleLessonThread.mixMatchCards
+        guard let next = cards.indices.first(where: { !pictureNameMatchCorrectCardIDs.contains(cards[$0].answer.id) }) else {
+            return pictureNameMatchIndex
+        }
+        return next
+    }
+
     mutating func reset() {
         stage = .wonder
         vaporDrops = 0
@@ -354,9 +345,8 @@ struct WaterCycleLabState: Equatable {
     private mutating func resetLessonThread() {
         lessonThread.resetProgress()
         lessonCardIndex = 0
-        isRecallCardRevealed = false
-        openMatchFeedback = nil
-        openMatchedCardIDs = []
+        pictureNameMatchIndex = 0
+        pictureNameMatchCorrectCardIDs = []
         askSession = WaterCycleLessonThread.askSession(for: currentLessonCard)
         latestAskResponse = nil
         mixMatchIndex = 0
@@ -669,7 +659,7 @@ struct WaterCycleLabView: View {
     private var lessonStageIcon: String {
         switch state.lessonThread.activeStage.kind {
         case .lookLearnFlashcards: "photo.stack.fill"
-        case .invertedRecall: "rectangle.2.swap"
+        case .pictureNameMatch: "rectangle.2.swap"
         case .contextualAsk: "bubble.left.and.text.bubble.right.fill"
         case .mixMatchFinale: "rectangle.2.swap"
         }
@@ -750,8 +740,8 @@ struct WaterCycleLabView: View {
                 switch state.lessonThread.activeStage.kind {
                 case .lookLearnFlashcards:
                     lookLearnLevel
-                case .invertedRecall:
-                    openPictureNameMatchLevel
+                case .pictureNameMatch:
+                    pictureNameMatchLevel
                 case .contextualAsk:
                     safeAskLevel
                 case .mixMatchFinale:
@@ -795,58 +785,24 @@ struct WaterCycleLabView: View {
         }
     }
 
-    private var openPictureNameMatchLevel: some View {
-        let card = state.currentLessonCard
-        let feedback = state.openMatchFeedback
-        let pictureModel = LearningCardViewModel(
-            id: "\(card.id).picture",
-            display: card.assetName.map(LearningCardDisplay.asset) ?? .text(card.title),
-            accessibilityLabel: "Picture for \(card.title)",
-            accessibilityHint: "Choose the matching water cycle name.",
-            isSelected: state.isRecallCardRevealed,
-            isMatched: state.openMatchedCardIDs.contains(card.id),
-            isIncorrect: false
-        )
-        let choices = WaterCycleLessonThread.cards.map { choice in
-            LearningCardViewModel(
-                id: choice.id,
-                display: .choice(choice.title),
-                accessibilityLabel: choice.title,
-                accessibilityHint: choice.id == card.id ? "Correct name for this picture." : "Name choice.",
-                isSelected: feedback?.choiceID == choice.id,
-                isMatched: state.openMatchedCardIDs.contains(choice.id) && choice.id == card.id,
-                isIncorrect: feedback == .incorrect(choiceID: choice.id)
-            )
-        }
+    private var pictureNameMatchLevel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(state.pictureNameMatchProgressLabel)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
 
-        return VStack(alignment: .leading, spacing: 12) {
-            LearningCardView(model: pictureModel)
-                .frame(minHeight: 150)
-                .accessibilityIdentifier("water-cycle-open-picture-card")
-
-            Text(state.isRecallCardRevealed ? "Matched: \(card.title)" : "Tap the name that matches this picture.")
-                .font(.system(size: 18, weight: .bold, design: .rounded))
-                .foregroundStyle(MatherTheme.ink)
-                .fixedSize(horizontal: false, vertical: true)
-                .accessibilityIdentifier("water-cycle-open-match-feedback")
-
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 118), spacing: 12)], spacing: 12) {
-                ForEach(choices) { choice in
-                    Button {
-                        withAnimation(.spring(response: 0.25, dampingFraction: 0.58)) {
-                            if let attempt = state.recordOpenMatchChoice(id: choice.id) {
-                                speakLessonText(attempt.isCorrect ? "Correct match." : "Try another match.")
-                            }
-                        }
-                    } label: {
-                        LearningCardView(model: choice, minTouchSize: 78)
-                            .frame(minHeight: 88)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(state.isRecallCardRevealed)
-                    .accessibilityIdentifier("water-cycle-open-match-choice-\(choice.id)")
+            MixMatchRecallView(
+                learningCard: state.currentPictureNameMatchCard,
+                onCorrect: { attempt in
+                    state.recordPictureNameMatchAttempt(attempt)
+                    speakLessonText(attempt.isCorrect ? "Correct match." : "Try another match.")
+                },
+                onIncorrect: { attempt in
+                    state.recordPictureNameMatchAttempt(attempt)
+                    speakLessonText("Try another match.")
                 }
-            }
+            )
+            .accessibilityIdentifier("water-cycle-picture-name-match")
         }
     }
 
@@ -989,16 +945,8 @@ struct WaterCycleLabView: View {
                 state.advanceLessonCard()
                 speakLessonCard()
             }
-        case .invertedRecall:
-            if !state.isRecallCardRevealed {
-                speakLessonText("Choose the name that matches \(state.currentLessonCard.title).")
-            } else if state.isOnLastLessonCard {
-                state.completeCurrentLessonStage()
-                speakLessonStage()
-            } else {
-                state.advanceLessonCard()
-                speakLessonCard()
-            }
+        case .pictureNameMatch:
+            speakLessonText(state.currentPictureNameMatchCard.prompt.speechText)
         case .contextualAsk:
             if state.latestAskResponse == nil, let turn = state.askSession.suggestedTurns.first {
                 if let response = state.selectAskTurn(id: turn.id) {

--- a/Features/WaterCycle/WaterCycleLessonThread.swift
+++ b/Features/WaterCycle/WaterCycleLessonThread.swift
@@ -13,9 +13,9 @@ enum WaterCycleLessonThread {
             ),
             LessonPlayStage(
                 id: "picture-name-match",
-                kind: .invertedRecall,
-                title: "Picture Match",
-                prompt: "Match the open picture card to its water cycle name."
+                kind: .pictureNameMatch,
+                title: "Picture-Name Match",
+                prompt: "Match each open picture to its water cycle name."
             ),
             LessonPlayStage(
                 id: "safe-ask",

--- a/Tests/MatherTests/LessonPlayThreadTests.swift
+++ b/Tests/MatherTests/LessonPlayThreadTests.swift
@@ -8,7 +8,7 @@ struct LessonPlayThreadTests {
             title: "Sample",
             stages: [
                 LessonPlayStage(id: "look", kind: .lookLearnFlashcards, title: "Look", prompt: "Look."),
-                LessonPlayStage(id: "recall", kind: .invertedRecall, title: "Recall", prompt: "Recall."),
+                LessonPlayStage(id: "picture-name", kind: .pictureNameMatch, title: "Picture-Name", prompt: "Match."),
                 LessonPlayStage(id: "ask", kind: .contextualAsk, title: "Ask", prompt: "Ask."),
                 LessonPlayStage(id: "match", kind: .mixMatchFinale, title: "Match", prompt: "Match.")
             ],
@@ -22,7 +22,7 @@ struct LessonPlayThreadTests {
         #expect(thread.progress == 0)
 
         thread.completeActiveStage()
-        #expect(thread.activeStage.kind == .invertedRecall)
+        #expect(thread.activeStage.kind == .pictureNameMatch)
         #expect(thread.progressLabel == "Level 2 of 4")
         #expect(thread.progress == 0.25)
 

--- a/Tests/MatherTests/WaterCycleLabTests.swift
+++ b/Tests/MatherTests/WaterCycleLabTests.swift
@@ -107,13 +107,14 @@ extension WaterCycleLabTests {
 
         state.revealFlashcardAnswer()
         state.completeCurrentLessonStage()
-        #expect(state.lessonThread.activeStage.kind == .invertedRecall)
+        #expect(state.lessonThread.activeStage.kind == .pictureNameMatch)
 
         state.reset()
         #expect(state.stage == .wonder)
         #expect(state.flashcardIndex == 0)
         #expect(state.isFlashcardAnswerRevealed == false)
         #expect(state.lessonThread.activeStage.kind == .lookLearnFlashcards)
+        #expect(state.pictureNameMatchCorrectCardIDs.isEmpty)
         #expect(state.mixMatchCorrectCardIDs.isEmpty)
     }
 
@@ -124,24 +125,26 @@ extension WaterCycleLabTests {
         #expect(state.stage == .complete)
         #expect(state.lessonThread.stages.map(\.kind) == [
             .lookLearnFlashcards,
-            .invertedRecall,
+            .pictureNameMatch,
             .contextualAsk,
             .mixMatchFinale
         ])
+        #expect(state.lessonThread.stages[1].title == "Picture-Name Match")
+        #expect(state.lessonThread.stages[1].prompt.contains("open picture"))
         #expect(state.currentLessonCard.title == "Sun Heat")
         #expect(state.currentLessonCard.assetName == "MemoryWaterCycleSunHeat")
 
         state.completeCurrentLessonStage()
-        #expect(state.lessonThread.activeStage.kind == .invertedRecall)
-        #expect(state.isRecallCardRevealed == false)
+        #expect(state.lessonThread.activeStage.kind == .pictureNameMatch)
+        #expect(state.currentPictureNameMatchCard.answer.id == "sun-heat")
+        #expect(state.pictureNameMatchProgressLabel == "Match 0 of 5")
 
-        let openMatchAttempt = state.recordOpenMatchChoice(id: "sun-heat")
-        #expect(openMatchAttempt == MixMatchRecallAttempt(choiceID: "sun-heat", isCorrect: true))
-        #expect(state.isRecallCardRevealed)
-        #expect(state.openMatchFeedback == .correct(choiceID: "sun-heat"))
-
-        state.completeCurrentLessonStage()
+        for card in WaterCycleLessonThread.mixMatchCards {
+            let attempt = MixMatchRecallAttempt(choiceID: card.answer.id, isCorrect: true)
+            state.recordPictureNameMatchAttempt(attempt)
+        }
         #expect(state.lessonThread.activeStage.kind == .contextualAsk)
+        #expect(state.pictureNameMatchProgressLabel == "Match 5 of 5")
         #expect(state.askSession.cardID == "sun-heat")
         #expect(state.askSession.suggestedTurns.count == 2)
 
@@ -175,17 +178,12 @@ extension WaterCycleLabTests {
         #expect(state.activeLessonPrimaryActionTitle == "Start picture match")
 
         state.completeCurrentLessonStage()
-        #expect(state.lessonThread.activeStage.kind == .invertedRecall)
-        #expect(state.activeLessonPrimaryActionTitle == "Pick the matching name")
+        #expect(state.lessonThread.activeStage.kind == .pictureNameMatch)
+        #expect(state.activeLessonPrimaryActionTitle == "Hear match clue")
 
-        _ = state.recordOpenMatchChoice(id: "sun-heat")
-        #expect(state.activeLessonPrimaryActionTitle == "Next picture")
-
-        for _ in 0..<4 { state.advanceLessonCard() }
-        _ = state.recordOpenMatchChoice(id: state.currentLessonCard.id)
-        #expect(state.activeLessonPrimaryActionTitle == "Ask this card")
-
-        state.completeCurrentLessonStage()
+        for card in WaterCycleLessonThread.mixMatchCards {
+            state.recordPictureNameMatchAttempt(MixMatchRecallAttempt(choiceID: card.answer.id, isCorrect: true))
+        }
         #expect(state.lessonThread.activeStage.kind == .contextualAsk)
         #expect(state.activeLessonPrimaryActionTitle == "Ask suggested question")
 
@@ -221,6 +219,31 @@ extension WaterCycleLabTests {
         #expect(state.activeLessonPrimaryActionTitle == "Try the cycle again")
         #expect(state.cyclesCompleted == 1)
     }
+
+    @Test func pictureNameMatchIgnoresIncorrectAttemptsAndAdvancesOnCurrentCorrectMatch() {
+        var state = WaterCycleLabState()
+        for _ in 0..<5 { state.advance() }
+        state.completeCurrentLessonStage()
+
+        #expect(state.lessonThread.activeStage.kind == .pictureNameMatch)
+        #expect(state.currentPictureNameMatchCard.answer.id == "sun-heat")
+
+        state.recordPictureNameMatchAttempt(MixMatchRecallAttempt(choiceID: "evaporation", isCorrect: false))
+        #expect(state.currentPictureNameMatchCard.answer.id == "sun-heat")
+        #expect(state.pictureNameMatchCorrectCardIDs.isEmpty)
+        #expect(state.pictureNameMatchProgressLabel == "Match 0 of 5")
+        #expect(state.lessonThread.activeStage.kind == .pictureNameMatch)
+
+        state.recordPictureNameMatchAttempt(MixMatchRecallAttempt(choiceID: "evaporation", isCorrect: true))
+        #expect(state.currentPictureNameMatchCard.answer.id == "sun-heat")
+        #expect(state.pictureNameMatchCorrectCardIDs.isEmpty)
+
+        state.recordPictureNameMatchAttempt(MixMatchRecallAttempt(choiceID: "sun-heat", isCorrect: true))
+        #expect(state.pictureNameMatchCorrectCardIDs == Set(["sun-heat"]))
+        #expect(state.currentPictureNameMatchCard.answer.id == "evaporation")
+        #expect(state.pictureNameMatchProgressLabel == "Match 1 of 5")
+    }
+
     @Test func mixMatchFinaleIgnoresIncorrectAttemptsAndAdvancesOnCurrentCorrectMatch() {
         var state = WaterCycleLabState()
         for _ in 0..<5 { state.advance() }
@@ -273,30 +296,4 @@ extension WaterCycleLabTests {
         #expect(state.activeLessonPrimaryActionTitle == "Try the cycle again")
     }
 
-    @Test func openPictureNameMatchRecordsDeterministicFeedback() {
-        var state = WaterCycleLabState()
-        for _ in 0..<5 { state.advance() }
-        state.completeCurrentLessonStage()
-
-        #expect(state.lessonThread.activeStage.title == "Picture Match")
-        #expect(state.isRecallCardRevealed == false)
-
-        let wrong = state.recordOpenMatchChoice(id: "evaporation")
-        #expect(wrong == MixMatchRecallAttempt(choiceID: "evaporation", isCorrect: false))
-        #expect(state.openMatchFeedback == .incorrect(choiceID: "evaporation"))
-        #expect(state.isRecallCardRevealed == false)
-        #expect(state.openMatchedCardIDs.isEmpty)
-
-        let correct = state.recordOpenMatchChoice(id: "sun-heat")
-        #expect(correct == MixMatchRecallAttempt(choiceID: "sun-heat", isCorrect: true))
-        #expect(state.openMatchFeedback == .correct(choiceID: "sun-heat"))
-        #expect(state.isRecallCardRevealed)
-        #expect(state.openMatchedCardIDs == Set(["sun-heat"]))
-
-        state.advanceLessonCard()
-        #expect(state.currentLessonCard.id == "evaporation")
-        #expect(state.openMatchFeedback == nil)
-        #expect(state.isRecallCardRevealed == false)
-        #expect(state.openMatchedCardIDs == Set(["sun-heat"]))
-    }
 }


### PR DESCRIPTION
## Summary
- Replace the Water Cycle stage-2 Flip Recall card with an open Picture-Name Match stage.
- Reuse MixMatchRecallView/LearningCard for open picture/name choices so the #836 correct/incorrect feedback stays intact.
- Keep Look & Learn before the match stage, and keep contextual ask plus Mix-Match finale after it.

## Tests
- git diff --check HEAD~1..HEAD
- rg check for removed Water Cycle flip/inverted-recall terms
- xcodebuild targeted test command attempted, but unavailable in this worker: /bin/bash: xcodebuild: command not found

Fixes #837