### PR TITLE
feat: add shape geometry learning loop

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -96,6 +96,8 @@ struct RootView: View {
                     WaterCycleLabView(appModel: appModel)
                 case .soundVolume:
                     SoundVolumeLabView(appModel: appModel)
+                case .shapeGeometry:
+                    ShapeGeometryLabView(appModel: appModel)
                 }
             }
             .navigationBarTitleDisplayMode(.inline)

--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -279,3 +279,64 @@ enum SoundVolumeContent {
         }
     }
 }
+
+enum ShapeGeometryContent {
+    struct Level: Identifiable, Equatable {
+        let id: String
+        let title: String
+        let cards: [LearningConceptCard]
+        let quizQuestions: [ConceptQuizQuestion]
+        let matchPairs: [ConceptMatchPair]
+    }
+
+    static let basicCards: [LearningConceptCard] = [
+        LearningConceptCard(id: "circle", title: "Circle", explanation: "A circle is round with no corners or sides.", visualKey: "●", audioPrompt: "Circle is round with no corners."),
+        LearningConceptCard(id: "triangle", title: "Triangle", explanation: "A triangle has three sides and three corners.", visualKey: "▲", audioPrompt: "Triangle has three sides."),
+        LearningConceptCard(id: "square", title: "Square", explanation: "A square has four equal sides and four square corners.", visualKey: "■", audioPrompt: "Square has four equal sides."),
+        LearningConceptCard(id: "rectangle", title: "Rectangle", explanation: "A rectangle has four square corners with opposite sides matching.", visualKey: "▭", audioPrompt: "Rectangle has four square corners."),
+        LearningConceptCard(id: "oval", title: "Oval", explanation: "An oval is stretched like an egg and has no corners.", visualKey: "⬭", audioPrompt: "Oval is a stretched round shape."),
+        LearningConceptCard(id: "diamond", title: "Diamond", explanation: "A diamond is a square turned onto a point.", visualKey: "◆", audioPrompt: "Diamond sits on a point."),
+        LearningConceptCard(id: "star", title: "Star", explanation: "A star has points that reach out from the middle.", visualKey: "★", audioPrompt: "Star has points."),
+        LearningConceptCard(id: "heart", title: "Heart", explanation: "A heart has two bumps on top and one point below.", visualKey: "♥", audioPrompt: "Heart has two bumps and one point."),
+    ]
+
+    static let huntCards: [LearningConceptCard] = [
+        LearningConceptCard(id: "clock", title: "Clock", explanation: "A wall clock can show a circle in the room.", visualKey: "🕘"),
+        LearningConceptCard(id: "pizza", title: "Pizza Slice", explanation: "A pizza slice can look like a triangle.", visualKey: "🍕"),
+        LearningConceptCard(id: "window", title: "Window", explanation: "A window often looks like a rectangle.", visualKey: "🪟"),
+        LearningConceptCard(id: "kite", title: "Kite", explanation: "A kite can look like a diamond in the sky.", visualKey: "🪁"),
+    ]
+
+    static let cards = basicCards
+
+    static let quizQuestions: [ConceptQuizQuestion] = [
+        ConceptQuizQuestion(id: "three-sides", prompt: "Which shape has three sides?", choices: ["Triangle", "Circle", "Oval"], correctChoice: "Triangle", feedback: "Yes — a triangle has three sides."),
+        ConceptQuizQuestion(id: "no-corners", prompt: "Which shape is round with no corners?", choices: ["Circle", "Square", "Diamond"], correctChoice: "Circle", feedback: "Correct — circles have no corners."),
+        ConceptQuizQuestion(id: "four-equal-sides", prompt: "Which shape has four equal sides?", choices: ["Square", "Rectangle", "Heart"], correctChoice: "Square", feedback: "Yes — every side of a square matches."),
+        ConceptQuizQuestion(id: "two-bumps", prompt: "Which shape has two bumps on top and one point below?", choices: ["Heart", "Star", "Oval"], correctChoice: "Heart", feedback: "Right — that is the heart outline clue."),
+    ]
+
+    static let matchPairs: [ConceptMatchPair] = [
+        ConceptMatchPair(id: "circle-round", left: "Circle picture", right: "Circle", feedback: "Circle locked — round with no corners.", leftVisualKey: "●", rightVisualKey: "⭕"),
+        ConceptMatchPair(id: "triangle-three", left: "Triangle picture", right: "Triangle", feedback: "Triangle locked — three sides.", leftVisualKey: "▲", rightVisualKey: "3"),
+        ConceptMatchPair(id: "square-equal", left: "Square picture", right: "Square", feedback: "Square locked — four equal sides.", leftVisualKey: "■", rightVisualKey: "4"),
+        ConceptMatchPair(id: "rectangle-long", left: "Rectangle picture", right: "Rectangle", feedback: "Rectangle locked — long box shape.", leftVisualKey: "▭", rightVisualKey: "▭"),
+        ConceptMatchPair(id: "oval-egg", left: "Oval picture", right: "Oval", feedback: "Oval locked — stretched round shape.", leftVisualKey: "⬭", rightVisualKey: "🥚"),
+        ConceptMatchPair(id: "diamond-point", left: "Diamond picture", right: "Diamond", feedback: "Diamond locked — point on top and bottom.", leftVisualKey: "◆", rightVisualKey: "💎"),
+    ]
+
+    static let huntMatchPairs: [ConceptMatchPair] = [
+        ConceptMatchPair(id: "clock-circle", left: "Clock", right: "Circle", feedback: "A clock can show a circle.", leftVisualKey: "🕘", rightVisualKey: "●"),
+        ConceptMatchPair(id: "pizza-triangle", left: "Pizza slice", right: "Triangle", feedback: "A pizza slice can show a triangle.", leftVisualKey: "🍕", rightVisualKey: "▲"),
+        ConceptMatchPair(id: "window-rectangle", left: "Window", right: "Rectangle", feedback: "A window can show a rectangle.", leftVisualKey: "🪟", rightVisualKey: "▭"),
+        ConceptMatchPair(id: "kite-diamond", left: "Kite", right: "Diamond", feedback: "A kite can show a diamond.", leftVisualKey: "🪁", rightVisualKey: "◆"),
+    ]
+
+    static let levels: [Level] = [
+        Level(id: "shape-names", title: "Level 1: Shape names", cards: basicCards, quizQuestions: quizQuestions, matchPairs: matchPairs),
+        Level(id: "shape-hunt", title: "Level 2: Shape hunt", cards: huntCards, quizQuestions: [
+            ConceptQuizQuestion(id: "clock-shape", prompt: "What shape can a clock show?", choices: ["Circle", "Triangle", "Star"], correctChoice: "Circle", feedback: "Yes — many clocks are circles."),
+            ConceptQuizQuestion(id: "kite-shape", prompt: "What shape can a kite show?", choices: ["Diamond", "Oval", "Heart"], correctChoice: "Diamond", feedback: "Correct — a kite can look like a diamond."),
+        ], matchPairs: huntMatchPairs),
+    ]
+}

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -22,6 +22,7 @@ enum AppRoute: Hashable {
     case memory
     case waterCycle
     case soundVolume
+    case shapeGeometry
 }
 
 @MainActor
