### PR TITLE
feat: add sound learning loop

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -94,6 +94,8 @@ struct RootView: View {
                     MemoryView(appModel: appModel)
                 case .waterCycle:
                     WaterCycleLabView(appModel: appModel)
+                case .soundVolume:
+                    SoundVolumeLabView(appModel: appModel)
                 }
             }
             .navigationBarTitleDisplayMode(.inline)

--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -174,3 +174,108 @@ enum WaterCycleContent {
         ConceptMatchPair(id: "rain-pond", left: "Rain", right: "Pond", feedback: "Rain fills ponds again.", leftVisualKey: "🌧️", rightVisualKey: "🏞️"),
     ]
 }
+
+
+enum SoundLoudnessZone: String, CaseIterable, Equatable {
+    case quiet
+    case normal
+    case loud
+    case tooLoud
+
+    var label: String {
+        switch self {
+        case .quiet: return "Quiet"
+        case .normal: return "Normal talking"
+        case .loud: return "Loud"
+        case .tooLoud: return "Too loud"
+        }
+    }
+
+    var estimatedRangeLabel: String {
+        switch self {
+        case .quiet: return "about 30–40 dB"
+        case .normal: return "about 55–65 dB"
+        case .loud: return "about 70–85 dB"
+        case .tooLoud: return "90 dB or more"
+        }
+    }
+
+    var safetyCopy: String {
+        switch self {
+        case .quiet:
+            return "Soft sounds are gentle for ears."
+        case .normal:
+            return "Talking voice is a safe middle zone."
+        case .loud:
+            return "Loud places can feel tiring — take breaks."
+        case .tooLoud:
+            return "Move away, lower the volume, or protect your ears."
+        }
+    }
+}
+
+enum SoundVolumeContent {
+    static let safetyNote = "Use listening clues only — no screaming. Protect your ears. A live microphone meter comes later and is not used in this activity."
+
+    static let cards: [LearningConceptCard] = [
+        LearningConceptCard(id: "quiet", title: "Quiet", explanation: "Quiet sounds are soft and gentle, like a whisper or leaves.", visualKey: "🍃", audioPrompt: "Quiet sounds are soft and gentle."),
+        LearningConceptCard(id: "conversation", title: "Conversation", explanation: "A talking voice sits in the middle loudness zone.", visualKey: "💬", audioPrompt: "Conversation is a middle loudness zone."),
+        LearningConceptCard(id: "traffic", title: "Traffic", explanation: "Busy traffic is loud and can turn into noise pollution.", visualKey: "🚗", audioPrompt: "Traffic can be loud and unwanted."),
+        LearningConceptCard(id: "siren", title: "Siren", explanation: "Sirens warn us, but they are very loud. Move away and protect ears.", visualKey: "🚨", audioPrompt: "Sirens are very loud warning sounds."),
+        LearningConceptCard(id: "headphones", title: "Headphones", explanation: "Keep headphones low, take breaks, and never play a volume that hurts.", visualKey: "🎧", audioPrompt: "Headphones should stay low and safe."),
+        LearningConceptCard(id: "pleasant", title: "Pleasant Sound", explanation: "Pleasant sounds feel nice and safe, like birds or soft music.", visualKey: "🐦", audioPrompt: "Pleasant sounds feel nice and safe."),
+        LearningConceptCard(id: "unpleasant", title: "Noisy Sound", explanation: "Noisy sounds feel harsh, distracting, or unwanted.", visualKey: "📣", audioPrompt: "Noisy sounds are unwanted or harsh."),
+        LearningConceptCard(id: "protect-ears", title: "Protect Ears", explanation: "Lower volume, move away, cover ears, or ask a grown-up for help.", visualKey: "👂", audioPrompt: "Protect ears when sound is too loud."),
+    ]
+
+    static let quizQuestions: [ConceptQuizQuestion] = [
+        ConceptQuizQuestion(
+            id: "quiet-example",
+            prompt: "Which sound belongs in the quiet zone?",
+            choices: ["Whisper", "Siren", "Busy traffic"],
+            correctChoice: "Whisper",
+            feedback: "Yes — a whisper is soft and gentle."
+        ),
+        ConceptQuizQuestion(
+            id: "safe-headphones",
+            prompt: "What is the safest headphone choice?",
+            choices: ["Turn it up until it hurts", "Keep volume low and take breaks", "Try to be louder than traffic"],
+            correctChoice: "Keep volume low and take breaks",
+            feedback: "Right — low volume and breaks help protect hearing."
+        ),
+        ConceptQuizQuestion(
+            id: "noise-pollution",
+            prompt: "What does noise pollution mean?",
+            choices: ["Too much unwanted sound", "Only music you like", "A silent room"],
+            correctChoice: "Too much unwanted sound",
+            feedback: "Yes — noise pollution is unwanted sound around us."
+        ),
+        ConceptQuizQuestion(
+            id: "too-loud-action",
+            prompt: "What should you do if a sound hurts your ears?",
+            choices: ["Move away or protect ears", "Make a louder sound", "Stand closer"],
+            correctChoice: "Move away or protect ears",
+            feedback: "Correct — move away, lower volume, or protect ears."
+        ),
+    ]
+
+    static let matchPairs: [ConceptMatchPair] = [
+        ConceptMatchPair(id: "whisper-quiet", left: "Whisper", right: "Quiet", feedback: "A whisper belongs in the quiet zone.", leftVisualKey: "🤫", rightVisualKey: "🍃"),
+        ConceptMatchPair(id: "talk-normal", left: "Friend talking", right: "Conversation", feedback: "Talking voice is a middle loudness clue.", leftVisualKey: "🗣️", rightVisualKey: "💬"),
+        ConceptMatchPair(id: "traffic-loud", left: "Busy road", right: "Traffic noise", feedback: "Busy roads can be loud and distracting.", leftVisualKey: "🚗", rightVisualKey: "📣"),
+        ConceptMatchPair(id: "siren-too-loud", left: "Siren", right: "Protect ears", feedback: "Sirens are useful warnings, but they are too loud up close.", leftVisualKey: "🚨", rightVisualKey: "👂"),
+        ConceptMatchPair(id: "birds-pleasant", left: "Birds", right: "Pleasant sound", feedback: "Birds can be a pleasant, gentle sound.", leftVisualKey: "🐦", rightVisualKey: "😊"),
+        ConceptMatchPair(id: "headphones-safe", left: "Headphones", right: "Keep volume low", feedback: "Low volume and breaks are safer for headphones.", leftVisualKey: "🎧", rightVisualKey: "🔉"),
+    ]
+
+    static let estimatedZones: [SoundLoudnessZone] = [.quiet, .normal, .loud, .tooLoud]
+
+    static func zone(forEstimatedDecibels decibels: Double) -> SoundLoudnessZone {
+        switch decibels {
+        case ..<50: return .quiet
+        case ..<70: return .normal
+        case ..<90: return .loud
+        default: return .tooLoud
+        }
+    }
+}

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -21,6 +21,7 @@ enum AppRoute: Hashable {
     case labLane(CapabilityLaneID)
     case memory
     case waterCycle
+    case soundVolume
 }
 
 @MainActor
