### PR TITLE
feat: salvage reusable learning loop content

### DIFF
--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// Reusable deterministic content for learn → quiz → match loops.
+struct LearningConceptCard: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let explanation: String
+    let visualKey: String
+    let audioPrompt: String
+
+    init(id: String, title: String, explanation: String, visualKey: String, audioPrompt: String? = nil) {
+        self.id = id
+        self.title = title
+        self.explanation = explanation
+        self.visualKey = visualKey
+        self.audioPrompt = audioPrompt ?? "Learn about \(title)."
+    }
+}
+
+struct ConceptQuizQuestion: Identifiable, Equatable {
+    let id: String
+    let prompt: String
+    let choices: [String]
+    let correctChoice: String
+    let feedback: String
+
+    init(id: String, prompt: String, choices: [String], correctChoice: String, feedback: String) {
+        self.id = id
+        self.prompt = prompt
+        self.choices = choices
+        self.correctChoice = correctChoice
+        self.feedback = feedback
+    }
+
+    func isCorrect(_ choice: String) -> Bool {
+        choice == correctChoice
+    }
+}
+
+struct ConceptMatchPair: Identifiable, Equatable {
+    let id: String
+    let left: String
+    let right: String
+    let feedback: String
+}
+
+struct LearningLoopSummary: Equatable {
+    let quizCorrect: Int
+    let quizTotal: Int
+    let matchedPairs: Int
+    let totalPairs: Int
+
+    var starCount: Int {
+        guard quizTotal + totalPairs > 0 else { return 0 }
+        let earned = quizCorrect + matchedPairs
+        let possible = quizTotal + totalPairs
+        switch Double(earned) / Double(possible) {
+        case 0.85...: return 3
+        case 0.55...: return 2
+        case 0.01...: return 1
+        default: return 0
+        }
+    }
+}
+
+enum LearningLoopScoring {
+    static func scoreQuiz(questions: [ConceptQuizQuestion], answersByQuestionId: [String: String]) -> Int {
+        questions.reduce(0) { score, question in
+            guard let answer = answersByQuestionId[question.id] else { return score }
+            return score + (question.isCorrect(answer) ? 1 : 0)
+        }
+    }
+
+    static func isMatch(left: String, right: String, pairs: [ConceptMatchPair]) -> Bool {
+        pairs.contains { $0.left == left && $0.right == right }
+    }
+
+    static func summary(
+        questions: [ConceptQuizQuestion],
+        answersByQuestionId: [String: String],
+        matchedPairIds: Set<String>,
+        pairs: [ConceptMatchPair]
+    ) -> LearningLoopSummary {
+        LearningLoopSummary(
+            quizCorrect: scoreQuiz(questions: questions, answersByQuestionId: answersByQuestionId),
+            quizTotal: questions.count,
+            matchedPairs: matchedPairIds.count,
+            totalPairs: pairs.count
+        )
+    }
+}
+
+enum WaterCycleContent {
+    static let cards: [LearningConceptCard] = [
+        LearningConceptCard(id: "sun", title: "Sun", explanation: "The sun warms water in ponds, lakes, and puddles.", visualKey: "☀️", audioPrompt: "The sun warms the water."),
+        LearningConceptCard(id: "pond", title: "Pond", explanation: "A pond holds water on the ground.", visualKey: "🏞️", audioPrompt: "A pond is water on the ground."),
+        LearningConceptCard(id: "evaporation", title: "Evaporation", explanation: "Warm water turns into invisible water vapour and rises.", visualKey: "♨️", audioPrompt: "Evaporation means water vapour goes up."),
+        LearningConceptCard(id: "water-vapour", title: "Water Vapour", explanation: "Water vapour is tiny water in the air.", visualKey: "💨", audioPrompt: "Water vapour floats in the air."),
+        LearningConceptCard(id: "condensation", title: "Condensation", explanation: "Water vapour cools and gathers into tiny drops.", visualKey: "🌫️", audioPrompt: "Condensation makes tiny drops."),
+        LearningConceptCard(id: "cloud", title: "Cloud", explanation: "A cloud is made from many tiny water drops.", visualKey: "☁️", audioPrompt: "Clouds hold tiny drops."),
+        LearningConceptCard(id: "rain", title: "Rain", explanation: "Drops get heavy and fall back down as rain.", visualKey: "🌧️", audioPrompt: "Rain falls back down."),
+    ]
+
+    static let quizQuestions: [ConceptQuizQuestion] = [
+        ConceptQuizQuestion(
+            id: "sun-warms-water",
+            prompt: "What does the sun do to pond water?",
+            choices: ["Warms it", "Freezes it", "Hides it"],
+            correctChoice: "Warms it",
+            feedback: "Yes — warm water can evaporate."
+        ),
+        ConceptQuizQuestion(
+            id: "vapour-rises",
+            prompt: "Which word means warm water vapour goes up?",
+            choices: ["Rain", "Evaporation", "Pond"],
+            correctChoice: "Evaporation",
+            feedback: "Evaporation sends water vapour up."
+        ),
+        ConceptQuizQuestion(
+            id: "cloud-rain",
+            prompt: "Which card shows water falling down?",
+            choices: ["Cloud", "Rain", "Sun"],
+            correctChoice: "Rain",
+            feedback: "Rain brings water back down."
+        ),
+    ]
+
+    static let matchPairs: [ConceptMatchPair] = [
+        ConceptMatchPair(id: "sun-evaporation", left: "Sun", right: "Evaporation", feedback: "The sun helps water evaporate."),
+        ConceptMatchPair(id: "pond-evaporation", left: "Pond", right: "Evaporation", feedback: "Water can rise from the pond."),
+        ConceptMatchPair(id: "cloud-condensation", left: "Cloud", right: "Condensation", feedback: "Condensation helps make clouds."),
+        ConceptMatchPair(id: "cloud-rain", left: "Cloud", right: "Rain", feedback: "Heavy cloud drops fall as rain."),
+        ConceptMatchPair(id: "rain-pond", left: "Rain", right: "Pond", feedback: "Rain fills ponds again."),
+    ]
+}

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+struct LearningCardIntroView: View {
+    let cards: [LearningConceptCard]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Learn")
+                .font(.title2.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 12)], spacing: 12) {
+                ForEach(cards) { card in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(card.visualKey)
+                            .font(.system(size: 44))
+                            .frame(maxWidth: .infinity, alignment: .center)
+                        Text(card.title)
+                            .font(.headline.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text(card.explanation)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(14)
+                    .frame(maxWidth: .infinity, minHeight: 150, alignment: .topLeading)
+                    .background(MatherTheme.card)
+                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(card.title). \(card.explanation)")
+                }
+            }
+        }
+    }
+}
+
+struct ConceptQuizRoundView: View {
+    let questions: [ConceptQuizQuestion]
+    @Binding var answersByQuestionId: [String: String]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Quiz")
+                .font(.title2.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            ForEach(questions) { question in
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(question.prompt)
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    HStack(spacing: 8) {
+                        ForEach(question.choices, id: \.self) { choice in
+                            Button {
+                                answersByQuestionId[question.id] = choice
+                            } label: {
+                                Text(choice)
+                                    .font(.subheadline.weight(.bold))
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.7)
+                                    .padding(.vertical, 10)
+                                    .padding(.horizontal, 12)
+                                    .frame(maxWidth: .infinity)
+                                    .background(choiceFill(for: choice, in: question))
+                                    .foregroundStyle(MatherTheme.ink)
+                                    .clipShape(Capsule())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("\(choice) answer")
+                        }
+                    }
+                    if let selected = answersByQuestionId[question.id] {
+                        Text(question.isCorrect(selected) ? question.feedback : "Try again — look back at the learn cards.")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(question.isCorrect(selected) ? .green : MatherTheme.coral)
+                    }
+                }
+                .padding(14)
+                .background(MatherTheme.card)
+                .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+            }
+        }
+    }
+
+    private func choiceFill(for choice: String, in question: ConceptQuizQuestion) -> Color {
+        guard let selected = answersByQuestionId[question.id], selected == choice else {
+            return MatherTheme.softBlue.opacity(0.45)
+        }
+        return question.isCorrect(choice) ? .green.opacity(0.28) : MatherTheme.coral.opacity(0.28)
+    }
+}
+
+struct ConceptMixMatchRoundView: View {
+    let pairs: [ConceptMatchPair]
+    @Binding var selectedLeft: String?
+    @Binding var matchedPairIds: Set<String>
+    let onFeedback: (String) -> Void
+
+    private var leftItems: [String] { Array(Set(pairs.map(\.left))).sorted() }
+    private var rightItems: [String] { Array(Set(pairs.map(\.right))).sorted() }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Mix + Match")
+                .font(.title2.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            HStack(alignment: .top, spacing: 14) {
+                matchColumn(title: "Start", items: leftItems, isLeft: true)
+                matchColumn(title: "Goes with", items: rightItems, isLeft: false)
+            }
+        }
+    }
+
+    private func matchColumn(title: String, items: [String], isLeft: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.caption.weight(.black))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+            ForEach(items, id: \.self) { item in
+                Button {
+                    handleTap(item, isLeft: isLeft)
+                } label: {
+                    Text(item)
+                        .font(.headline.weight(.black))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(tileFill(item: item, isLeft: isLeft))
+                        .foregroundStyle(MatherTheme.ink)
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(item)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func handleTap(_ item: String, isLeft: Bool) {
+        if isLeft {
+            selectedLeft = item
+            onFeedback("Now pick what goes with \(item).")
+            return
+        }
+        guard let left = selectedLeft else {
+            onFeedback("Pick a start card first.")
+            return
+        }
+        if let pair = pairs.first(where: { $0.left == left && $0.right == item }) {
+            matchedPairIds.insert(pair.id)
+            selectedLeft = nil
+            onFeedback(pair.feedback)
+        } else {
+            onFeedback("Not that pair yet — try another match.")
+        }
+    }
+
+    private func tileFill(item: String, isLeft: Bool) -> Color {
+        let isMatched = pairs.contains { pair in
+            matchedPairIds.contains(pair.id) && (isLeft ? pair.left == item : pair.right == item)
+        }
+        if isMatched { return .green.opacity(0.28) }
+        if isLeft, selectedLeft == item { return MatherTheme.warm.opacity(0.6) }
+        return MatherTheme.card
+    }
+}

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Mather
+
+final class LearningLoopTests: XCTestCase {
+    func testWaterCycleContentCoversExpectedCards() {
+        let titles = Set(WaterCycleContent.cards.map(\.title))
+        XCTAssertEqual(WaterCycleContent.cards.count, 7)
+        XCTAssertTrue(titles.isSuperset(of: ["Evaporation", "Condensation", "Cloud", "Rain", "Pond", "Sun", "Water Vapour"]))
+    }
+
+    func testQuizScoringUsesCorrectAnswers() {
+        let questions = WaterCycleContent.quizQuestions
+        let answers = Dictionary(uniqueKeysWithValues: questions.map { ($0.id, $0.correctChoice) })
+        XCTAssertEqual(LearningLoopScoring.scoreQuiz(questions: questions, answersByQuestionId: answers), questions.count)
+    }
+
+    func testQuizScoringRejectsWrongAnswers() {
+        let questions = WaterCycleContent.quizQuestions
+        XCTAssertEqual(
+            LearningLoopScoring.scoreQuiz(questions: questions, answersByQuestionId: ["sun-warms-water": "Freezes it"]),
+            0
+        )
+    }
+
+    func testPairMatchingRequiresDefinedCauseEffectPair() {
+        let pairs = WaterCycleContent.matchPairs
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Sun", right: "Evaporation", pairs: pairs))
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Cloud", right: "Rain", pairs: pairs))
+        XCTAssertFalse(LearningLoopScoring.isMatch(left: "Sun", right: "Rain", pairs: pairs))
+    }
+
+    func testSummaryComputesStarsFromQuizAndMatches() {
+        let questions = WaterCycleContent.quizQuestions
+        let answers = Dictionary(uniqueKeysWithValues: questions.map { ($0.id, $0.correctChoice) })
+        let matchedIds = Set(WaterCycleContent.matchPairs.map(\.id))
+        let summary = LearningLoopScoring.summary(
+            questions: questions,
+            answersByQuestionId: answers,
+            matchedPairIds: matchedIds,
+            pairs: WaterCycleContent.matchPairs
+        )
+        XCTAssertEqual(summary.quizCorrect, 3)
+        XCTAssertEqual(summary.matchedPairs, 5)
+        XCTAssertEqual(summary.starCount, 3)
+    }
+}

--- a/docs/offline-visual-style.md
+++ b/docs/offline-visual-style.md
@@ -1,0 +1,14 @@
+# Offline visual style for Explorer and Learning Loops
+
+Mather's build-66 Explorer/Water Cycle wave uses deterministic, checked-in visuals only.
+
+## Style
+
+- Big kid-readable world icons.
+- Rounded pastel cards using `MatherTheme` colors.
+- Sticker-like emoji/SF-symbol compositions until reviewed project-owned artwork is available.
+- No runtime network calls, image generation, or remote asset loading.
+
+## Provenance
+
+The initial Water Cycle Lab and capability tiles are vector/text/emoji compositions generated from local source code. If future generated artwork is imported, commit only the reviewed final assets and include the prompt/source note here before merge.


### PR DESCRIPTION
## Summary

Replacement salvage for conflicting PR #868 after #867 shipped as v2.6.13.

This keeps current `main` / #867 intact and brings forward only the additive, low-conflict learning-loop pieces:

- reusable learn → quiz → mix/match domain primitives
- SwiftUI rounds for concept cards, quiz selection, and pairing
- deterministic Water Cycle concept content for Sun, Pond, Evaporation, Water Vapour, Condensation, Cloud, and Rain
- focused unit coverage for content, quiz scoring, pair matching, and summary stars
- offline visual/style provenance docs

Intentionally not carried over from #868: the older Explorer Lab and Water Cycle screen rewrites, because current `main` already includes the richer build-66 UI fixes from #867 and a more advanced playable Water Cycle lesson flow.

References #868, #865, #866.

## Validation

- `git diff --check origin/main..HEAD` ✅
- conflict-marker scan on salvaged files ✅
- lightweight brace-balance scan on changed Swift files ✅
- Full iOS/Xcode tests not run in this Linux worker (`swift`/`xcodebuild` unavailable locally).
