### PR TITLE
Stage Sound Lab intro flow

### DIFF
--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -214,8 +214,57 @@ enum SoundLoudnessZone: String, CaseIterable, Equatable {
     }
 }
 
+struct SoundVolumeIntroPage: Identifiable, Equatable {
+    let id: String
+    let eyebrow: String
+    let title: String
+    let subtitle: String
+    let visualKey: String
+    let primaryActionTitle: String
+    let primaryActionIcon: String
+}
+
 enum SoundVolumeContent {
     static let safetyNote = "Use listening clues only — no screaming. Protect your ears. A live microphone meter comes later and is not used in this activity."
+
+    static let introPages: [SoundVolumeIntroPage] = [
+        SoundVolumeIntroPage(
+            id: "welcome",
+            eyebrow: "Step 1 of 4",
+            title: "Meet sound and volume",
+            subtitle: "Sound can be soft, comfy, noisy, or too loud. We will learn one small idea at a time.",
+            visualKey: "🔊",
+            primaryActionTitle: "Next: listening rules",
+            primaryActionIcon: "arrow.right.circle.fill"
+        ),
+        SoundVolumeIntroPage(
+            id: "safety",
+            eyebrow: "Step 2 of 4",
+            title: "Use hearing-safe play",
+            subtitle: "Use listening clues only — no screaming, no loud-noise challenge, and no microphone permission in this activity.",
+            visualKey: "👂",
+            primaryActionTitle: "Next: loudness zones",
+            primaryActionIcon: "arrow.right.circle.fill"
+        ),
+        SoundVolumeIntroPage(
+            id: "zones",
+            eyebrow: "Step 3 of 4",
+            title: "Sort sounds into zones",
+            subtitle: "The zone cards are examples, not a live sound meter. If a sound hurts, move away or protect your ears.",
+            visualKey: "📊",
+            primaryActionTitle: "Next: sound clues",
+            primaryActionIcon: "arrow.right.circle.fill"
+        ),
+        SoundVolumeIntroPage(
+            id: "clues",
+            eyebrow: "Step 4 of 4",
+            title: "Ready for quiz and match",
+            subtitle: "Look for picture clues like whisper, traffic, siren, headphones, birds, and protect ears.",
+            visualKey: "🧩",
+            primaryActionTitle: "Start Sound Lab",
+            primaryActionIcon: "play.fill"
+        ),
+    ]
 
     static let cards: [LearningConceptCard] = [
         LearningConceptCard(id: "quiet", title: "Quiet", explanation: "Quiet sounds are soft and gentle, like a whisper or leaves.", visualKey: "🍃", audioPrompt: "Quiet sounds are soft and gentle."),

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -279,10 +279,17 @@ struct ConceptMixMatchRoundView: View {
 
 struct SoundVolumeLabView: View {
     @Bindable var appModel: AppModel
+    @State private var introPageIndex = 0
+    @State private var hasStartedActivities = false
     @State private var answersByQuestionId: [String: String] = [:]
     @State private var selectedMatchPairId: String?
     @State private var matchedPairIds: Set<String> = []
     @State private var feedback = SoundVolumeContent.safetyNote
+
+    private var introPages: [SoundVolumeIntroPage] { SoundVolumeContent.introPages }
+    private var introPage: SoundVolumeIntroPage { introPages[introPageIndex] }
+    private var isFirstIntroPage: Bool { introPageIndex == 0 }
+    private var isLastIntroPage: Bool { introPageIndex == introPages.count - 1 }
 
     private var summary: LearningLoopSummary {
         LearningLoopScoring.summary(
@@ -297,24 +304,26 @@ struct SoundVolumeLabView: View {
         GeometryReader { proxy in
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
-                    header
-                    safetyBanner
-                    loudnessZones
-                    LearningCardIntroView(cards: SoundVolumeContent.cards)
-                    ConceptQuizRoundView(
-                        questions: SoundVolumeContent.quizQuestions,
-                        answersByQuestionId: $answersByQuestionId
-                    )
-                    ConceptMixMatchRoundView(
-                        pairs: SoundVolumeContent.matchPairs,
-                        selectedLeft: $selectedMatchPairId,
-                        matchedPairIds: $matchedPairIds,
-                        onFeedback: { feedback = $0 }
-                    )
-                    summaryCard
+                    if hasStartedActivities {
+                        activityHeader
+                        ConceptQuizRoundView(
+                            questions: SoundVolumeContent.quizQuestions,
+                            answersByQuestionId: $answersByQuestionId
+                        )
+                        ConceptMixMatchRoundView(
+                            pairs: SoundVolumeContent.matchPairs,
+                            selectedLeft: $selectedMatchPairId,
+                            matchedPairIds: $matchedPairIds,
+                            onFeedback: { feedback = $0 }
+                        )
+                        summaryCard
+                    } else {
+                        stagedIntroCard
+                    }
                 }
                 .padding(.horizontal, horizontalPadding(for: proxy.size.width))
-                .padding(.vertical, 22)
+                .padding(.top, 22)
+                .padding(.bottom, hasStartedActivities ? 22 : 118)
                 .frame(maxWidth: 900)
                 .frame(maxWidth: .infinity)
             }
@@ -336,6 +345,11 @@ struct SoundVolumeLabView: View {
             .padding(.vertical, 8)
             .background(.thinMaterial)
         }
+        .safeAreaInset(edge: .bottom) {
+            if !hasStartedActivities {
+                introControls
+            }
+        }
         .onDisappear {
             if summary.starCount > 0 || matchedPairIds.count == SoundVolumeContent.matchPairs.count {
                 appModel.markExplorerLabModeCompleted(laneID: .physics, mode: .review)
@@ -344,7 +358,119 @@ struct SoundVolumeLabView: View {
         }
     }
 
-    private var header: some View {
+    private var stagedIntroCard: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(introPage.eyebrow.uppercased())
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.accent)
+                    .tracking(1.3)
+                HStack(alignment: .top, spacing: 14) {
+                    Text(introPage.visualKey)
+                        .font(.system(size: 64))
+                        .frame(width: 76)
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(introPage.title)
+                            .font(.largeTitle.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                            .minimumScaleFactor(0.72)
+                        Text(introPage.subtitle)
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                introPageContent
+                introProgressDots
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder
+    private var introPageContent: some View {
+        switch introPage.id {
+        case "welcome":
+            soundClueChips(SoundVolumeContent.cards.prefix(4).map { ($0.visualKey, $0.title) })
+        case "safety":
+            safetyBanner
+        case "zones":
+            loudnessZones
+        default:
+            soundClueChips(SoundVolumeContent.cards.map { ($0.visualKey, $0.title) })
+        }
+    }
+
+    private var introProgressDots: some View {
+        HStack(spacing: 8) {
+            ForEach(introPages.indices, id: \.self) { index in
+                Capsule()
+                    .fill(index == introPageIndex ? MatherTheme.accent : MatherTheme.softBlue.opacity(0.35))
+                    .frame(width: index == introPageIndex ? 28 : 10, height: 10)
+                    .accessibilityLabel("Intro step \(index + 1) of \(introPages.count)")
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var introControls: some View {
+        VStack(spacing: 10) {
+            Button {
+                advanceIntro()
+            } label: {
+                Label(introPage.primaryActionTitle, systemImage: introPage.primaryActionIcon)
+            }
+            .buttonStyle(PrimaryActionButtonStyle())
+            .accessibilityIdentifier("SoundVolumeIntroPrimaryAction")
+
+            if !isFirstIntroPage {
+                Button {
+                    introPageIndex = max(0, introPageIndex - 1)
+                } label: {
+                    Label("Back", systemImage: "chevron.left")
+                        .font(.headline.weight(.black))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 8)
+        .background(.thinMaterial)
+    }
+
+    private func advanceIntro() {
+        if isLastIntroPage {
+            hasStartedActivities = true
+            feedback = "Start with the quiz, then match each sound clue to its safe idea."
+        } else {
+            introPageIndex += 1
+        }
+    }
+
+    private func soundClueChips(_ chips: [(String, String)]) -> some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: 132), spacing: 10)], spacing: 10) {
+            ForEach(Array(chips.enumerated()), id: \.offset) { _, chip in
+                HStack(spacing: 8) {
+                    Text(chip.0)
+                    Text(chip.1)
+                        .font(.caption.weight(.black))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                }
+                .padding(.vertical, 10)
+                .padding(.horizontal, 12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(MatherTheme.softBlue.opacity(0.20))
+                .clipShape(Capsule())
+                .accessibilityElement(children: .combine)
+            }
+        }
+    }
+
+    private var activityHeader: some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 10) {
                 HStack(alignment: .top, spacing: 12) {
@@ -355,7 +481,7 @@ struct SoundVolumeLabView: View {
                             .font(.largeTitle.weight(.black))
                             .foregroundStyle(MatherTheme.ink)
                             .minimumScaleFactor(0.75)
-                        Text("Learn quiet, conversation, traffic, sirens, headphones, pleasant sounds, noisy sounds, and hearing safety.")
+                        Text("Quiz and match safe listening clues. No microphone permission or live meter is used.")
                             .font(.headline.weight(.semibold))
                             .foregroundStyle(MatherTheme.cardSubtitle)
                     }

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -94,6 +94,16 @@ extension LearningLoopTests {
 
 
 extension LearningLoopTests {
+    func testSoundVolumeIntroUsesStagedSafePagesBeforeActivity() {
+        let pages = SoundVolumeContent.introPages
+
+        XCTAssertEqual(pages.map(\.id), ["welcome", "safety", "zones", "clues"])
+        XCTAssertEqual(pages.last?.primaryActionTitle, "Start Sound Lab")
+        XCTAssertTrue(pages[1].subtitle.contains("no microphone permission"))
+        XCTAssertTrue(pages[1].subtitle.contains("no loud-noise challenge"))
+        XCTAssertTrue(pages[2].subtitle.contains("not a live sound meter"))
+    }
+
     func testSoundVolumeContentCoversSafeHearingConcepts() {
         let titles = Set(SoundVolumeContent.cards.map(\.title))
 


### PR DESCRIPTION
## Summary
- Breaks Sound + Volume Lab landing content into four short staged intro cards: welcome, safety, loudness zones, and clue review.
- Adds persistent bottom Next/Back controls so the primary action remains visible on small devices.
- Keeps the activity hearing-safe: no microphone permission, no live meter, and no loud-noise challenge.
- Adds model coverage for the staged Sound Lab intro metadata.

Closes #884.

## Validation
- git diff --check
- xcodebuild not run locally: Linux worker has no Xcode; remote Mac SSH was unreachable during validation (hostname resolution/connection timeout).
