### PR TITLE
fix: stage sound decibel flow

### DIFF
--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -264,7 +264,7 @@ enum SoundVolumeContent {
     static let introPages: [SoundVolumeIntroPage] = [
         SoundVolumeIntroPage(
             id: "welcome",
-            eyebrow: "Step 1 of 4",
+            eyebrow: "Step 1 of 5",
             title: "Meet sound and volume",
             subtitle: "Sound can be soft, comfy, noisy, or too loud. We will learn one small idea at a time.",
             visualKey: "🔊",
@@ -273,16 +273,25 @@ enum SoundVolumeContent {
         ),
         SoundVolumeIntroPage(
             id: "safety",
-            eyebrow: "Step 2 of 4",
+            eyebrow: "Step 2 of 5",
             title: "Use hearing-safe play",
             subtitle: "Use listening clues only — no screaming, no loud-noise challenge, and no microphone permission in this activity.",
             visualKey: "👂",
+            primaryActionTitle: "Next: decibels",
+            primaryActionIcon: "arrow.right.circle.fill"
+        ),
+        SoundVolumeIntroPage(
+            id: "decibels",
+            eyebrow: "Step 3 of 5",
+            title: "What is a decibel?",
+            subtitle: "A decibel, written dB, is a number people use to talk about how loud a sound is. Bigger dB usually means louder sound.",
+            visualKey: "dB",
             primaryActionTitle: "Next: loudness zones",
             primaryActionIcon: "arrow.right.circle.fill"
         ),
         SoundVolumeIntroPage(
             id: "zones",
-            eyebrow: "Step 3 of 4",
+            eyebrow: "Step 4 of 5",
             title: "Sort sounds into zones",
             subtitle: "The zone cards are examples, not a live sound meter. If a sound hurts, move away or protect your ears.",
             visualKey: "📊",
@@ -291,7 +300,7 @@ enum SoundVolumeContent {
         ),
         SoundVolumeIntroPage(
             id: "clues",
-            eyebrow: "Step 4 of 4",
+            eyebrow: "Step 5 of 5",
             title: "Ready for quiz and match",
             subtitle: "Look for picture clues like whisper, traffic, siren, headphones, birds, and protect ears.",
             visualKey: "🧩",
@@ -301,6 +310,7 @@ enum SoundVolumeContent {
     ]
 
     static let cards: [LearningConceptCard] = [
+        LearningConceptCard(id: "decibel", title: "Decibel (dB)", explanation: "A decibel is a number for loudness. Bigger dB usually means a louder sound.", visualKey: "dB", audioPrompt: "A decibel, or dB, is a number for loudness."),
         LearningConceptCard(id: "quiet", title: "Quiet", explanation: "Quiet sounds are soft and gentle, like a whisper or leaves.", visualKey: "🍃", audioPrompt: "Quiet sounds are soft and gentle."),
         LearningConceptCard(id: "conversation", title: "Conversation", explanation: "A talking voice sits in the middle loudness zone.", visualKey: "💬", audioPrompt: "Conversation is a middle loudness zone."),
         LearningConceptCard(id: "traffic", title: "Traffic", explanation: "Busy traffic is loud and can turn into noise pollution.", visualKey: "🚗", audioPrompt: "Traffic can be loud and unwanted."),

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -327,10 +327,58 @@ struct ConceptMixMatchRoundView: View {
     }
 }
 
+
+private enum SoundVolumeActivityStage: CaseIterable {
+    case quiz
+    case match
+    case summary
+
+    var title: String {
+        switch self {
+        case .quiz: return "Quiz"
+        case .match: return "Mix + Match"
+        case .summary: return "Stars"
+        }
+    }
+
+    var primaryActionTitle: String {
+        switch self {
+        case .quiz: return "Go to Mix + Match"
+        case .match: return "See Sound Score"
+        case .summary: return "Review Quiz"
+        }
+    }
+
+    var primaryActionIcon: String {
+        switch self {
+        case .quiz: return "rectangle.grid.2x2.fill"
+        case .match: return "star.fill"
+        case .summary: return "arrow.counterclockwise"
+        }
+    }
+
+    var next: SoundVolumeActivityStage {
+        switch self {
+        case .quiz: return .match
+        case .match: return .summary
+        case .summary: return .quiz
+        }
+    }
+
+    var previous: SoundVolumeActivityStage {
+        switch self {
+        case .quiz: return .summary
+        case .match: return .quiz
+        case .summary: return .match
+        }
+    }
+}
+
 struct SoundVolumeLabView: View {
     @Bindable var appModel: AppModel
     @State private var introPageIndex = 0
     @State private var hasStartedActivities = false
+    @State private var activityStage: SoundVolumeActivityStage = .quiz
     @State private var answersByQuestionId: [String: String] = [:]
     @State private var selectedMatchPairId: String?
     @State private var matchedPairIds: Set<String> = []
@@ -338,9 +386,10 @@ struct SoundVolumeLabView: View {
     @State private var feedback = SoundVolumeContent.safetyNote
 
     private var introPages: [SoundVolumeIntroPage] { SoundVolumeContent.introPages }
-    private var introPage: SoundVolumeIntroPage { introPages[introPageIndex] }
-    private var isFirstIntroPage: Bool { introPageIndex == 0 }
-    private var isLastIntroPage: Bool { introPageIndex == introPages.count - 1 }
+    private var introPage: SoundVolumeIntroPage { introPages[clampedIntroPageIndex] }
+    private var clampedIntroPageIndex: Int { min(max(introPageIndex, 0), max(introPages.count - 1, 0)) }
+    private var isFirstIntroPage: Bool { clampedIntroPageIndex == 0 }
+    private var isLastIntroPage: Bool { clampedIntroPageIndex == introPages.count - 1 }
 
     private var summary: LearningLoopSummary {
         LearningLoopScoring.summary(
@@ -357,19 +406,9 @@ struct SoundVolumeLabView: View {
                 VStack(alignment: .leading, spacing: 18) {
                     if hasStartedActivities {
                         activityHeader
-                        ConceptQuizRoundView(
-                            questions: SoundVolumeContent.quizQuestions,
-                            answersByQuestionId: $answersByQuestionId
-                        )
-                        ConceptMixMatchRoundView(
-                            pairs: SoundVolumeContent.matchPairs,
-                            shuffleSeed: matchShuffleSeed,
-                            selectedLeft: $selectedMatchPairId,
-                            matchedPairIds: $matchedPairIds,
-                            onFeedback: { feedback = $0 },
-                            onHapticCue: playSoundMatchHaptic
-                        )
-                        summaryCard
+                        activityStagePicker
+                        currentActivityStage
+                        activityStageControls
                     } else {
                         stagedIntroCard
                     }
@@ -447,6 +486,8 @@ struct SoundVolumeLabView: View {
             soundClueChips(SoundVolumeContent.cards.prefix(4).map { ($0.visualKey, $0.title) })
         case "safety":
             safetyBanner
+        case "decibels":
+            decibelTeachingCard
         case "zones":
             loudnessZones
         default:
@@ -497,9 +538,10 @@ struct SoundVolumeLabView: View {
     private func advanceIntro() {
         if isLastIntroPage {
             hasStartedActivities = true
-            feedback = "Start with the quiz, then match each sound clue to its safe idea."
+            activityStage = .quiz
+            feedback = "Start with the quiz. Mix + Match comes on the next screen."
         } else {
-            introPageIndex += 1
+            introPageIndex = clampedIntroPageIndex + 1
         }
     }
 
@@ -520,6 +562,75 @@ struct SoundVolumeLabView: View {
                 .clipShape(Capsule())
                 .accessibilityElement(children: .combine)
             }
+        }
+    }
+
+
+    private var activityStagePicker: some View {
+        HStack(spacing: 8) {
+            ForEach(SoundVolumeActivityStage.allCases, id: \.self) { stage in
+                Text(stage.title)
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(stage == activityStage ? .white : MatherTheme.accent)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 10)
+                    .frame(maxWidth: .infinity)
+                    .background(stage == activityStage ? MatherTheme.accent : MatherTheme.accent.opacity(0.14))
+                    .clipShape(Capsule())
+                    .accessibilityLabel("Sound Lab stage \(stage.title)\(stage == activityStage ? ", current" : "")")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var currentActivityStage: some View {
+        switch activityStage {
+        case .quiz:
+            ConceptQuizRoundView(
+                questions: SoundVolumeContent.quizQuestions,
+                answersByQuestionId: $answersByQuestionId
+            )
+        case .match:
+            ConceptMixMatchRoundView(
+                pairs: SoundVolumeContent.matchPairs,
+                shuffleSeed: matchShuffleSeed,
+                selectedLeft: $selectedMatchPairId,
+                matchedPairIds: $matchedPairIds,
+                onFeedback: { feedback = $0 },
+                onHapticCue: playSoundMatchHaptic
+            )
+        case .summary:
+            summaryCard
+        }
+    }
+
+    private var activityStageControls: some View {
+        HStack(spacing: 10) {
+            if activityStage != .quiz {
+                Button {
+                    activityStage = activityStage.previous
+                } label: {
+                    Label("Back", systemImage: "chevron.left")
+                        .font(.headline.weight(.black))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+            }
+
+            Button {
+                activityStage = activityStage.next
+                if activityStage == .match {
+                    feedback = "Now match each sound clue to its safe idea."
+                } else if activityStage == .summary {
+                    feedback = "Review your Sound Lab score."
+                }
+            } label: {
+                Label(activityStage.primaryActionTitle, systemImage: activityStage.primaryActionIcon)
+                    .font(.headline.weight(.black))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(PrimaryActionButtonStyle())
         }
     }
 
@@ -579,6 +690,29 @@ struct SoundVolumeLabView: View {
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(MatherTheme.cardSubtitle)
             }
+        }
+        .padding(14)
+        .background(MatherTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .accessibilityElement(children: .combine)
+    }
+
+
+    private var decibelTeachingCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Decibel = dB")
+                .font(.title2.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            Text("A decibel is a loudness number. A whisper has a small dB number. A siren has a big dB number. We use dB cards only after learning what the unit means.")
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
+            HStack(spacing: 10) {
+                Label("small dB = softer", systemImage: "speaker.fill")
+                Label("big dB = louder", systemImage: "speaker.wave.3.fill")
+            }
+            .font(.caption.weight(.black))
+            .foregroundStyle(MatherTheme.accent)
         }
         .padding(14)
         .background(MatherTheme.card)

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -97,18 +97,20 @@ extension LearningLoopTests {
     func testSoundVolumeIntroUsesStagedSafePagesBeforeActivity() {
         let pages = SoundVolumeContent.introPages
 
-        XCTAssertEqual(pages.map(\.id), ["welcome", "safety", "zones", "clues"])
+        XCTAssertEqual(pages.map(\.id), ["welcome", "safety", "decibels", "zones", "clues"])
         XCTAssertEqual(pages.last?.primaryActionTitle, "Start Sound Lab")
         XCTAssertTrue(pages[1].subtitle.contains("no microphone permission"))
         XCTAssertTrue(pages[1].subtitle.contains("no loud-noise challenge"))
-        XCTAssertTrue(pages[2].subtitle.contains("not a live sound meter"))
+        XCTAssertTrue(pages[2].subtitle.contains("decibel"))
+        XCTAssertTrue(pages[3].subtitle.contains("not a live sound meter"))
     }
 
     func testSoundVolumeContentCoversSafeHearingConcepts() {
         let titles = Set(SoundVolumeContent.cards.map(\.title))
 
-        XCTAssertEqual(SoundVolumeContent.cards.count, 8)
+        XCTAssertEqual(SoundVolumeContent.cards.count, 9)
         XCTAssertTrue(titles.isSuperset(of: [
+            "Decibel (dB)",
             "Quiet",
             "Conversation",
             "Traffic",


### PR DESCRIPTION
## Summary

Adds a kid-friendly decibel introduction before Sound Lab uses dB/loudness zones, then separates Sound Lab activity work into explicit Quiz, Mix + Match, and Score stages so kids are not forced through compressed quiz+match content on one screen.

## Changes

- Adds a dedicated “What is a decibel?” intro page before loudness zone cards.
- Adds a Decibel (dB) concept card with simple kid-facing copy.
- Reworks Sound Lab activities into staged screens: Quiz → Mix + Match → Stars.
- Preserves existing haptics, shuffle seed behavior, safe-listening copy, and completion scoring.
- Updates LearningLoop tests for the five-page sound intro and new decibel card.

## Testing

- `git diff --check` ✅
- Source contract grep for decibel page/card and staged activity controls ✅
- `swift test --filter LearningLoopTests` not run: Linux worker has no Swift toolchain (`swift: command not found`).
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:MatherTests/LearningLoopTests` not run locally: Linux worker has no Xcode (`xcodebuild: command not found`).
- Remote Mac validation attempted, but SSH to `ganesh@mba` timed out / alias resolution failed from this worker.

Fixes #900
Fixes #904
