### PR TITLE
feat: add capability explorer and water cycle lab

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -88,6 +88,8 @@ struct RootView: View {
                     LabView(appModel: appModel)
                 case .memory:
                     MemoryView(appModel: appModel)
+                case .waterCycle:
+                    WaterCycleLabView(appModel: appModel)
                 }
             }
             .navigationBarTitleDisplayMode(.inline)

--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// Reusable deterministic content for learn → quiz → match loops.
+struct LearningConceptCard: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let explanation: String
+    let visualKey: String
+    let audioPrompt: String
+
+    init(id: String, title: String, explanation: String, visualKey: String, audioPrompt: String? = nil) {
+        self.id = id
+        self.title = title
+        self.explanation = explanation
+        self.visualKey = visualKey
+        self.audioPrompt = audioPrompt ?? "Learn about \(title)."
+    }
+}
+
+struct ConceptQuizQuestion: Identifiable, Equatable {
+    let id: String
+    let prompt: String
+    let choices: [String]
+    let correctChoice: String
+    let feedback: String
+
+    init(id: String, prompt: String, choices: [String], correctChoice: String, feedback: String) {
+        self.id = id
+        self.prompt = prompt
+        self.choices = choices
+        self.correctChoice = correctChoice
+        self.feedback = feedback
+    }
+
+    func isCorrect(_ choice: String) -> Bool {
+        choice == correctChoice
+    }
+}
+
+struct ConceptMatchPair: Identifiable, Equatable {
+    let id: String
+    let left: String
+    let right: String
+    let feedback: String
+}
+
+struct LearningLoopSummary: Equatable {
+    let quizCorrect: Int
+    let quizTotal: Int
+    let matchedPairs: Int
+    let totalPairs: Int
+
+    var starCount: Int {
+        guard quizTotal + totalPairs > 0 else { return 0 }
+        let earned = quizCorrect + matchedPairs
+        let possible = quizTotal + totalPairs
+        switch Double(earned) / Double(possible) {
+        case 0.85...: return 3
+        case 0.55...: return 2
+        case 0.01...: return 1
+        default: return 0
+        }
+    }
+}
+
+enum LearningLoopScoring {
+    static func scoreQuiz(questions: [ConceptQuizQuestion], answersByQuestionId: [String: String]) -> Int {
+        questions.reduce(0) { score, question in
+            guard let answer = answersByQuestionId[question.id] else { return score }
+            return score + (question.isCorrect(answer) ? 1 : 0)
+        }
+    }
+
+    static func isMatch(left: String, right: String, pairs: [ConceptMatchPair]) -> Bool {
+        pairs.contains { $0.left == left && $0.right == right }
+    }
+
+    static func summary(
+        questions: [ConceptQuizQuestion],
+        answersByQuestionId: [String: String],
+        matchedPairIds: Set<String>,
+        pairs: [ConceptMatchPair]
+    ) -> LearningLoopSummary {
+        LearningLoopSummary(
+            quizCorrect: scoreQuiz(questions: questions, answersByQuestionId: answersByQuestionId),
+            quizTotal: questions.count,
+            matchedPairs: matchedPairIds.count,
+            totalPairs: pairs.count
+        )
+    }
+}
+
+enum WaterCycleContent {
+    static let cards: [LearningConceptCard] = [
+        LearningConceptCard(id: "sun", title: "Sun", explanation: "The sun warms water in ponds, lakes, and puddles.", visualKey: "☀️", audioPrompt: "The sun warms the water."),
+        LearningConceptCard(id: "pond", title: "Pond", explanation: "A pond holds water on the ground.", visualKey: "🏞️", audioPrompt: "A pond is water on the ground."),
+        LearningConceptCard(id: "evaporation", title: "Evaporation", explanation: "Warm water turns into invisible water vapour and rises.", visualKey: "♨️", audioPrompt: "Evaporation means water vapour goes up."),
+        LearningConceptCard(id: "water-vapour", title: "Water Vapour", explanation: "Water vapour is tiny water in the air.", visualKey: "💨", audioPrompt: "Water vapour floats in the air."),
+        LearningConceptCard(id: "condensation", title: "Condensation", explanation: "Water vapour cools and gathers into tiny drops.", visualKey: "🌫️", audioPrompt: "Condensation makes tiny drops."),
+        LearningConceptCard(id: "cloud", title: "Cloud", explanation: "A cloud is made from many tiny water drops.", visualKey: "☁️", audioPrompt: "Clouds hold tiny drops."),
+        LearningConceptCard(id: "rain", title: "Rain", explanation: "Drops get heavy and fall back down as rain.", visualKey: "🌧️", audioPrompt: "Rain falls back down."),
+    ]
+
+    static let quizQuestions: [ConceptQuizQuestion] = [
+        ConceptQuizQuestion(
+            id: "sun-warms-water",
+            prompt: "What does the sun do to pond water?",
+            choices: ["Warms it", "Freezes it", "Hides it"],
+            correctChoice: "Warms it",
+            feedback: "Yes — warm water can evaporate."
+        ),
+        ConceptQuizQuestion(
+            id: "vapour-rises",
+            prompt: "Which word means warm water vapour goes up?",
+            choices: ["Rain", "Evaporation", "Pond"],
+            correctChoice: "Evaporation",
+            feedback: "Evaporation sends water vapour up."
+        ),
+        ConceptQuizQuestion(
+            id: "cloud-rain",
+            prompt: "Which card shows water falling down?",
+            choices: ["Cloud", "Rain", "Sun"],
+            correctChoice: "Rain",
+            feedback: "Rain brings water back down."
+        ),
+    ]
+
+    static let matchPairs: [ConceptMatchPair] = [
+        ConceptMatchPair(id: "sun-evaporation", left: "Sun", right: "Evaporation", feedback: "The sun helps water evaporate."),
+        ConceptMatchPair(id: "pond-evaporation", left: "Pond", right: "Evaporation", feedback: "Water can rise from the pond."),
+        ConceptMatchPair(id: "cloud-condensation", left: "Cloud", right: "Condensation", feedback: "Condensation helps make clouds."),
+        ConceptMatchPair(id: "cloud-rain", left: "Cloud", right: "Rain", feedback: "Heavy cloud drops fall as rain."),
+        ConceptMatchPair(id: "rain-pond", left: "Rain", right: "Pond", feedback: "Rain fills ponds again."),
+    ]
+}

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -18,6 +18,7 @@ enum AppRoute {
     case compassAngles
     case lab
     case memory
+    case waterCycle
 }
 
 @MainActor
