### PR TITLE
fix: polish TestFlight feedback from build 64

### DIFF
--- a/Features/AngleCannon/AngleCannonView.swift
+++ b/Features/AngleCannon/AngleCannonView.swift
@@ -180,6 +180,8 @@ struct AngleCannonView: View {
                 canvasSize: canvasSize
             )
 
+            drawScenarioBackdrop(ctx: ctx, size: canvasSize)
+
             // Ground
             var ground = Path()
             ground.move(to: CGPoint(x: 0, y: canvasSize.height * 0.92))
@@ -479,23 +481,34 @@ struct AngleCannonView: View {
         let tipX = origin.x + barrelLen * cos(a)
         let tipY = origin.y - barrelLen * sin(a)
 
+        // Playful, high-contrast barrel: chunky silhouette plus coral inset so it reads as a toy.
         var barrel = Path()
         barrel.move(to: origin)
         barrel.addLine(to: CGPoint(x: tipX, y: tipY))
         ctx.stroke(barrel,
-                   with: .color(MatherTheme.ink.opacity(0.9)),
-                   style: StrokeStyle(lineWidth: 12, lineCap: .round))
+                   with: .color(MatherTheme.ink.opacity(0.92)),
+                   style: StrokeStyle(lineWidth: 15, lineCap: .round))
+        ctx.stroke(barrel,
+                   with: .color(MatherTheme.coral.opacity(0.86)),
+                   style: StrokeStyle(lineWidth: 8, lineCap: .round))
 
         // Carriage
         let wheelR: CGFloat = 16
+        let body = RoundedRectangle(cornerRadius: 14).path(in: CGRect(x: origin.x - 42, y: origin.y - 18, width: 74, height: 28))
+        ctx.fill(body, with: .color(MatherTheme.warm.opacity(0.95)))
+        ctx.stroke(body, with: .color(MatherTheme.ink.opacity(0.24)), lineWidth: 2)
+        let decal = ctx.resolve(Text("★").font(.system(size: 15, weight: .black)).foregroundStyle(.white.opacity(0.9)))
+        ctx.draw(decal, at: CGPoint(x: origin.x - 8, y: origin.y - 4))
         ctx.fill(Circle().path(in: CGRect(x: origin.x - wheelR * 2.2,
                                           y: origin.y - wheelR * 0.6,
                                           width: wheelR * 2, height: wheelR * 2)),
-                 with: .color(MatherTheme.ink.opacity(0.7)))
+                 with: .color(MatherTheme.ink.opacity(0.78)))
         ctx.fill(Circle().path(in: CGRect(x: origin.x - wheelR * 0.4,
                                           y: origin.y - wheelR * 0.6,
                                           width: wheelR * 2, height: wheelR * 2)),
-                 with: .color(MatherTheme.ink.opacity(0.7)))
+                 with: .color(MatherTheme.ink.opacity(0.78)))
+        ctx.fill(Circle().path(in: CGRect(x: origin.x - wheelR * 1.7, y: origin.y - 2, width: 9, height: 9)), with: .color(.white.opacity(0.72)))
+        ctx.fill(Circle().path(in: CGRect(x: origin.x + wheelR * 0.1, y: origin.y - 2, width: 9, height: 9)), with: .color(.white.opacity(0.72)))
 
         // Muzzle flash ring when firing
         if firePulse {
@@ -503,6 +516,24 @@ struct AngleCannonView: View {
                                                  width: 28, height: 28)),
                        with: .color(MatherTheme.warm.opacity(0.8)), lineWidth: 3)
         }
+    }
+
+    private func drawScenarioBackdrop(ctx: GraphicsContext, size: CGSize) {
+        let sky = CGRect(x: 0, y: 0, width: size.width, height: size.height * 0.92)
+        ctx.fill(Rectangle().path(in: sky), with: .color(MatherTheme.softBlue.opacity(0.10)))
+
+        // Soft scenery makes the game feel less like a physics diagram while keeping targets readable.
+        let farHill = CGRect(x: -size.width * 0.10, y: size.height * 0.66, width: size.width * 0.78, height: size.height * 0.30)
+        let nearHill = CGRect(x: size.width * 0.42, y: size.height * 0.62, width: size.width * 0.76, height: size.height * 0.34)
+        ctx.fill(Ellipse().path(in: farHill), with: .color(MatherTheme.accent.opacity(0.10)))
+        ctx.fill(Ellipse().path(in: nearHill), with: .color(MatherTheme.warm.opacity(0.11)))
+
+        let cloudText = scenario.id == "moon-gate" ? "☁️   🌙   ☁️" : "☁️        ☁️"
+        let cloud = ctx.resolve(Text(cloudText).font(.system(size: 28)).foregroundStyle(.white.opacity(0.92)))
+        ctx.draw(cloud, at: CGPoint(x: size.width * 0.62, y: size.height * 0.16))
+
+        let prop = ctx.resolve(Text(scenario.environmentSymbol).font(.system(size: 42)))
+        ctx.draw(prop, at: CGPoint(x: size.width * 0.86, y: size.height * 0.72))
     }
 
     // MARK: - Actions

