### PR TITLE
fix: harden UI review control discovery

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -299,7 +299,15 @@ final class ScreenshotTests: XCTestCase {
             replayLesson = app.buttons["Replay stage"]
         }
         XCTAssertTrue(scrollUntilExists(replayLesson, in: app, direction: .up, maxSwipes: 4))
-        XCTAssertTrue(scrollUntilExists(app.buttons["water-cycle-reset"], in: app, direction: .up, maxSwipes: 4))
+
+        let resetByIdentifier = app.buttons["water-cycle-reset"]
+        let resetAction: XCUIElement
+        if resetByIdentifier.exists {
+            resetAction = resetByIdentifier
+        } else {
+            resetAction = app.buttons["Reset"]
+        }
+        XCTAssertTrue(scrollUntilExists(resetAction, in: app, direction: .up, maxSwipes: 4))
         snapshot(app, "WaterCycle-Complete-Compact")
     }
 
@@ -632,9 +640,13 @@ final class ScreenshotTests: XCTestCase {
         }
 
         let sumSprintTitle = app.staticTexts["Sum Sprint"]
-        if let completeSplit = firstExistingControl(in: app, identifiers: ["gravity-complete-split-button"], timeout: 3) {
-            completeSplit.tap()
-        } else {
+        if let completeSplit = firstExistingControl(in: app, identifiers: ["gravity-complete-split-button"], timeout: 3),
+           !sumSprintTitle.exists {
+            completeSplit.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+            _ = sumSprintTitle.waitForExistence(timeout: 3)
+        }
+
+        if !sumSprintTitle.exists {
             for _ in 0..<leftPanCount {
                 if sumSprintTitle.exists { break }
                 tapGravityIncrement(


### PR DESCRIPTION
## Summary\n- allow the Water Cycle lesson reset assertion to fall back to the visible Reset label when XCTest does not expose the button identifier\n- tap the Gravity Split completion control by coordinate and fall back to increment controls if Sum Sprint does not appear\n\n## Verification\n- git diff --check\n- iOS UI Review run 25217647571 exposed the remaining failures at ScreenshotTests.swift:302 and ScreenshotTests.swift:636\n\n## Context\nFollow-up to #853 after the main UI review rerun reached the lesson controls and the issue #222 route on hosted iPhone/iPad runners.