@@ -125,6 +126,7 @@ final class VerticalSliceEngine {
     func showCompassAngles() { route = .compassAngles }
     func showLab() { route = .lab }
     func showMemory() { route = .memory }
+    func showWaterCycle() { route = .waterCycle }
 
     func startSession() {
         // Freeze the active theme from the user's current selection — unless a custom

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -1,68 +1,129 @@
 import SwiftUI
 
-/// The Explorer Lab — a game picker for all physics and geometry activities.
+/// The Explorer Lab — capability-first worlds that route kids into staged play.
 struct LabView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Bindable var appModel: AppModel
+    @State private var selectedWorld: ExplorerWorld?
 
-    private struct GameTile {
+    private struct ExplorerWorld: Identifiable {
+        let id: String
         let emoji: String
-        let name: String
-        let tagline: String
+        let title: String
+        let subtitle: String
+        let badge: String
         let fill: Color
-        let action: () -> Void
+        let activities: [ExplorerActivity]
     }
 
-    private var tiles: [GameTile] {
+    private struct ExplorerActivity: Identifiable, Equatable {
+        let id: String
+        let emoji: String
+        let title: String
+        let subtitle: String
+        let isRecommended: Bool
+        let action: (AppModel) -> Void
+
+        init(emoji: String, title: String, subtitle: String, isRecommended: Bool, action: @escaping (AppModel) -> Void) {
+            self.id = title.lowercased().replacingOccurrences(of: " ", with: "-")
+            self.emoji = emoji
+            self.title = title
+            self.subtitle = subtitle
+            self.isRecommended = isRecommended
+            self.action = action
+        }
+
+        static func == (lhs: ExplorerActivity, rhs: ExplorerActivity) -> Bool { lhs.id == rhs.id }
+    }
+
+    private var worlds: [ExplorerWorld] {
         [
-            GameTile(emoji: "⚡", name: "Sum Sprint",
-                     tagline: "Race through sums 11–20",
-                     fill: MatherTheme.warm) {
-                appModel.pickProfileThenRun {
-                    appModel.engine.showSumSprint()
-                    appModel.sumSprintEngine.showDifficultyPick()
-                }
-            },
-            GameTile(emoji: "🗺️", name: "Room Quest",
-                     tagline: "Collect tokens around the room",
-                     fill: MatherTheme.accent) {
-                appModel.pickProfileThenRun { appModel.engine.showRoomQuest() }
-            },
-            GameTile(emoji: "🪞", name: "Symmetry Fold",
-                     tagline: "Tilt to fold shapes in half",
-                     fill: MatherTheme.coral) {
-                appModel.pickProfileThenRun { appModel.engine.showSymmetryFold() }
-            },
-            GameTile(emoji: "🏭", name: "Rectangle Factory",
-                     tagline: "Drag frames to find factors",
-                     fill: MatherTheme.softBlue) {
-                appModel.pickProfileThenRun { appModel.engine.showRectangleFactory() }
-            },
-            GameTile(emoji: "💥", name: "Angle Cannon",
-                     tagline: "Tilt to aim — hit the target",
-                     fill: MatherTheme.warm) {
-                appModel.pickProfileThenRun { appModel.engine.showAngleCannon() }
-            },
-            GameTile(emoji: "📐", name: "Protractor",
-                     tagline: "Spread two fingers to measure angles",
-                     fill: MatherTheme.accent) {
-                appModel.pickProfileThenRun { appModel.engine.showTwoFingerProtractor() }
-            },
-            GameTile(emoji: "🎨", name: "Gravity Artist",
-                     tagline: "Predict where the ball lands",
-                     fill: MatherTheme.panelDeep) {
-                appModel.pickProfileThenRun { appModel.engine.showGravityArtist() }
-            },
-            GameTile(emoji: "🧭", name: "Compass Walk",
-                     tagline: "Turn your body to match the angle",
-                     fill: MatherTheme.softBlue) {
-                appModel.pickProfileThenRun { appModel.engine.showCompassAngles() }
-            },
-            GameTile(emoji: "🃏", name: "Memory Match",
-                     tagline: "Match animals to their names",
-                     fill: MatherTheme.coral) {
-                appModel.pickProfileThenRun { appModel.engine.showMemory() }
-            },
+            ExplorerWorld(
+                id: "numbers",
+                emoji: "🔢",
+                title: "Numbers",
+                subtitle: "Sums, bonds, and fast recall",
+                badge: "★★☆",
+                fill: MatherTheme.warm,
+                activities: [
+                    ExplorerActivity(emoji: "⚡", title: "Sum Sprint", subtitle: "Race through sums 11–20", isRecommended: true) { appModel in
+                        appModel.pickProfileThenRun {
+                            appModel.engine.showSumSprint()
+                            appModel.sumSprintEngine.showDifficultyPick()
+                        }
+                    },
+                    ExplorerActivity(emoji: "🧱", title: "Make & Break", subtitle: "Build numbers with counters", isRecommended: false) { appModel in
+                        appModel.pickProfileThenRun { appModel.engine.showSessionConfig() }
+                    },
+                ]
+            ),
+            ExplorerWorld(
+                id: "geometry",
+                emoji: "📐",
+                title: "Geometry",
+                subtitle: "Shapes, angles, and symmetry",
+                badge: "★☆☆",
+                fill: MatherTheme.coral,
+                activities: [
+                    ExplorerActivity(emoji: "🪞", title: "Symmetry Fold", subtitle: "Tilt to fold shapes in half", isRecommended: true) { appModel in
+                        appModel.pickProfileThenRun { appModel.engine.showSymmetryFold() }
+                    },
+                    ExplorerActivity(emoji: "🏭", title: "Rectangle Factory", subtitle: "Drag frames to find factors", isRecommended: false) { appModel in
+                        appModel.pickProfileThenRun { appModel.engine.showRectangleFactory() }
+                    },
+                    ExplorerActivity(emoji: "📐", title: "Protractor", subtitle: "Spread two fingers to measure angles", isRecommended: false) { appModel in
+                        appModel.pickProfileThenRun { appModel.engine.showTwoFingerProtractor() }
+                    },
+                ]
+            ),
+            ExplorerWorld(
+                id: "physics",
+                emoji: "🌦️",
+                title: "Physics",
+                subtitle: "Forces, motion, and science loops",
+                badge: "★★☆",
+                fill: MatherTheme.softBlue,
+                activities: [
+                    ExplorerActivity(emoji: "💧", title: "Water Cycle Lab", subtitle: "Learn, quiz, and match the cycle", isRecommended: true) { appModel in
+                        appModel.pickProfileThenRun { appModel.engine.showWaterCycle() }
+                    },
+                    ExplorerActivity(emoji: "💥", title: "Angle Cannon", subtitle: "Tilt to aim — hit the target", isRecommended: false) { appModel in
+                        appModel.pickProfileThenRun { appModel.engine.showAngleCannon() }
+                    },
+                    ExplorerActivity(emoji: "🎨", title: "Gravity Artist", subtitle: "Predict where the ball lands", isRecommended: false) { appModel in
+                        appModel.pickProfileThenRun { appModel.engine.showGravityArtist() }
+                    },
+                ]
+            ),
+            ExplorerWorld(
+                id: "maps",
+                emoji: "🗺️",
+                title: "Maps",
+                subtitle: "Rooms, places, and directions",
+                badge: "★☆☆",
+                fill: MatherTheme.accent,
+                activities: [
+                    ExplorerActivity(emoji: "🗺️", title: "Room Quest", subtitle: "Collect tokens around the room", isRecommended: true) { appModel in
+                        appModel.pickProfileThenRun { appModel.engine.showRoomQuest() }
+                    },
+                    ExplorerActivity(emoji: "🧭", title: "Compass Walk", subtitle: "Turn your body to match the angle", isRecommended: false) { appModel in
+                        appModel.pickProfileThenRun { appModel.engine.showCompassAngles() }
+                    },
+                ]
+            ),
+            ExplorerWorld(
+                id: "discovery",
+                emoji: "🃏",
+                title: "Discovery",
+                subtitle: "Cards, memory, and review",
+                badge: "★☆☆",
+                fill: MatherTheme.panelDeep,
+                activities: [
+                    ExplorerActivity(emoji: "🃏", title: "Memory Match", subtitle: "Match pictures, words, and ideas", isRecommended: true) { appModel in
+                        appModel.pickProfileThenRun { appModel.engine.showMemory() }
+                    },
+                ]
+            ),
         ]
     }
 
@@ -72,31 +133,11 @@ struct LabView: View {
             GeometryReader { proxy in
                 ScrollView {
                     VStack(alignment: .leading, spacing: 20) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Explorer Lab")
-                                    .font(.system(size: 36, weight: .black, design: .rounded))
-                                    .foregroundStyle(MatherTheme.ink)
-                                Text("Pick a game and discover maths")
-                                    .font(.subheadline.weight(.medium))
-                                    .foregroundStyle(MatherTheme.cardSubtitle)
-                            }
-                            Spacer()
-                            Button {
-                                appModel.engine.showHome()
-                            } label: {
-                                Image(systemName: "house.fill")
-                                    .font(.title2.weight(.semibold))
-                                    .foregroundStyle(MatherTheme.accent)
-                                    .frame(width: 44, height: 44)
-                            }
-                            .accessibilityLabel("Home")
-                        }
-
-                        LazyVGrid(columns: ResponsiveLayout.labColumns(for: proxy.size.width), spacing: 16) {
-                            ForEach(Array(tiles.enumerated()), id: \.offset) { _, tile in
-                                gameTileButton(tile)
-                            }
+                        header
+                        if let selectedWorld {
+                            worldDetail(selectedWorld)
+                        } else {
+                            worldGrid(width: proxy.size.width)
                         }
                     }
                     .padding(24)
@@ -105,54 +146,125 @@ struct LabView: View {
         }
     }
 
-    private func gameTileButton(_ tile: GameTile) -> some View {
-        Button(action: tile.action) {
-            VStack(alignment: .leading, spacing: 0) {
-                ZStack {
-                    tile.fill.opacity(0.85)
-                    Text(tile.emoji)
-                        .font(.system(size: 52))
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(.vertical, 20)
-                }
-                .clipShape(
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: 16, bottomLeadingRadius: 0,
-                        bottomTrailingRadius: 0, topTrailingRadius: 16,
-                        style: .continuous
-                    )
-                )
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(tile.name)
-                        .font(.headline.weight(.black))
-                        .foregroundStyle(MatherTheme.ink)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.8)
-                    Text(tile.tagline)
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(MatherTheme.card)
-                .clipShape(
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: 0, bottomLeadingRadius: 16,
-                        bottomTrailingRadius: 16, topTrailingRadius: 0,
-                        style: .continuous
-                    )
-                )
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Explorer Lab")
+                    .font(.system(size: 36, weight: .black, design: .rounded))
+                    .foregroundStyle(MatherTheme.ink)
+                Text(selectedWorld == nil ? "Pick a world" : "Pick a way to play")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
             }
-            .shadow(
-                color: colorScheme == .dark ? .black.opacity(0.3) : .black.opacity(0.08),
-                radius: 8, y: 4
-            )
+            Spacer()
+            if selectedWorld != nil {
+                Button { selectedWorld = nil } label: {
+                    Image(systemName: "square.grid.2x2.fill")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(MatherTheme.accent)
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel("All Worlds")
+            }
+            Button { appModel.engine.showHome() } label: {
+                Image(systemName: "house.fill")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(MatherTheme.accent)
+                    .frame(width: 44, height: 44)
+            }
+            .accessibilityLabel("Home")
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(tile.name)
+    }
+
+    private func worldGrid(width: CGFloat) -> some View {
+        LazyVGrid(columns: ResponsiveLayout.labColumns(for: width), spacing: 16) {
+            ForEach(worlds) { world in
+                Button { selectedWorld = world } label: {
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(alignment: .top) {
+                            Text(world.emoji)
+                                .font(.system(size: 54))
+                            Spacer()
+                            Text(world.badge)
+                                .font(.caption.weight(.black))
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 5)
+                                .background(.white.opacity(0.65))
+                                .clipShape(Capsule())
+                        }
+                        Text(world.title)
+                            .font(.title2.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text(world.subtitle)
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .lineLimit(2)
+                        Text("Enter world")
+                            .font(.caption.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 7)
+                            .background(.white.opacity(0.55))
+                            .clipShape(Capsule())
+                    }
+                    .padding(16)
+                    .frame(maxWidth: .infinity, minHeight: 178, alignment: .topLeading)
+                    .background(world.fill.opacity(0.72))
+                    .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+                    .shadow(color: colorScheme == .dark ? .black.opacity(0.3) : .black.opacity(0.08), radius: 8, y: 4)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("\(world.title) World")
+                .accessibilityIdentifier("explorer-world-\(world.id)")
+            }
+        }
+    }
+
+    private func worldDetail(_ world: ExplorerWorld) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 12) {
+                Text(world.emoji).font(.system(size: 48))
+                VStack(alignment: .leading) {
+                    Text("\(world.title) World")
+                        .font(.title.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text(world.subtitle)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                }
+            }
+            ForEach(world.activities) { activity in
+                Button { activity.action(appModel) } label: {
+                    HStack(spacing: 14) {
+                        Text(activity.emoji).font(.system(size: 38))
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(activity.title)
+                                    .font(.headline.weight(.black))
+                                if activity.isRecommended {
+                                    Text("Recommended next")
+                                        .font(.caption2.weight(.black))
+                                        .padding(.horizontal, 8)
+                                        .padding(.vertical, 4)
+                                        .background(MatherTheme.warm.opacity(0.45))
+                                        .clipShape(Capsule())
+                                }
+                            }
+                            Text(activity.subtitle)
+                                .font(.caption.weight(.bold))
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                        }
+                        Spacer()
+                        Image(systemName: "play.fill")
+                            .foregroundStyle(MatherTheme.accent)
+                    }
+                    .padding(16)
+                    .background(MatherTheme.card)
+                    .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(activity.title)
+            }
+        }
     }
 }

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+struct LearningCardIntroView: View {
+    let cards: [LearningConceptCard]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Learn")
+                .font(.title2.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 12)], spacing: 12) {
+                ForEach(cards) { card in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(card.visualKey)
+                            .font(.system(size: 44))
+                            .frame(maxWidth: .infinity, alignment: .center)
+                        Text(card.title)
+                            .font(.headline.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text(card.explanation)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(14)
+                    .frame(maxWidth: .infinity, minHeight: 150, alignment: .topLeading)
+                    .background(MatherTheme.card)
+                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(card.title). \(card.explanation)")
+                }
+            }
+        }
+    }
+}
+
+struct ConceptQuizRoundView: View {
+    let questions: [ConceptQuizQuestion]
+    @Binding var answersByQuestionId: [String: String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Quiz")
+                .font(.title2.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            ForEach(questions) { question in
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(question.prompt)
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    HStack(spacing: 8) {
+                        ForEach(question.choices, id: \.self) { choice in
+                            Button {
+                                answersByQuestionId[question.id] = choice
+                            } label: {
+                                Text(choice)
+                                    .font(.subheadline.weight(.bold))
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.7)
+                                    .padding(.vertical, 10)
+                                    .padding(.horizontal, 12)
+                                    .frame(maxWidth: .infinity)
+                                    .background(choiceFill(for: choice, in: question))
+                                    .foregroundStyle(MatherTheme.ink)
+                                    .clipShape(Capsule())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("\(choice) answer")
+                        }
+                    }
+                    if let selected = answersByQuestionId[question.id] {
+                        Text(question.isCorrect(selected) ? question.feedback : "Try again — look back at the learn cards.")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(question.isCorrect(selected) ? .green : MatherTheme.coral)
+                    }
+                }
+                .padding(14)
+                .background(MatherTheme.card)
+                .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            }
+        }
+    }
+
+    private func choiceFill(for choice: String, in question: ConceptQuizQuestion) -> Color {
+        guard let selected = answersByQuestionId[question.id], selected == choice else {
+            return MatherTheme.softBlue.opacity(0.45)
+        }
+        return question.isCorrect(choice) ? .green.opacity(0.28) : MatherTheme.coral.opacity(0.28)
+    }
+}
+
+struct ConceptMixMatchRoundView: View {
+    let pairs: [ConceptMatchPair]
+    @Binding var selectedLeft: String?
+    @Binding var matchedPairIds: Set<String>
+    let onFeedback: (String) -> Void
+
+    private var leftItems: [String] { Array(Set(pairs.map(\.left))).sorted() }
+    private var rightItems: [String] { Array(Set(pairs.map(\.right))).sorted() }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Mix + Match")
+                .font(.title2.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            HStack(alignment: .top, spacing: 14) {
+                matchColumn(title: "Start", items: leftItems, isLeft: true)
+                matchColumn(title: "Goes with", items: rightItems, isLeft: false)
+            }
+        }
+    }
+
+    private func matchColumn(title: String, items: [String], isLeft: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.caption.weight(.black))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+            ForEach(items, id: \.self) { item in
+                Button {
+                    handleTap(item, isLeft: isLeft)
+                } label: {
+                    Text(item)
+                        .font(.headline.weight(.black))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(tileFill(item: item, isLeft: isLeft))
+                        .foregroundStyle(MatherTheme.ink)
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(item)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func handleTap(_ item: String, isLeft: Bool) {
+        if isLeft {
+            selectedLeft = item
+            onFeedback("Now pick what goes with \(item).")
+            return
+        }
+        guard let left = selectedLeft else {
+            onFeedback("Pick a start card first.")
+            return
+        }
+        if let pair = pairs.first(where: { $0.left == left && $0.right == item }) {
+            matchedPairIds.insert(pair.id)
+            selectedLeft = nil
+            onFeedback(pair.feedback)
+        } else {
+            onFeedback("Not that pair yet — try another match.")
+        }
+    }
+
+    private func tileFill(item: String, isLeft: Bool) -> Color {
+        let isMatched = pairs.contains { pair in
+            matchedPairIds.contains(pair.id) && (isLeft ? pair.left == item : pair.right == item)
+        }
+        if isMatched { return .green.opacity(0.28) }
+        if isLeft, selectedLeft == item { return MatherTheme.warm.opacity(0.6) }
+        return MatherTheme.card
+    }
+}

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct WaterCycleLabView: View {
+    @Bindable var appModel: AppModel
+    @State private var answersByQuestionId: [String: String] = [:]
+    @State private var selectedLeft: String?
+    @State private var matchedPairIds: Set<String> = []
+    @State private var feedback = "Learn the water cycle, then try the quiz and matches."
+
+    private var summary: LearningLoopSummary {
+        LearningLoopScoring.summary(
+            questions: WaterCycleContent.quizQuestions,
+            answersByQuestionId: answersByQuestionId,
+            matchedPairIds: matchedPairIds,
+            pairs: WaterCycleContent.matchPairs
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            MatherTheme.background.ignoresSafeArea()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    header
+                    LearningCardIntroView(cards: WaterCycleContent.cards)
+                    ConceptQuizRoundView(
+                        questions: WaterCycleContent.quizQuestions,
+                        answersByQuestionId: $answersByQuestionId
+                    )
+                    ConceptMixMatchRoundView(
+                        pairs: WaterCycleContent.matchPairs,
+                        selectedLeft: $selectedLeft,
+                        matchedPairIds: $matchedPairIds,
+                        onFeedback: { feedback = $0 }
+                    )
+                    summaryCard
+                }
+                .padding(24)
+            }
+        }
+        .accessibilityIdentifier("water-cycle-lab")
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Water Cycle Lab")
+                    .font(.system(size: 34, weight: .black, design: .rounded))
+                    .foregroundStyle(MatherTheme.ink)
+                Text("Sun → vapour → cloud → rain → pond")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                Text(feedback)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(MatherTheme.accent)
+            }
+            Spacer()
+            Button {
+                appModel.engine.showLab()
+            } label: {
+                Image(systemName: "square.grid.2x2.fill")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(MatherTheme.accent)
+                    .frame(width: 44, height: 44)
+            }
+            .accessibilityLabel("Explorer Lab")
+        }
+    }
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(repeating: "⭐️", count: summary.starCount).isEmpty ? "Keep exploring" : String(repeating: "⭐️", count: summary.starCount))
+                .font(.title.weight(.black))
+            Text("Quiz: \(summary.quizCorrect)/\(summary.quizTotal) • Matches: \(summary.matchedPairs)/\(summary.totalPairs)")
+                .font(.headline.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            Text("Water keeps moving: the sun warms it, vapour rises, clouds form, rain falls, and ponds fill again.")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MatherTheme.warm.opacity(0.22))
+        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .accessibilityIdentifier("water-cycle-summary")
+    }
+}

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Mather
+
+final class LearningLoopTests: XCTestCase {
+    func testWaterCycleContentCoversExpectedCards() {
+        let titles = Set(WaterCycleContent.cards.map(\.title))
+        XCTAssertEqual(WaterCycleContent.cards.count, 7)
+        XCTAssertTrue(titles.isSuperset(of: ["Evaporation", "Condensation", "Cloud", "Rain", "Pond", "Sun", "Water Vapour"]))
+    }
+
+    func testQuizScoringUsesCorrectAnswers() {
+        let questions = WaterCycleContent.quizQuestions
+        let answers = Dictionary(uniqueKeysWithValues: questions.map { ($0.id, $0.correctChoice) })
+        XCTAssertEqual(LearningLoopScoring.scoreQuiz(questions: questions, answersByQuestionId: answers), questions.count)
+    }
+
+    func testQuizScoringRejectsWrongAnswers() {
+        let questions = WaterCycleContent.quizQuestions
+        XCTAssertEqual(
+            LearningLoopScoring.scoreQuiz(questions: questions, answersByQuestionId: ["sun-warms-water": "Freezes it"]),
+            0
+        )
+    }
+
+    func testPairMatchingRequiresDefinedCauseEffectPair() {
+        let pairs = WaterCycleContent.matchPairs
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Sun", right: "Evaporation", pairs: pairs))
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Cloud", right: "Rain", pairs: pairs))
+        XCTAssertFalse(LearningLoopScoring.isMatch(left: "Sun", right: "Rain", pairs: pairs))
+    }
+
+    func testSummaryComputesStarsFromQuizAndMatches() {
+        let questions = WaterCycleContent.quizQuestions
+        let answers = Dictionary(uniqueKeysWithValues: questions.map { ($0.id, $0.correctChoice) })
+        let matchedIds = Set(WaterCycleContent.matchPairs.map(\.id))
+        let summary = LearningLoopScoring.summary(
+            questions: questions,
+            answersByQuestionId: answers,
+            matchedPairIds: matchedIds,
+            pairs: WaterCycleContent.matchPairs
+        )
+        XCTAssertEqual(summary.quizCorrect, 3)
+        XCTAssertEqual(summary.matchedPairs, 5)
+        XCTAssertEqual(summary.starCount, 3)
+    }
+}