@@ -134,6 +135,7 @@ final class VerticalSliceEngine {
     func showMemory() { route = .memory }
     func showWaterCycle() { route = .waterCycle }
     func showSoundVolume() { route = .soundVolume }
+    func showShapeGeometry() { route = .shapeGeometry }
 
     func startSession() {
         // Freeze the active theme from the user's current selection — unless a custom

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -543,6 +543,11 @@ struct LabLaneDetailView: View {
                 .font(.system(size: 52, weight: .bold))
                 .foregroundStyle(tint.opacity(0.35))
                 .offset(x: 20, y: 12)
+        case .shapeGeometry:
+            Image(systemName: "diamond.fill")
+                .font(.system(size: 48, weight: .bold))
+                .foregroundStyle(tint.opacity(0.35))
+                .offset(x: 20, y: 12)
         case .waterCycle:
             Image(systemName: "cloud.rain.fill")
                 .font(.system(size: 48, weight: .bold))
@@ -587,7 +592,7 @@ struct LabLaneDetailView: View {
             case .sumSprint:
                 appModel.sumSprintEngine.showDifficultyPick()
             case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
-                 .twoFingerProtractor, .gravityArtist, .compassAngles, .waterCycle, .soundVolume, .memoryMatch:
+                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
                 break
             }
         }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -121,6 +121,7 @@ enum LabActivityID: String, CaseIterable, Hashable {
     case twoFingerProtractor
     case gravityArtist
     case compassAngles
+    case shapeGeometry
     case waterCycle
     case soundVolume
     case memoryMatch
@@ -147,6 +148,8 @@ extension LabActivityID {
             return .gravityArtist
         case .compassAngles:
             return .compassAngles
+        case .shapeGeometry:
+            return .shapeGeometry
         case .waterCycle:
             return .waterCycle
         case .soundVolume:
@@ -343,7 +346,7 @@ struct LabLaneDetailPresentation: Equatable {
 extension LabActivityID {
     var sensorNeeds: [LabSensorNeed] {
         switch self {
-        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .waterCycle, .soundVolume, .memoryMatch:
+        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
             return [.noSpecialSensor]
         case .symmetryFold, .angleCannon, .gravityArtist:
             return [.motion]
@@ -558,6 +561,13 @@ struct CapabilityLane: Identifiable, Equatable {
                 CapabilityAgeEntry(ageBand: .preteen, posture: "systems and coordinates", entryPlay: "puzzle challenges"),
             ],
             activities: [
+                LabActivity(
+                    id: .shapeGeometry,
+                    emoji: "🔷",
+                    title: "Shape Lab",
+                    tagline: "Learn shape names, clues, and picture matches",
+                    modes: [.learn, .review]
+                ),
                 LabActivity(
                     id: .symmetryFold,
                     emoji: "🪞",

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -458,3 +458,139 @@ struct SoundVolumeLabView: View {
         }
     }
 }
+
+struct ShapeGeometryLabView: View {
+    @Bindable var appModel: AppModel
+    @State private var levelIndex = 0
+    @State private var answersByQuestionId: [String: String] = [:]
+    @State private var selectedMatchPairId: String?
+    @State private var matchedPairIds: Set<String> = []
+    @State private var feedback = "Start with shape cards, then match each picture to its name."
+
+    private var level: ShapeGeometryContent.Level {
+        ShapeGeometryContent.levels[levelIndex]
+    }
+
+    private var summary: LearningLoopSummary {
+        LearningLoopScoring.summary(
+            questions: level.quizQuestions,
+            answersByQuestionId: answersByQuestionId,
+            matchedPairIds: matchedPairIds,
+            pairs: level.matchPairs
+        )
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header
+                    levelPicker
+                    LearningCardIntroView(cards: level.cards)
+                    ConceptQuizRoundView(questions: level.quizQuestions, answersByQuestionId: $answersByQuestionId)
+                    ConceptMixMatchRoundView(
+                        pairs: level.matchPairs,
+                        selectedLeft: $selectedMatchPairId,
+                        matchedPairIds: $matchedPairIds,
+                        onFeedback: { feedback = $0 }
+                    )
+                    summaryCard
+                }
+                .padding(.horizontal, proxy.size.width < 420 ? 14 : 24)
+                .padding(.vertical, 22)
+                .frame(maxWidth: 900)
+                .frame(maxWidth: .infinity)
+            }
+            .background(MatherTheme.background.ignoresSafeArea())
+        }
+        .navigationTitle("Shape Lab")
+        .safeAreaInset(edge: .top) {
+            HStack {
+                Button { appModel.engine.showLabLane(.geometry) } label: {
+                    Label("Geometry", systemImage: "chevron.left")
+                        .font(.subheadline.weight(.black))
+                }
+                .buttonStyle(.bordered)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(.thinMaterial)
+        }
+        .onDisappear {
+            if summary.starCount > 0 || matchedPairIds.count == level.matchPairs.count {
+                appModel.markExplorerLabModeCompleted(laneID: .geometry, mode: .review)
+                appModel.setExplorerLabConceptConfidence(.steady, for: ConceptId(rawValue: "shape-names"), laneID: .geometry)
+            }
+        }
+    }
+
+    private var header: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 12) {
+                    Text("🔷")
+                        .font(.system(size: 58))
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Shape Names Lab")
+                            .font(.largeTitle.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                            .minimumScaleFactor(0.75)
+                        Text("Learn circles, triangles, squares, rectangles, ovals, stars, hearts, and diamonds — then play Bond Blast-style matches.")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                    }
+                }
+                Text(feedback)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(MatherTheme.panelDeep)
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(MatherTheme.softBlue.opacity(0.28))
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var levelPicker: some View {
+        HStack(spacing: 10) {
+            ForEach(Array(ShapeGeometryContent.levels.enumerated()), id: \.element.id) { index, level in
+                Button {
+                    levelIndex = index
+                    answersByQuestionId = [:]
+                    selectedMatchPairId = nil
+                    matchedPairIds = []
+                    feedback = "Now playing \(level.title)."
+                } label: {
+                    Text(level.title)
+                        .font(.subheadline.weight(.black))
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 12)
+                        .frame(maxWidth: .infinity)
+                        .background(index == levelIndex ? MatherTheme.accent.opacity(0.26) : MatherTheme.card)
+                        .foregroundStyle(MatherTheme.ink)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .accessibilityLabel("Shape Lab level picker")
+    }
+
+    private var summaryCard: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Shape Score")
+                    .font(.title2.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text("Quiz: \(summary.quizCorrect)/\(summary.quizTotal) • Matches: \(summary.matchedPairs)/\(summary.totalPairs) • Stars: \(summary.starCount)")
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                Text(summary.starCount >= 2 ? "Shape detective mode unlocked." : "Try another level or match again.")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.panelDeep)
+            }
+        }
+    }
+}

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -113,6 +113,7 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.geometry))
         XCTAssertNotEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.numbers))
         XCTAssertEqual(LabActivityID.sumSprint.appRoute, .sumSprint)
