### PR TITLE
feat: add Compass Walk + Turn

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -15,6 +15,7 @@ final class AppModel {
     let engine: VerticalSliceEngine
     let hapticsService: HapticsService
     let motionService: MotionService
+    let stepCountService: StepCountService
     let soundDetectionService: SoundDetectionService
     let roomQuestScanner: RoomQuestLiveScanner
     let roomQuestEngine: RoomQuestEngine
@@ -73,6 +74,7 @@ final class AppModel {
         let roomQuestStationStore = RoomQuestStationStore(modelContext: modelContext)
         let hapticsService = HapticsService()
         let motionService = MotionService()
+        let stepCountService = StepCountService()
         let soundDetectionService = SoundDetectionService()
         let roomQuestScanner = RoomQuestLiveScanner()
 
@@ -85,6 +87,7 @@ final class AppModel {
         self.roomQuestStationStore = roomQuestStationStore
         self.hapticsService = hapticsService
         self.motionService = motionService
+        self.stepCountService = stepCountService
         self.soundDetectionService = soundDetectionService
         self.roomQuestScanner = roomQuestScanner
         roomQuestScanner.featureFlags = featureFlags

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -18,6 +18,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSMotionUsageDescription</key>
+	<string>Mather counts a few small careful steps during motion games. If motion access is unavailable, your child can use tap-to-count instead.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Mather listens for claps to celebrate with you. You can turn Clap reaction off any time in Settings.</string>
 	<key>NSCameraUsageDescription</key>

--- a/Features/CompassAngles/CompassAnglesView.swift
+++ b/Features/CompassAngles/CompassAnglesView.swift
@@ -1,11 +1,9 @@
 import SwiftUI
 
 // Compass Angles — ages 7–9
-// The child holds the iPad and physically turns their body.
-// CMDeviceMotion.attitude relative yaw tracks the rotation angle.
-// No magnetometer: pure gyroscope relative rotation — no permission needed.
-// A compass rose shows the live heading; a blue target dot shows the goal.
-// When the child turns to within ±10° of the target angle the activity snaps.
+// The child takes a few small careful steps, then physically turns their body.
+// Step sensing uses StepCountService with manual fallback; turn sensing keeps the
+// existing body-relative yaw snap math from MotionService.
 
 // MARK: - Snap math helpers (pure — testable)
 
@@ -30,13 +28,7 @@ enum CompassMath {
     }
 }
 
-// MARK: - Level config
-
-private struct CompassLevel {
-    let targetDeg: Double          // positive = turn right, negative = turn left
-    let instruction: String        // spoken
-    let directionHint: String      // shown in UI
-}
+// MARK: - Level/state config
 
 enum BodyTurnDirection {
     case left
@@ -44,12 +36,111 @@ enum BodyTurnDirection {
     case around
 }
 
-private let levels: [CompassLevel] = [
-    CompassLevel(targetDeg: 90,  instruction: "Turn 90 degrees to the right",       directionHint: "Turn right 90°"),
-    CompassLevel(targetDeg: 180, instruction: "Turn all the way around, 180 degrees", directionHint: "Turn 180°"),
-    CompassLevel(targetDeg: 45,  instruction: "Turn 45 degrees to the right",       directionHint: "Turn right 45°"),
-    CompassLevel(targetDeg: -90, instruction: "Turn 90 degrees to the left",        directionHint: "Turn left 90°"),
-    CompassLevel(targetDeg: 270, instruction: "Turn 270 degrees, three-quarters around", directionHint: "Turn 270°"),
+enum CompassWalkDirection: String, CaseIterable {
+    case forward
+    case left
+    case right
+
+    var title: String {
+        switch self {
+        case .forward: "forward"
+        case .left: "to your left"
+        case .right: "to your right"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .forward: "arrow.up"
+        case .left: "arrow.left"
+        case .right: "arrow.right"
+        }
+    }
+}
+
+enum CompassWalkTurnPhase: Equatable {
+    case ready
+    case walking
+    case turning
+    case success
+}
+
+struct CompassWalkTurnLevel: Equatable, Identifiable {
+    let id: Int
+    let walkDirection: CompassWalkDirection
+    let steps: Int
+    let targetDeg: Double          // positive = turn right, negative = turn left
+
+    var instruction: String {
+        "Walk \(steps) small steps \(walkDirection.title), then \(turnPhrase)."
+    }
+
+    var walkHint: String {
+        "Walk \(steps) small careful steps \(walkDirection.title)."
+    }
+
+    var turnHint: String {
+        switch CompassAnglesView.turnDirection(for: targetDeg) {
+        case .right: "Then turn right \(Int(targetDeg.magnitude))°."
+        case .left: "Then turn left \(Int(targetDeg.magnitude))°."
+        case .around: "Then turn around \(Int(targetDeg.magnitude))°."
+        }
+    }
+
+    var shortHint: String { "\(walkHint) \(turnHint)" }
+
+    private var turnPhrase: String {
+        switch CompassAnglesView.turnDirection(for: targetDeg) {
+        case .right: "turn right \(Int(targetDeg.magnitude)) degrees"
+        case .left: "turn left \(Int(targetDeg.magnitude)) degrees"
+        case .around: "turn around \(Int(targetDeg.magnitude)) degrees"
+        }
+    }
+}
+
+struct CompassWalkTurnState: Equatable {
+    let level: CompassWalkTurnLevel
+    private(set) var phase: CompassWalkTurnPhase = .ready
+    private(set) var stepProgress: StepWalkProgress
+
+    init(level: CompassWalkTurnLevel, phase: CompassWalkTurnPhase = .ready) {
+        self.level = level
+        self.phase = phase
+        self.stepProgress = StepWalkProgress(requiredSteps: level.steps)
+    }
+
+    var isWalkComplete: Bool { stepProgress.isComplete }
+
+    mutating func startWalking() {
+        phase = .walking
+        stepProgress = StepWalkProgress(requiredSteps: level.steps)
+    }
+
+    mutating func applyCountedSteps(_ steps: Int) {
+        guard phase == .walking else { return }
+        stepProgress.setCountedSteps(steps)
+        if stepProgress.isComplete { phase = .turning }
+    }
+
+    mutating func startTurningIfWalkComplete() {
+        guard stepProgress.isComplete else { return }
+        phase = .turning
+    }
+
+    mutating func applyYaw(_ yaw: Double, tolerance: Double = 10) {
+        guard phase == .turning else { return }
+        if CompassMath.isInSnapZone(yaw: yaw, target: level.targetDeg, tolerance: tolerance) {
+            phase = .success
+        }
+    }
+}
+
+let compassWalkTurnLevels: [CompassWalkTurnLevel] = [
+    CompassWalkTurnLevel(id: 1, walkDirection: .forward, steps: 3, targetDeg: 90),
+    CompassWalkTurnLevel(id: 2, walkDirection: .right, steps: 2, targetDeg: 180),
+    CompassWalkTurnLevel(id: 3, walkDirection: .forward, steps: 4, targetDeg: 45),
+    CompassWalkTurnLevel(id: 4, walkDirection: .left, steps: 2, targetDeg: -90),
+    CompassWalkTurnLevel(id: 5, walkDirection: .forward, steps: 3, targetDeg: 270)
 ]
 
 // MARK: - Main view
@@ -58,13 +149,15 @@ struct CompassAnglesView: View {
     @Bindable var appModel: AppModel
 
     @State private var levelIndex: Int = 0
-    @State private var matched: Bool = false
+    @State private var phase: CompassWalkTurnPhase = .ready
     @State private var wonCount: Int = 0
     @State private var sessionStart: Date = .now
     @State private var showDegreeLabel: Bool = false
 
-    private var level: CompassLevel { levels[levelIndex % levels.count] }
+    private var level: CompassWalkTurnLevel { compassWalkTurnLevels[levelIndex % compassWalkTurnLevels.count] }
     private var currentYaw: Double { appModel.motionService.relativeYaw }
+    private var stepService: StepCountService { appModel.stepCountService }
+    private var turnMatched: Bool { phase == .success }
 
     var body: some View {
         ZStack {
@@ -75,11 +168,14 @@ struct CompassAnglesView: View {
                     ZStack {
                         compassCanvas(size: geo.size)
                         if showDegreeLabel { degreeLabel }
-                        if !appModel.motionService.trackingRelativeYaw { setupOverlay }
+                        if phase == .ready { setupOverlay }
                     }
                 }
                 .onChange(of: appModel.motionService.relativeYaw) { _, yaw in
                     checkSnap(yaw: yaw)
+                }
+                .onChange(of: stepService.countedSteps) { _, _ in
+                    checkWalkProgress()
                 }
                 bottomBar
             }
@@ -89,6 +185,7 @@ struct CompassAnglesView: View {
             appModel.motionService.startUpdates()
         }
         .onDisappear {
+            appModel.stepCountService.stop()
             appModel.motionService.stopRelativeYawTracking()
             appModel.motionService.stopUpdates()
             guard wonCount > 0 else { return }
@@ -96,7 +193,7 @@ struct CompassAnglesView: View {
                 gameName: "Compass Walk",
                 startedAt: sessionStart,
                 scoreValue: wonCount,
-                scoreLabel: "turns completed"
+                scoreLabel: "walk-turn levels completed"
             )
         }
     }
@@ -106,20 +203,19 @@ struct CompassAnglesView: View {
     private var headerBar: some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text("Compass Angles")
+                Text("Compass Walk")
                     .font(.title2.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
-                Text(level.directionHint)
+                Text(level.shortHint)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
-                Text(Self.bodyRelativeHint(for: level.targetDeg))
-                    .font(.caption.weight(.semibold))
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("Clear space • small steps • no running")
+                    .font(.caption.weight(.bold))
                     .foregroundStyle(MatherTheme.cardSubtitle)
             }
             Spacer()
-            Button {
-                appModel.engine.showHome()
-            } label: {
+            Button { appModel.engine.showHome() } label: {
                 Image(systemName: "xmark.circle.fill")
                     .font(.system(size: 30))
                     .foregroundStyle(.secondary)
@@ -131,94 +227,82 @@ struct CompassAnglesView: View {
         .padding(.bottom, 8)
     }
 
-    // MARK: - Setup overlay (before tracking starts)
+    // MARK: - Setup overlay
 
     private var setupOverlay: some View {
         VStack(spacing: 16) {
-            Image(systemName: "arrow.turn.up.right")
+            Image(systemName: "figure.walk")
                 .font(.system(size: 48))
                 .foregroundStyle(MatherTheme.softBlue)
-            Text("Hold iPad flat, then tap START")
+            Text("Make a safe space first")
                 .font(.headline.weight(.semibold))
                 .foregroundStyle(MatherTheme.ink)
                 .multilineTextAlignment(.center)
-            Text("Turn your body until the red pointer reaches the blue target.")
+            Text("Take small careful steps. Keep the iPad steady. No running, jumping, stairs, or bumps.")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(MatherTheme.cardSubtitle)
                 .multilineTextAlignment(.center)
-            Button("START") {
-                appModel.motionService.startRelativeYawTracking()
-                appModel.speechService.speak(level.instruction,
-                                             enabled: appModel.featureFlags.audioEnabled)
-            }
-            .font(.headline.weight(.bold))
-            .foregroundStyle(.white)
-            .padding(.horizontal, 32)
-            .padding(.vertical, 16)
-            .background(MatherTheme.accent)
-            .clipShape(Capsule())
+            Text(level.instruction)
+                .font(.title3.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+                .multilineTextAlignment(.center)
+            Button("START") { beginWalkPhase() }
+                .font(.headline.weight(.bold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 32)
+                .padding(.vertical, 16)
+                .background(MatherTheme.accent)
+                .clipShape(Capsule())
         }
         .padding(28)
         .background(MatherTheme.card.opacity(0.95))
         .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .padding(24)
     }
 
     // MARK: - Compass canvas
 
     private func compassCanvas(size: CGSize) -> some View {
-        let centre = CGPoint(x: size.width / 2, y: size.height / 2)
         let radius = min(size.width, size.height) * 0.38
 
         return Canvas { ctx, canvasSize in
             let cx = canvasSize.width / 2
             let cy = canvasSize.height / 2
 
-            // Outer ring
-            let ringRect = CGRect(x: cx - radius, y: cy - radius,
-                                   width: radius * 2, height: radius * 2)
-            ctx.stroke(Circle().path(in: ringRect),
-                       with: .color(MatherTheme.ink.opacity(0.15)), lineWidth: 2)
+            let ringRect = CGRect(x: cx - radius, y: cy - radius, width: radius * 2, height: radius * 2)
+            ctx.stroke(Circle().path(in: ringRect), with: .color(MatherTheme.ink.opacity(0.15)), lineWidth: 2)
 
-            // Tick marks for every 30°
             for deg in stride(from: 0.0, to: 360.0, by: 30.0) {
                 let isMajor = deg.truncatingRemainder(dividingBy: 90) == 0
                 let rad = deg * .pi / 180
                 let inner = radius * (isMajor ? 0.82 : 0.88)
-                let outer = radius
                 let ix = cx + inner * sin(rad)
                 let iy = cy - inner * cos(rad)
-                let ox = cx + outer * sin(rad)
-                let oy = cy - outer * cos(rad)
+                let ox = cx + radius * sin(rad)
+                let oy = cy - radius * cos(rad)
                 var tick = Path()
                 tick.move(to: CGPoint(x: ix, y: iy))
                 tick.addLine(to: CGPoint(x: ox, y: oy))
-                ctx.stroke(tick, with: .color(MatherTheme.ink.opacity(isMajor ? 0.5 : 0.2)),
-                           lineWidth: isMajor ? 2 : 1)
+                ctx.stroke(tick, with: .color(MatherTheme.ink.opacity(isMajor ? 0.5 : 0.2)), lineWidth: isMajor ? 2 : 1)
             }
 
-            // Target arc sweep (blue dotted)
             let targetRad = level.targetDeg * .pi / 180
-            let arcStartAngle: Double = -.pi / 2   // 12-o'clock
-            let arcEndAngle = arcStartAngle + targetRad
             var targetArc = Path()
             targetArc.addArc(center: CGPoint(x: cx, y: cy),
                              radius: radius * 0.65,
-                             startAngle: .radians(arcStartAngle),
-                             endAngle: .radians(arcEndAngle),
+                             startAngle: .radians(-.pi / 2),
+                             endAngle: .radians(-.pi / 2 + targetRad),
                              clockwise: level.targetDeg < 0)
             ctx.stroke(targetArc,
-                       with: .color(MatherTheme.softBlue.opacity(0.5)),
+                       with: .color(MatherTheme.softBlue.opacity(phase == .turning || phase == .success ? 0.55 : 0.22)),
                        style: StrokeStyle(lineWidth: 4, lineCap: .round, dash: [8, 6]))
 
-            // Target dot
             let tdx = cx + radius * 0.65 * sin(targetRad)
             let tdy = cy - radius * 0.65 * cos(targetRad)
             let tdr: CGFloat = 10
-            ctx.fill(Circle().path(in: CGRect(x: tdx - tdr, y: tdy - tdr,
-                                               width: tdr*2, height: tdr*2)),
+            ctx.fill(Circle().path(in: CGRect(x: tdx - tdr, y: tdy - tdr, width: tdr * 2, height: tdr * 2)),
                      with: .color(MatherTheme.softBlue))
 
-            // Live rotation needle (red, from centre to edge, rotates with yaw)
             let yawRad = currentYaw * .pi / 180
             let needleTipX = cx + radius * 0.8 * sin(yawRad)
             let needleTipY = cy - radius * 0.8 * cos(yawRad)
@@ -227,18 +311,13 @@ struct CompassAnglesView: View {
             var needle = Path()
             needle.move(to: CGPoint(x: tailX, y: tailY))
             needle.addLine(to: CGPoint(x: needleTipX, y: needleTipY))
-            let needleColor: Color = matched ? MatherTheme.accent : MatherTheme.coral
-            ctx.stroke(needle, with: .color(needleColor), lineWidth: 4)
+            let needleColor: Color = turnMatched ? MatherTheme.accent : MatherTheme.coral
+            ctx.stroke(needle, with: .color(needleColor.opacity(phase == .walking ? 0.35 : 1)), lineWidth: 4)
 
-            // Centre dot
             let cr: CGFloat = 8
-            ctx.fill(Circle().path(in: CGRect(x: cx - cr, y: cy - cr, width: cr*2, height: cr*2)),
-                     with: .color(MatherTheme.ink))
+            ctx.fill(Circle().path(in: CGRect(x: cx - cr, y: cy - cr, width: cr * 2, height: cr * 2)), with: .color(MatherTheme.ink))
 
-            // North label (always at top)
-            let northLabel = ctx.resolve(
-                Text("N").font(.system(size: 16, weight: .bold)).foregroundStyle(MatherTheme.ink.opacity(0.4))
-            )
+            let northLabel = ctx.resolve(Text("N").font(.system(size: 16, weight: .bold)).foregroundStyle(MatherTheme.ink.opacity(0.4)))
             ctx.draw(northLabel, at: CGPoint(x: cx, y: cy - radius * 0.92))
         }
     }
@@ -249,8 +328,8 @@ struct CompassAnglesView: View {
         VStack(spacing: 4) {
             Text("\(Int(CompassMath.angularDistance(currentYaw, 0).rounded()))°")
                 .font(.system(size: 64, weight: .black, design: .rounded))
-                .foregroundStyle(matched ? MatherTheme.accent : MatherTheme.ink)
-            if matched {
+                .foregroundStyle(turnMatched ? MatherTheme.accent : MatherTheme.ink)
+            if turnMatched {
                 Text("You turned \(Int(level.targetDeg.magnitude))°!")
                     .font(.headline.weight(.bold))
                     .foregroundStyle(MatherTheme.accent)
@@ -261,18 +340,18 @@ struct CompassAnglesView: View {
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
         .shadow(color: .black.opacity(0.08), radius: 12, y: 4)
         .transition(.scale.combined(with: .opacity))
-        .animation(.spring(response: 0.3), value: matched)
+        .animation(.spring(response: 0.3), value: turnMatched)
     }
 
     // MARK: - Bottom bar
 
     private var bottomBar: some View {
         VStack(spacing: 8) {
-            turnCueCard
+            phaseCueCard
 
-            if matched {
+            if phase == .success {
                 Button(action: advanceLevel) {
-                    Text(wonCount >= levels.count ? "All done!" : "Next turn →")
+                    Text(wonCount >= compassWalkTurnLevels.count ? "All done!" : "Next walk →")
                         .font(.headline.weight(.bold))
                         .foregroundStyle(.white)
                         .frame(maxWidth: .infinity)
@@ -283,37 +362,107 @@ struct CompassAnglesView: View {
                 .padding(.horizontal, 24)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
-            Text("Turn your whole body to match the angle")
-                .font(.caption)
+
+            Text("Clear space, small steps, no running")
+                .font(.caption.weight(.semibold))
                 .foregroundStyle(.tertiary)
                 .padding(.bottom, 16)
         }
-        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: matched)
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: phase)
     }
 
-    private var turnCueCard: some View {
-        HStack(spacing: 12) {
-            Image(systemName: Self.turnCueSymbol(for: level.targetDeg))
-                .font(.system(size: 18, weight: .bold))
-                .foregroundStyle(MatherTheme.softBlue)
-                .frame(width: 34, height: 34)
-                .background(MatherTheme.softBlue.opacity(0.12), in: Circle())
+    private var phaseCueCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                Image(systemName: phaseIcon)
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(MatherTheme.softBlue)
+                    .frame(width: 34, height: 34)
+                    .background(MatherTheme.softBlue.opacity(0.12), in: Circle())
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(Self.turnCueTitle(for: level.targetDeg))
-                    .font(.subheadline.weight(.black))
-                    .foregroundStyle(MatherTheme.ink)
-                Text(Self.bodyRelativeHint(for: level.targetDeg))
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(MatherTheme.cardSubtitle)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(phaseTitle)
+                        .font(.subheadline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text(phaseSubtitle)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 0)
             }
 
-            Spacer(minLength: 0)
+            if phase == .walking {
+                stepProgressView
+            }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .background(MatherTheme.card.opacity(0.92), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         .padding(.horizontal, 24)
+    }
+
+    private var stepProgressView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ProgressView(value: stepService.progress.fractionComplete)
+                .tint(MatherTheme.accent)
+            HStack {
+                Text("\(min(stepService.countedSteps, level.steps)) / \(level.steps) small steps")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(MatherTheme.ink)
+                Spacer()
+                if case .manualFallback(let reason) = stepService.mode {
+                    Button("I took a step") {
+                        stepService.addManualStep()
+                        checkWalkProgress()
+                    }
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(MatherTheme.accent, in: Capsule())
+                    .accessibilityHint(reason)
+                } else {
+                    Button("Use tap count") {
+                        stepService.useManualFallback()
+                    }
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.softBlue)
+                }
+            }
+            if case .manualFallback(let reason) = stepService.mode {
+                Text(reason)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
+        }
+    }
+
+    private var phaseIcon: String {
+        switch phase {
+        case .ready: "figure.walk"
+        case .walking: level.walkDirection.symbol
+        case .turning: Self.turnCueSymbol(for: level.targetDeg)
+        case .success: "checkmark.circle.fill"
+        }
+    }
+
+    private var phaseTitle: String {
+        switch phase {
+        case .ready: "Ready: check your space"
+        case .walking: "Step phase"
+        case .turning: "Turn phase"
+        case .success: "Walk + turn complete!"
+        }
+    }
+
+    private var phaseSubtitle: String {
+        switch phase {
+        case .ready: level.instruction
+        case .walking: level.walkHint
+        case .turning: Self.bodyRelativeHint(for: level.targetDeg)
+        case .success: "Nice careful movement."
+        }
     }
 
     nonisolated static func turnDirection(for targetDeg: Double) -> BodyTurnDirection {
@@ -327,9 +476,9 @@ struct CompassAnglesView: View {
     nonisolated static func bodyRelativeHint(for targetDeg: Double) -> String {
         switch turnDirection(for: targetDeg) {
         case .right:
-            return "Move your body to the right until the red pointer touches the blue dot."
+            return "Now turn your body to the right until the red pointer touches the blue dot."
         case .left:
-            return "Move your body to the left until the red pointer touches the blue dot."
+            return "Now turn your body to the left until the red pointer touches the blue dot."
         case .around:
             return "Keep turning your body until the red pointer reaches the blue dot."
         }
@@ -353,30 +502,50 @@ struct CompassAnglesView: View {
 
     // MARK: - Logic
 
+    private func beginWalkPhase() {
+        phase = .walking
+        showDegreeLabel = false
+        appModel.motionService.stopRelativeYawTracking()
+        stepService.start(requiredSteps: level.steps)
+        appModel.speechService.speak(
+            "Clear space. Walk \(level.steps) small careful steps \(level.walkDirection.title). No running.",
+            enabled: appModel.featureFlags.audioEnabled
+        )
+    }
+
+    private func checkWalkProgress() {
+        guard phase == .walking, stepService.isComplete else { return }
+        phase = .turning
+        showDegreeLabel = true
+        stepService.stop()
+        appModel.motionService.startRelativeYawTracking()
+        appModel.hapticsService.success(enabled: appModel.featureFlags.hapticsEnabled)
+        appModel.speechService.speak(level.turnHint, enabled: appModel.featureFlags.audioEnabled)
+    }
+
     private func checkSnap(yaw: Double) {
-        guard !matched else { return }
+        guard phase == .turning else { return }
         showDegreeLabel = true
         if CompassMath.isInSnapZone(yaw: yaw, target: level.targetDeg) {
-            matched = true
+            phase = .success
             wonCount += 1
             appModel.hapticsService.success(enabled: appModel.featureFlags.hapticsEnabled)
             appModel.speechService.speak(
-                "Perfect! You turned \(Int(level.targetDeg.magnitude)) degrees.",
+                "Perfect! You walked carefully, then turned \(Int(level.targetDeg.magnitude)) degrees.",
                 enabled: appModel.featureFlags.audioEnabled
             )
         }
     }
 
     private func advanceLevel() {
-        if wonCount >= levels.count {
+        if wonCount >= compassWalkTurnLevels.count {
             appModel.engine.showHome()
             return
         }
         levelIndex += 1
-        matched = false
+        phase = .ready
         showDegreeLabel = false
-        // Re-zero for the next turn
-        appModel.motionService.startRelativeYawTracking()
-        appModel.speechService.speak(level.instruction, enabled: appModel.featureFlags.audioEnabled)
+        stepService.stop()
+        appModel.motionService.stopRelativeYawTracking()
     }
 }

--- a/Services/StepCountService.swift
+++ b/Services/StepCountService.swift
@@ -1,0 +1,106 @@
+import CoreMotion
+import Foundation
+import Observation
+
+/// Pure, testable progress helper for small-step walking challenges.
+struct StepWalkProgress: Equatable {
+    let requiredSteps: Int
+    private(set) var countedSteps: Int
+
+    init(requiredSteps: Int, countedSteps: Int = 0) {
+        self.requiredSteps = max(1, requiredSteps)
+        self.countedSteps = max(0, countedSteps)
+    }
+
+    var remainingSteps: Int { max(0, requiredSteps - countedSteps) }
+    var isComplete: Bool { countedSteps >= requiredSteps }
+    var fractionComplete: Double { min(1, Double(countedSteps) / Double(requiredSteps)) }
+
+    mutating func setCountedSteps(_ steps: Int) {
+        countedSteps = max(0, steps)
+    }
+
+    mutating func addManualStep() {
+        countedSteps += 1
+    }
+}
+
+enum StepCountMode: Equatable {
+    case idle
+    case pedometer
+    case manualFallback(reason: String)
+}
+
+/// Wraps CMPedometer behind a tiny observable surface with a simulator/manual fallback.
+/// The game never requires hardware or Motion & Fitness permission to complete.
+@MainActor
+@Observable
+final class StepCountService {
+    nonisolated(unsafe) private let pedometer: CMPedometer
+    private var startDate: Date?
+
+    private(set) var progress = StepWalkProgress(requiredSteps: 1)
+    private(set) var mode: StepCountMode = .idle
+
+    init(pedometer: CMPedometer = CMPedometer()) {
+        self.pedometer = pedometer
+    }
+
+    var isStepCountingAvailable: Bool {
+        CMPedometer.isStepCountingAvailable()
+    }
+
+    var isComplete: Bool { progress.isComplete }
+    var countedSteps: Int { progress.countedSteps }
+    var requiredSteps: Int { progress.requiredSteps }
+
+    func start(requiredSteps: Int) {
+        stop()
+        progress = StepWalkProgress(requiredSteps: requiredSteps)
+        startDate = Date()
+
+        guard isStepCountingAvailable else {
+            mode = .manualFallback(reason: "Step sensing is not available here. Tap each small step instead.")
+            return
+        }
+
+        mode = .pedometer
+        pedometer.startUpdates(from: startDate ?? Date()) { [weak self] data, error in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if error != nil {
+                    self.pedometer.stopUpdates()
+                    self.mode = .manualFallback(reason: "Motion permission was not available. Tap each small step instead.")
+                    return
+                }
+                guard let data else { return }
+                self.progress.setCountedSteps(data.numberOfSteps.intValue)
+            }
+        }
+    }
+
+    func stop() {
+        pedometer.stopUpdates()
+        startDate = nil
+        mode = .idle
+    }
+
+    func useManualFallback(reason: String = "Tap after each small careful step.") {
+        pedometer.stopUpdates()
+        mode = .manualFallback(reason: reason)
+    }
+
+    func addManualStep() {
+        if case .manualFallback = mode {
+            progress.addManualStep()
+        } else if mode == .idle {
+            mode = .manualFallback(reason: "Tap after each small careful step.")
+            progress.addManualStep()
+        }
+    }
+
+    // Exposed for tests and previews so no hardware/permission is required.
+    func applyCountedSteps(_ steps: Int) {
+        progress.setCountedSteps(steps)
+    }
+}

--- a/Tests/MatherTests/CompassAnglesTests.swift
+++ b/Tests/MatherTests/CompassAnglesTests.swift
@@ -118,3 +118,79 @@ struct CompassAnglesTests {
     }
 
 }
+
+@Suite("Compass Walk + Turn sequencing")
+struct CompassWalkTurnTests {
+    @Test func levelsIncludeStepAndTurnInstructions() {
+        #expect(compassWalkTurnLevels.count >= 5)
+        #expect(compassWalkTurnLevels.allSatisfy { $0.steps > 0 })
+        #expect(compassWalkTurnLevels.first?.instruction.contains("small steps") == true)
+        #expect(compassWalkTurnLevels.first?.instruction.contains("turn") == true)
+    }
+
+    @Test func stepProgressCompletesAtRequiredThreshold() {
+        var progress = StepWalkProgress(requiredSteps: 3)
+        #expect(progress.remainingSteps == 3)
+        #expect(!progress.isComplete)
+        progress.setCountedSteps(2)
+        #expect(!progress.isComplete)
+        #expect(progress.remainingSteps == 1)
+        progress.setCountedSteps(3)
+        #expect(progress.isComplete)
+        #expect(progress.fractionComplete == 1)
+    }
+
+    @Test func manualStepFallbackCanCompleteWalk() {
+        var progress = StepWalkProgress(requiredSteps: 2)
+        progress.addManualStep()
+        #expect(!progress.isComplete)
+        progress.addManualStep()
+        #expect(progress.isComplete)
+    }
+
+    @Test func stateMovesFromWalkToTurnAfterSteps() {
+        let level = CompassWalkTurnLevel(id: 99, walkDirection: .forward, steps: 3, targetDeg: 90)
+        var state = CompassWalkTurnState(level: level)
+        #expect(state.phase == .ready)
+        state.startWalking()
+        #expect(state.phase == .walking)
+        state.applyCountedSteps(2)
+        #expect(state.phase == .walking)
+        state.applyCountedSteps(3)
+        #expect(state.phase == .turning)
+    }
+
+    @Test func stateCompletesOnlyAfterTurnSnap() {
+        let level = CompassWalkTurnLevel(id: 100, walkDirection: .left, steps: 2, targetDeg: -90)
+        var state = CompassWalkTurnState(level: level)
+        state.startWalking()
+        state.applyCountedSteps(2)
+        state.applyYaw(-75)
+        #expect(state.phase == .turning)
+        state.applyYaw(-84)
+        #expect(state.phase == .success)
+    }
+
+    @Test func yawBeforeWalkCompletionDoesNotWin() {
+        let level = CompassWalkTurnLevel(id: 101, walkDirection: .right, steps: 4, targetDeg: 180)
+        var state = CompassWalkTurnState(level: level)
+        state.startWalking()
+        state.applyYaw(180)
+        #expect(state.phase == .walking)
+    }
+
+    @MainActor
+    @Test func stepCountServiceManualFallbackStateIsTestableWithoutHardware() {
+        let service = StepCountService()
+        service.start(requiredSteps: 3)
+        service.useManualFallback(reason: "testing fallback")
+        service.addManualStep()
+        service.addManualStep()
+        #expect(service.countedSteps == 2)
+        #expect(!service.isComplete)
+        service.addManualStep()
+        #expect(service.isComplete)
+        service.stop()
+        #expect(service.mode == .idle)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a walk/step phase before each Compass Angles turn so kids complete prompts like “Walk 3 small steps forward, then turn right 90°.” The turn phase keeps the existing relative-yaw snap behavior.

## Changes

- Added walk+turn level model and pure state sequencing for ready → walking → turning → success.
- Added `StepCountService` around `CMPedometer` with simulator/permission manual tap-count fallback.
- Updated Compass UI copy for clear space, small careful steps, and no running.
- Added Motion & Fitness privacy copy for step-count games.
- Added unit coverage for step thresholds, fallback counting, phase sequencing, and turn completion math.

## Testing

- `git diff --check` passed.
- Swift/Xcode tests not run on Linux because this worker has no Swift/Xcode toolchain (`swift: command not found`). Attempted remote Mac validation via SSH, but the host connection timed out, so GitHub CI should run the full Xcode suite.

Fixes ganesh47/mather#872