### PR TITLE
Sound Mix + Match haptics and shuffled rows

### DIFF
--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -69,6 +69,27 @@ enum ConceptMatchAttempt: Equatable {
     case missingSelection
 }
 
+struct ConceptMatchRowOrder: Equatable {
+    let leftPairIds: [String]
+    let rightPairIds: [String]
+}
+
+struct LearningLoopSeededRandomGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        self.state = seed == 0 ? 0x9E3779B97F4A7C15 : seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E3779B97F4A7C15
+        var result = state
+        result = (result ^ (result >> 30)) &* 0xBF58476D1CE4E5B9
+        result = (result ^ (result >> 27)) &* 0x94D049BB133111EB
+        return result ^ (result >> 31)
+    }
+}
+
 struct LearningLoopSummary: Equatable {
     let quizCorrect: Int
     let quizTotal: Int
@@ -114,6 +135,19 @@ enum LearningLoopScoring {
             return .mismatch(feedback: "Not that pair yet — try another match.")
         }
         return .locked(pairId: pair.id, feedback: pair.feedback)
+    }
+
+    static func shuffledMatchRowOrder(pairs: [ConceptMatchPair], seed: UInt64) -> ConceptMatchRowOrder {
+        var leftGenerator = LearningLoopSeededRandomGenerator(seed: seed)
+        var rightGenerator = LearningLoopSeededRandomGenerator(seed: seed ^ 0xD1B54A32D192ED03)
+        return ConceptMatchRowOrder(
+            leftPairIds: pairs.map(\.id).shuffled(using: &leftGenerator),
+            rightPairIds: pairs.map(\.id).shuffled(using: &rightGenerator)
+        )
+    }
+
+    static func orderedMatchRowOrder(pairs: [ConceptMatchPair]) -> ConceptMatchRowOrder {
+        ConceptMatchRowOrder(leftPairIds: pairs.map(\.id), rightPairIds: pairs.map(\.id))
     }
 
     static func summary(

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -90,11 +90,36 @@ struct ConceptQuizRoundView: View {
     }
 }
 
