### PR TITLE
feat: add shape geometry learning loop

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -82,6 +82,8 @@ struct RootView: View {
                     AngleCannonView(appModel: appModel)
                 case .twoFingerProtractor:
                     TwoFingerProtractorView(appModel: appModel)
+                case .shapeGeometry:
+                    ShapeGeometryLabView(appModel: appModel)
                 case .gravityArtist:
                     GravityArtistView(appModel: appModel)
                 case .compassAngles:

--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -279,3 +279,76 @@ enum SoundVolumeContent {
         }
     }
 }
+
+struct ShapeGeometryLevel: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let cardIDs: [String]
+
+    func cards(from deck: [LearningConceptCard]) -> [LearningConceptCard] {
+        cardIDs.compactMap { id in deck.first { $0.id == id } }
+    }
+
+    func quizQuestions(from questions: [ConceptQuizQuestion]) -> [ConceptQuizQuestion] {
+        questions.filter { cardIDs.contains($0.id.replacingOccurrences(of: "shape-quiz-", with: "")) }
+    }
+
+    func matchPairs(from pairs: [ConceptMatchPair]) -> [ConceptMatchPair] {
+        pairs.filter { cardIDs.contains($0.id.replacingOccurrences(of: "shape-match-", with: "")) }
+    }
+}
+
+enum ShapeGeometryContent {
+    static let cards: [LearningConceptCard] = [
+        LearningConceptCard(id: "circle", title: "Circle", explanation: "A circle is round. It has no corners and no straight sides.", visualKey: "⚪", audioPrompt: "Circle is round with no corners."),
+        LearningConceptCard(id: "triangle", title: "Triangle", explanation: "A triangle has 3 straight sides and 3 corners.", visualKey: "🔺", audioPrompt: "Triangle has three sides."),
+        LearningConceptCard(id: "square", title: "Square", explanation: "A square has 4 equal sides and 4 square corners.", visualKey: "◼️", audioPrompt: "Square has four equal sides."),
+        LearningConceptCard(id: "rectangle", title: "Rectangle", explanation: "A rectangle has 4 straight sides and 4 square corners. Opposite sides match.", visualKey: "▭", audioPrompt: "Rectangle has four square corners."),
+        LearningConceptCard(id: "oval", title: "Oval", explanation: "An oval is round and stretched like an egg. It has no corners.", visualKey: "🥚", audioPrompt: "Oval is a stretched circle shape."),
+        LearningConceptCard(id: "diamond", title: "Diamond", explanation: "A diamond has 4 sides and stands on a point.", visualKey: "💎", audioPrompt: "Diamond stands on a point."),
+        LearningConceptCard(id: "star", title: "Star", explanation: "A star has points that stick out around the shape.", visualKey: "⭐", audioPrompt: "Star has points."),
+        LearningConceptCard(id: "heart", title: "Heart", explanation: "A heart has two rounded bumps and a point at the bottom.", visualKey: "❤️", audioPrompt: "Heart has two bumps and a point."),
+    ]
+
+    static let levels: [ShapeGeometryLevel] = [
+        ShapeGeometryLevel(
+            id: "basic-shapes",
+            title: "Level 1: Shape starters",
+            subtitle: "Circle, triangle, square, and rectangle",
+            cardIDs: ["circle", "triangle", "square", "rectangle"]
+        ),
+        ShapeGeometryLevel(
+            id: "expanded-shapes",
+            title: "Level 2: More shapes",
+            subtitle: "Oval, diamond, star, and heart",
+            cardIDs: ["oval", "diamond", "star", "heart"]
+        ),
+    ]
+
+    static let quizQuestions: [ConceptQuizQuestion] = [
+        ConceptQuizQuestion(id: "shape-quiz-circle", prompt: "Which shape is round with no corners?", choices: ["Circle", "Triangle", "Rectangle"], correctChoice: "Circle", feedback: "Yes — a circle is round with no corners."),
+        ConceptQuizQuestion(id: "shape-quiz-triangle", prompt: "Which shape has 3 straight sides?", choices: ["Square", "Triangle", "Oval"], correctChoice: "Triangle", feedback: "Triangle means 3 sides and 3 corners."),
+        ConceptQuizQuestion(id: "shape-quiz-square", prompt: "Which shape has 4 equal sides?", choices: ["Square", "Heart", "Oval"], correctChoice: "Square", feedback: "A square has four equal sides."),
+        ConceptQuizQuestion(id: "shape-quiz-rectangle", prompt: "Which shape has 4 square corners and opposite sides that match?", choices: ["Circle", "Rectangle", "Star"], correctChoice: "Rectangle", feedback: "A rectangle has four square corners."),
+        ConceptQuizQuestion(id: "shape-quiz-oval", prompt: "Which shape is stretched and round like an egg?", choices: ["Oval", "Diamond", "Triangle"], correctChoice: "Oval", feedback: "An oval is a stretched round shape."),
+        ConceptQuizQuestion(id: "shape-quiz-diamond", prompt: "Which shape stands on a point?", choices: ["Heart", "Diamond", "Circle"], correctChoice: "Diamond", feedback: "A diamond has four sides and a point at top and bottom."),
+        ConceptQuizQuestion(id: "shape-quiz-star", prompt: "Which shape has points sticking out?", choices: ["Star", "Oval", "Rectangle"], correctChoice: "Star", feedback: "A star has points around it."),
+        ConceptQuizQuestion(id: "shape-quiz-heart", prompt: "Which shape has two rounded bumps and one bottom point?", choices: ["Triangle", "Heart", "Square"], correctChoice: "Heart", feedback: "A heart has two rounded bumps and a bottom point."),
+    ]
+
+    static let matchPairs: [ConceptMatchPair] = cards.map { card in
+        ConceptMatchPair(
+            id: "shape-match-\(card.id)",
+            left: card.title,
+            right: card.title,
+            feedback: "Locked: \(card.title) matches its name.",
+            leftVisualKey: card.visualKey,
+            rightVisualKey: nil
+        )
+    }
+
+    static func level(withID id: String) -> ShapeGeometryLevel? {
+        levels.first { $0.id == id }
+    }
+}

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -15,6 +15,7 @@ enum AppRoute: Hashable {
     case factoryCards
     case angleCannon
     case twoFingerProtractor
+    case shapeGeometry
     case gravityArtist
     case compassAngles
     case lab
@@ -127,6 +128,7 @@ final class VerticalSliceEngine {
     func showFactoryCards() { route = .factoryCards }
     func showAngleCannon() { route = .angleCannon }
     func showTwoFingerProtractor() { route = .twoFingerProtractor }
+    func showShapeGeometry() { route = .shapeGeometry }
     func showGravityArtist() { route = .gravityArtist }
     func showCompassAngles() { route = .compassAngles }
     func showLab() { route = .lab }

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -525,6 +525,11 @@ struct LabLaneDetailView: View {
                 .font(.system(size: 52, weight: .bold))
                 .foregroundStyle(tint.opacity(0.35))
                 .offset(x: 18, y: 12)
+        case .shapeGeometry:
+            Image(systemName: "square.on.circle")
+                .font(.system(size: 52, weight: .bold))
+                .foregroundStyle(tint.opacity(0.35))
+                .offset(x: 20, y: 12)
         case .rectangleFactory, .factoryCards:
             Grid(horizontalSpacing: 3, verticalSpacing: 3) {
                 ForEach(0..<2, id: \.self) { _ in
@@ -587,7 +592,7 @@ struct LabLaneDetailView: View {
             case .sumSprint:
                 appModel.sumSprintEngine.showDifficultyPick()
             case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
-                 .twoFingerProtractor, .gravityArtist, .compassAngles, .waterCycle, .soundVolume, .memoryMatch:
+                 .twoFingerProtractor, .shapeGeometry, .gravityArtist, .compassAngles, .waterCycle, .soundVolume, .memoryMatch:
                 break
             }
         }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -119,6 +119,7 @@ enum LabActivityID: String, CaseIterable, Hashable {
     case factoryCards
     case angleCannon
     case twoFingerProtractor
+    case shapeGeometry
     case gravityArtist
     case compassAngles
     case waterCycle
@@ -143,6 +144,8 @@ extension LabActivityID {
             return .angleCannon
         case .twoFingerProtractor:
             return .twoFingerProtractor
+        case .shapeGeometry:
+            return .shapeGeometry
         case .gravityArtist:
             return .gravityArtist
         case .compassAngles:
@@ -343,7 +346,7 @@ struct LabLaneDetailPresentation: Equatable {
 extension LabActivityID {
     var sensorNeeds: [LabSensorNeed] {
         switch self {
-        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .waterCycle, .soundVolume, .memoryMatch:
+        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
             return [.noSpecialSensor]
         case .symmetryFold, .angleCannon, .gravityArtist:
             return [.motion]
@@ -578,6 +581,13 @@ struct CapabilityLane: Identifiable, Equatable {
                     title: "Protractor",
                     tagline: "Spread two fingers to measure angles",
                     modes: [.learn, .explore]
+                ),
+                LabActivity(
+                    id: .shapeGeometry,
+                    emoji: "🔷",
+                    title: "Shape Cards",
+                    tagline: "Learn shapes, quiz, then match pictures and names",
+                    modes: [.learn, .review, .challenge]
                 ),
             ]
         ),

--- a/Features/ShapeGeometry/ShapeGeometryLabView.swift
+++ b/Features/ShapeGeometry/ShapeGeometryLabView.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+
+struct ShapeGeometryLabView: View {
+    @Bindable var appModel: AppModel
+
+    @State private var selectedLevelIndex = 0
+    @State private var answersByQuestionId: [String: String] = [:]
+    @State private var selectedLeft: String?
+    @State private var matchedPairIds: Set<String> = []
+    @State private var feedback = "Pick a level, learn the shape cards, then match each picture to its name."
+
+    private var level: ShapeGeometryLevel {
+        ShapeGeometryContent.levels[selectedLevelIndex]
+    }
+
+    private var levelCards: [LearningConceptCard] {
+        level.cards(from: ShapeGeometryContent.cards)
+    }
+
+    private var levelQuestions: [ConceptQuizQuestion] {
+        level.quizQuestions(from: ShapeGeometryContent.quizQuestions)
+    }
+
+    private var levelPairs: [ConceptMatchPair] {
+        level.matchPairs(from: ShapeGeometryContent.matchPairs)
+    }
+
+    private var quizCorrect: Int {
+        LearningLoopScoring.scoreQuiz(questions: levelQuestions, answersByQuestionId: answersByQuestionId)
+    }
+
+    private var summary: LearningLoopSummary {
+        LearningLoopScoring.summary(
+            questions: levelQuestions,
+            answersByQuestionId: answersByQuestionId,
+            matchedPairIds: matchedPairIds,
+            pairs: levelPairs
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            MatherTheme.background.ignoresSafeArea()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header
+                    levelPicker
+                    LearningCardIntroView(cards: levelCards)
+                    ConceptQuizRoundView(questions: levelQuestions, answersByQuestionId: $answersByQuestionId)
+                    ConceptMixMatchRoundView(
+                        pairs: levelPairs,
+                        selectedLeft: $selectedLeft,
+                        matchedPairIds: $matchedPairIds,
+                        onFeedback: { feedback = $0 }
+                    )
+                    summaryCard
+                }
+                .padding(24)
+            }
+        }
+        .navigationTitle("Shape Cards")
+        .onChange(of: selectedLevelIndex) { _, _ in
+            resetLevelState()
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                Button {
+                    appModel.engine.showLabLane(.geometry)
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.title3.weight(.black))
+                        .foregroundStyle(MatherTheme.coral)
+                        .frame(width: 64, height: 64)
+                        .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Back to Geometry Lab")
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Shape Cards")
+                        .font(.system(size: 34, weight: .black, design: .rounded))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text("Learn common shapes, answer quick questions, then lock picture/name pairs.")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                }
+            }
+
+            Text(feedback)
+                .font(.headline.weight(.bold))
+                .foregroundStyle(MatherTheme.ink)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+                .background(MatherTheme.coral.opacity(0.12), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        }
+        .padding(16)
+        .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Shape Cards. Geometry learning loop. \(feedback)")
+    }
+
+    private var levelPicker: some View {
+        HStack(spacing: 10) {
+            ForEach(Array(ShapeGeometryContent.levels.enumerated()), id: \.element.id) { index, candidate in
+                Button {
+                    selectedLevelIndex = index
+                } label: {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(candidate.title)
+                            .font(.headline.weight(.black))
+                        Text(candidate.subtitle)
+                            .font(.caption.weight(.semibold))
+                            .lineLimit(2)
+                    }
+                    .foregroundStyle(MatherTheme.ink)
+                    .frame(maxWidth: .infinity, minHeight: 86, alignment: .leading)
+                    .padding(12)
+                    .background(index == selectedLevelIndex ? MatherTheme.coral.opacity(0.22) : MatherTheme.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 18, style: .continuous)
+                            .stroke(index == selectedLevelIndex ? MatherTheme.coral : Color.secondary.opacity(0.12), lineWidth: index == selectedLevelIndex ? 2 : 1)
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Select \(candidate.title). \(candidate.subtitle)")
+            }
+        }
+    }
+
+    private var summaryCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Level progress")
+                .font(.title3.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            Text("Quiz \(quizCorrect)/\(levelQuestions.count) • Matches \(matchedPairIds.count)/\(levelPairs.count) • Stars \(summary.starCount)")
+                .font(.headline.weight(.bold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+            if matchedPairIds.count == levelPairs.count {
+                Button {
+                    if selectedLevelIndex < ShapeGeometryContent.levels.count - 1 {
+                        selectedLevelIndex += 1
+                    } else {
+                        resetLevelState()
+                    }
+                } label: {
+                    Label(selectedLevelIndex < ShapeGeometryContent.levels.count - 1 ? "Try Level 2" : "Practice again", systemImage: "arrow.right.circle.fill")
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity, minHeight: 56)
+                        .background(MatherTheme.coral, in: Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(16)
+        .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .accessibilityElement(children: .combine)
+    }
+
+    private func resetLevelState() {
+        answersByQuestionId = [:]
+        selectedLeft = nil
+        matchedPairIds = []
+        feedback = "Level \(selectedLevelIndex + 1) ready: learn, quiz, then match the shape pictures to names."
+    }
+}

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -98,6 +98,10 @@ final class LabModelsTests: XCTestCase {
         XCTAssertTrue(presentation.sections.contains(.recall))
         XCTAssertTrue(presentation.sections.contains(.activities))
         XCTAssertEqual(numbers.activities.map(\.id), [.sumSprint, .rectangleFactory, .factoryCards])
+
+        let geometry = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .geometry })
+        XCTAssertEqual(LabLaneDetailPresentation(lane: geometry).activityCountLabel, "4 games ready")
+        XCTAssertEqual(geometry.activities.map(\.id), [.symmetryFold, .angleCannon, .twoFingerProtractor, .shapeGeometry])
     }
 
     func testPhysicsLaneAddsSoundLabAsThirdReadyActivity() throws {
@@ -114,6 +118,7 @@ final class LabModelsTests: XCTestCase {
         XCTAssertNotEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.numbers))
         XCTAssertEqual(LabActivityID.sumSprint.appRoute, .sumSprint)
         XCTAssertEqual(LabActivityID.waterCycle.appRoute, .waterCycle)
+        XCTAssertEqual(LabActivityID.shapeGeometry.appRoute, .shapeGeometry)
         XCTAssertEqual(LabActivityID.soundVolume.appRoute, .soundVolume)
         XCTAssertEqual(LabActivityID.memoryMatch.appRoute, .memory)
     }
@@ -137,15 +142,17 @@ extension LabModelsTests {
         let geometry = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .geometry })
         var sampler = geometry.starterMixMatchSampler
 
-        XCTAssertEqual(sampler.progressLabel, "1 / 8")
+        let totalCards = geometry.starterMixMatchCards.count
+
+        XCTAssertEqual(sampler.progressLabel, "1 / \(totalCards)")
         XCTAssertEqual(sampler.currentCard?.prompt, "3 sides")
 
         sampler.advance()
-        XCTAssertEqual(sampler.progressLabel, "2 / 8")
+        XCTAssertEqual(sampler.progressLabel, "2 / \(totalCards)")
         XCTAssertEqual(sampler.currentCard?.prompt, "4 equal sides")
 
         sampler.rewind()
-        XCTAssertEqual(sampler.progressLabel, "1 / 8")
+        XCTAssertEqual(sampler.progressLabel, "1 / \(totalCards)")
     }
 
 
@@ -227,6 +234,7 @@ extension LabModelsTests {
         XCTAssertEqual(LabActivityID.gravityArtist.sensorNeeds, [.motion])
         XCTAssertEqual(LabActivityID.compassAngles.sensorNeeds, [.compass])
         XCTAssertEqual(LabActivityID.roomQuest.sensorNeeds, [.cameraMarkerMode, .haptics])
+        XCTAssertEqual(LabActivityID.shapeGeometry.sensorNeeds, [.noSpecialSensor])
         XCTAssertEqual(LabActivityID.soundVolume.sensorNeeds, [.noSpecialSensor])
         XCTAssertEqual(LabActivityID.memoryMatch.sensorNeeds, [.noSpecialSensor])
     }

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -30,6 +30,7 @@ struct LabRouteRegressionTests {
             .factoryCards: .factoryCards,
             .angleCannon: .angleCannon,
             .twoFingerProtractor: .twoFingerProtractor,
+            .shapeGeometry: .shapeGeometry,
             .gravityArtist: .gravityArtist,
             .compassAngles: .compassAngles,
             .waterCycle: .waterCycle,

--- a/Tests/MatherTests/ShapeGeometryContentTests.swift
+++ b/Tests/MatherTests/ShapeGeometryContentTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import Mather
+
+final class ShapeGeometryContentTests: XCTestCase {
+    func testShapeDeckCoversBasicAndExpandedShapes() {
+        let titles = Set(ShapeGeometryContent.cards.map(\.title))
+
+        XCTAssertEqual(ShapeGeometryContent.cards.count, 8)
+        XCTAssertTrue(titles.isSuperset(of: [
+            "Circle", "Triangle", "Square", "Rectangle",
+            "Oval", "Diamond", "Star", "Heart",
+        ]))
+        XCTAssertEqual(Set(ShapeGeometryContent.cards.map(\.id)).count, ShapeGeometryContent.cards.count)
+    }
+
+    func testShapeLevelsGroupDeterministicFourCardRounds() throws {
+        XCTAssertEqual(ShapeGeometryContent.levels.map(\.id), ["basic-shapes", "expanded-shapes"])
+
+        for level in ShapeGeometryContent.levels {
+            XCTAssertEqual(level.cardIDs.count, 4)
+            XCTAssertEqual(level.cards(from: ShapeGeometryContent.cards).count, 4)
+            XCTAssertEqual(level.quizQuestions(from: ShapeGeometryContent.quizQuestions).count, 4)
+            XCTAssertEqual(level.matchPairs(from: ShapeGeometryContent.matchPairs).count, 4)
+        }
+
+        let basic = try XCTUnwrap(ShapeGeometryContent.level(withID: "basic-shapes"))
+        XCTAssertEqual(basic.cardIDs, ["circle", "triangle", "square", "rectangle"])
+    }
+
+    func testShapeQuizQuestionsAcceptOnlyCorrectChoices() {
+        for question in ShapeGeometryContent.quizQuestions {
+            XCTAssertTrue(question.isCorrect(question.correctChoice), question.id)
+            for wrongChoice in question.choices where wrongChoice != question.correctChoice {
+                XCTAssertFalse(question.isCorrect(wrongChoice), question.id)
+            }
+        }
+    }
+
+    func testShapeMatchPairsCarryPictureAndNamePresentation() {
+        XCTAssertEqual(ShapeGeometryContent.matchPairs.count, ShapeGeometryContent.cards.count)
+        XCTAssertTrue(ShapeGeometryContent.matchPairs.allSatisfy { $0.id.hasPrefix("shape-match-") })
+        XCTAssertTrue(ShapeGeometryContent.matchPairs.allSatisfy { $0.left == $0.right })
+        XCTAssertTrue(ShapeGeometryContent.matchPairs.allSatisfy { $0.leftVisualKey?.isEmpty == false })
+
+        let pairs = ShapeGeometryContent.matchPairs
+        XCTAssertTrue(LearningLoopScoring.isMatch(left: "Rectangle", right: "Rectangle", pairs: pairs))
+        XCTAssertFalse(LearningLoopScoring.isMatch(left: "Rectangle", right: "Triangle", pairs: pairs))
+    }
+
+    func testShapeSummaryScoresCompletionForOneLevel() throws {
+        let level = try XCTUnwrap(ShapeGeometryContent.level(withID: "expanded-shapes"))
+        let questions = level.quizQuestions(from: ShapeGeometryContent.quizQuestions)
+        let pairs = level.matchPairs(from: ShapeGeometryContent.matchPairs)
+        let answers = Dictionary(uniqueKeysWithValues: questions.map { ($0.id, $0.correctChoice) })
+        let summary = LearningLoopScoring.summary(
+            questions: questions,
+            answersByQuestionId: answers,
+            matchedPairIds: Set(pairs.map(\.id)),
+            pairs: pairs
+        )
+
+        XCTAssertEqual(summary.quizCorrect, 4)
+        XCTAssertEqual(summary.matchedPairs, 4)
+        XCTAssertEqual(summary.starCount, 3)
+    }
+}


### PR DESCRIPTION
Recovering the shape geometry learning loop work after PR #877 went stale during the #878 merge/rebase cycle.\n\nCloses #873.\n\nValidation:\n- git diff --check passed\n- Rebased onto current main after #878\n- Resolved sound/shape content conflicts\n- Updated starter Mix-Match sampler test to use the lane card count instead of hard-coding 8