### PR TITLE
fix: probe water cycle lesson state in screenshot review

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -279,10 +279,27 @@ final class ScreenshotTests: XCTestCase {
             tapWhenReachable(primaryAction, in: app, scrollDirection: .up)
         }
 
-        XCTAssertTrue(app.otherElements["water-cycle-playable-lesson"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.buttons["water-cycle-lesson-primary-action"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.buttons["water-cycle-replay-lesson-stage"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.buttons["water-cycle-reset"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Look & Learn"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Card 1 of 5"].waitForExistence(timeout: 5))
+
+        let lessonPrimaryByIdentifier = app.buttons["water-cycle-lesson-primary-action"]
+        let lessonPrimaryAction: XCUIElement
+        if lessonPrimaryByIdentifier.exists {
+            lessonPrimaryAction = lessonPrimaryByIdentifier
+        } else {
+            lessonPrimaryAction = app.buttons["Next look card"]
+        }
+        XCTAssertTrue(scrollUntilExists(lessonPrimaryAction, in: app, direction: .up, maxSwipes: 4))
+
+        let replayLessonByIdentifier = app.buttons["water-cycle-replay-lesson-stage"]
+        let replayLesson: XCUIElement
+        if replayLessonByIdentifier.exists {
+            replayLesson = replayLessonByIdentifier
+        } else {
+            replayLesson = app.buttons["Replay stage"]
+        }
+        XCTAssertTrue(scrollUntilExists(replayLesson, in: app, direction: .up, maxSwipes: 4))
+        XCTAssertTrue(scrollUntilExists(app.buttons["water-cycle-reset"], in: app, direction: .up, maxSwipes: 4))
         snapshot(app, "WaterCycle-Complete-Compact")
     }
 


### PR DESCRIPTION
## Summary\n- update the Water Cycle compact screenshot test to wait for visible lesson-state text instead of a container accessibility identifier that is not exposed to XCTest\n- keep validating lesson primary/replay/reset controls with identifier-or-label fallbacks\n\n## Verification\n- git diff --check\n- iOS UI Review rerun 25215843163 reproduced the remaining failure at the new lesson container assertion, motivating this follow-up\n\n## Context\nFollow-up to #850. The first fix merged and main CI passed, but the manual iOS UI Review rerun still failed because XCTest did not expose the water-cycle-playable-lesson container.