+enum ConceptMixMatchHapticCue {
+    case select
+    case success
+    case error
+    case complete
+}
+
 struct ConceptMixMatchRoundView: View {
     let pairs: [ConceptMatchPair]
+    let shuffleSeed: UInt64?
     @Binding var selectedLeft: String?
     @Binding var matchedPairIds: Set<String>
     let onFeedback: (String) -> Void
+    let onHapticCue: (ConceptMixMatchHapticCue) -> Void
+
+    init(
+        pairs: [ConceptMatchPair],
+        shuffleSeed: UInt64? = nil,
+        selectedLeft: Binding<String?>,
+        matchedPairIds: Binding<Set<String>>,
+        onFeedback: @escaping (String) -> Void,
+        onHapticCue: @escaping (ConceptMixMatchHapticCue) -> Void = { _ in }
+    ) {
+        self.pairs = pairs
+        self.shuffleSeed = shuffleSeed
+        self._selectedLeft = selectedLeft
+        self._matchedPairIds = matchedPairIds
+        self.onFeedback = onFeedback
+        self.onHapticCue = onHapticCue
+    }
 
     @State private var mismatchedPairId: String?
 
@@ -104,6 +129,17 @@ struct ConceptMixMatchRoundView: View {
 
     private var isComplete: Bool {
         matchCount == pairs.count
+    }
+
+    private var rowOrder: ConceptMatchRowOrder {
+        if let shuffleSeed {
+            return LearningLoopScoring.shuffledMatchRowOrder(pairs: pairs, seed: shuffleSeed)
+        }
+        return LearningLoopScoring.orderedMatchRowOrder(pairs: pairs)
+    }
+
+    private var pairsById: [String: ConceptMatchPair] {
+        Dictionary(uniqueKeysWithValues: pairs.map { ($0.id, $0) })
     }
 
     var body: some View {
@@ -145,7 +181,7 @@ struct ConceptMixMatchRoundView: View {
             VStack(spacing: 8) {
                 Text(" ")
                     .font(.caption.weight(.black))
-                ForEach(pairs) { pair in
+                ForEach(rightPairs) { pair in
                     Image(systemName: matchedPairIds.contains(pair.id) ? "checkmark.circle.fill" : "arrow.right")
                         .font(.system(size: 16, weight: .black))
                         .foregroundStyle(matchedPairIds.contains(pair.id) ? MatherTheme.accent : Color.secondary.opacity(0.45))
@@ -167,11 +203,19 @@ struct ConceptMixMatchRoundView: View {
             Text(title)
                 .font(.caption.weight(.black))
                 .foregroundStyle(MatherTheme.cardSubtitle)
-            ForEach(pairs) { pair in
+            ForEach(side == .left ? leftPairs : rightPairs) { pair in
                 matchCard(pair: pair, side: side)
             }
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private var leftPairs: [ConceptMatchPair] {
+        rowOrder.leftPairIds.compactMap { pairsById[$0] }
+    }
+
+    private var rightPairs: [ConceptMatchPair] {
+        rowOrder.rightPairIds.compactMap { pairsById[$0] }
     }
 
     private func matchCard(pair: ConceptMatchPair, side: MatchSide) -> some View {
@@ -239,6 +283,9 @@ struct ConceptMixMatchRoundView: View {
         case .left:
             selectedLeft = selectedLeft == pair.id ? nil : pair.id
             mismatchedPairId = nil
+            if selectedLeft != nil {
+                onHapticCue(.select)
+            }
             onFeedback(selectedLeft == nil ? "Pick a picture card." : "Now pick what goes with \(pair.left).")
         case .right:
             switch LearningLoopScoring.matchAttempt(
@@ -251,11 +298,14 @@ struct ConceptMixMatchRoundView: View {
                 matchedPairIds.insert(pairId)
                 selectedLeft = nil
                 mismatchedPairId = nil
+                onHapticCue(matchedPairIds.count == pairs.count ? .complete : .success)
                 onFeedback(feedback)
             case .mismatch(let feedback):
                 mismatchedPairId = pair.id
+                onHapticCue(.error)
                 onFeedback(feedback)
             case .missingSelection:
+                onHapticCue(.error)
                 onFeedback("Pick a picture card first.")
             case .alreadyMatched:
                 break
@@ -282,6 +332,7 @@ struct SoundVolumeLabView: View {
     @State private var answersByQuestionId: [String: String] = [:]
     @State private var selectedMatchPairId: String?
     @State private var matchedPairIds: Set<String> = []
+    @State private var matchShuffleSeed = UInt64.random(in: UInt64.min...UInt64.max)
     @State private var feedback = SoundVolumeContent.safetyNote
 
     private var summary: LearningLoopSummary {
@@ -307,9 +358,11 @@ struct SoundVolumeLabView: View {
                     )
                     ConceptMixMatchRoundView(
                         pairs: SoundVolumeContent.matchPairs,
+                        shuffleSeed: matchShuffleSeed,
                         selectedLeft: $selectedMatchPairId,
                         matchedPairIds: $matchedPairIds,
-                        onFeedback: { feedback = $0 }
+                        onFeedback: { feedback = $0 },
+                        onHapticCue: playSoundMatchHaptic
                     )
                     summaryCard
                 }
@@ -341,6 +394,21 @@ struct SoundVolumeLabView: View {
                 appModel.markExplorerLabModeCompleted(laneID: .physics, mode: .review)
                 appModel.setExplorerLabConceptConfidence(.steady, for: ConceptId(rawValue: "sound-volume"), laneID: .physics)
             }
+        }
+    }
+
+    private func playSoundMatchHaptic(_ cue: ConceptMixMatchHapticCue) {
+        let enabled = appModel.featureFlags.hapticsEnabled
+        switch cue {
+        case .select:
+            appModel.hapticsService.cardPickup(enabled: enabled)
+        case .success:
+            appModel.hapticsService.cardSnapCorrect(enabled: enabled)
+        case .error:
+            appModel.hapticsService.cardSnapMismatch(enabled: enabled)
+        case .complete:
+            appModel.hapticsService.cardSnapCorrect(enabled: enabled)
+            appModel.hapticsService.bondMatchComplete(enabled: enabled)
         }
     }
 

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -134,6 +134,20 @@ extension LearningLoopTests {
         XCTAssertFalse(LearningLoopScoring.isMatch(left: "Siren", right: "Quiet", pairs: pairs))
     }
 
+    func testSoundVolumeMatchRowsShuffleDeterministicallyBySeed() {
+        let pairs = SoundVolumeContent.matchPairs
+        let first = LearningLoopScoring.shuffledMatchRowOrder(pairs: pairs, seed: 883)
+        let repeatOrder = LearningLoopScoring.shuffledMatchRowOrder(pairs: pairs, seed: 883)
+        let different = LearningLoopScoring.shuffledMatchRowOrder(pairs: pairs, seed: 884)
+        let ordered = LearningLoopScoring.orderedMatchRowOrder(pairs: pairs)
+
+        XCTAssertEqual(first, repeatOrder)
+        XCTAssertNotEqual(first, ordered)
+        XCTAssertNotEqual(first, different)
+        XCTAssertEqual(Set(first.leftPairIds), Set(pairs.map(\.id)))
+        XCTAssertEqual(Set(first.rightPairIds), Set(pairs.map(\.id)))
+    }
+
     func testSoundVolumeEstimatedZonesAreExplicitlyEstimatedAndConservative() {
         XCTAssertEqual(SoundVolumeContent.zone(forEstimatedDecibels: 35), .quiet)
         XCTAssertEqual(SoundVolumeContent.zone(forEstimatedDecibels: 60), .normal)


### PR DESCRIPTION
## Summary
- add deterministic shuffled picture/name row ordering for Sound Lab Mix + Match sessions
- wire Sound Lab match attempts into Bond Blast-style haptic cues, respecting the existing haptics setting and fallback service
- add learning-loop coverage for deterministic shuffled row order

Closes #883
Closes #888

## Validation
- git diff --check HEAD~1 HEAD
- targeted XCTest not run: local Linux worker has no Swift/Xcode toolchain, and ganesh-mba SSH DNS resolution failed during validation (ssh: Could not resolve hostname mba)