@@ -132,6 +133,7 @@ final class VerticalSliceEngine {
     func showLabLane(_ laneID: CapabilityLaneID) { route = .labLane(laneID) }
     func showMemory() { route = .memory }
     func showWaterCycle() { route = .waterCycle }
+    func showSoundVolume() { route = .soundVolume }
 
     func startSession() {
         // Freeze the active theme from the user's current selection — unless a custom

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -548,6 +548,11 @@ struct LabLaneDetailView: View {
                 .font(.system(size: 48, weight: .bold))
                 .foregroundStyle(tint.opacity(0.35))
                 .offset(x: 20, y: 12)
+        case .soundVolume:
+            Image(systemName: "speaker.wave.2.fill")
+                .font(.system(size: 48, weight: .bold))
+                .foregroundStyle(tint.opacity(0.35))
+                .offset(x: 20, y: 12)
         case .memoryMatch:
             Image(systemName: "rectangle.on.rectangle.angled")
                 .font(.system(size: 48, weight: .bold))
@@ -582,7 +587,7 @@ struct LabLaneDetailView: View {
             case .sumSprint:
                 appModel.sumSprintEngine.showDifficultyPick()
             case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
-                 .twoFingerProtractor, .gravityArtist, .compassAngles, .waterCycle, .memoryMatch:
+                 .twoFingerProtractor, .gravityArtist, .compassAngles, .waterCycle, .soundVolume, .memoryMatch:
                 break
             }
         }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -122,6 +122,7 @@ enum LabActivityID: String, CaseIterable, Hashable {
     case gravityArtist
     case compassAngles
     case waterCycle
+    case soundVolume
     case memoryMatch
 }
 
@@ -148,6 +149,8 @@ extension LabActivityID {
             return .compassAngles
         case .waterCycle:
             return .waterCycle
+        case .soundVolume:
+            return .soundVolume
         case .memoryMatch:
             return .memory
         }
@@ -340,7 +343,7 @@ struct LabLaneDetailPresentation: Equatable {
 extension LabActivityID {
     var sensorNeeds: [LabSensorNeed] {
         switch self {
-        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .waterCycle, .memoryMatch:
+        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .waterCycle, .soundVolume, .memoryMatch:
             return [.noSpecialSensor]
         case .symmetryFold, .angleCannon, .gravityArtist:
             return [.motion]
@@ -581,7 +584,7 @@ struct CapabilityLane: Identifiable, Equatable {
         CapabilityLane(
             id: .physics,
             emoji: "🧪",
-            promise: "Predict motion, gravity, water, and cause-and-effect systems.",
+            promise: "Predict motion, gravity, water, sound, and cause-and-effect systems.",
             ageBandHint: "Ages 2–12",
             modes: [.explore, .challenge, .review],
             ageEntries: [
@@ -604,6 +607,13 @@ struct CapabilityLane: Identifiable, Equatable {
                     title: "Water Cycle Lab",
                     tagline: "Predict, make clouds, then rain",
                     modes: [.learn, .explore, .review]
+                ),
+                LabActivity(
+                    id: .soundVolume,
+                    emoji: "🔊",
+                    title: "Sound Lab",
+                    tagline: "Match quiet, noisy, and safe listening clues",
+                    modes: [.learn, .review]
                 ),
             ]
         ),
@@ -718,6 +728,10 @@ struct CapabilityLane: Identifiable, Equatable {
             MixMatchCard(laneID: .physics, concept: "prediction", prompt: "aim higher", match: "lands farther"),
             MixMatchCard(laneID: .physics, concept: "water-cycle", prompt: "sun warms water", match: "evaporation"),
             MixMatchCard(laneID: .physics, concept: "water-cycle", prompt: "cloud gets heavy", match: "rain"),
+            MixMatchCard(laneID: .physics, concept: "sound", prompt: "whisper", match: "quiet"),
+            MixMatchCard(laneID: .physics, concept: "sound", prompt: "busy road", match: "noise pollution"),
+            MixMatchCard(laneID: .physics, concept: "hearing-safety", prompt: "headphones", match: "keep volume low"),
+            MixMatchCard(laneID: .physics, concept: "hearing-safety", prompt: "siren", match: "protect ears"),
             MixMatchCard(laneID: .physics, concept: "float-sink", prompt: "wood block", match: "float"),
             MixMatchCard(laneID: .physics, concept: "balance", prompt: "same weight both sides", match: "level"),
         ],

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -1,3 +1,4 @@
+import Observation
 import SwiftUI
 
 struct LearningCardIntroView: View {
@@ -273,5 +274,187 @@ struct ConceptMixMatchRoundView: View {
         if isMatched { return MatherTheme.accent.opacity(0.75) }
         if isSelected { return MatherTheme.warm }
         return Color.secondary.opacity(0.12)
+    }
+}
+
+struct SoundVolumeLabView: View {
+    @Bindable var appModel: AppModel
+    @State private var answersByQuestionId: [String: String] = [:]
+    @State private var selectedMatchPairId: String?
+    @State private var matchedPairIds: Set<String> = []
+    @State private var feedback = SoundVolumeContent.safetyNote
+
+    private var summary: LearningLoopSummary {
+        LearningLoopScoring.summary(
+            questions: SoundVolumeContent.quizQuestions,
+            answersByQuestionId: answersByQuestionId,
+            matchedPairIds: matchedPairIds,
+            pairs: SoundVolumeContent.matchPairs
+        )
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header
+                    safetyBanner
+                    loudnessZones
+                    LearningCardIntroView(cards: SoundVolumeContent.cards)
+                    ConceptQuizRoundView(
+                        questions: SoundVolumeContent.quizQuestions,
+                        answersByQuestionId: $answersByQuestionId
+                    )
+                    ConceptMixMatchRoundView(
+                        pairs: SoundVolumeContent.matchPairs,
+                        selectedLeft: $selectedMatchPairId,
+                        matchedPairIds: $matchedPairIds,
+                        onFeedback: { feedback = $0 }
+                    )
+                    summaryCard
+                }
+                .padding(.horizontal, horizontalPadding(for: proxy.size.width))
+                .padding(.vertical, 22)
+                .frame(maxWidth: 900)
+                .frame(maxWidth: .infinity)
+            }
+            .background(MatherTheme.background.ignoresSafeArea())
+        }
+        .navigationTitle("Sound Lab")
+        .safeAreaInset(edge: .top) {
+            HStack {
+                Button {
+                    appModel.engine.showLabLane(.physics)
+                } label: {
+                    Label("Physics", systemImage: "chevron.left")
+                        .font(.subheadline.weight(.black))
+                }
+                .buttonStyle(.bordered)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(.thinMaterial)
+        }
+        .onDisappear {
+            if summary.starCount > 0 || matchedPairIds.count == SoundVolumeContent.matchPairs.count {
+                appModel.markExplorerLabModeCompleted(laneID: .physics, mode: .review)
+                appModel.setExplorerLabConceptConfidence(.steady, for: ConceptId(rawValue: "sound-volume"), laneID: .physics)
+            }
+        }
+    }
+
+    private var header: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 12) {
+                    Text("🔊")
+                        .font(.system(size: 58))
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Sound + Volume Lab")
+                            .font(.largeTitle.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                            .minimumScaleFactor(0.75)
+                        Text("Learn quiet, conversation, traffic, sirens, headphones, pleasant sounds, noisy sounds, and hearing safety.")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                    }
+                }
+                Text(feedback)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(MatherTheme.panelDeep)
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(MatherTheme.softBlue.opacity(0.28))
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var safetyBanner: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "ear")
+                .font(.title2.weight(.black))
+                .foregroundStyle(MatherTheme.accent)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Hearing-safe play")
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text("No microphone permission, no live meter, and no loud-noise challenge in this round. Match the clues and choose safe actions.")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
+        }
+        .padding(14)
+        .background(MatherTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .accessibilityElement(children: .combine)
+    }
+
+    private var loudnessZones: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Estimated loudness zones")
+                .font(.title2.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            Text("These are learning examples, not a calibrated sound meter.")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 10)], spacing: 10) {
+                ForEach(SoundVolumeContent.estimatedZones, id: \.self) { zone in
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(zone.label)
+                            .font(.headline.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text(zone.estimatedRangeLabel)
+                            .font(.caption.weight(.black))
+                            .foregroundStyle(MatherTheme.accent)
+                        Text(zone.safetyCopy)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(12)
+                    .frame(maxWidth: .infinity, minHeight: 122, alignment: .topLeading)
+                    .background(zoneFill(zone))
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(zone.label), estimated \(zone.estimatedRangeLabel). \(zone.safetyCopy)")
+                }
+            }
+        }
+    }
+
+    private var summaryCard: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Sound Lab Score")
+                    .font(.title2.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text("Quiz: \(summary.quizCorrect)/\(summary.quizTotal) • Matches: \(summary.matchedPairs)/\(summary.totalPairs) • Stars: \(summary.starCount)")
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                Text("Remember: safe listening beats loud listening.")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.panelDeep)
+            }
+        }
+    }
+
+    private func horizontalPadding(for width: CGFloat) -> CGFloat {
+        width < 420 ? 14 : 24
+    }
+
+    private func zoneFill(_ zone: SoundLoudnessZone) -> Color {
+        switch zone {
+        case .quiet:
+            return MatherTheme.softBlue.opacity(0.22)
+        case .normal:
+            return MatherTheme.accent.opacity(0.14)
+        case .loud:
+            return MatherTheme.warm.opacity(0.24)
+        case .tooLoud:
+            return MatherTheme.coral.opacity(0.20)
+        }
     }
 }

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -100,11 +100,21 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(numbers.activities.map(\.id), [.sumSprint, .rectangleFactory, .factoryCards])
     }
 
