### PR TITLE
fix: add Country Cards map game

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -86,6 +86,8 @@ struct RootView: View {
                     GravityArtistView(appModel: appModel)
                 case .compassAngles:
                     CompassAnglesView(appModel: appModel)
+                case .countryCards:
+                    CountryCardsView(appModel: appModel)
                 case .lab:
                     LabView(appModel: appModel)
                 case .labLane(let laneID):

--- a/Domain/CountryCardsModels.swift
+++ b/Domain/CountryCardsModels.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+struct CountryCardFact: Identifiable, Equatable, Hashable {
+    let id: String
+    let name: String
+    let capital: String
+    let language: String
+    let flagEmoji: String
+    let currency: String
+    let mapShape: String
+    let continent: String
+    let mapClue: String
+
+    var accessibilitySummary: String {
+        "\(name), capital \(capital), language \(language), flag \(flagEmoji), currency \(currency), shape \(mapShape), continent \(continent)."
+    }
+}
+
+enum CountryCardFacet: String, CaseIterable, Identifiable, Equatable {
+    case countryName = "Country"
+    case capital = "Capital"
+    case language = "Language"
+    case flag = "Flag"
+    case currency = "Currency"
+    case mapShape = "Map shape"
+
+    var id: String { rawValue }
+}
+
+struct CountryFlashcard: Identifiable, Equatable {
+    let country: CountryCardFact
+    let facet: CountryCardFacet
+
+    var id: String { "\(country.id)-\(facet.id)" }
+
+    var prompt: String {
+        switch facet {
+        case .countryName:
+            return "Which country is this?"
+        case .capital:
+            return "Capital of \(country.name)"
+        case .language:
+            return "Language clue"
+        case .flag:
+            return "Flag flashcard"
+        case .currency:
+            return "Currency used"
+        case .mapShape:
+            return "Shape on the map"
+        }
+    }
+
+    var answer: String {
+        switch facet {
+        case .countryName:
+            return country.name
+        case .capital:
+            return country.capital
+        case .language:
+            return country.language
+        case .flag:
+            return "\(country.flagEmoji) \(country.name)"
+        case .currency:
+            return country.currency
+        case .mapShape:
+            return country.mapShape
+        }
+    }
+
+    var detail: String {
+        switch facet {
+        case .countryName:
+            return "Find \(country.name) in \(country.continent)."
+        case .capital:
+            return "\(country.capital) is the capital city."
+        case .language:
+            return "A common language: \(country.language)."
+        case .flag:
+            return "Look for the flag colors and symbol."
+        case .currency:
+            return "Money clue: \(country.currency)."
+        case .mapShape:
+            return country.mapClue
+        }
+    }
+}
+
+enum CountryCardsDeck {
+    static let starterCountries: [CountryCardFact] = [
+        CountryCardFact(id: "india", name: "India", capital: "New Delhi", language: "Hindi and English", flagEmoji: "🇮🇳", currency: "Indian rupee", mapShape: "diamond kite with a long south point", continent: "Asia", mapClue: "Look for the triangle-like peninsula pointing into the Indian Ocean."),
+        CountryCardFact(id: "japan", name: "Japan", capital: "Tokyo", language: "Japanese", flagEmoji: "🇯🇵", currency: "Japanese yen", mapShape: "curved island chain", continent: "Asia", mapClue: "Look for a thin chain of islands east of Asia."),
+        CountryCardFact(id: "france", name: "France", capital: "Paris", language: "French", flagEmoji: "🇫🇷", currency: "Euro", mapShape: "hexagon", continent: "Europe", mapClue: "France is often nicknamed the hexagon."),
+        CountryCardFact(id: "egypt", name: "Egypt", capital: "Cairo", language: "Arabic", flagEmoji: "🇪🇬", currency: "Egyptian pound", mapShape: "square corner with Nile ribbon", continent: "Africa", mapClue: "Find the Nile River running north to the Mediterranean Sea."),
+        CountryCardFact(id: "brazil", name: "Brazil", capital: "Brasília", language: "Portuguese", flagEmoji: "🇧🇷", currency: "Brazilian real", mapShape: "large east-bulging shield", continent: "South America", mapClue: "It is the biggest country in South America and reaches the Atlantic."),
+        CountryCardFact(id: "australia", name: "Australia", capital: "Canberra", language: "English", flagEmoji: "🇦🇺", currency: "Australian dollar", mapShape: "wide island continent", continent: "Australia", mapClue: "It is the large island continent between the Indian and Pacific oceans.")
+    ]
+
+    static let continents: [String] = ["Africa", "Asia", "Australia", "Europe", "North America", "South America"]
+
+    static var deterministicFlashcards: [CountryFlashcard] {
+        starterCountries.flatMap { country in
+            CountryCardFacet.allCases.map { facet in
+                CountryFlashcard(country: country, facet: facet)
+            }
+        }
+    }
+
+    static func country(id: String) -> CountryCardFact? {
+        starterCountries.first { $0.id == id }
+    }
+}
+
+struct CountryContinentBucketGame: Equatable {
+    private(set) var placedCountryIDs: Set<String> = []
+
+    var remainingCountries: [CountryCardFact] {
+        CountryCardsDeck.starterCountries.filter { !placedCountryIDs.contains($0.id) }
+    }
+
+    var completionLabel: String {
+        "\(placedCountryIDs.count) / \(CountryCardsDeck.starterCountries.count) countries sorted"
+    }
+
+    func continent(for countryID: String) -> String? {
+        CountryCardsDeck.country(id: countryID)?.continent
+    }
+
+    func isCorrectPlacement(countryID: String, continent: String) -> Bool {
+        self.continent(for: countryID) == continent
+    }
+
+    mutating func place(countryID: String, in continent: String) -> Bool {
+        guard isCorrectPlacement(countryID: countryID, continent: continent) else { return false }
+        placedCountryIDs.insert(countryID)
+        return true
+    }
+}

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -17,6 +17,7 @@ enum AppRoute: Hashable {
     case twoFingerProtractor
     case gravityArtist
     case compassAngles
+    case countryCards
     case lab
     case labLane(CapabilityLaneID)
     case memory
@@ -130,6 +131,7 @@ final class VerticalSliceEngine {
     func showTwoFingerProtractor() { route = .twoFingerProtractor }
     func showGravityArtist() { route = .gravityArtist }
     func showCompassAngles() { route = .compassAngles }
+    func showCountryCards() { route = .countryCards }
     func showLab() { route = .lab }
     func showLabLane(_ laneID: CapabilityLaneID) { route = .labLane(laneID) }
     func showMemory() { route = .memory }

--- a/Features/CountryCards/CountryCardsView.swift
+++ b/Features/CountryCards/CountryCardsView.swift
@@ -1,0 +1,278 @@
+import SwiftUI
+
+struct CountryCardsView: View {
+    @Bindable var appModel: AppModel
+    @State private var mode: CountryCardsMode = .flashcards
+    @State private var cardIndex = 0
+    @State private var bucketGame = CountryContinentBucketGame()
+    @State private var selectedCountryID: String = CountryCardsDeck.starterCountries.first?.id ?? ""
+    @State private var bucketFeedback = "Pick a country, then tap its continent bucket."
+
+    private var currentCard: CountryFlashcard {
+        let cards = CountryCardsDeck.deterministicFlashcards
+        return cards[cardIndex % max(cards.count, 1)]
+    }
+
+    var body: some View {
+        ZStack {
+            MatherTheme.background.ignoresSafeArea()
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 18) {
+                    header
+                    modePicker
+
+                    switch mode {
+                    case .flashcards:
+                        flashcardPanel
+                    case .continentBuckets:
+                        bucketPanel
+                    }
+                }
+                .padding(22)
+            }
+        }
+        .navigationTitle("Country Cards")
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Button {
+                    appModel.engine.showLabLane(.mapWorld)
+                } label: {
+                    Label("Map & World", systemImage: "chevron.left")
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(MatherTheme.accent)
+                        .frame(minHeight: 56)
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+
+                Button {
+                    appModel.engine.showHome()
+                } label: {
+                    Image(systemName: "house.fill")
+                        .font(.title2.weight(.semibold))
+                        .foregroundStyle(MatherTheme.accent)
+                        .frame(width: 56, height: 56)
+                }
+                .accessibilityLabel("Home")
+            }
+
+            Label("Country Cards", systemImage: "map.fill")
+                .font(.system(size: 34, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+            Text("Flashcards for country names, capitals, languages, flags, currency, and shapes on the map — then sort countries into continent buckets.")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+    }
+
+    private var modePicker: some View {
+        Picker("Country game mode", selection: $mode) {
+            ForEach(CountryCardsMode.allCases) { mode in
+                Text(mode.label).tag(mode)
+            }
+        }
+        .pickerStyle(.segmented)
+        .accessibilityLabel("Country game mode")
+    }
+
+    private var flashcardPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Flashcard \(cardIndex + 1) of \(CountryCardsDeck.deterministicFlashcards.count)")
+                .font(.caption.weight(.black))
+                .foregroundStyle(MatherTheme.accent)
+
+            VStack(alignment: .leading, spacing: 12) {
+                Text(currentCard.country.flagEmoji)
+                    .font(.system(size: 64))
+                    .accessibilityHidden(true)
+                Text(currentCard.prompt)
+                    .font(.title3.weight(.black))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                Text(currentCard.answer)
+                    .font(.system(size: 36, weight: .black, design: .rounded))
+                    .foregroundStyle(MatherTheme.ink)
+                    .minimumScaleFactor(0.75)
+                Text(currentCard.detail)
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+            .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                    .stroke(MatherTheme.accent.opacity(0.18), lineWidth: 1)
+            )
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(currentCard.country.accessibilitySummary)
+
+            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+                factChip("Country", currentCard.country.name)
+                factChip("Capital", currentCard.country.capital)
+                factChip("Language", currentCard.country.language)
+                factChip("Currency", currentCard.country.currency)
+                factChip("Shape", currentCard.country.mapShape)
+                factChip("Continent", currentCard.country.continent)
+            }
+
+            HStack(spacing: 12) {
+                Button("Previous") { previousCard() }
+                    .buttonStyle(CountryCardsButtonStyle(tint: MatherTheme.softBlue))
+                Button("Next card") { nextCard() }
+                    .buttonStyle(CountryCardsButtonStyle(tint: MatherTheme.accent))
+            }
+        }
+    }
+
+    private var bucketPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Label("Continent bucket mode", systemImage: "tray.full.fill")
+                .font(.title3.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            Text(bucketGame.completionLabel)
+                .font(.caption.weight(.black))
+                .foregroundStyle(MatherTheme.accent)
+            Text(bucketFeedback)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Countries to sort")
+                    .font(.headline.weight(.black))
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+                    ForEach(CountryCardsDeck.starterCountries) { country in
+                        Button {
+                            selectedCountryID = country.id
+                            bucketFeedback = "Now place \(country.flagEmoji) \(country.name) into a continent bucket."
+                        } label: {
+                            HStack {
+                                Text(country.flagEmoji)
+                                Text(country.name)
+                                    .font(.caption.weight(.black))
+                                Spacer(minLength: 0)
+                                if bucketGame.placedCountryIDs.contains(country.id) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(MatherTheme.accent)
+                                }
+                            }
+                            .padding(10)
+                            .frame(maxWidth: .infinity, minHeight: 54, alignment: .leading)
+                            .background(country.id == selectedCountryID ? MatherTheme.accent.opacity(0.14) : MatherTheme.card, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(bucketGame.placedCountryIDs.contains(country.id))
+                    }
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Continent buckets")
+                    .font(.headline.weight(.black))
+                LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+                    ForEach(CountryCardsDeck.continents, id: \.self) { continent in
+                        Button {
+                            placeSelectedCountry(in: continent)
+                        } label: {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Image(systemName: "shippingbox.fill")
+                                    .foregroundStyle(MatherTheme.accent)
+                                Text(continent)
+                                    .font(.headline.weight(.black))
+                                    .foregroundStyle(MatherTheme.ink)
+                                Text(bucketContents(for: continent))
+                                    .font(.caption2.weight(.semibold))
+                                    .foregroundStyle(MatherTheme.cardSubtitle)
+                                    .lineLimit(2)
+                            }
+                            .frame(maxWidth: .infinity, minHeight: 112, alignment: .topLeading)
+                            .padding(12)
+                            .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Place selected country in \(continent)")
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .background(MatherTheme.card.opacity(0.72), in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+    }
+
+    private func factChip(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.black))
+                .foregroundStyle(MatherTheme.accent)
+            Text(value)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(MatherTheme.ink)
+                .lineLimit(2)
+                .minimumScaleFactor(0.7)
+        }
+        .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
+        .padding(10)
+        .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private func nextCard() {
+        cardIndex = (cardIndex + 1) % CountryCardsDeck.deterministicFlashcards.count
+    }
+
+    private func previousCard() {
+        cardIndex = (cardIndex - 1 + CountryCardsDeck.deterministicFlashcards.count) % CountryCardsDeck.deterministicFlashcards.count
+    }
+
+    private func placeSelectedCountry(in continent: String) {
+        guard let country = CountryCardsDeck.country(id: selectedCountryID) else { return }
+        if bucketGame.place(countryID: selectedCountryID, in: continent) {
+            bucketFeedback = "Nice! \(country.flagEmoji) \(country.name) belongs in \(continent)."
+            if let next = bucketGame.remainingCountries.first {
+                selectedCountryID = next.id
+            }
+        } else {
+            bucketFeedback = "Try again: \(country.name) is not in \(continent). Look for the map clue."
+        }
+    }
+
+    private func bucketContents(for continent: String) -> String {
+        let names = CountryCardsDeck.starterCountries
+            .filter { bucketGame.placedCountryIDs.contains($0.id) && $0.continent == continent }
+            .map(\.name)
+        return names.isEmpty ? "Drop countries here" : names.joined(separator: ", ")
+    }
+}
+
+private enum CountryCardsMode: String, CaseIterable, Identifiable {
+    case flashcards
+    case continentBuckets
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .flashcards: return "Flashcards"
+        case .continentBuckets: return "Buckets"
+        }
+    }
+}
+
+private struct CountryCardsButtonStyle: ButtonStyle {
+    let tint: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.headline.weight(.black))
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity, minHeight: 58)
+            .background(tint.opacity(configuration.isPressed ? 0.72 : 1), in: Capsule())
+    }
+}

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -543,6 +543,11 @@ struct LabLaneDetailView: View {
                 .font(.system(size: 52, weight: .bold))
                 .foregroundStyle(tint.opacity(0.35))
                 .offset(x: 20, y: 12)
+        case .countryCards:
+            Image(systemName: "map.fill")
+                .font(.system(size: 48, weight: .bold))
+                .foregroundStyle(tint.opacity(0.35))
+                .offset(x: 20, y: 12)
         case .waterCycle:
             Image(systemName: "cloud.rain.fill")
                 .font(.system(size: 48, weight: .bold))
@@ -587,7 +592,7 @@ struct LabLaneDetailView: View {
             case .sumSprint:
                 appModel.sumSprintEngine.showDifficultyPick()
             case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
-                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
+                 .twoFingerProtractor, .gravityArtist, .compassAngles, .countryCards, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
                 break
             }
         }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -121,6 +121,7 @@ enum LabActivityID: String, CaseIterable, Hashable {
     case twoFingerProtractor
     case gravityArtist
     case compassAngles
+    case countryCards
     case shapeGeometry
     case waterCycle
     case soundVolume
@@ -148,6 +149,8 @@ extension LabActivityID {
             return .gravityArtist
         case .compassAngles:
             return .compassAngles
+        case .countryCards:
+            return .countryCards
         case .shapeGeometry:
             return .shapeGeometry
         case .waterCycle:
@@ -653,6 +656,13 @@ struct CapabilityLane: Identifiable, Equatable {
                     title: "Compass Walk",
                     tagline: "Turn your body to match the angle",
                     modes: [.explore, .challenge, .timed]
+                ),
+                LabActivity(
+                    id: .countryCards,
+                    emoji: "🌍",
+                    title: "Country Cards",
+                    tagline: "Flashcards for capitals, flags, languages, currency, and continents",
+                    modes: [.learn, .review, .challenge]
                 ),
             ]
         ),

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -349,7 +349,7 @@ struct LabLaneDetailPresentation: Equatable {
 extension LabActivityID {
     var sensorNeeds: [LabSensorNeed] {
         switch self {
-        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
+        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .countryCards, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
             return [.noSpecialSensor]
         case .symmetryFold, .angleCannon, .gravityArtist:
             return [.motion]

--- a/Tests/MatherTests/CountryCardsTests.swift
+++ b/Tests/MatherTests/CountryCardsTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import Mather
+
+final class CountryCardsTests: XCTestCase {
+    func testStarterDeckCoversRequestedFlashcardFacts() {
+        let countries = CountryCardsDeck.starterCountries
+
+        XCTAssertEqual(countries.count, 6)
+        XCTAssertTrue(countries.allSatisfy { !$0.name.isEmpty })
+        XCTAssertTrue(countries.allSatisfy { !$0.capital.isEmpty })
+        XCTAssertTrue(countries.allSatisfy { !$0.language.isEmpty })
+        XCTAssertTrue(countries.allSatisfy { !$0.flagEmoji.isEmpty })
+        XCTAssertTrue(countries.allSatisfy { !$0.currency.isEmpty })
+        XCTAssertTrue(countries.allSatisfy { !$0.mapShape.isEmpty })
+        XCTAssertTrue(countries.allSatisfy { CountryCardsDeck.continents.contains($0.continent) })
+    }
+
+    func testDeterministicFlashcardsIncludeEveryFacetForEveryCountry() {
+        let flashcards = CountryCardsDeck.deterministicFlashcards
+
+        XCTAssertEqual(flashcards.count, CountryCardsDeck.starterCountries.count * CountryCardFacet.allCases.count)
+        XCTAssertEqual(flashcards.prefix(6).map(\.facet), CountryCardFacet.allCases)
+        XCTAssertEqual(flashcards.first?.country.name, "India")
+        XCTAssertEqual(flashcards.first { $0.country.id == "france" && $0.facet == .mapShape }?.answer, "hexagon")
+        XCTAssertEqual(Set(flashcards.map(\.id)).count, flashcards.count)
+    }
+
+    func testContinentBucketGameOnlyAcceptsCorrectPlacements() {
+        var game = CountryContinentBucketGame()
+
+        XCTAssertFalse(game.place(countryID: "brazil", in: "Europe"))
+        XCTAssertEqual(game.completionLabel, "0 / 6 countries sorted")
+        XCTAssertTrue(game.place(countryID: "brazil", in: "South America"))
+        XCTAssertEqual(game.completionLabel, "1 / 6 countries sorted")
+        XCTAssertFalse(game.remainingCountries.contains { $0.id == "brazil" })
+        XCTAssertEqual(game.continent(for: "japan"), "Asia")
+    }
+}

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -109,6 +109,18 @@ final class LabModelsTests: XCTestCase {
         XCTAssertTrue(physics.starterMixMatchCards.contains { $0.concept == "hearing-safety" && $0.prompt == "siren" && $0.match == "protect ears" })
     }
 
+
+    func testMapWorldLaneAddsCountryCardsGame() throws {
+        let mapWorld = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .mapWorld })
+
+        XCTAssertEqual(mapWorld.activities.map(\.id), [.roomQuest, .compassAngles, .countryCards])
+        XCTAssertEqual(LabLaneDetailPresentation(lane: mapWorld).activityCountLabel, "3 games ready")
+        let countryCards = try XCTUnwrap(mapWorld.activities.first { $0.id == .countryCards })
+        XCTAssertTrue(countryCards.tagline.contains("capitals"))
+        XCTAssertTrue(countryCards.tagline.contains("currency"))
+        XCTAssertTrue(countryCards.tagline.contains("continents"))
+    }
+
     func testLabLaneRouteCarriesSelectedLaneWithoutChangingGameRoutes() throws {
         XCTAssertEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.geometry))
         XCTAssertNotEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.numbers))
@@ -116,6 +128,7 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(LabActivityID.shapeGeometry.appRoute, .shapeGeometry)
         XCTAssertEqual(LabActivityID.waterCycle.appRoute, .waterCycle)
         XCTAssertEqual(LabActivityID.soundVolume.appRoute, .soundVolume)
+        XCTAssertEqual(LabActivityID.countryCards.appRoute, .countryCards)
         XCTAssertEqual(LabActivityID.memoryMatch.appRoute, .memory)
     }
 


### PR DESCRIPTION
## Summary

Adds a new Map & World “Country Cards” game for issue #887 with deterministic starter country flashcards and a continent bucket sorting mode.

## Changes

- Added country learning models covering names, capitals, languages, flags, currency, map-shape clues, and continents.
- Added a Country Cards SwiftUI screen with Flashcards and Buckets modes.
- Wired Country Cards into the Map & World lane and app route.
- Added unit coverage for the starter deck, deterministic flashcards, bucket placement rules, and lab routing.

## Testing

- `git diff --check` ✅
- Static content checks for new model/view/test files ✅
- Not run: Swift/Xcode tests locally (`swift` and `xcodegen` are unavailable on this Linux worker; `ganesh-mba` SSH DNS lookup failed).

Fixes ganesh47/mather#887