--- a/Features/GravityArtist/GravityArtistView.swift
+++ b/Features/GravityArtist/GravityArtistView.swift
@@ -364,37 +364,19 @@ struct GravityArtistView: View {
             HStack(spacing: 16) {
                 switch phase {
                 case .aim:
-                    Button("PREDICT ROLL") {
+                    crispActionButton(title: "PREDICT ROLL", fill: MatherTheme.warm) {
                         handlePredict()
                     }
-                    .font(.headline.weight(.bold))
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-                    .background(MatherTheme.warm)
-                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
 
                 case .predicted:
-                    Button("OBSERVE") {
+                    crispActionButton(title: "OBSERVE", fill: MatherTheme.coral) {
                         handleFire()
                     }
-                    .font(.headline.weight(.bold))
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-                    .background(MatherTheme.coral)
-                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
 
                 case .fired:
-                    Button("Try Again") {
+                    crispActionButton(title: "NEW ROLL", fill: MatherTheme.softBlue) {
                         handleNextRound()
                     }
-                    .font(.headline.weight(.bold))
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
-                    .background(MatherTheme.softBlue)
-                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                 }
             }
             .padding(.horizontal, 24)
@@ -404,6 +386,23 @@ struct GravityArtistView: View {
                 .foregroundStyle(.tertiary)
                 .padding(.bottom, 16)
         }
+    }
+
+    private func crispActionButton(title: String, fill: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 19, weight: .black, design: .rounded))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, minHeight: 62)
+                .background(fill, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .stroke(.white.opacity(0.65), lineWidth: 2)
+                )
+                .shadow(color: fill.opacity(0.24), radius: 6, y: 3)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("gravity-crisp-action-button")
     }
 
     // MARK: - Actions

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -26,6 +26,7 @@ struct LabLaneDetailView: View {
                     header(selectedLane, presentation: presentation, progress: progress, tint: tint)
                     gamesSection(selectedLane, tint: tint)
                     supportPanel(selectedLane, progress: progress, tint: tint)
+                    researchQuestSection(selectedLane, tint: tint)
                     recallSection(selectedLane, tint: tint)
                 }
                 .padding(24)