+    func testPhysicsLaneAddsSoundLabAsThirdReadyActivity() throws {
+        let physics = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .physics })
+
+        XCTAssertEqual(physics.activities.map(\.id), [.gravityArtist, .waterCycle, .soundVolume])
+        XCTAssertEqual(LabLaneDetailPresentation(lane: physics).activityCountLabel, "3 games ready")
+        XCTAssertTrue(physics.starterMixMatchCards.contains { $0.concept == "sound" && $0.prompt == "whisper" && $0.match == "quiet" })
+        XCTAssertTrue(physics.starterMixMatchCards.contains { $0.concept == "hearing-safety" && $0.prompt == "siren" && $0.match == "protect ears" })
+    }
+
     func testLabLaneRouteCarriesSelectedLaneWithoutChangingGameRoutes() throws {
         XCTAssertEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.geometry))
         XCTAssertNotEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.numbers))
         XCTAssertEqual(LabActivityID.sumSprint.appRoute, .sumSprint)
         XCTAssertEqual(LabActivityID.waterCycle.appRoute, .waterCycle)
+        XCTAssertEqual(LabActivityID.soundVolume.appRoute, .soundVolume)
         XCTAssertEqual(LabActivityID.memoryMatch.appRoute, .memory)
     }
 
@@ -217,6 +227,7 @@ extension LabModelsTests {
         XCTAssertEqual(LabActivityID.gravityArtist.sensorNeeds, [.motion])
         XCTAssertEqual(LabActivityID.compassAngles.sensorNeeds, [.compass])
         XCTAssertEqual(LabActivityID.roomQuest.sensorNeeds, [.cameraMarkerMode, .haptics])
+        XCTAssertEqual(LabActivityID.soundVolume.sensorNeeds, [.noSpecialSensor])
         XCTAssertEqual(LabActivityID.memoryMatch.sensorNeeds, [.noSpecialSensor])
     }
 

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -33,6 +33,7 @@ struct LabRouteRegressionTests {
             .gravityArtist: .gravityArtist,
             .compassAngles: .compassAngles,
             .waterCycle: .waterCycle,
+            .soundVolume: .soundVolume,
             .memoryMatch: .memory,
         ]
 

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -91,3 +91,55 @@ extension LearningLoopTests {
         XCTAssertTrue(WaterCycleContent.matchPairs.allSatisfy { $0.rightVisualKey?.isEmpty == false })
     }
 }
