### PR TITLE
Fix build 69 lab feedback

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -92,6 +92,8 @@ struct RootView: View {
                     LabLaneDetailView(appModel: appModel, laneID: laneID)
                 case .memory:
                     MemoryView(appModel: appModel)
+                case .memoryDeck(let deckKind):
+                    MemoryView(appModel: appModel, initialDeckKind: deckKind)
                 case .waterCycle:
                     WaterCycleLabView(appModel: appModel)
                 case .soundVolume:

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -20,6 +20,7 @@ enum AppRoute: Hashable {
     case lab
     case labLane(CapabilityLaneID)
     case memory
+    case memoryDeck(MemoryDeckKind)
     case waterCycle
     case soundVolume
     case shapeGeometry

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -582,7 +582,7 @@ struct LabLaneDetailView: View {
 
     private func launch(_ activityID: LabActivityID) {
         appModel.pickProfileThenRun {
-            appModel.engine.show(activityID.appRoute)
+            appModel.engine.show(route(for: activityID, laneID: lane.id))
             switch activityID {
             case .sumSprint:
                 appModel.sumSprintEngine.showDifficultyPick()
@@ -590,6 +590,18 @@ struct LabLaneDetailView: View {
                  .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
                 break
             }
+        }
+    }
+
+    private func route(for activityID: LabActivityID, laneID: CapabilityLaneID) -> AppRoute {
+        guard activityID == .memoryMatch else { return activityID.appRoute }
+        switch laneID {
+        case .chemistry:
+            return .memoryDeck(.fruits)
+        case .mapWorld:
+            return .memoryDeck(.countries)
+        default:
+            return .memory
         }
     }
 

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -553,7 +553,7 @@ struct LabLaneDetailView: View {
                 .font(.system(size: 48, weight: .bold))
                 .foregroundStyle(tint.opacity(0.35))
                 .offset(x: 20, y: 12)
-        case .memoryMatch:
+        case .memoryMatch, .countryCards, .fruitCards:
             Image(systemName: "rectangle.on.rectangle.angled")
                 .font(.system(size: 48, weight: .bold))
                 .foregroundStyle(tint.opacity(0.35))
@@ -587,7 +587,7 @@ struct LabLaneDetailView: View {
             case .sumSprint:
                 appModel.sumSprintEngine.showDifficultyPick()
             case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
-                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
+                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .fruitCards:
                 break
             }
         }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -352,7 +352,7 @@ struct LabLaneDetailPresentation: Equatable {
 extension LabActivityID {
     var sensorNeeds: [LabSensorNeed] {
         switch self {
-        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
+        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .fruitCards:
             return [.noSpecialSensor]
         case .symmetryFold, .angleCannon, .gravityArtist:
             return [.motion]

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -654,6 +654,13 @@ struct CapabilityLane: Identifiable, Equatable {
                     tagline: "Turn your body to match the angle",
                     modes: [.explore, .challenge, .timed]
                 ),
+                LabActivity(
+                    id: .memoryMatch,
+                    emoji: "🌍",
+                    title: "Country Cards",
+                    tagline: "Flashcards for capitals, flags, languages, currency, and continents",
+                    modes: [.learn, .review, .challenge]
+                ),
             ]
         ),
         CapabilityLane(
@@ -690,7 +697,15 @@ struct CapabilityLane: Identifiable, Equatable {
                 CapabilityAgeEntry(ageBand: .upperElementary, posture: "properties and prediction", entryPlay: "safe reaction cards"),
                 CapabilityAgeEntry(ageBand: .preteen, posture: "families and systems", entryPlay: "property puzzles"),
             ],
-            activities: []
+            activities: [
+                LabActivity(
+                    id: .memoryMatch,
+                    emoji: "🍎",
+                    title: "Fruit Cards",
+                    tagline: "Match fruit shape, color, taste, smell, and where it is found",
+                    modes: [.learn, .review, .challenge]
+                ),
+            ]
         ),
         CapabilityLane(
             id: .electronics,

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -125,6 +125,8 @@ enum LabActivityID: String, CaseIterable, Hashable {
     case waterCycle
     case soundVolume
     case memoryMatch
+    case countryCards
+    case fruitCards
 }
 
 extension LabActivityID {
@@ -156,6 +158,10 @@ extension LabActivityID {
             return .soundVolume
         case .memoryMatch:
             return .memory
+        case .countryCards:
+            return .memoryDeck(.countries)
+        case .fruitCards:
+            return .memoryDeck(.fruits)
         }
     }
 }
@@ -655,7 +661,7 @@ struct CapabilityLane: Identifiable, Equatable {
                     modes: [.explore, .challenge, .timed]
                 ),
                 LabActivity(
-                    id: .memoryMatch,
+                    id: .countryCards,
                     emoji: "🌍",
                     title: "Country Cards",
                     tagline: "Flashcards for capitals, flags, languages, currency, and continents",
@@ -699,7 +705,7 @@ struct CapabilityLane: Identifiable, Equatable {
             ],
             activities: [
                 LabActivity(
-                    id: .memoryMatch,
+                    id: .fruitCards,
                     emoji: "🍎",
                     title: "Fruit Cards",
                     tagline: "Match fruit shape, color, taste, smell, and where it is found",

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -530,10 +530,33 @@ struct SoundVolumeLabView: View {
 struct ShapeGeometryLabView: View {
     @Bindable var appModel: AppModel
     @State private var levelIndex = 0
+    @State private var stage: ShapeGeometryStage = .learn
     @State private var answersByQuestionId: [String: String] = [:]
     @State private var selectedMatchPairId: String?
     @State private var matchedPairIds: Set<String> = []
-    @State private var feedback = "Start with shape cards, then match each picture to its name."
+    @State private var feedback = "Start with one playful shape screen at a time."
+
+    private enum ShapeGeometryStage: Int, CaseIterable {
+        case learn, quiz, match, summary
+
+        var title: String {
+            switch self {
+            case .learn: "Look"
+            case .quiz: "Quiz"
+            case .match: "Match"
+            case .summary: "Stars"
+            }
+        }
+
+        var nextTitle: String {
+            switch self {
+            case .learn: "Start quiz"
+            case .quiz: "Play match"
+            case .match: "See stars"
+            case .summary: "Play again"
+            }
+        }
+    }
 
     private var level: ShapeGeometryContent.Level {
         ShapeGeometryContent.levels[levelIndex]
@@ -550,25 +573,29 @@ struct ShapeGeometryLabView: View {
 
     var body: some View {
         GeometryReader { proxy in
-            ScrollView {
-                VStack(alignment: .leading, spacing: 18) {
-                    header
-                    levelPicker
-                    LearningCardIntroView(cards: level.cards)
-                    ConceptQuizRoundView(questions: level.quizQuestions, answersByQuestionId: $answersByQuestionId)
-                    ConceptMixMatchRoundView(
-                        pairs: level.matchPairs,
-                        selectedLeft: $selectedMatchPairId,
-                        matchedPairIds: $matchedPairIds,
-                        onFeedback: { feedback = $0 }
-                    )
-                    summaryCard
+            VStack(alignment: .leading, spacing: 14) {
+                header
+                levelPicker
+                stageProgress
+
+                ViewThatFits(in: .vertical) {
+                    currentStageView
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
+                        .frame(maxHeight: max(260, proxy.size.height - 330), alignment: .top)
+
+                    ScrollView {
+                        currentStageView
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(maxHeight: max(260, proxy.size.height - 330))
                 }
-                .padding(.horizontal, proxy.size.width < 420 ? 14 : 24)
-                .padding(.vertical, 22)
-                .frame(maxWidth: 900)
-                .frame(maxWidth: .infinity)
+
+                stageControls
             }
+            .padding(.horizontal, proxy.size.width < 420 ? 14 : 24)
+            .padding(.vertical, 18)
+            .frame(maxWidth: 900)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .background(MatherTheme.background.ignoresSafeArea())
         }
         .navigationTitle("Shape Lab")
@@ -629,7 +656,8 @@ struct ShapeGeometryLabView: View {
                     answersByQuestionId = [:]
                     selectedMatchPairId = nil
                     matchedPairIds = []
-                    feedback = "Now playing \(level.title)."
+                    stage = .learn
+                    feedback = "Now playing \(level.title), one screen at a time."
                 } label: {
                     Text(level.title)
                         .font(.subheadline.weight(.black))
@@ -644,6 +672,73 @@ struct ShapeGeometryLabView: View {
             }
         }
         .accessibilityLabel("Shape Lab level picker")
+    }
+
+    private var stageProgress: some View {
+        HStack(spacing: 8) {
+            ForEach(ShapeGeometryStage.allCases, id: \.rawValue) { shapeStage in
+                Text(shapeStage.title)
+                    .font(.caption.weight(.black))
+                    .padding(.vertical, 7)
+                    .padding(.horizontal, 10)
+                    .frame(maxWidth: .infinity)
+                    .background(shapeStage == stage ? MatherTheme.accent.opacity(0.24) : MatherTheme.card)
+                    .foregroundStyle(shapeStage == stage ? MatherTheme.ink : MatherTheme.cardSubtitle)
+                    .clipShape(Capsule())
+            }
+        }
+        .accessibilityIdentifier("shape-lab-stage-progress")
+    }
+
+    @ViewBuilder
+    private var currentStageView: some View {
+        switch stage {
+        case .learn:
+            LearningCardIntroView(cards: level.cards)
+        case .quiz:
+            ConceptQuizRoundView(questions: level.quizQuestions, answersByQuestionId: $answersByQuestionId)
+        case .match:
+            ConceptMixMatchRoundView(
+                pairs: level.matchPairs,
+                selectedLeft: $selectedMatchPairId,
+                matchedPairIds: $matchedPairIds,
+                onFeedback: { feedback = $0 }
+            )
+        case .summary:
+            summaryCard
+        }
+    }
+
+    private var stageControls: some View {
+        HStack(spacing: 12) {
+            Button {
+                if let previous = ShapeGeometryStage(rawValue: stage.rawValue - 1) {
+                    stage = previous
+                    feedback = "Back to \(previous.title.lowercased()) mode."
+                }
+            } label: {
+                Label("Back", systemImage: "chevron.left")
+            }
+            .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.panelDeep.opacity(0.24)))
+            .disabled(stage == .learn)
+
+            Button {
+                if stage == .summary {
+                    answersByQuestionId = [:]
+                    selectedMatchPairId = nil
+                    matchedPairIds = []
+                    stage = .learn
+                    feedback = "New round: look, quiz, match, then stars."
+                } else if let next = ShapeGeometryStage(rawValue: stage.rawValue + 1) {
+                    stage = next
+                    feedback = "Now playing \(next.title.lowercased()) mode."
+                }
+            } label: {
+                Label(stage.nextTitle, systemImage: stage == .summary ? "arrow.counterclockwise" : "arrow.right.circle.fill")
+            }
+            .buttonStyle(PrimaryActionButtonStyle())
+        }
+        .accessibilityIdentifier("shape-lab-stage-controls")
     }
 
     private var summaryCard: some View {

--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -23,6 +23,7 @@ enum MemoryDeckKind: String, Equatable {
     case countryFlags
     case indiaStates
     case waterCycle
+    case fruits
 
     var displayName: String {
         switch self {
@@ -35,6 +36,7 @@ enum MemoryDeckKind: String, Equatable {
         case .countryFlags: return "Countries & Flags"
         case .indiaStates: return "Indian States & Capitals"
         case .waterCycle: return "Water Cycle"
+        case .fruits: return "Fruits"
         }
     }
 }
@@ -359,14 +361,14 @@ enum MemoryDeck {
     ]
 
     static let countries: [MemoryAnimal] = [
-        countryCapital("country-india", country: "India", capital: "New Delhi", continent: "Asia", clue: "home of the Taj Mahal"),
-        countryCapital("country-japan", country: "Japan", capital: "Tokyo", continent: "Asia", clue: "known for cherry blossoms and bullet trains"),
-        countryCapital("country-france", country: "France", capital: "Paris", continent: "Europe", clue: "home of the Eiffel Tower"),
-        countryCapital("country-egypt", country: "Egypt", capital: "Cairo", continent: "Africa", clue: "home of the Great Pyramids"),
-        countryCapital("country-brazil", country: "Brazil", capital: "Brasília", continent: "South America", clue: "home of the Amazon rainforest"),
-        countryCapital("country-australia", country: "Australia", capital: "Canberra", continent: "Australia", clue: "home of kangaroos and koalas"),
-        countryCapital("country-canada", country: "Canada", capital: "Ottawa", continent: "North America", clue: "known for maple leaves and snowy winters"),
-        countryCapital("country-kenya", country: "Kenya", capital: "Nairobi", continent: "Africa", clue: "known for savannas and wildlife parks")
+        countryCapital("country-india", country: "India", capital: "New Delhi", continent: "Asia", language: "Hindi and English", currency: "Indian rupee", mapShape: "wide triangle-like peninsula", clue: "home of the Taj Mahal"),
+        countryCapital("country-japan", country: "Japan", capital: "Tokyo", continent: "Asia", language: "Japanese", currency: "yen", mapShape: "long island chain", clue: "known for cherry blossoms and bullet trains"),
+        countryCapital("country-france", country: "France", capital: "Paris", continent: "Europe", language: "French", currency: "euro", mapShape: "hexagon-like outline", clue: "home of the Eiffel Tower"),
+        countryCapital("country-egypt", country: "Egypt", capital: "Cairo", continent: "Africa", language: "Arabic", currency: "Egyptian pound", mapShape: "square-like shape with Sinai corner", clue: "home of the Great Pyramids"),
+        countryCapital("country-brazil", country: "Brazil", capital: "Brasília", continent: "South America", language: "Portuguese", currency: "Brazilian real", mapShape: "large east-bulging outline", clue: "home of the Amazon rainforest"),
+        countryCapital("country-australia", country: "Australia", capital: "Canberra", continent: "Australia", language: "English", currency: "Australian dollar", mapShape: "big island continent", clue: "home of kangaroos and koalas"),
+        countryCapital("country-canada", country: "Canada", capital: "Ottawa", continent: "North America", language: "English and French", currency: "Canadian dollar", mapShape: "very wide northern outline", clue: "known for maple leaves and snowy winters"),
+        countryCapital("country-kenya", country: "Kenya", capital: "Nairobi", continent: "Africa", language: "Swahili and English", currency: "Kenyan shilling", mapShape: "east Africa shape by the Indian Ocean", clue: "known for savannas and wildlife parks")
     ]
 
     static let countryFlags: [MemoryAnimal] = [
@@ -389,6 +391,17 @@ enum MemoryDeck {
         indiaStateCapital("state-rajasthan", state: "Rajasthan", capital: "Jaipur", region: "northwest India", clue: "pink city and desert forts"),
         indiaStateCapital("state-kerala", state: "Kerala", capital: "Thiruvananthapuram", region: "south India", clue: "backwaters and coconut trees"),
         indiaStateCapital("state-assam", state: "Assam", capital: "Dispur", region: "northeast India", clue: "tea gardens and one-horned rhinos")
+    ]
+
+    static let fruits: [MemoryAnimal] = [
+        fruit("fruit-apple", name: "Apple", emoji: "🍎", shape: "round", colors: "red, green, or yellow", taste: "sweet and crisp", smell: "fresh and fruity", foundIn: "India, China, the United States, and Europe"),
+        fruit("fruit-banana", name: "Banana", emoji: "🍌", shape: "long and curved", colors: "yellow", taste: "sweet and soft", smell: "gentle tropical smell", foundIn: "India, Ecuador, the Philippines, and Brazil"),
+        fruit("fruit-mango", name: "Mango", emoji: "🥭", shape: "oval", colors: "yellow, orange, green, or red", taste: "very sweet and juicy", smell: "rich tropical smell", foundIn: "India, Mexico, Thailand, and Pakistan"),
+        fruit("fruit-orange", name: "Orange", emoji: "🍊", shape: "round", colors: "orange", taste: "sweet and tangy", smell: "bright citrus smell", foundIn: "Brazil, India, China, and Spain"),
+        fruit("fruit-grape", name: "Grape", emoji: "🍇", shape: "small round bunches", colors: "green, red, or purple", taste: "sweet and juicy", smell: "light fruity smell", foundIn: "Italy, China, the United States, and India"),
+        fruit("fruit-watermelon", name: "Watermelon", emoji: "🍉", shape: "large oval", colors: "green outside and red inside", taste: "sweet and watery", smell: "fresh melon smell", foundIn: "India, China, Turkey, and Brazil"),
+        fruit("fruit-pineapple", name: "Pineapple", emoji: "🍍", shape: "oval with spiky crown", colors: "gold and green", taste: "sweet and tangy", smell: "strong tropical smell", foundIn: "Costa Rica, India, the Philippines, and Thailand"),
+        fruit("fruit-strawberry", name: "Strawberry", emoji: "🍓", shape: "heart-shaped", colors: "red with tiny seeds", taste: "sweet and a little tart", smell: "sweet berry smell", foundIn: "United States, Mexico, Spain, and India")
     ]
 
     static let waterCycle: [MemoryAnimal] = [
@@ -414,7 +427,7 @@ enum MemoryDeck {
     ]
 
     static let allAnimalsById: [String: MemoryAnimal] = {
-        Dictionary(uniqueKeysWithValues: (domesticAnimals + birds + vehicles + planets + fishes + countries + countryFlags + indiaStates + waterCycle).map { ($0.id, $0) })
+        Dictionary(uniqueKeysWithValues: (domesticAnimals + birds + vehicles + planets + fishes + countries + countryFlags + indiaStates + waterCycle + fruits).map { ($0.id, $0) })
     }()
 
     static let imageAssetProvenance: [MemoryImageAssetProvenance] = [
@@ -686,7 +699,33 @@ enum MemoryDeck {
         )
     }
 
-    private static func countryCapital(_ id: String, country: String, capital: String, continent: String, clue: String) -> MemoryAnimal {
+    private static func fruit(_ id: String, name: String, emoji: String, shape: String, colors: String, taste: String, smell: String, foundIn: String) -> MemoryAnimal {
+        MemoryAnimal(
+            id: id,
+            name: name,
+            picture: .emoji(emoji),
+            metadata: MemoryCardMetadata(
+                deck: .fruits,
+                category: "fruit",
+                kind: "fruit",
+                habitat: foundIn,
+                colors: colors,
+                use: taste,
+                movement: "grows on plants and travels from farms to markets",
+                sound: smell,
+                factCards: [
+                    MemoryFactCard(title: "Fruit", value: name),
+                    MemoryFactCard(title: "Shape", value: shape),
+                    MemoryFactCard(title: "Color", value: colors),
+                    MemoryFactCard(title: "Taste", value: taste),
+                    MemoryFactCard(title: "Smell", value: smell),
+                    MemoryFactCard(title: "Usually Found", value: foundIn)
+                ]
+            )
+        )
+    }
+
+    private static func countryCapital(_ id: String, country: String, capital: String, continent: String, language: String, currency: String, mapShape: String, clue: String) -> MemoryAnimal {
         MemoryAnimal(
             id: id,
             name: capital,
@@ -700,7 +739,11 @@ enum MemoryDeck {
                 factCards: [
                     MemoryFactCard(title: "Country", value: country),
                     MemoryFactCard(title: "Capital", value: capital),
+                    MemoryFactCard(title: "Language", value: language),
+                    MemoryFactCard(title: "Currency", value: currency),
                     MemoryFactCard(title: "Continent", value: continent),
+                    MemoryFactCard(title: "Map Shape", value: mapShape),
+                    MemoryFactCard(title: "Bucket", value: "Place in \(continent)"),
                     MemoryFactCard(title: "Known For", value: clue)
                 ]
             )
@@ -839,8 +882,29 @@ struct MemoryView: View {
     @State private var askSession: MemoryAskConversationSession? = nil
     @State private var latestAskResponse: MemoryAskResponse? = nil
 
+    init(appModel: AppModel, initialDeckKind: MemoryDeckKind? = nil) {
+        self.appModel = appModel
+        _deckSelection = State(initialValue: DeckSelection(kind: initialDeckKind))
+    }
+
     enum DeckSelection: CaseIterable {
-        case domestic, birds, vehicles, planets, fishes, countries, countryFlags, indiaStates, waterCycle
+        case domestic, birds, vehicles, planets, fishes, countries, countryFlags, indiaStates, waterCycle, fruits
+
+        init(kind: MemoryDeckKind?) {
+            switch kind {
+            case .domesticAnimals: self = .domestic
+            case .birds: self = .birds
+            case .vehicles: self = .vehicles
+            case .planets: self = .planets
+            case .fishes: self = .fishes
+            case .countries: self = .countries
+            case .countryFlags: self = .countryFlags
+            case .indiaStates: self = .indiaStates
+            case .waterCycle: self = .waterCycle
+            case .fruits: self = .fruits
+            case nil: self = .domestic
+            }
+        }
 
         var label: String {
             switch self {
@@ -853,6 +917,7 @@ struct MemoryView: View {
             case .countryFlags: return "🏳️ Countries & Flags"
             case .indiaStates: return "📍 India States & Capitals"
             case .waterCycle: return "💧 Water Cycle"
+            case .fruits: return "🍎 Fruits"
             }
         }
 
@@ -867,6 +932,7 @@ struct MemoryView: View {
             case .countryFlags: return "Countries & Flags"
             case .indiaStates: return "India States & Capitals"
             case .waterCycle: return "Water Cycle"
+            case .fruits: return "Fruits"
             }
         }
 
@@ -881,6 +947,7 @@ struct MemoryView: View {
             case .countryFlags: return MemoryDeck.countryFlags
             case .indiaStates: return MemoryDeck.indiaStates
             case .waterCycle: return MemoryDeck.waterCycle
+            case .fruits: return MemoryDeck.fruits
             }
         }
     }
@@ -1633,6 +1700,8 @@ struct MemoryView: View {
             deckLabel = "India Guide"
         case .waterCycle:
             deckLabel = "Water Cycle Guide"
+        case .fruits:
+            deckLabel = "Fruit Guide"
         }
 
         switch source {

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -734,7 +734,7 @@ struct WaterCycleLabView: View {
             ViewThatFits(in: .vertical) {
                 activeLessonStageBoard
                     .frame(maxWidth: .infinity, alignment: .topLeading)
-                    .frame(height: boardHeight, alignment: .top)
+                    .frame(maxHeight: boardHeight, alignment: .top)
 
                 ScrollView {
                     activeLessonStageBoard
@@ -902,6 +902,9 @@ struct WaterCycleLabView: View {
                         withAnimation(.spring(response: 0.25, dampingFraction: 0.58)) {
                             if let attempt = state.recordOpenMatchChoice(id: choice.id) {
                                 speakLessonText(attempt.isCorrect ? "Correct match." : "Try another match.")
+                                if attempt.isCorrect {
+                                    advanceAfterCorrectOpenMatch()
+                                }
                             }
                         }
                     } label: {
@@ -1085,6 +1088,17 @@ struct WaterCycleLabView: View {
             } else {
                 speakLessonText(state.currentMixMatchCard.prompt.speechText)
             }
+        }
+    }
+
+    private func advanceAfterCorrectOpenMatch() {
+        guard state.lessonThread.activeStage.kind == .invertedRecall else { return }
+        if state.isOnLastLessonCard {
+            state.completeCurrentLessonStage()
+            speakLessonStage()
+        } else {
+            state.advanceLessonCard()
+            speakLessonCard()
         }
     }
 

--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -229,6 +229,12 @@ final class MemoryCardDescribeService {
             } else {
                 firstSentence = "\(animal.canonicalName) is part of the water cycle."
             }
+        case .fruits:
+            if let foundIn = metadata.habitat {
+                firstSentence = "\(animal.canonicalName) is a fruit usually found in \(foundIn.lowercased())."
+            } else {
+                firstSentence = "\(animal.canonicalName) is a fruit with shape, color, taste, and smell clues."
+            }
         }
 
         let secondParts: [String]

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -5,17 +5,18 @@ import Testing
 @MainActor
 struct LabRouteRegressionTests {
     @Test
-    func everyExplorerLabActivityIsReachableFromAtLeastOneCapabilityLane() {
+    func everyExplorerLabActivityIsReachableFromExactlyOneCapabilityLane() {
         let activitiesByLane = CapabilityLane.defaultExplorerLanes.flatMap { lane in
             lane.activities.map { (laneID: lane.id, activityID: $0.id) }
         }
         let activityIDs = activitiesByLane.map(\.activityID)
 
         #expect(Set(activityIDs) == Set(LabActivityID.allCases))
+        #expect(activityIDs.count == LabActivityID.allCases.count)
 
         for activityID in LabActivityID.allCases {
             let hostLanes = activitiesByLane.filter { $0.activityID == activityID }.map(\.laneID)
-            #expect(!hostLanes.isEmpty, "\(activityID.rawValue) should be exposed by at least one lane")
+            #expect(hostLanes.count == 1, "\(activityID.rawValue) should be exposed by exactly one lane")
         }
     }
 

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -5,18 +5,17 @@ import Testing
 @MainActor
 struct LabRouteRegressionTests {
     @Test
-    func everyExplorerLabActivityIsReachableFromExactlyOneCapabilityLane() {
+    func everyExplorerLabActivityIsReachableFromAtLeastOneCapabilityLane() {
         let activitiesByLane = CapabilityLane.defaultExplorerLanes.flatMap { lane in
             lane.activities.map { (laneID: lane.id, activityID: $0.id) }
         }
         let activityIDs = activitiesByLane.map(\.activityID)
 
         #expect(Set(activityIDs) == Set(LabActivityID.allCases))
-        #expect(activityIDs.count == LabActivityID.allCases.count)
 
         for activityID in LabActivityID.allCases {
             let hostLanes = activitiesByLane.filter { $0.activityID == activityID }.map(\.laneID)
-            #expect(hostLanes.count == 1, "\(activityID.rawValue) should be exposed by exactly one lane")
+            #expect(!hostLanes.isEmpty, "\(activityID.rawValue) should be exposed by at least one lane")
         }
     }
 

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -70,10 +70,12 @@ struct LabRouteRegressionTests {
         #expect(discovery.starterMixMatchCards.count >= 8)
         #expect(discovery.modeChoiceCards.count == discovery.modes.count)
 
+        #expect(chemistry.activities.map(\.id) == [.memoryMatch])
+        #expect(chemistry.activities.first?.title == "Fruit Cards")
+
+        #expect(electronics.activities.isEmpty)
         for futureShell in [chemistry, electronics] {
-            #expect(futureShell.activities.isEmpty)
             #expect(!futureShell.promise.isEmpty)
-            #expect(futureShell.ageBandHint == "Future lane")
             #expect(futureShell.starterMixMatchCards.count >= 8)
             #expect(futureShell.modeChoiceCards.count == futureShell.modes.count)
         }

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -36,6 +36,8 @@ struct LabRouteRegressionTests {
             .waterCycle: .waterCycle,
             .soundVolume: .soundVolume,
             .memoryMatch: .memory,
+            .countryCards: .memoryDeck(.countries),
+            .fruitCards: .memoryDeck(.fruits),
         ]
 
         #expect(Set(expectedRoutes.keys) == Set(LabActivityID.allCases))
@@ -70,7 +72,7 @@ struct LabRouteRegressionTests {
         #expect(discovery.starterMixMatchCards.count >= 8)
         #expect(discovery.modeChoiceCards.count == discovery.modes.count)
 
-        #expect(chemistry.activities.map(\.id) == [.memoryMatch])
+        #expect(chemistry.activities.map(\.id) == [.fruitCards])
         #expect(chemistry.activities.first?.title == "Fruit Cards")
 
         #expect(electronics.activities.isEmpty)
@@ -97,7 +99,7 @@ struct LabRouteRegressionTests {
     @Test
     func laneDetailPresentationPrioritizesActivitiesBeforeSupportMetadata() throws {
         let readyLane = try #require(CapabilityLane.defaultExplorerLanes.first { $0.id == .numbers })
-        let futureLane = try #require(CapabilityLane.defaultExplorerLanes.first { $0.id == .chemistry })
+        let futureLane = try #require(CapabilityLane.defaultExplorerLanes.first { $0.id == .electronics })
 
         #expect(LabLaneDetailPresentation(lane: readyLane).sections == [
             .visualSummary,

--- a/Tests/MatherTests/MemoryViewTests.swift
+++ b/Tests/MatherTests/MemoryViewTests.swift
@@ -183,12 +183,14 @@ struct MemoryViewTests {
         #expect(MemoryView.DeckSelection.allCases.contains(.countryFlags))
         #expect(MemoryView.DeckSelection.allCases.contains(.indiaStates))
         #expect(MemoryView.DeckSelection.allCases.contains(.waterCycle))
+        #expect(MemoryView.DeckSelection.allCases.contains(.fruits))
         #expect(MemoryView.DeckSelection.planets.animals.map(\.id) == MemoryDeck.planets.map(\.id))
         #expect(MemoryView.DeckSelection.fishes.animals.map(\.id) == MemoryDeck.fishes.map(\.id))
         #expect(MemoryView.DeckSelection.countries.animals.map(\.id) == MemoryDeck.countries.map(\.id))
         #expect(MemoryView.DeckSelection.countryFlags.animals.map(\.id) == MemoryDeck.countryFlags.map(\.id))
         #expect(MemoryView.DeckSelection.indiaStates.animals.map(\.id) == MemoryDeck.indiaStates.map(\.id))
         #expect(MemoryView.DeckSelection.waterCycle.animals.map(\.id) == MemoryDeck.waterCycle.map(\.id))
+        #expect(MemoryView.DeckSelection.fruits.animals.map(\.id) == MemoryDeck.fruits.map(\.id))
     }
 
     @Test func requestedDecksProvideEnoughDistinctPairs() {
@@ -332,6 +334,9 @@ struct MemoryViewTests {
         #expect(plan.map(\.assetName) == assets)
         #expect(importedAssetNames == Set(assets))
         #expect(MemoryDeck.waterCycle.allSatisfy { $0.metadata.deck == .waterCycle })
+        #expect(MemoryDeck.fruits.allSatisfy { $0.metadata.deck == .fruits })
+        #expect(MemoryDeck.fruits.first?.detailCards.map(\.title).contains("Taste") == true)
+        #expect(MemoryDeck.fruits.first?.detailCards.map(\.title).contains("Usually Found") == true)
         #expect(MemoryDeck.waterCycle.allSatisfy { $0.metadata.category == "water cycle concept" })
         #expect(MemoryDeck.waterCycle.allSatisfy { animal in
             Set(animal.detailCards.map(\.title)).isSuperset(of: ["Concept", "Action", "Where", "Everyday Words", "Cycle Step"])
@@ -466,6 +471,16 @@ struct MemoryViewTests {
         let waterCycleContent = MemoryView.learningContent(for: MemoryDeck.waterCycle[0], deckSelection: .waterCycle, description: waterCycleDescription)
         #expect(waterCycleContent.sourceBadge == "Water Cycle Guide")
         #expect(waterCycleContent.readAloudText.contains("Source: Water Cycle Guide."))
+
+        let fruitDescription = MemoryCardDescription(
+            title: "Mango",
+            shortDescription: "Mango is a sweet fruit with shape, color, smell, and country clues.",
+            factChips: [MemoryFactChip(title: "Taste", value: "very sweet and juicy")],
+            source: .curatedFallback
+        )
+        let fruitContent = MemoryView.learningContent(for: MemoryDeck.fruits[2], deckSelection: .fruits, description: fruitDescription)
+        #expect(fruitContent.sourceBadge == "Fruit Guide")
+        #expect(fruitContent.readAloudText.contains("Source: Fruit Guide."))
     }
 }
 
@@ -482,7 +497,7 @@ struct MemoryCardDescribeServiceTests {
     }
 
     @Test func allMemoryCardsExposeStructuredMetadata() {
-        let allAnimals = MemoryDeck.domesticAnimals + MemoryDeck.birds + MemoryDeck.vehicles + MemoryDeck.planets + MemoryDeck.fishes + MemoryDeck.countries + MemoryDeck.countryFlags + MemoryDeck.indiaStates + MemoryDeck.waterCycle
+        let allAnimals = MemoryDeck.domesticAnimals + MemoryDeck.birds + MemoryDeck.vehicles + MemoryDeck.planets + MemoryDeck.fishes + MemoryDeck.countries + MemoryDeck.countryFlags + MemoryDeck.indiaStates + MemoryDeck.waterCycle + MemoryDeck.fruits
 
         #expect(MemoryDeck.allAnimalsById.count == allAnimals.count)
         #expect(allAnimals.allSatisfy { !$0.metadata.category.isEmpty })
@@ -496,6 +511,9 @@ struct MemoryCardDescribeServiceTests {
         #expect(MemoryDeck.countryFlags.allSatisfy { $0.metadata.deck == .countryFlags })
         #expect(MemoryDeck.indiaStates.allSatisfy { $0.metadata.deck == .indiaStates })
         #expect(MemoryDeck.waterCycle.allSatisfy { $0.metadata.deck == .waterCycle })
+        #expect(MemoryDeck.fruits.allSatisfy { $0.metadata.deck == .fruits })
+        #expect(MemoryDeck.fruits.first?.detailCards.map(\.title).contains("Taste") == true)
+        #expect(MemoryDeck.fruits.first?.detailCards.map(\.title).contains("Usually Found") == true)
     }
 
     @MainActor @Test func fallbackDescriptionUsesCuratedFlagMetadata() async {


### PR DESCRIPTION
## Summary
- tighten Water Cycle stage layout and auto-advance picture matches after correct answers
- convert Shape Lab into Look → Quiz → Match → Stars screens instead of one long scroll
- add Chemistry Fruit Cards and Map & World Country Cards with richer memory facts and direct deck launch routes

Closes #882. Closes #885. Closes #886. Closes #887. Closes #889. Closes #890. Closes #891.

## Validation
- `git diff --check`
- Not run locally: Linux worker has no Swift toolchain (`swift: command not found`); macOS SSH target DNS lookup failed. Relying on GitHub Actions for Xcode build/test.