@@ -134,6 +135,45 @@ struct LabLaneDetailView: View {
         .padding(14)
         .background(MatherTheme.card.opacity(0.82), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         .accessibilityElement(children: .contain)
+    }
+
+    private func researchQuestSection(_ lane: CapabilityLane, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Research quest", systemImage: "sparkles")
+                .font(.headline.weight(.black))
+                .foregroundStyle(tint)
+            Text("Try one tiny experiment, notice what changed, then earn a discovery spark.")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+            HStack(spacing: 10) {
+                researchQuestChip(icon: "lightbulb.fill", title: "Wonder", detail: lane.promise, tint: tint)
+                researchQuestChip(icon: "hand.tap.fill", title: "Try", detail: lane.isReady ? "Play a game" : "Preview ideas", tint: tint)
+                researchQuestChip(icon: "star.fill", title: "Notice", detail: "Collect a spark", tint: tint)
+            }
+        }
+        .padding(14)
+        .background(MatherTheme.card.opacity(0.82), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Research quest. Try one tiny experiment, notice what changed, then earn a discovery spark.")
+    }
+
+    private func researchQuestChip(icon: String, title: String, detail: String, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Image(systemName: icon)
+                .font(.headline.weight(.black))
+                .foregroundStyle(tint)
+            Text(title)
+                .font(.caption.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            Text(detail)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .lineLimit(2)
+                .minimumScaleFactor(0.75)
+        }
+        .frame(maxWidth: .infinity, minHeight: 88, alignment: .topLeading)
+        .padding(10)
+        .background(tint.opacity(0.10), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 
     private func gamesSection(_ lane: CapabilityLane, tint: Color) -> some View {

--- a/Features/SymmetryFold/SymmetryFoldView.swift
+++ b/Features/SymmetryFold/SymmetryFoldView.swift
@@ -137,8 +137,8 @@ struct SymmetryFoldView: View {
         switch playMode {
         case .lesson:
             return currentLevel < levels.count
-                ? "Keep the lesson going, or try a timed challenge for this shape."
-                : "Lesson complete. You can finish now, or try one timed challenge."
+                ? "Keep collecting mirror badges, or try the timer challenge for this shape."
+                : "Mirror mission complete. You can finish now, or try one timed challenge."
         case .timedChallenge:
             return currentLevel < levels.count
                 ? "Timed challenge cleared. Ready for the next shape?"
@@ -390,6 +390,10 @@ struct SymmetryFoldView: View {
                 .font(.headline.weight(.black))
                 .foregroundStyle(MatherTheme.ink)
                 .multilineTextAlignment(.center)
+            Text("Mirror badge earned: \(config.shapeName.capitalized) ✨")
+                .font(.headline.weight(.black))
+                .foregroundStyle(config.color)
+                .multilineTextAlignment(.center)
             Text(successBodyText)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MatherTheme.cardSubtitle)
@@ -458,7 +462,14 @@ struct SymmetryFoldView: View {
                 .animation(.easeInOut(duration: 0.2), value: wrongDirectionCue)
             }
 
-            // Level progress dots (5) — active dot is slightly larger
+            Text(Self.mirrorMissionLabel(currentLevel: currentLevel, totalLevels: levels.count))
+                .font(.caption.weight(.black))
+                .foregroundStyle(config.color)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(config.color.opacity(0.12), in: Capsule())
+
+            // Level progress dots — active dot is slightly larger
             HStack(spacing: 8) {
                 ForEach(1...levels.count, id: \.self) { lvl in
                     let isActive = lvl == currentLevel
@@ -645,6 +656,11 @@ struct SymmetryFoldView: View {
     }
 
     nonisolated static let creativeLevelNames = ["heart", "butterfly", "flower", "kite", "leaf", "badge"]
+
+    nonisolated static func mirrorMissionLabel(currentLevel: Int, totalLevels: Int) -> String {
+        let collected = max(0, min(currentLevel - 1, totalLevels))
+        return "Mirror mission • \(collected)/\(totalLevels) badges"
+    }
 
     nonisolated static func challengeCountdownText(for secondsRemaining: Double) -> String {
         "\(max(0, Int(ceil(secondsRemaining))))s left"

--- a/Tests/MatherTests/SymmetryFoldTests.swift
+++ b/Tests/MatherTests/SymmetryFoldTests.swift
@@ -129,6 +129,13 @@ struct SymmetryFoldTests {
     }
 
     @Test
+    func mirrorMissionLabelCountsEarnedBadges() {
+        #expect(SymmetryFoldView.mirrorMissionLabel(currentLevel: 1, totalLevels: 6) == "Mirror mission • 0/6 badges")
+        #expect(SymmetryFoldView.mirrorMissionLabel(currentLevel: 4, totalLevels: 6) == "Mirror mission • 3/6 badges")
+        #expect(SymmetryFoldView.mirrorMissionLabel(currentLevel: 99, totalLevels: 6) == "Mirror mission • 6/6 badges")
+    }
+
+    @Test
     func challengeCountdownRoundsUpAndClamps() {
         #expect(SymmetryFoldView.challengeCountdownText(for: 7.01) == "8s left")
         #expect(SymmetryFoldView.challengeCountdownText(for: 0.2) == "1s left")


### PR DESCRIPTION
## Summary
- Adds a playful Research quest strip to Explorer Lab lane details for #855.
- Adds Angle Cannon scenery plus a chunkier toy cannon treatment for #856.
- Adds Symmetry Fold mirror-badge mission copy/progress to gamify beyond folding for #857.
- Reworks Gravity Sensor Lab action buttons into crisp solid rounded controls for #858.

## TestFlight feedback covered
- Closes #855
- Closes #856
- Closes #857
- Closes #858

## Validation
- `git diff --check`
- `xcodebuild`/`swift` unavailable in this Linux runner (`command not found`), so iOS build/test must run in GitHub Actions.
