### PR TITLE
Add Chemistry Lab fruit memory cards

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -25,6 +25,7 @@ final class AppModel {
     let explorerLabMasteryStore: ExplorerLabMasteryStore
 
     var explorerLabMasteryProfile: ExplorerLabMasteryProfile
+    var preferredMemoryDeckKind: MemoryDeckKind? = nil
     var showingProfilePicker = false
     private var pendingGameAction: (() -> Void)?
 

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -558,6 +558,11 @@ struct LabLaneDetailView: View {
                 .font(.system(size: 48, weight: .bold))
                 .foregroundStyle(tint.opacity(0.35))
                 .offset(x: 20, y: 12)
+        case .fruitMemory:
+            Image(systemName: "apple.logo")
+                .font(.system(size: 48, weight: .bold))
+                .foregroundStyle(tint.opacity(0.35))
+                .offset(x: 20, y: 12)
         }
     }
 
@@ -582,12 +587,21 @@ struct LabLaneDetailView: View {
 
     private func launch(_ activityID: LabActivityID) {
         appModel.pickProfileThenRun {
+            switch activityID {
+            case .memoryMatch:
+                appModel.preferredMemoryDeckKind = nil
+            case .fruitMemory:
+                appModel.preferredMemoryDeckKind = .fruits
+            default:
+                break
+            }
+
             appModel.engine.show(activityID.appRoute)
             switch activityID {
             case .sumSprint:
                 appModel.sumSprintEngine.showDifficultyPick()
             case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
-                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
+                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .fruitMemory:
                 break
             }
         }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -125,6 +125,7 @@ enum LabActivityID: String, CaseIterable, Hashable {
     case waterCycle
     case soundVolume
     case memoryMatch
+    case fruitMemory
 }
 
 extension LabActivityID {
@@ -154,7 +155,7 @@ extension LabActivityID {
             return .waterCycle
         case .soundVolume:
             return .soundVolume
-        case .memoryMatch:
+        case .memoryMatch, .fruitMemory:
             return .memory
         }
     }
@@ -346,7 +347,7 @@ struct LabLaneDetailPresentation: Equatable {
 extension LabActivityID {
     var sensorNeeds: [LabSensorNeed] {
         switch self {
-        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch:
+        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .fruitMemory:
             return [.noSpecialSensor]
         case .symmetryFold, .angleCannon, .gravityArtist:
             return [.motion]
@@ -681,16 +682,24 @@ struct CapabilityLane: Identifiable, Equatable {
         CapabilityLane(
             id: .chemistry,
             emoji: "⚗️",
-            promise: "Future: sort materials, mix safely, and predict properties.",
-            ageBandHint: "Future lane",
-            modes: [.explore, .challenge, .review],
+            promise: "Sort fruits by color, shape, smell, taste, and where they grow.",
+            ageBandHint: "Ages 4–12",
+            modes: [.learn, .review, .challenge],
             ageEntries: [
                 CapabilityAgeEntry(ageBand: .preschool, posture: "material sorting", entryPlay: "color and texture"),
                 CapabilityAgeEntry(ageBand: .earlyElementary, posture: "states and mixtures", entryPlay: "mix and separate"),
                 CapabilityAgeEntry(ageBand: .upperElementary, posture: "properties and prediction", entryPlay: "safe reaction cards"),
                 CapabilityAgeEntry(ageBand: .preteen, posture: "families and systems", entryPlay: "property puzzles"),
             ],
-            activities: []
+            activities: [
+                LabActivity(
+                    id: .fruitMemory,
+                    emoji: "🍎",
+                    title: "Fruit Memory Cards",
+                    tagline: "Match fruits and learn shape, color, taste, smell, and places",
+                    modes: [.learn, .review, .challenge]
+                ),
+            ]
         ),
         CapabilityLane(
             id: .electronics,

--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -23,6 +23,7 @@ enum MemoryDeckKind: String, Equatable {
     case countryFlags
     case indiaStates
     case waterCycle
+    case fruits
 
     var displayName: String {
         switch self {
@@ -35,6 +36,7 @@ enum MemoryDeckKind: String, Equatable {
         case .countryFlags: return "Countries & Flags"
         case .indiaStates: return "Indian States & Capitals"
         case .waterCycle: return "Water Cycle"
+        case .fruits: return "Fruit Lab"
         }
     }
 }
@@ -391,6 +393,17 @@ enum MemoryDeck {
         indiaStateCapital("state-assam", state: "Assam", capital: "Dispur", region: "northeast India", clue: "tea gardens and one-horned rhinos")
     ]
 
+    static let fruits: [MemoryAnimal] = [
+        fruit("fruit-apple", name: "Apple", emoji: "🍎", shape: "round", color: "red, green, or yellow", taste: "sweet and crisp", smell: "fresh and lightly sweet", region: "many countries, including India and the United States"),
+        fruit("fruit-banana", name: "Banana", emoji: "🍌", shape: "long curved crescent", color: "yellow when ripe", taste: "sweet and soft", smell: "mild and fruity", region: "tropical regions such as India, Ecuador, and the Philippines"),
+        fruit("fruit-mango", name: "Mango", emoji: "🥭", shape: "oval", color: "yellow, orange, red, or green", taste: "very sweet and juicy", smell: "strong, tropical, and sweet", region: "India and other warm tropical regions"),
+        fruit("fruit-orange", name: "Orange", emoji: "🍊", shape: "round", color: "bright orange", taste: "sweet and tangy", smell: "zesty citrus", region: "warm regions such as Brazil, India, and the Mediterranean"),
+        fruit("fruit-grape", name: "Grape", emoji: "🍇", shape: "small round oval", color: "green, red, purple, or black", taste: "sweet or tangy", smell: "soft and juicy", region: "vineyards in Europe, India, and the Americas"),
+        fruit("fruit-strawberry", name: "Strawberry", emoji: "🍓", shape: "heart-shaped", color: "red with tiny yellow seeds", taste: "sweet and a little tart", smell: "bright and berry-sweet", region: "cool farms in many countries, including the United States, Mexico, and India"),
+        fruit("fruit-pineapple", name: "Pineapple", emoji: "🍍", shape: "oval with a leafy crown", color: "golden yellow inside with green-brown skin", taste: "sweet and tangy", smell: "tropical and juicy", region: "tropical regions such as Costa Rica, the Philippines, and India"),
+        fruit("fruit-watermelon", name: "Watermelon", emoji: "🍉", shape: "large round or oval", color: "green outside and red inside", taste: "sweet and watery", smell: "fresh and gentle", region: "warm regions in India, China, Africa, and the Americas")
+    ]
+
     static let waterCycle: [MemoryAnimal] = [
         waterCycleConcept("water-cycle-evaporation", name: "Evaporation", asset: "MemoryWaterCycleEvaporation", action: "warm water goes up", whereSeen: "above warm ponds, lakes, and puddles", everydayWords: "The sun warms water into vapor", cycleStep: "Water rises into the air"),
         waterCycleConcept("water-cycle-condensation", name: "Condensation", asset: "MemoryWaterCycleCondensation", action: "tiny drops make a cloud", whereSeen: "inside cool clouds", everydayWords: "Vapor cools and gathers as tiny drops", cycleStep: "Drops gather together"),
@@ -414,7 +427,7 @@ enum MemoryDeck {
     ]
 
     static let allAnimalsById: [String: MemoryAnimal] = {
-        Dictionary(uniqueKeysWithValues: (domesticAnimals + birds + vehicles + planets + fishes + countries + countryFlags + indiaStates + waterCycle).map { ($0.id, $0) })
+        Dictionary(uniqueKeysWithValues: (domesticAnimals + birds + vehicles + planets + fishes + countries + countryFlags + indiaStates + waterCycle + fruits).map { ($0.id, $0) })
     }()
 
     static let imageAssetProvenance: [MemoryImageAssetProvenance] = [
@@ -753,6 +766,31 @@ enum MemoryDeck {
         )
     }
 
+    private static func fruit(_ id: String, name: String, emoji: String, shape: String, color: String, taste: String, smell: String, region: String) -> MemoryAnimal {
+        MemoryAnimal(
+            id: id,
+            name: name,
+            picture: .emoji(emoji),
+            metadata: MemoryCardMetadata(
+                deck: .fruits,
+                category: "fruit",
+                kind: "fruit",
+                habitat: region,
+                colors: color,
+                use: taste,
+                movement: smell,
+                factCards: [
+                    MemoryFactCard(title: "Fruit", value: name),
+                    MemoryFactCard(title: "Shape", value: shape),
+                    MemoryFactCard(title: "Color", value: color),
+                    MemoryFactCard(title: "Taste", value: taste),
+                    MemoryFactCard(title: "Smell", value: smell),
+                    MemoryFactCard(title: "Often Found", value: region)
+                ]
+            )
+        )
+    }
+
     private static func waterCycleConcept(_ id: String, name: String, asset: String, action: String, whereSeen: String, everydayWords: String, cycleStep: String) -> MemoryAnimal {
         MemoryAnimal(
             id: id,
@@ -824,6 +862,7 @@ struct MemoryView: View {
     @Bindable var appModel: AppModel
 
     @State private var deck: [MemoryAnimal] = MemoryDeck.domesticAnimals
+    @State private var appliedPreferredDeck = false
     @State private var difficulty: MemoryDifficulty = .easy
     @State private var cards: [MemoryCard] = []
     @State private var firstSelected: MemoryCard? = nil
@@ -840,7 +879,7 @@ struct MemoryView: View {
     @State private var latestAskResponse: MemoryAskResponse? = nil
 
     enum DeckSelection: CaseIterable {
-        case domestic, birds, vehicles, planets, fishes, countries, countryFlags, indiaStates, waterCycle
+        case domestic, birds, vehicles, planets, fishes, countries, countryFlags, indiaStates, waterCycle, fruits
 
         var label: String {
             switch self {
@@ -853,6 +892,7 @@ struct MemoryView: View {
             case .countryFlags: return "🏳️ Countries & Flags"
             case .indiaStates: return "📍 India States & Capitals"
             case .waterCycle: return "💧 Water Cycle"
+            case .fruits: return "🍎 Fruit Lab"
             }
         }
 
@@ -867,6 +907,22 @@ struct MemoryView: View {
             case .countryFlags: return "Countries & Flags"
             case .indiaStates: return "India States & Capitals"
             case .waterCycle: return "Water Cycle"
+            case .fruits: return "Fruit Lab"
+            }
+        }
+
+        init?(kind: MemoryDeckKind) {
+            switch kind {
+            case .domesticAnimals: self = .domestic
+            case .birds: self = .birds
+            case .vehicles: self = .vehicles
+            case .planets: self = .planets
+            case .fishes: self = .fishes
+            case .countries: self = .countries
+            case .countryFlags: self = .countryFlags
+            case .indiaStates: self = .indiaStates
+            case .waterCycle: self = .waterCycle
+            case .fruits: self = .fruits
             }
         }
 
@@ -881,6 +937,7 @@ struct MemoryView: View {
             case .countryFlags: return MemoryDeck.countryFlags
             case .indiaStates: return MemoryDeck.indiaStates
             case .waterCycle: return MemoryDeck.waterCycle
+            case .fruits: return MemoryDeck.fruits
             }
         }
     }
@@ -909,6 +966,7 @@ struct MemoryView: View {
             learningSheet(for: content)
         }
         .onAppear {
+            applyPreferredDeckIfNeeded()
             sessionStart = .now
             dealRound()
         }
@@ -921,6 +979,15 @@ struct MemoryView: View {
                 scoreLabel: "rounds"
             )
         }
+    }
+
+    private func applyPreferredDeckIfNeeded() {
+        guard !appliedPreferredDeck else { return }
+        appliedPreferredDeck = true
+        guard let preferred = appModel.preferredMemoryDeckKind, let selected = DeckSelection(kind: preferred) else { return }
+        deckSelection = selected
+        deck = selected.animals
+        recentPairHistory = []
     }
 
     private var header: some View {
@@ -1633,6 +1700,8 @@ struct MemoryView: View {
             deckLabel = "India Guide"
         case .waterCycle:
             deckLabel = "Water Cycle Guide"
+        case .fruits:
+            deckLabel = "Fruit Guide"
         }
 
         switch source {

--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -229,6 +229,12 @@ final class MemoryCardDescribeService {
             } else {
                 firstSentence = "\(animal.canonicalName) is part of the water cycle."
             }
+        case .fruits:
+            if let region = metadata.habitat {
+                firstSentence = "\(animal.canonicalName) is a fruit often found in \(region.lowercased())."
+            } else {
+                firstSentence = "\(animal.canonicalName) is a fruit."
+            }
         }
 
         let secondParts: [String]
@@ -236,6 +242,12 @@ final class MemoryCardDescribeService {
             secondParts = [
                 metadata.habitat.map { "You can notice it \($0.lowercased())" },
                 animal.detailCards.first { $0.title == "Everyday Words" }.map(\.value)
+            ].compactMap { $0 }
+        } else if metadata.deck == .fruits {
+            secondParts = [
+                animal.detailCards.first { $0.title == "Shape" }.map { "It is usually \($0.value.lowercased())" },
+                animal.detailCards.first { $0.title == "Taste" }.map { "It tastes \($0.value.lowercased())" },
+                animal.detailCards.first { $0.title == "Smell" }.map { "It smells \($0.value.lowercased())" }
             ].compactMap { $0 }
         } else {
             secondParts = [

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -100,6 +100,14 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(numbers.activities.map(\.id), [.sumSprint, .rectangleFactory, .factoryCards])
     }
 
+    func testChemistryLaneAddsFruitMemoryCardsStarterGame() throws {
+        let chemistry = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .chemistry })
+
+        XCTAssertEqual(chemistry.activities.map(\.id), [.fruitMemory])
+        XCTAssertEqual(LabLaneDetailPresentation(lane: chemistry).activityCountLabel, "1 game ready")
+        XCTAssertEqual(chemistry.promise, "Sort fruits by color, shape, smell, taste, and where they grow.")
+    }
+
     func testPhysicsLaneAddsSoundLabAsThirdReadyActivity() throws {
         let physics = try XCTUnwrap(CapabilityLane.defaultExplorerLanes.first { $0.id == .physics })
 
@@ -117,6 +125,7 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(LabActivityID.waterCycle.appRoute, .waterCycle)
         XCTAssertEqual(LabActivityID.soundVolume.appRoute, .soundVolume)
         XCTAssertEqual(LabActivityID.memoryMatch.appRoute, .memory)
+        XCTAssertEqual(LabActivityID.fruitMemory.appRoute, .memory)
     }
 
 }
@@ -231,6 +240,7 @@ extension LabModelsTests {
         XCTAssertEqual(LabActivityID.roomQuest.sensorNeeds, [.cameraMarkerMode, .haptics])
         XCTAssertEqual(LabActivityID.soundVolume.sensorNeeds, [.noSpecialSensor])
         XCTAssertEqual(LabActivityID.memoryMatch.sensorNeeds, [.noSpecialSensor])
+        XCTAssertEqual(LabActivityID.fruitMemory.sensorNeeds, [.noSpecialSensor])
     }
 
     func testUnavailableSensorAffordancesExposeVisibleFallbackCopy() {

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -36,6 +36,7 @@ struct LabRouteRegressionTests {
             .waterCycle: .waterCycle,
             .soundVolume: .soundVolume,
             .memoryMatch: .memory,
+            .fruitMemory: .memory,
         ]
 
         #expect(Set(expectedRoutes.keys) == Set(LabActivityID.allCases))
@@ -70,13 +71,15 @@ struct LabRouteRegressionTests {
         #expect(discovery.starterMixMatchCards.count >= 8)
         #expect(discovery.modeChoiceCards.count == discovery.modes.count)
 
-        for futureShell in [chemistry, electronics] {
-            #expect(futureShell.activities.isEmpty)
-            #expect(!futureShell.promise.isEmpty)
-            #expect(futureShell.ageBandHint == "Future lane")
-            #expect(futureShell.starterMixMatchCards.count >= 8)
-            #expect(futureShell.modeChoiceCards.count == futureShell.modes.count)
-        }
+        #expect(chemistry.activities.map(\.id) == [.fruitMemory])
+        #expect(chemistry.ageBandHint == "Ages 4–12")
+        #expect(chemistry.modeChoiceCards.count == chemistry.modes.count)
+
+        #expect(electronics.activities.isEmpty)
+        #expect(!electronics.promise.isEmpty)
+        #expect(electronics.ageBandHint == "Future lane")
+        #expect(electronics.starterMixMatchCards.count >= 8)
+        #expect(electronics.modeChoiceCards.count == electronics.modes.count)
     }
 
     @Test
@@ -95,7 +98,7 @@ struct LabRouteRegressionTests {
     @Test
     func laneDetailPresentationPrioritizesActivitiesBeforeSupportMetadata() throws {
         let readyLane = try #require(CapabilityLane.defaultExplorerLanes.first { $0.id == .numbers })
-        let futureLane = try #require(CapabilityLane.defaultExplorerLanes.first { $0.id == .chemistry })
+        let futureLane = try #require(CapabilityLane.defaultExplorerLanes.first { $0.id == .electronics })
 
         #expect(LabLaneDetailPresentation(lane: readyLane).sections == [
             .visualSummary,

--- a/Tests/MatherTests/MemoryViewTests.swift
+++ b/Tests/MatherTests/MemoryViewTests.swift
@@ -332,6 +332,7 @@ struct MemoryViewTests {
         #expect(plan.map(\.assetName) == assets)
         #expect(importedAssetNames == Set(assets))
         #expect(MemoryDeck.waterCycle.allSatisfy { $0.metadata.deck == .waterCycle })
+        #expect(MemoryDeck.fruits.allSatisfy { $0.metadata.deck == .fruits })
         #expect(MemoryDeck.waterCycle.allSatisfy { $0.metadata.category == "water cycle concept" })
         #expect(MemoryDeck.waterCycle.allSatisfy { animal in
             Set(animal.detailCards.map(\.title)).isSuperset(of: ["Concept", "Action", "Where", "Everyday Words", "Cycle Step"])
@@ -482,7 +483,7 @@ struct MemoryCardDescribeServiceTests {
     }
 
     @Test func allMemoryCardsExposeStructuredMetadata() {
-        let allAnimals = MemoryDeck.domesticAnimals + MemoryDeck.birds + MemoryDeck.vehicles + MemoryDeck.planets + MemoryDeck.fishes + MemoryDeck.countries + MemoryDeck.countryFlags + MemoryDeck.indiaStates + MemoryDeck.waterCycle
+        let allAnimals = MemoryDeck.domesticAnimals + MemoryDeck.birds + MemoryDeck.vehicles + MemoryDeck.planets + MemoryDeck.fishes + MemoryDeck.countries + MemoryDeck.countryFlags + MemoryDeck.indiaStates + MemoryDeck.waterCycle + MemoryDeck.fruits
 
         #expect(MemoryDeck.allAnimalsById.count == allAnimals.count)
         #expect(allAnimals.allSatisfy { !$0.metadata.category.isEmpty })
@@ -496,6 +497,15 @@ struct MemoryCardDescribeServiceTests {
         #expect(MemoryDeck.countryFlags.allSatisfy { $0.metadata.deck == .countryFlags })
         #expect(MemoryDeck.indiaStates.allSatisfy { $0.metadata.deck == .indiaStates })
         #expect(MemoryDeck.waterCycle.allSatisfy { $0.metadata.deck == .waterCycle })
+        #expect(MemoryDeck.fruits.allSatisfy { $0.metadata.deck == .fruits })
+    }
+
+    @Test func fruitDeckProvidesDeterministicChemistryFactCards() {
+        #expect(MemoryDeck.fruits.count == 8)
+        #expect(MemoryDeck.fruits.map(\.id).first == "fruit-apple")
+        #expect(Set(MemoryDeck.fruits.map(\.id)).count == MemoryDeck.fruits.count)
+        #expect(MemoryDeck.fruits.allSatisfy { $0.detailCards.map(\.title) == ["Fruit", "Shape", "Color", "Taste", "Smell", "Often Found"] })
+        #expect(MemoryDeck.fruits.contains { $0.name == "Mango" && $0.detailCards.contains(MemoryFactCard(title: "Often Found", value: "India and other warm tropical regions")) })
     }
 
     @MainActor @Test func fallbackDescriptionUsesCuratedFlagMetadata() async {
@@ -511,6 +521,21 @@ struct MemoryCardDescribeServiceTests {
         #expect(description.shortDescription.localizedCaseInsensitiveContains("flag of india"))
         #expect(description.shortDescription.localizedCaseInsensitiveContains("country in asia"))
         #expect(Array(description.factChips.map(\.title).prefix(4)) == ["Country", "Flag", "ISO Code", "Capital"])
+    }
+
+    @MainActor @Test func fallbackDescriptionUsesCuratedFruitMetadata() async {
+        let service = MemoryCardDescribeService(
+            appleIntelligenceEnabled: { false },
+            aiAdapter: StubAIAdapter(isAvailable: false, response: nil)
+        )
+
+        let description = await service.describe(MemoryDeck.fruits[2])
+
+        #expect(description.title == "Mango")
+        #expect(description.source == .curatedFallback)
+        #expect(description.shortDescription.localizedCaseInsensitiveContains("fruit often found in india"))
+        #expect(description.shortDescription.localizedCaseInsensitiveContains("tastes very sweet and juicy"))
+        #expect(Array(description.factChips.map(\.title).prefix(4)) == ["Fruit", "Shape", "Color", "Taste"] )
     }
 
     @MainActor @Test func fallbackDescriptionUsesCuratedBirdMetadata() async {


### PR DESCRIPTION
## Summary\n- Adds a Chemistry Lab starter activity that launches Memory Match with a new Fruit Lab deck.\n- Adds a deterministic kid-friendly fruit dataset covering name, shape, color, taste, smell, and common regions.\n- Updates lab routing/sensor metadata and regression tests for the new activity.\n\nCloses #885\n\n## Validation\n- git diff --check\n- Attempted remote iOS validation on ganesh-mba, but SSH host resolution/connectivity failed from this runner.\n