+        XCTAssertEqual(LabActivityID.shapeGeometry.appRoute, .shapeGeometry)
         XCTAssertEqual(LabActivityID.waterCycle.appRoute, .waterCycle)
         XCTAssertEqual(LabActivityID.soundVolume.appRoute, .soundVolume)
         XCTAssertEqual(LabActivityID.memoryMatch.appRoute, .memory)
@@ -137,15 +138,15 @@ extension LabModelsTests {
         let geometry = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .geometry })
         var sampler = geometry.starterMixMatchSampler
 
-        XCTAssertEqual(sampler.progressLabel, "1 / 8")
+        XCTAssertEqual(sampler.progressLabel, "1 / \(geometry.starterMixMatchCards.count)")
         XCTAssertEqual(sampler.currentCard?.prompt, "3 sides")
 
         sampler.advance()
-        XCTAssertEqual(sampler.progressLabel, "2 / 8")
+        XCTAssertEqual(sampler.progressLabel, "2 / \(geometry.starterMixMatchCards.count)")
         XCTAssertEqual(sampler.currentCard?.prompt, "4 equal sides")
 
         sampler.rewind()
-        XCTAssertEqual(sampler.progressLabel, "1 / 8")
+        XCTAssertEqual(sampler.progressLabel, "1 / \(geometry.starterMixMatchCards.count)")
     }
 
 