+
+
+extension LearningLoopTests {
+    func testSoundVolumeContentCoversSafeHearingConcepts() {
+        let titles = Set(SoundVolumeContent.cards.map(\.title))
+
+        XCTAssertEqual(SoundVolumeContent.cards.count, 8)
+        XCTAssertTrue(titles.isSuperset(of: [
+            "Quiet",
+            "Conversation",
+            "Traffic",
+            "Siren",
+            "Headphones",
+            "Pleasant Sound",
+            "Noisy Sound",
+            "Protect Ears",
+        ]))
+        XCTAssertTrue(SoundVolumeContent.safetyNote.contains("no screaming"))
+        XCTAssertTrue(SoundVolumeContent.safetyNote.contains("microphone meter comes later"))
+    }
+
+    func testSoundVolumeQuizScoringUsesCorrectSafeAnswers() {
+        let questions = SoundVolumeContent.quizQuestions
+        let answers = Dictionary(uniqueKeysWithValues: questions.map { ($0.id, $0.correctChoice) })
+
+        XCTAssertEqual(questions.count, 4)
+        XCTAssertEqual(LearningLoopScoring.scoreQuiz(questions: questions, answersByQuestionId: answers), questions.count)
+        XCTAssertTrue(questions.contains { $0.correctChoice == "Keep volume low and take breaks" })
+        XCTAssertFalse(questions.flatMap(\.choices).contains { $0.localizedCaseInsensitiveContains("scream") })
+    }
+
+    func testSoundVolumeMatchPairsUsePictureNameVisualKeys() {
+        let pairs = SoundVolumeContent.matchPairs
+        let pairIDs = Set(pairs.map(\.id))
+
+        XCTAssertEqual(pairs.count, 6)
+        XCTAssertTrue(pairIDs.isSuperset(of: ["whisper-quiet", "talk-normal", "traffic-loud", "siren-too-loud", "birds-pleasant", "headphones-safe"]))
+        XCTAssertTrue(pairs.allSatisfy { $0.leftVisualKey?.isEmpty == false })
+        XCTAssertTrue(pairs.allSatisfy { $0.rightVisualKey?.isEmpty == false })
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Siren", right: "Protect ears", pairs: pairs))
+        XCTAssertFalse(LearningLoopScoring.isMatch(left: "Siren", right: "Quiet", pairs: pairs))
+    }
+
+    func testSoundVolumeEstimatedZonesAreExplicitlyEstimatedAndConservative() {
+        XCTAssertEqual(SoundVolumeContent.zone(forEstimatedDecibels: 35), .quiet)
+        XCTAssertEqual(SoundVolumeContent.zone(forEstimatedDecibels: 60), .normal)
+        XCTAssertEqual(SoundVolumeContent.zone(forEstimatedDecibels: 80), .loud)
+        XCTAssertEqual(SoundVolumeContent.zone(forEstimatedDecibels: 95), .tooLoud)
+        XCTAssertTrue(SoundLoudnessZone.tooLoud.safetyCopy.contains("protect your ears"))
+        XCTAssertTrue(SoundLoudnessZone.normal.estimatedRangeLabel.contains("about"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Sound Lab D1 content for quiet/whisper, conversation, traffic, sirens, headphones, pleasant/unpleasant sounds, noise pollution, estimated loudness zones, and hearing safety.
- Reuses the merged #875 learning-loop surface for learn → quiz → Bond-style picture/name matching.
- Registers Sound Lab in the Physics lane with route/model/test coverage.

## Safety / scope
- No microphone permission is requested in this PR.
- No live microphone/decibel meter is implemented here; D2 microphone/estimated loudness meter is intentionally deferred pending runtime/audio validation.
- Copy explicitly avoids loud-noise challenges: no screaming, protect ears, estimated/not calibrated zones only.

## Tests / validation
- `git diff --check`
- Added unit coverage for sound content inventory, quiz correctness, match pairs/visual keys, estimated loudness zones, route mapping, sensor affordance, and Physics lane inventory.
- Linux worker lacks Xcode tooling (`xcodebuild`/`xcodegen` unavailable), so iOS build/tests should run in GitHub CI.

Addresses #871 D1 content loop. D2 microphone/estimated loudness meter deferred pending runtime validation.