--- a/docs/offline-visual-style.md
+++ b/docs/offline-visual-style.md
@@ -1,0 +1,14 @@
+# Offline visual style for Explorer and Learning Loops
+
+Mather's build-66 Explorer/Water Cycle wave uses deterministic, checked-in visuals only.
+
+## Style
+
+- Big kid-readable world icons.
+- Rounded pastel cards using `MatherTheme` colors.
+- Sticker-like emoji/SF-symbol compositions until reviewed project-owned artwork is available.
+- No runtime network calls, image generation, or remote asset loading.
+
+## Provenance
+
+The initial Water Cycle Lab and capability tiles are vector/text/emoji compositions generated from local source code. If future generated artwork is imported, commit only the reviewed final assets and include the prompt/source note here before merge.


### PR DESCRIPTION
## Summary

Implements a coherent build-66 TestFlight feedback wave for #865 and #866: Explorer Lab is now capability/world-first, existing activities remain reachable from world detail screens, and Physics includes a new deterministic Water Cycle Lab using a reusable learn → quiz → mix-match substrate.

## Changes

- Reworked Explorer Lab top level into capability tiles: Numbers, Geometry, Physics, Maps, Discovery.
- Added reusable learning-loop domain primitives and SwiftUI rounds for flash-card learning, scored quiz, and mix/match pairing.
- Added Water Cycle Lab v1 with local deterministic content for Sun, Pond, Evaporation, Water Vapour, Condensation, Cloud, and Rain.
- Added unit coverage for Water Cycle content, quiz scoring, pair matching, and summary stars.
- Documented offline visual/style provenance; no runtime network/image generation dependencies.

## Testing

- `git diff --check` ✅
- Static brace-balance scan over changed Swift files ✅
- Full xcodebuild not run in this Linux worker; `xcodebuild`, `swiftc`, and `xcodegen` are not available locally, and SSH to the Mac builder failed due temporary DNS resolution for `mba`.

Fixes ganesh47/mather#865
Fixes ganesh47/mather#866
