### PR TITLE
fix: harden Water Cycle lesson thread state

### DIFF
--- a/Domain/LessonPlayThread.swift
+++ b/Domain/LessonPlayThread.swift
@@ -74,6 +74,13 @@ struct LessonPlayStage: Identifiable, Codable, Equatable, Hashable {
 }
 
 struct LessonPlayThread: Identifiable, Codable, Equatable {
+    private static let fallbackStage = LessonPlayStage(
+        id: "safe-fallback",
+        kind: .lookLearnFlashcards,
+        title: "Review",
+        prompt: "Start the learning cards again."
+    )
+
     let id: String
     let title: String
     let stages: [LessonPlayStage]
@@ -98,7 +105,9 @@ struct LessonPlayThread: Identifiable, Codable, Equatable {
     }
 
     var activeStage: LessonPlayStage {
-        stages[activeStageIndex]
+        guard !stages.isEmpty else { return Self.fallbackStage }
+        let safeIndex = min(max(activeStageIndex, 0), stages.count - 1)
+        return stages[safeIndex]
     }
 
     var isComplete: Bool {
@@ -106,7 +115,9 @@ struct LessonPlayThread: Identifiable, Codable, Equatable {
     }
 
     var progressLabel: String {
-        "Level \(activeStageIndex + 1) of \(stages.count)"
+        guard !stages.isEmpty else { return "Level 0 of 0" }
+        let safeIndex = min(max(activeStageIndex, 0), stages.count - 1)
+        return "Level \(safeIndex + 1) of \(stages.count)"
     }
 
     var progress: Double {
@@ -115,6 +126,7 @@ struct LessonPlayThread: Identifiable, Codable, Equatable {
     }
 
     mutating func completeActiveStage() {
+        guard !stages.isEmpty else { return }
         completedStageIDs.insert(activeStage.id)
         guard activeStageIndex < stages.count - 1 else { return }
         activeStageIndex += 1

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -135,12 +135,18 @@ struct WaterCycleLabState: Equatable {
         WaterCycleConceptFlashcard.reviewDeck[flashcardIndex % WaterCycleConceptFlashcard.reviewDeck.count]
     }
 
+    private var playableLessonCards: [LessonPlayCard] {
+        lessonThread.cards.isEmpty ? WaterCycleLessonThread.cards : lessonThread.cards
+    }
+
     var currentLessonCard: LessonPlayCard {
-        lessonThread.cards[lessonCardIndex % lessonThread.cards.count]
+        let cards = playableLessonCards
+        return cards[safeModulo(lessonCardIndex, cards.count)]
     }
 
     var currentMixMatchCard: LearningCard {
-        WaterCycleLessonThread.mixMatchCards[mixMatchIndex % WaterCycleLessonThread.mixMatchCards.count]
+        let cards = WaterCycleLessonThread.mixMatchCards
+        return cards[safeModulo(mixMatchIndex, cards.count)]
     }
 
 
@@ -149,7 +155,9 @@ struct WaterCycleLabState: Equatable {
     }
 
     var lessonCardProgressLabel: String {
-        "Card \(lessonCardIndex + 1) of \(lessonThread.cards.count)"
+        let cards = playableLessonCards
+        let safeIndex = min(max(lessonCardIndex, 0), max(cards.count - 1, 0))
+        return "Card \(safeIndex + 1) of \(cards.count)"
     }
 
     var mixMatchProgressLabel: String {
@@ -183,7 +191,8 @@ struct WaterCycleLabState: Equatable {
     }
 
     var isOnLastLessonCard: Bool {
-        lessonCardIndex == lessonThread.cards.count - 1
+        let cards = playableLessonCards
+        return lessonCardIndex >= cards.count - 1
     }
 
     var activeLessonProgressLabel: String {
@@ -295,7 +304,8 @@ struct WaterCycleLabState: Equatable {
 
     mutating func advanceLessonCard() {
         guard stage == .complete else { return }
-        lessonCardIndex = (lessonCardIndex + 1) % lessonThread.cards.count
+        let cards = playableLessonCards
+        lessonCardIndex = (lessonCardIndex + 1) % cards.count
         isRecallCardRevealed = false
         openMatchFeedback = nil
         askSession = WaterCycleLessonThread.askSession(for: currentLessonCard)
@@ -357,9 +367,15 @@ struct WaterCycleLabState: Equatable {
     private func nextUnmatchedMixMatchIndex() -> Int {
         let cards = WaterCycleLessonThread.mixMatchCards
         guard let next = cards.indices.first(where: { !mixMatchCorrectCardIDs.contains(cards[$0].answer.id) }) else {
-            return mixMatchIndex
+            return safeModulo(mixMatchIndex, cards.count)
         }
         return next
+    }
+
+    private func safeModulo(_ index: Int, _ count: Int) -> Int {
+        guard count > 0 else { return 0 }
+        let remainder = index % count
+        return remainder >= 0 ? remainder : remainder + count
     }
 
     mutating func reset() {

--- a/Tests/MatherTests/LessonPlayThreadTests.swift
+++ b/Tests/MatherTests/LessonPlayThreadTests.swift
@@ -67,3 +67,23 @@ struct LessonPlayThreadTests {
         #expect(unsupported.kind == .refusal)
     }
 }
+
+extension LessonPlayThreadTests {
+    @Test func emptyThreadUsesSafeFallbackInsteadOfIndexTrap() {
+        var thread = LessonPlayThread(
+            id: "empty-thread",
+            title: "Empty",
+            stages: [],
+            cards: []
+        )
+
+        #expect(thread.activeStage.id == "safe-fallback")
+        #expect(thread.progressLabel == "Level 0 of 0")
+        #expect(thread.progress == 1)
+        #expect(thread.isComplete)
+
+        thread.completeActiveStage()
+        #expect(thread.activeStage.id == "safe-fallback")
+        #expect(thread.progressLabel == "Level 0 of 0")
+    }
+}


### PR DESCRIPTION
## Summary

Harden the Water Cycle lesson/play path after build 70 TestFlight crash feedback reported: “Crashed while plying water cycle.” Apple did not expose structured crash fields in the GitHub-safe payload, so this applies focused bounds/state guards around the Water Cycle lesson thread rather than broad behavior changes.

## Changes

- Add a safe fallback for empty `LessonPlayThread.stages` instead of indexing directly into `stages[activeStageIndex]`.
- Guard `LessonPlayThread.progressLabel` and `completeActiveStage()` for empty stage lists.
- Make `WaterCycleLabState` use fallback lesson cards and safe modulo for lesson/mix-match card access.
- Remove a duplicated Water Cycle stage label in the status bar.
- Add regression coverage for the empty-thread fallback path.

## Validation

- `git diff --check` ✅
- Added `LessonPlayThreadTests.emptyThreadUsesSafeFallbackInsteadOfIndexTrap`
- Swift/Xcode tests not run locally: Linux worker has no Swift/Xcode toolchain; CI should validate.

Fixes #910
