### PR TITLE
fix: assert full water cycle lesson progress label

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -280,7 +280,7 @@ final class ScreenshotTests: XCTestCase {
         }
 
         XCTAssertTrue(app.staticTexts["Look & Learn"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.staticTexts["Card 1 of 5"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Level 1 of 4 - Card 1 of 5"].waitForExistence(timeout: 5))
 
         let lessonPrimaryByIdentifier = app.buttons["water-cycle-lesson-primary-action"]
         let lessonPrimaryAction: XCUIElement


### PR DESCRIPTION
## Summary\n- update the Water Cycle compact screenshot review to expect the full active lesson progress label\n- preserves the visible lesson-state probe added in #851 while matching the app state contract\n\n## Verification\n- git diff --check\n- iOS UI Review run 25216759289 failed at ScreenshotTests.swift:283 because XCTest saw Look & Learn but not the partial Card 1 of 5 label; state tests confirm the visible label is Level 1 of 4 - Card 1 of 5\n\n## Context\nFollow-up to #851 after the main UI review rerun exposed the exact progress-label mismatch.