### PR TITLE
fix: harden Sound Lab intro bounds

### DIFF
--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -261,6 +261,14 @@ struct SoundVolumeIntroPage: Identifiable, Equatable {
 enum SoundVolumeContent {
     static let safetyNote = "Use listening clues only — no screaming. Protect your ears. A live microphone meter comes later and is not used in this activity."
 
+    static func clampedIntroPageIndex(_ index: Int) -> Int {
+        min(max(index, 0), introPages.count - 1)
+    }
+
+    static func introPage(for index: Int) -> SoundVolumeIntroPage {
+        introPages[clampedIntroPageIndex(index)]
+    }
+
     static let introPages: [SoundVolumeIntroPage] = [
         SoundVolumeIntroPage(
             id: "welcome",

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -338,9 +338,10 @@ struct SoundVolumeLabView: View {
     @State private var feedback = SoundVolumeContent.safetyNote
 
     private var introPages: [SoundVolumeIntroPage] { SoundVolumeContent.introPages }
-    private var introPage: SoundVolumeIntroPage { introPages[introPageIndex] }
-    private var isFirstIntroPage: Bool { introPageIndex == 0 }
-    private var isLastIntroPage: Bool { introPageIndex == introPages.count - 1 }
+    private var safeIntroPageIndex: Int { SoundVolumeContent.clampedIntroPageIndex(introPageIndex) }
+    private var introPage: SoundVolumeIntroPage { SoundVolumeContent.introPage(for: introPageIndex) }
+    private var isFirstIntroPage: Bool { safeIntroPageIndex == 0 }
+    private var isLastIntroPage: Bool { safeIntroPageIndex == introPages.count - 1 }
 
     private var summary: LearningLoopSummary {
         LearningLoopScoring.summary(
@@ -458,8 +459,8 @@ struct SoundVolumeLabView: View {
         HStack(spacing: 8) {
             ForEach(introPages.indices, id: \.self) { index in
                 Capsule()
-                    .fill(index == introPageIndex ? MatherTheme.accent : MatherTheme.softBlue.opacity(0.35))
-                    .frame(width: index == introPageIndex ? 28 : 10, height: 10)
+                    .fill(index == safeIntroPageIndex ? MatherTheme.accent : MatherTheme.softBlue.opacity(0.35))
+                    .frame(width: index == safeIntroPageIndex ? 28 : 10, height: 10)
                     .accessibilityLabel("Intro step \(index + 1) of \(introPages.count)")
             }
         }
@@ -478,7 +479,7 @@ struct SoundVolumeLabView: View {
 
             if !isFirstIntroPage {
                 Button {
-                    introPageIndex = max(0, introPageIndex - 1)
+                    introPageIndex = SoundVolumeContent.clampedIntroPageIndex(introPageIndex - 1)
                 } label: {
                     Label("Back", systemImage: "chevron.left")
                         .font(.headline.weight(.black))
@@ -499,7 +500,7 @@ struct SoundVolumeLabView: View {
             hasStartedActivities = true
             feedback = "Start with the quiz, then match each sound clue to its safe idea."
         } else {
-            introPageIndex += 1
+            introPageIndex = SoundVolumeContent.clampedIntroPageIndex(safeIntroPageIndex + 1)
         }
     }
 

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -104,6 +104,17 @@ extension LearningLoopTests {
         XCTAssertTrue(pages[2].subtitle.contains("not a live sound meter"))
     }
 
+    func testSoundVolumeIntroPageLookupClampsOutOfRangeIndexes() {
+        let pages = SoundVolumeContent.introPages
+
+        XCTAssertEqual(SoundVolumeContent.clampedIntroPageIndex(-3), 0)
+        XCTAssertEqual(SoundVolumeContent.clampedIntroPageIndex(0), 0)
+        XCTAssertEqual(SoundVolumeContent.clampedIntroPageIndex(pages.count), pages.count - 1)
+        XCTAssertEqual(SoundVolumeContent.clampedIntroPageIndex(pages.count + 5), pages.count - 1)
+        XCTAssertEqual(SoundVolumeContent.introPage(for: -1), pages[0])
+        XCTAssertEqual(SoundVolumeContent.introPage(for: pages.count + 2), pages[pages.count - 1])
+    }
+
     func testSoundVolumeContentCoversSafeHearingConcepts() {
         let titles = Set(SoundVolumeContent.cards.map(\.title))
 


### PR DESCRIPTION
## Summary
- Hardens the build 70 Sound Lab intro flow against out-of-range intro page state.
- Routes all intro page reads/progress indicators through a clamped index helper instead of directly subscripting `introPages[introPageIndex]`.
- Adds regression coverage for negative and past-end Sound Lab intro page lookups.

## Issue #899 triage
ASC/TestFlight provided only crash metadata in GitHub-safe form for build 70 (iOS 26.3.1, locale en-IN) and no structured crash fields. The most plausible new build-70 crash surface in the recent Sound Lab intro work was direct array subscripting during staged intro navigation. This change removes that concrete trap path without copying private crash diagnostics into the repo.

Fixes #899.

## Validation
- `git diff --check`
- Targeted Xcode test/build not run locally: this Linux worker has no `xcodebuild`; SSH validation on `mba` did not connect during this lane.
