### PR TITLE
fix: polish build 65 TestFlight feedback

### DIFF
--- a/Features/GravityArtist/GravityArtistView.swift
+++ b/Features/GravityArtist/GravityArtistView.swift
@@ -110,6 +110,7 @@ struct GravityArtistView: View {
     @State private var targetX: Double = 0
     @State private var hitTarget: Bool = false
     @State private var roundsPlayed: Int = 0
+    @State private var successStreak: Int = 0
     @State private var phase: GamePhase = .aim
     @State private var sessionStart: Date = .now
 
@@ -170,14 +171,27 @@ struct GravityArtistView: View {
     private var headerBar: some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Gravity Sensor Lab")
+                Text("Gravity Quest")
                     .font(.title2.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
                 Text(phaseHint)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    missionBadge("1 Predict", isActive: phase == .aim)
+                    missionBadge("2 Simulate", isActive: phase == .predicted)
+                    missionBadge("3 Learn", isActive: phase == .fired)
+                }
             }
             Spacer()
+            VStack(alignment: .trailing, spacing: 4) {
+                Text("⭐ \(successStreak)")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.warm)
+                Text("Round \(roundsPlayed + 1)")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
             Button {
                 appModel.engine.showHome()
             } label: {
@@ -192,11 +206,20 @@ struct GravityArtistView: View {
         .padding(.bottom, 8)
     }
 
+    private func missionBadge(_ title: String, isActive: Bool) -> some View {
+        Text(title)
+            .font(.caption2.weight(.black))
+            .foregroundStyle(isActive ? .white : MatherTheme.cardSubtitle)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(isActive ? MatherTheme.accent : MatherTheme.panel.opacity(0.72), in: Capsule())
+    }
+
     private var phaseHint: String {
         switch phase {
-        case .aim:       return "Tilt to find which way gravity pulls"
-        case .predicted: return "Prediction locked — now observe the roll"
-        case .fired:     return hitTarget ? "Pebble followed gravity!" : "Try a new tilt direction."
+        case .aim:       return "Guess where the pebble will roll"
+        case .predicted: return "Prediction locked — tilt, watch, and compare"
+        case .fired:     return hitTarget ? "You predicted gravity!" : "New guess: what changed?"
         }
     }
 
@@ -293,8 +316,9 @@ struct GravityArtistView: View {
     private func drawGravityTray(ctx: GraphicsContext, size: CGSize) {
         let tray = CGRect(x: size.width * 0.18, y: size.height * 0.13,
                           width: size.width * 0.64, height: size.height * 0.44)
-        ctx.fill(RoundedRectangle(cornerRadius: 28).path(in: tray), with: .color(MatherTheme.softBlue.opacity(0.10)))
-        ctx.stroke(RoundedRectangle(cornerRadius: 28).path(in: tray), with: .color(MatherTheme.softBlue.opacity(0.45)), lineWidth: 4)
+        ctx.fill(RoundedRectangle(cornerRadius: 28).path(in: tray), with: .color(MatherTheme.softBlue.opacity(0.08)))
+        ctx.fill(RoundedRectangle(cornerRadius: 28).path(in: tray.insetBy(dx: 6, dy: 6)), with: .color(MatherTheme.panelDeep.opacity(0.10)))
+        ctx.stroke(RoundedRectangle(cornerRadius: 28).path(in: tray), with: .color(MatherTheme.softBlue.opacity(0.36)), lineWidth: 3)
 
         let neutral = neutralRoll ?? appModel.motionService.tiltRoll
         let vector = GravitySensorPhysics.normalizedVector(roll: appModel.motionService.tiltRoll, neutralRoll: neutral)
@@ -308,7 +332,9 @@ struct GravityArtistView: View {
         for (index, offset) in [CGPoint(x: -48, y: -18), CGPoint(x: 0, y: 10), CGPoint(x: 44, y: -8)].enumerated() {
             let start = CGPoint(x: center.x + offset.x, y: center.y + offset.y)
             let pos = GravitySensorPhysics.pebblePosition(origin: start, vector: vector, distance: 54 + Double(index * 18), bounds: pebbleBounds)
-            ctx.fill(Circle().path(in: CGRect(x: pos.x - 11, y: pos.y - 11, width: 22, height: 22)), with: .color(MatherTheme.warm.opacity(0.85)))
+            ctx.fill(Circle().path(in: CGRect(x: pos.x - 13, y: pos.y - 13, width: 26, height: 26)), with: .color(MatherTheme.warm.opacity(0.90)))
+            ctx.fill(Circle().path(in: CGRect(x: pos.x - 4, y: pos.y - 4, width: 3, height: 3)), with: .color(MatherTheme.ink.opacity(0.55)))
+            ctx.fill(Circle().path(in: CGRect(x: pos.x + 3, y: pos.y - 4, width: 3, height: 3)), with: .color(MatherTheme.ink.opacity(0.55)))
         }
 
         let label = ctx.resolve(Text("gravity pulls this way").font(.caption.bold()).foregroundStyle(MatherTheme.ink.opacity(0.70)))
@@ -361,6 +387,7 @@ struct GravityArtistView: View {
 
     private var bottomBar: some View {
         VStack(spacing: 10) {
+            conceptCard
             HStack(spacing: 16) {
                 switch phase {
                 case .aim:
@@ -385,6 +412,33 @@ struct GravityArtistView: View {
                 .font(.caption)
                 .foregroundStyle(.tertiary)
                 .padding(.bottom, 16)
+        }
+    }
+
+    private var conceptCard: some View {
+        HStack(spacing: 10) {
+            Image(systemName: phase == .fired ? (hitTarget ? "star.fill" : "lightbulb.fill") : "questionmark.bubble.fill")
+                .font(.headline.weight(.black))
+                .foregroundStyle(MatherTheme.warm)
+            Text(conceptCardText)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(MatherTheme.card.opacity(0.86), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .padding(.horizontal, 24)
+    }
+
+    private var conceptCardText: String {
+        switch phase {
+        case .aim:
+            return "Flashcard: gravity pulls objects screen-down. Predict the path first."
+        case .predicted:
+            return "Now simulate: compare your dotted guess with the real roll."
+        case .fired:
+            return hitTarget ? "Reward: your prediction matched the simulation." : "Learning: change angle or power, then test again."
         }
     }
 
@@ -437,12 +491,14 @@ struct GravityArtistView: View {
         roundsPlayed += 1
 
         if hitTarget {
+            successStreak += 1
             appModel.hapticsService.success(enabled: appModel.featureFlags.hapticsEnabled)
             appModel.speechService.speak(
                 "Bull's eye! The launch angle was \(Int(currentAngle.rounded())) degrees.",
                 enabled: appModel.featureFlags.audioEnabled
             )
         } else {
+            successStreak = 0
             appModel.hapticsService.failure(enabled: appModel.featureFlags.hapticsEnabled)
             appModel.speechService.speak(
                 "So close! Try again.",

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -299,9 +299,9 @@ struct LabLaneCardPresentation: Equatable {
         title = lane.title
         promiseLine = lane.promise
         progressMicrocopy = "\(progress.progressSummaryLabel) • \(progress.nextRecommendedModeLabel)"
-        openAffordanceLabel = "Open lane"
+        openAffordanceLabel = "Enter world"
         accessibilityLabel = "\(lane.title). \(lane.ageBandHint). \(lane.promise)"
-        accessibilityHint = "Opens \(lane.title) to choose games, review cards, play styles, and sensor options."
+        accessibilityHint = "Opens \(lane.title) to choose missions, review cards, play styles, and sensor options."
         sections = [
             .visualSummary,
             .promise,
@@ -402,12 +402,14 @@ struct CapabilityLaneProgress: Equatable {
     }
 
     var progressSummaryLabel: String {
-        "\(progressLabel) • \(masteryPercentLabel)"
+        "🚀 \(completedModeCount)/\(availableModes.count) missions unlocked"
     }
 
     var nextRecommendedModeLabel: String {
-        guard let nextRecommendedMode else { return "Choose any mode" }
-        return "Try \(nextRecommendedMode.rawValue) next"
+        guard let nextRecommendedMode else { return "⭐ Choose any mission" }
+        return completedModeCount == 0
+            ? "⭐ First \(nextRecommendedMode.rawValue) mission waiting"
+            : "⭐ Try \(nextRecommendedMode.rawValue) next"
     }
 
     var nextRecommendedMode: PlayMode? {

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -4,12 +4,14 @@ import SwiftUI
 struct LabView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Bindable var appModel: AppModel
+    @State private var playfulPulse = false
 
     private let lanes = CapabilityLane.defaultExplorerLanes
 
     var body: some View {
         ZStack {
             MatherTheme.background.ignoresSafeArea()
+            playgroundBackdrop
             GeometryReader { proxy in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 20) {
@@ -25,6 +27,30 @@ struct LabView: View {
                 }
             }
         }
+        .onAppear {
+            withAnimation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true)) {
+                playfulPulse = true
+            }
+        }
+    }
+
+    private var playgroundBackdrop: some View {
+        ZStack {
+            Circle()
+                .fill(MatherTheme.warm.opacity(0.10))
+                .frame(width: 180, height: 180)
+                .offset(x: -170, y: -260)
+            Circle()
+                .fill(MatherTheme.softBlue.opacity(0.12))
+                .frame(width: 220, height: 220)
+                .offset(x: 180, y: 120)
+            Image(systemName: "sparkles")
+                .font(.system(size: 34, weight: .black))
+                .foregroundStyle(MatherTheme.accent.opacity(0.16))
+                .offset(x: 130, y: -210)
+        }
+        .ignoresSafeArea()
+        .accessibilityHidden(true)
     }
 
     private var header: some View {
@@ -33,10 +59,10 @@ struct LabView: View {
                 Text("Explorer Lab")
                     .font(.system(size: 36, weight: .black, design: .rounded))
                     .foregroundStyle(MatherTheme.ink)
-                Text("Pick a capability lane")
+                Text("Choose a world to explore")
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(MatherTheme.cardSubtitle)
-                Text("Games, review cards, play styles, and sensors live inside each lane")
+                Text("Missions, mini cards, and sensor-powered experiments wait inside")
                     .font(.caption.weight(.bold))
                     .foregroundStyle(MatherTheme.accent)
             }
@@ -97,7 +123,7 @@ struct LabView: View {
                 progressPreview(progress, tint: tint)
 
                 HStack(spacing: 10) {
-                    Label(lane.isReady ? "\(lane.activities.count) game\(lane.activities.count == 1 ? "" : "s")" : "Games coming soon", systemImage: lane.isReady ? "gamecontroller.fill" : "sparkles")
+                    Label(lane.isReady ? "\(lane.activities.count) mission\(lane.activities.count == 1 ? "" : "s")" : "Missions coming soon", systemImage: lane.isReady ? "gamecontroller.fill" : "sparkles")
                         .font(.caption.weight(.black))
                         .foregroundStyle(tint)
                     Spacer(minLength: 8)
@@ -117,6 +143,7 @@ struct LabView: View {
                 color: colorScheme == .dark ? .black.opacity(0.3) : .black.opacity(0.08),
                 radius: 8, y: 4
             )
+            .scaleEffect(playfulPulse ? 1.01 : 0.995, anchor: .center)
         }
         .buttonStyle(.plain)
         .accessibilityLabel(presentation.accessibilityLabel)
@@ -126,15 +153,66 @@ struct LabView: View {
     private func laneVisual(_ lane: CapabilityLane, tint: Color) -> some View {
         ZStack {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .fill(tint.opacity(0.14))
-            Circle()
-                .fill(tint.opacity(0.18))
-                .frame(width: 48, height: 48)
-                .offset(x: 18, y: -18)
+                .fill(
+                    LinearGradient(
+                        colors: [tint.opacity(0.28), tint.opacity(0.10), MatherTheme.card.opacity(0.42)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            laneMiniScene(lane.id, tint: tint)
             Text(lane.emoji)
                 .font(.system(size: 46))
+                .scaleEffect(playfulPulse ? 1.06 : 0.98)
+                .rotationEffect(.degrees(playfulPulse ? 2 : -2))
         }
         .frame(width: 84, height: 84)
+    }
+
+    @ViewBuilder
+    private func laneMiniScene(_ laneID: CapabilityLaneID, tint: Color) -> some View {
+        switch laneID {
+        case .numbers:
+            HStack(spacing: 4) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(tint.opacity(0.22))
+                        .frame(width: 12, height: 12)
+                        .offset(y: playfulPulse ? CGFloat(-index * 3) : CGFloat(index * 2))
+                }
+            }
+            .offset(x: 16, y: 22)
+        case .geometry:
+            Image(systemName: "triangle.fill")
+                .font(.system(size: 34, weight: .black))
+                .foregroundStyle(tint.opacity(0.24))
+                .rotationEffect(.degrees(playfulPulse ? 12 : -6))
+                .offset(x: 20, y: 18)
+        case .physics:
+            Image(systemName: "moon.stars.fill")
+                .font(.system(size: 30, weight: .black))
+                .foregroundStyle(tint.opacity(0.24))
+                .offset(x: 20, y: -18)
+            Circle()
+                .fill(MatherTheme.warm.opacity(0.32))
+                .frame(width: 16, height: 16)
+                .offset(x: playfulPulse ? 24 : 10, y: playfulPulse ? 20 : 8)
+        case .mapWorld:
+            Image(systemName: "map.fill")
+                .font(.system(size: 34, weight: .black))
+                .foregroundStyle(tint.opacity(0.24))
+                .offset(x: 18, y: 18)
+        case .discoveryCards:
+            Image(systemName: "rectangle.on.rectangle.angled")
+                .font(.system(size: 34, weight: .black))
+                .foregroundStyle(tint.opacity(0.24))
+                .offset(x: 18, y: 18)
+        case .chemistry, .electronics:
+            Image(systemName: "sparkles")
+                .font(.system(size: 34, weight: .black))
+                .foregroundStyle(tint.opacity(0.24))
+                .offset(x: 18, y: 18)
+        }
     }
 
     private func progress(for lane: CapabilityLane) -> CapabilityLaneProgress {

--- a/Features/SymmetryFold/SymmetryFoldView.swift
+++ b/Features/SymmetryFold/SymmetryFoldView.swift
@@ -223,18 +223,18 @@ struct SymmetryFoldView: View {
                 }
             }
             Spacer(minLength: 12)
-            Button("Done") {
+            Button {
                 stopAllTasks()
                 appModel.motionService.stopUpdates()
                 appModel.engine.showHome()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 34, weight: .black))
+                    .foregroundStyle(config.color)
+                    .frame(width: 56, height: 56)
+                    .background(config.color.opacity(0.12), in: Circle())
             }
-            .font(.headline.weight(.semibold))
-            .foregroundStyle(.white)
-            .frame(minWidth: 88, minHeight: 72)
-            .background(
-                MatherTheme.ink.opacity(0.65),
-                in: RoundedRectangle(cornerRadius: 12, style: .continuous)
-            )
+            .accessibilityLabel("Done")
             .accessibilityIdentifier("symmetry-fold-done-button")
         }
     }
@@ -453,7 +453,7 @@ struct SymmetryFoldView: View {
                             .font(.subheadline.weight(.bold))
                             .foregroundStyle(config.color)
                     } else {
-                        Text("Tilt left to fold")
+                        Text("Tilt left to match the mirror")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(MatherTheme.cardSubtitle)
                     }

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -647,23 +647,46 @@ struct WaterCycleLabView: View {
     }
 
     private func pondView(_ metrics: WaterCycleSceneMetrics) -> some View {
-        ZStack(alignment: .bottom) {
-            Capsule().fill(MatherTheme.softBlue.opacity(0.25)).frame(height: metrics.pondHeight)
-            Capsule().fill(MatherTheme.softBlue).frame(height: CGFloat(32 + state.pondDrops * 10) * metrics.scale)
-            HStack(spacing: 12) {
-                ForEach(0..<state.pondDrops, id: \.self) { _ in
-                    Circle().fill(.white.opacity(0.65)).frame(width: metrics.pondDropSize, height: metrics.pondDropSize)
+        let waterTone = Color(red: 0.42, green: 0.70, blue: 0.86)
+        let waterLevelHeight = CGFloat(30 + state.pondDrops * 9) * metrics.scale
+
+        return ZStack(alignment: .bottom) {
+            Capsule()
+                .fill(waterTone.opacity(0.18))
+                .frame(height: metrics.pondHeight)
+            Capsule()
+                .fill(
+                    LinearGradient(
+                        colors: [waterTone.opacity(0.78), waterTone.opacity(0.58)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .frame(height: waterLevelHeight)
+                .overlay(alignment: .leading) {
+                    Label("pond • \(state.pondDrops) drops", systemImage: "drop.fill")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(.white.opacity(0.92))
+                        .padding(.leading, 18)
+                        .accessibilityHidden(true)
                 }
-            }
-            .padding(.bottom, 28)
+                .overlay(alignment: .trailing) {
+                    HStack(spacing: 5) {
+                        ForEach(0..<state.pondDrops, id: \.self) { _ in
+                            Image(systemName: "drop.fill")
+                                .font(.system(size: max(8, metrics.pondDropSize * 0.55), weight: .bold))
+                                .foregroundStyle(.white.opacity(0.58))
+                        }
+                    }
+                    .padding(.trailing, 18)
+                }
         }
-        .overlay(alignment: .topLeading) {
-            Text("pond")
-                .font(.caption.weight(.black))
-                .foregroundStyle(MatherTheme.ink)
-                .padding(.leading, 24)
-                .padding(.top, 14)
-        }
+        .overlay(
+            Capsule()
+                .stroke(waterTone.opacity(0.32), lineWidth: 1.5)
+        )
+        .shadow(color: waterTone.opacity(0.10), radius: 4, y: 2)
+        .accessibilityLabel("Pond visual showing \(state.pondDrops) water drops collected")
     }
 
     private var lessonStageIcon: String {

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -74,7 +74,7 @@ final class LabModelsTests: XCTestCase {
         )
 
         XCTAssertEqual(presentation.title, "Numbers Lab")
-        XCTAssertEqual(presentation.openAffordanceLabel, "Open lane")
+        XCTAssertEqual(presentation.openAffordanceLabel, "Enter world")
         XCTAssertEqual(
             presentation.sections,
             [.visualSummary, .promise, .progressStatus]
@@ -145,18 +145,18 @@ extension LabModelsTests {
 
         XCTAssertEqual(progress.progressLabel, "0 / 4 modes")
         XCTAssertEqual(progress.masteryPercentLabel, "0% ready")
-        XCTAssertEqual(progress.progressSummaryLabel, "0 / 4 modes • 0% ready")
+        XCTAssertEqual(progress.progressSummaryLabel, "🚀 0/4 missions unlocked")
         XCTAssertEqual(progress.nextRecommendedMode, .learn)
-        XCTAssertEqual(progress.nextRecommendedModeLabel, "Try Learn next")
+        XCTAssertEqual(progress.nextRecommendedModeLabel, "⭐ First Learn mission waiting")
 
         progress.markCompleted(.learn)
         progress.markCompleted(.timed)
 
         XCTAssertEqual(progress.progressLabel, "2 / 4 modes")
         XCTAssertEqual(progress.masteryPercentLabel, "50% ready")
-        XCTAssertEqual(progress.progressSummaryLabel, "2 / 4 modes • 50% ready")
+        XCTAssertEqual(progress.progressSummaryLabel, "🚀 2/4 missions unlocked")
         XCTAssertEqual(progress.nextRecommendedMode, .challenge)
-        XCTAssertEqual(progress.nextRecommendedModeLabel, "Try Challenge next")
+        XCTAssertEqual(progress.nextRecommendedModeLabel, "⭐ Try Challenge next")
     }
 
     func testCapabilityLaneProgressTracksReviewedCardsOnlyForItsLane() throws {
@@ -181,8 +181,8 @@ extension LabModelsTests {
 
         let progress = CapabilityLaneProgress(masteryState: masteryState)
 
-        XCTAssertEqual(progress.progressSummaryLabel, "2 / 4 modes • 50% ready")
-        XCTAssertEqual(progress.nextRecommendedModeLabel, "Try Challenge next")
+        XCTAssertEqual(progress.progressSummaryLabel, "🚀 2/4 missions unlocked")
+        XCTAssertEqual(progress.nextRecommendedModeLabel, "⭐ Try Challenge next")
         XCTAssertEqual(progress.reviewedCardIDs, ["numbers-number-bond-five-and-five"])
     }
 


### PR DESCRIPTION
## Summary
- makes Explorer Lab read more like playful mission worlds with livelier cards and progress copy
- turns Gravity Artist into a clearer “Gravity Quest” loop with mission stages, streak reward, and concept card
- softens Water Cycle pond affordance and improves the drop-count visual
- makes Symmetry Fold exit/tilt copy more child-friendly
- updates Lab model tests for the intentional world/mission copy changes

## Issues
Closes #860
Closes #861
Closes #862
Closes #863

## Validation
- `git diff --check origin/main...HEAD`
- GitHub Actions / PR #864: CodeQL ✅, Analyze Actions Workflows ✅, Dependency Review ✅, Build & Test ✅
- Local iOS simulator validation not available in this Linux runner; CI macOS simulator build/test is the validation gate used.
