### PR TITLE
fix: align water cycle screenshot review with lesson mode

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -279,13 +279,10 @@ final class ScreenshotTests: XCTestCase {
             tapWhenReachable(primaryAction, in: app, scrollDirection: .up)
         }
 
-        let completedPrimaryAction = app.buttons
-            .matching(identifier: "water-cycle-primary-action")
-            .matching(NSPredicate(format: "label CONTAINS[c] %@", "Try the cycle again"))
-            .firstMatch
-        XCTAssertTrue(completedPrimaryAction.waitForExistence(timeout: 5))
-        XCTAssertTrue(scrollUntilExists(app.buttons["water-cycle-replay-prompt"], in: app, direction: .up, maxSwipes: 4))
-        XCTAssertTrue(scrollUntilExists(app.buttons["water-cycle-reset"], in: app, direction: .up, maxSwipes: 4))
+        XCTAssertTrue(app.otherElements["water-cycle-playable-lesson"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["water-cycle-lesson-primary-action"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["water-cycle-replay-lesson-stage"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["water-cycle-reset"].waitForExistence(timeout: 5))
         snapshot(app, "WaterCycle-Complete-Compact")
     }
 


### PR DESCRIPTION
## Summary\n- update the Water Cycle compact screenshot review to assert the post-cycle lesson scene introduced by the current app flow\n- verify the lesson primary, replay, and reset controls instead of the retired inquiry-cycle completion controls\n\n## Verification\n- git diff --check\n- swift test --filter WaterCycleLabTests (not run: swift toolchain unavailable in this Linux workspace)\n\n## Context\n- Investigated failing scheduled iOS UI Review (main) run https://github.com/ganesh47/mather/actions/runs/25214534394\n- Failure was ScreenshotTests.testScreenshot_WaterCycleCompactCompletion expecting water-cycle-primary-action after completion; current UI transitions to water-cycle-playable-lesson and water-cycle-lesson-primary-action.