@@ -223,6 +224,7 @@ extension LabModelsTests {
 
     func testActivitySensorNeedsMapToHonestLaneAffordances() {
         XCTAssertEqual(LabActivityID.sumSprint.sensorNeeds, [.noSpecialSensor])
+        XCTAssertEqual(LabActivityID.shapeGeometry.sensorNeeds, [.noSpecialSensor])
         XCTAssertEqual(LabActivityID.angleCannon.sensorNeeds, [.motion])
         XCTAssertEqual(LabActivityID.gravityArtist.sensorNeeds, [.motion])
         XCTAssertEqual(LabActivityID.compassAngles.sensorNeeds, [.compass])

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -32,6 +32,7 @@ struct LabRouteRegressionTests {
             .twoFingerProtractor: .twoFingerProtractor,
             .gravityArtist: .gravityArtist,
             .compassAngles: .compassAngles,
+            .shapeGeometry: .shapeGeometry,
             .waterCycle: .waterCycle,
             .soundVolume: .soundVolume,
             .memoryMatch: .memory,

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -142,4 +142,58 @@ extension LearningLoopTests {
         XCTAssertTrue(SoundLoudnessZone.tooLoud.safetyCopy.contains("protect your ears"))
         XCTAssertTrue(SoundLoudnessZone.normal.estimatedRangeLabel.contains("about"))
     }
+    func testShapeGeometryContentCoversExpectedCardsAndLevels() {
+        let titles = Set(ShapeGeometryContent.cards.map(\.title))
+        XCTAssertEqual(ShapeGeometryContent.cards.count, 8)
+        XCTAssertTrue(titles.isSuperset(of: ["Circle", "Triangle", "Square", "Rectangle", "Oval", "Star", "Heart", "Diamond"]))
+        XCTAssertEqual(ShapeGeometryContent.levels.count, 2)
+        XCTAssertTrue(ShapeGeometryContent.levels.allSatisfy { !$0.cards.isEmpty && !$0.matchPairs.isEmpty })
+    }
+    func testShapeGeometryQuizScoringUsesCorrectAnswers() {
+        let questions = ShapeGeometryContent.quizQuestions
+        let answers = Dictionary(uniqueKeysWithValues: questions.map { ($0.id, $0.correctChoice) })
+        XCTAssertEqual(LearningLoopScoring.scoreQuiz(questions: questions, answersByQuestionId: answers), questions.count)
+    }
+    func testShapeGeometryPairMatchingRequiresDefinedShapeNamePair() {
+        let pairs = ShapeGeometryContent.matchPairs
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Triangle picture", right: "Triangle", pairs: pairs))
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Circle picture", right: "Circle", pairs: pairs))
+        XCTAssertFalse(LearningLoopScoring.isMatch(left: "Triangle picture", right: "Circle", pairs: pairs))
+        XCTAssertTrue(pairs.allSatisfy { $0.leftVisualKey?.isEmpty == false && $0.rightVisualKey?.isEmpty == false })
+    }
+    func testShapeHuntLevelMatchesObjectsToShapeNames() {
+        let pairs = ShapeGeometryContent.huntMatchPairs
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Clock", right: "Circle", pairs: pairs))
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Kite", right: "Diamond", pairs: pairs))
+    }
+}
+
+extension LearningLoopTests {
+    func testShapeGeometryContentCoversExpectedCardsAndLevels() {
+        let titles = Set(ShapeGeometryContent.cards.map(\.title))
+        XCTAssertEqual(ShapeGeometryContent.cards.count, 8)
+        XCTAssertTrue(titles.isSuperset(of: ["Circle", "Triangle", "Square", "Rectangle", "Oval", "Star", "Heart", "Diamond"]))
+        XCTAssertEqual(ShapeGeometryContent.levels.count, 2)
+        XCTAssertTrue(ShapeGeometryContent.levels.allSatisfy { !$0.cards.isEmpty && !$0.matchPairs.isEmpty })
+    }
+
+    func testShapeGeometryQuizScoringUsesCorrectAnswers() {
+        let questions = ShapeGeometryContent.quizQuestions
+        let answers = Dictionary(uniqueKeysWithValues: questions.map { ($0.id, $0.correctChoice) })
+        XCTAssertEqual(LearningLoopScoring.scoreQuiz(questions: questions, answersByQuestionId: answers), questions.count)
+    }
+
+    func testShapeGeometryPairMatchingRequiresDefinedShapeNamePair() {
+        let pairs = ShapeGeometryContent.matchPairs
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Triangle picture", right: "Triangle", pairs: pairs))
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Circle picture", right: "Circle", pairs: pairs))
+        XCTAssertFalse(LearningLoopScoring.isMatch(left: "Triangle picture", right: "Circle", pairs: pairs))
+        XCTAssertTrue(pairs.allSatisfy { $0.leftVisualKey?.isEmpty == false && $0.rightVisualKey?.isEmpty == false })
+    }
+
+    func testShapeHuntLevelMatchesObjectsToShapeNames() {
+        let pairs = ShapeGeometryContent.huntMatchPairs
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Clock", right: "Circle", pairs: pairs))
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Kite", right: "Diamond", pairs: pairs))
+    }
 }


### PR DESCRIPTION
## Summary
- Reopens the #873 shape-learning slice on top of current main after the original PR was closed while main already contained sound-loop work.
- Adds Shape Lab levels with flashcards, quiz questions, and Bond Blast-style picture/name matching.
- Registers Shape Lab in Geometry routing/lab inventory and keeps the sampler test flexible for the expanded geometry card deck.

## Tests / validation
- git diff --check
- GitHub CI should run Build & Test / CodeQL / Dependency Review.

Closes #873.