### PR TITLE
#912: Add gameplay scheduler foundation

### DIFF
--- a/Domain/GameplayStageModels.swift
+++ b/Domain/GameplayStageModels.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+enum GameplayStageKind: String, Codable, CaseIterable, Equatable, Hashable {
+    case flashcards
+    case easyMemory
+    case flipMemory
+    case bondBlast
+    case multipleChoice
+}
+
+struct GameplayCategory: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let title: String
+    let subtitle: String
+}
+
+struct GameplayPropertyType: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let displayName: String
+    let prompt: String
+}
+
+struct GameplayProperty: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let typeID: String
+    let value: String
+    let explanation: String
+    let visualKey: String?
+    let visualAssetName: String?
+
+    init(
+        id: String,
+        typeID: String,
+        value: String,
+        explanation: String = "",
+        visualKey: String? = nil,
+        visualAssetName: String? = nil
+    ) {
+        self.id = id
+        self.typeID = typeID
+        self.value = value
+        self.explanation = explanation
+        self.visualKey = visualKey
+        self.visualAssetName = visualAssetName
+    }
+}
+
+struct GameplayEntity: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let name: String
+    let summary: String
+    let visualKey: String?
+    let visualAssetName: String?
+    let properties: [GameplayProperty]
+
+    init(
+        id: String,
+        name: String,
+        summary: String = "",
+        visualKey: String? = nil,
+        visualAssetName: String? = nil,
+        properties: [GameplayProperty]
+    ) {
+        self.id = id
+        self.name = name
+        self.summary = summary
+        self.visualKey = visualKey
+        self.visualAssetName = visualAssetName
+        self.properties = properties
+    }
+}
+
+struct GameplayStageDefinition: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let kind: GameplayStageKind
+    let title: String
+    let prompt: String
+    let propertyTypeIDs: [String]
+    let maximumItemCount: Int
+
+    init(
+        id: String,
+        kind: GameplayStageKind,
+        title: String,
+        prompt: String,
+        propertyTypeIDs: [String] = [],
+        maximumItemCount: Int = 6
+    ) {
+        self.id = id
+        self.kind = kind
+        self.title = title
+        self.prompt = prompt
+        self.propertyTypeIDs = propertyTypeIDs
+        self.maximumItemCount = max(1, maximumItemCount)
+    }
+}
+
+struct GameplayProgressionPolicy: Codable, Equatable, Hashable {
+    let minimumAccuracyToAdvance: Double
+    let retryMissedItemsFirst: Bool
+
+    init(minimumAccuracyToAdvance: Double = 0.7, retryMissedItemsFirst: Bool = true) {
+        self.minimumAccuracyToAdvance = min(max(minimumAccuracyToAdvance, 0), 1)
+        self.retryMissedItemsFirst = retryMissedItemsFirst
+    }
+}
+
+struct GameplayThreadDefinition: Identifiable, Codable, Equatable {
+    let id: String
+    let title: String
+    let category: GameplayCategory
+    let propertyTypes: [GameplayPropertyType]
+    let entities: [GameplayEntity]
+    let stages: [GameplayStageDefinition]
+    let progressionPolicy: GameplayProgressionPolicy
+
+    var propertyTypesByID: [String: GameplayPropertyType] {
+        Dictionary(uniqueKeysWithValues: propertyTypes.map { ($0.id, $0) })
+    }
+
+    init(
+        id: String,
+        title: String,
+        category: GameplayCategory,
+        propertyTypes: [GameplayPropertyType],
+        entities: [GameplayEntity],
+        stages: [GameplayStageDefinition] = GameplayThreadDefinition.defaultStages,
+        progressionPolicy: GameplayProgressionPolicy = GameplayProgressionPolicy()
+    ) {
+        self.id = id
+        self.title = title
+        self.category = category
+        self.propertyTypes = propertyTypes
+        self.entities = entities
+        self.stages = stages
+        self.progressionPolicy = progressionPolicy
+    }
+
+    static let defaultStages: [GameplayStageDefinition] = [
+        GameplayStageDefinition(id: "flashcards", kind: .flashcards, title: "Look + Learn", prompt: "Meet each card."),
+        GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Match with the cards still visible."),
+        GameplayStageDefinition(id: "flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Remember where the matches are."),
+        GameplayStageDefinition(id: "bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect names, pictures, and facts."),
+        GameplayStageDefinition(id: "multiple-choice", kind: .multipleChoice, title: "Quiz", prompt: "Pick the best answer.")
+    ]
+}
+
+struct GameplayRoundItem: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let entityID: String
+    let propertyID: String?
+    let propertyTypeID: String?
+}
+
+struct GameplayRoundDefinition: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let stageID: String
+    let kind: GameplayStageKind
+    let items: [GameplayRoundItem]
+    let seed: UInt64
+}
+
+struct GameplayStageResult: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let stageID: String
+    let correctCount: Int
+    let mistakeCount: Int
+    let hintsUsed: Int
+    let durationSeconds: TimeInterval
+    let completedAt: Date
+
+    var attemptedCount: Int { correctCount + mistakeCount }
+    var accuracy: Double {
+        guard attemptedCount > 0 else { return 0 }
+        return Double(correctCount) / Double(attemptedCount)
+    }
+}
+
+struct GameplayScoreSummary: Codable, Equatable, Hashable {
+    let correctCount: Int
+    let mistakeCount: Int
+    let hintsUsed: Int
+    let durationSeconds: TimeInterval
+    let stars: Int
+
+    var attemptedCount: Int { correctCount + mistakeCount }
+    var accuracy: Double {
+        guard attemptedCount > 0 else { return 0 }
+        return Double(correctCount) / Double(attemptedCount)
+    }
+
+    static func summarize(_ results: [GameplayStageResult]) -> GameplayScoreSummary {
+        let correct = results.reduce(0) { $0 + $1.correctCount }
+        let mistakes = results.reduce(0) { $0 + $1.mistakeCount }
+        let hints = results.reduce(0) { $0 + $1.hintsUsed }
+        let duration = results.reduce(0) { $0 + $1.durationSeconds }
+        let attempts = max(correct + mistakes, 1)
+        let accuracy = Double(correct) / Double(attempts)
+        let baseStars: Int
+        if accuracy >= 0.9 { baseStars = 3 }
+        else if accuracy >= 0.7 { baseStars = 2 }
+        else if accuracy >= 0.45 { baseStars = 1 }
+        else { baseStars = 0 }
+        let hintPenalty = hints >= 4 ? 1 : 0
+        return GameplayScoreSummary(
+            correctCount: correct,
+            mistakeCount: mistakes,
+            hintsUsed: hints,
+            durationSeconds: duration,
+            stars: max(0, baseStars - hintPenalty)
+        )
+    }
+}

--- a/Domain/SpacedRepetitionModels.swift
+++ b/Domain/SpacedRepetitionModels.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+struct GameplayExposureKey: Codable, Equatable, Hashable {
+    let entityID: String
+    let propertyID: String?
+    let stageID: String
+
+    init(entityID: String, propertyID: String? = nil, stageID: String) {
+        self.entityID = entityID
+        self.propertyID = propertyID
+        self.stageID = stageID
+    }
+}
+
+enum GameplayConfidenceBand: String, Codable, Equatable, Hashable, CaseIterable {
+    case new
+    case learning
+    case steady
+    case reviewNeeded
+}
+
+struct GameplayExposureRecord: Codable, Equatable, Hashable {
+    let key: GameplayExposureKey
+    var correctCount: Int
+    var mistakeCount: Int
+    var lastSeenAt: Date?
+    var dueAt: Date
+    var confidenceBand: GameplayConfidenceBand
+
+    init(
+        key: GameplayExposureKey,
+        correctCount: Int = 0,
+        mistakeCount: Int = 0,
+        lastSeenAt: Date? = nil,
+        dueAt: Date = .distantPast,
+        confidenceBand: GameplayConfidenceBand = .new
+    ) {
+        self.key = key
+        self.correctCount = correctCount
+        self.mistakeCount = mistakeCount
+        self.lastSeenAt = lastSeenAt
+        self.dueAt = dueAt
+        self.confidenceBand = confidenceBand
+    }
+
+    var attemptCount: Int { correctCount + mistakeCount }
+}
+
+struct SpacedRepetitionSelectionPolicy: Codable, Equatable, Hashable {
+    let maximumItemCount: Int
+    let dueItemRatio: Double
+    let reviewNeededPriority: Int
+    let newItemPriority: Int
+    let steadyPriority: Int
+
+    init(
+        maximumItemCount: Int = 6,
+        dueItemRatio: Double = 0.7,
+        reviewNeededPriority: Int = 0,
+        newItemPriority: Int = 1,
+        steadyPriority: Int = 3
+    ) {
+        self.maximumItemCount = max(1, maximumItemCount)
+        self.dueItemRatio = min(max(dueItemRatio, 0), 1)
+        self.reviewNeededPriority = reviewNeededPriority
+        self.newItemPriority = newItemPriority
+        self.steadyPriority = steadyPriority
+    }
+}
+
+struct SpacedRepetitionUpdate: Codable, Equatable, Hashable {
+    let key: GameplayExposureKey
+    let wasCorrect: Bool
+    let occurredAt: Date
+}

--- a/Mather.xcodeproj/project.pbxproj
+++ b/Mather.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		D0FA2DF7DD9A64D4BB9C8080 /* ProblemGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 000C9B49685F8A6A3703EB65 /* ProblemGeneratorTests.swift */; };
 		E3179A83922DC2E5F2E1796F /* MatherTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8A34215EE8D8788E7185EB /* MatherTheme.swift */; };
 		FAE49D35BAA07CE0B5573806 /* SessionHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBF689FCFE4D506002AB78E /* SessionHistoryStore.swift */; };
+		211111111111111111111111 /* GameplayStageModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111111111111111111111111 /* GameplayStageModels.swift */; };
+		211111111111111111111112 /* SpacedRepetitionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111111111111111111111112 /* SpacedRepetitionModels.swift */; };
+		211111111111111111111113 /* SpacedRepetitionScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111111111111111111111113 /* SpacedRepetitionScheduler.swift */; };
+		211111111111111111111114 /* GameplaySchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111111111111111111111114 /* GameplaySchedulerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,6 +87,10 @@
 		DBDE340757D1657A76B2F5C5 /* EquationResolveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EquationResolveView.swift; sourceTree = "<group>"; };
 		E1C7741AD8CC742E6F122094 /* MatherTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MatherTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8DA96C428EF71E628E7BF19 /* Mather.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mather.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		111111111111111111111111 /* GameplayStageModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayStageModels.swift; sourceTree = "<group>"; };
+		111111111111111111111112 /* SpacedRepetitionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacedRepetitionModels.swift; sourceTree = "<group>"; };
+		111111111111111111111113 /* SpacedRepetitionScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacedRepetitionScheduler.swift; sourceTree = "<group>"; };
+		111111111111111111111114 /* GameplaySchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplaySchedulerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -98,6 +106,7 @@
 		13C13543035DCDDA54D258B6 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				111111111111111111111113 /* SpacedRepetitionScheduler.swift */,
 				C12E4243979B82D1D254C7BF /* HapticsService.swift */,
 				57321A0556CEB2A30DE5A7A7 /* SpeechService.swift */,
 			);
@@ -116,6 +125,7 @@
 		25FB5EFDA536B37D6A1D2832 /* MatherTests */ = {
 			isa = PBXGroup;
 			children = (
+				111111111111111111111114 /* GameplaySchedulerTests.swift */,
 				000C9B49685F8A6A3703EB65 /* ProblemGeneratorTests.swift */,
 				A5C80ECCAE5D25201666CBD0 /* SliceStateMachineTests.swift */,
 				6312C329D7FA010DA974C358 /* VerticalSliceEngineTests.swift */,
@@ -127,6 +137,8 @@
 		4356714DEE880CBB965F848D /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				111111111111111111111111 /* GameplayStageModels.swift */,
+				111111111111111111111112 /* SpacedRepetitionModels.swift */,
 				4BE99DB8FC85397C3E504E0B /* ProblemGenerator.swift */,
 				B557BC960B2E1946C97F0B6A /* SliceModels.swift */,
 				AF3772D0CE080725B37A115F /* SliceStateMachine.swift */,
@@ -299,6 +311,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				211111111111111111111114 /* GameplaySchedulerTests.swift in Sources */,
 				D0FA2DF7DD9A64D4BB9C8080 /* ProblemGeneratorTests.swift in Sources */,
 				739452A890EDE3E9C9B6B9C4 /* SliceStateMachineTests.swift in Sources */,
 				7B95DE9FB34D4A152F5553FB /* VerticalSliceEngineTests.swift in Sources */,
@@ -309,6 +322,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				211111111111111111111111 /* GameplayStageModels.swift in Sources */,
+				211111111111111111111112 /* SpacedRepetitionModels.swift in Sources */,
+				211111111111111111111113 /* SpacedRepetitionScheduler.swift in Sources */,
 				A3E583B00B7BE54D5F3E0535 /* AppModel.swift in Sources */,
 				B8C505B0ADB2C5A6FA25D6CB /* ConcreteBuildView.swift in Sources */,
 				B3671AB5F1E14FFAA4088BF5 /* EquationResolveView.swift in Sources */,

--- a/Services/SpacedRepetitionScheduler.swift
+++ b/Services/SpacedRepetitionScheduler.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+enum SpacedRepetitionScheduler {
+    static func makeRound(
+        thread: GameplayThreadDefinition,
+        stage: GameplayStageDefinition,
+        records: [GameplayExposureKey: GameplayExposureRecord] = [:],
+        now: Date = Date(),
+        seed: UInt64 = 0,
+        policy: SpacedRepetitionSelectionPolicy? = nil
+    ) -> GameplayRoundDefinition {
+        let effectivePolicy = policy ?? SpacedRepetitionSelectionPolicy(maximumItemCount: stage.maximumItemCount)
+        let candidates = candidateItems(thread: thread, stage: stage)
+        let ranked = candidates.sorted { lhs, rhs in
+            let leftRecord = records[recordKey(for: lhs, stageID: stage.id)]
+            let rightRecord = records[recordKey(for: rhs, stageID: stage.id)]
+            let leftRank = rank(item: lhs, record: leftRecord, now: now, seed: seed)
+            let rightRank = rank(item: rhs, record: rightRecord, now: now, seed: seed)
+            return leftRank < rightRank
+        }
+        let selected = Array(ranked.prefix(effectivePolicy.maximumItemCount))
+        return GameplayRoundDefinition(
+            id: "\(stage.id)-round-\(seed)",
+            stageID: stage.id,
+            kind: stage.kind,
+            items: selected,
+            seed: seed
+        )
+    }
+
+    static func candidateItems(thread: GameplayThreadDefinition, stage: GameplayStageDefinition) -> [GameplayRoundItem] {
+        let propertyTypeFilter = Set(stage.propertyTypeIDs)
+        var items: [GameplayRoundItem] = []
+        for entity in thread.entities {
+            if stage.kind == .flashcards || entity.properties.isEmpty {
+                items.append(GameplayRoundItem(id: "\(entity.id)::entity", entityID: entity.id, propertyID: nil, propertyTypeID: nil))
+                continue
+            }
+            let properties = entity.properties.filter { propertyTypeFilter.isEmpty || propertyTypeFilter.contains($0.typeID) }
+            for property in properties {
+                items.append(GameplayRoundItem(id: "\(entity.id)::\(property.id)", entityID: entity.id, propertyID: property.id, propertyTypeID: property.typeID))
+            }
+        }
+        return items
+    }
+
+    static func applying(
+        updates: [SpacedRepetitionUpdate],
+        to records: [GameplayExposureKey: GameplayExposureRecord],
+        stageInterval: TimeInterval = 60 * 60 * 24
+    ) -> [GameplayExposureKey: GameplayExposureRecord] {
+        var next = records
+        for update in updates {
+            var record = next[update.key] ?? GameplayExposureRecord(key: update.key)
+            if update.wasCorrect {
+                record.correctCount += 1
+            } else {
+                record.mistakeCount += 1
+            }
+            record.lastSeenAt = update.occurredAt
+            record.confidenceBand = confidenceBand(correctCount: record.correctCount, mistakeCount: record.mistakeCount)
+            record.dueAt = dueDate(for: record, after: update.occurredAt, baseInterval: stageInterval)
+            next[update.key] = record
+        }
+        return next
+    }
+
+    static func recordKey(for item: GameplayRoundItem, stageID: String) -> GameplayExposureKey {
+        GameplayExposureKey(entityID: item.entityID, propertyID: item.propertyID, stageID: stageID)
+    }
+
+    private static func rank(item: GameplayRoundItem, record: GameplayExposureRecord?, now: Date, seed: UInt64) -> GameplayItemRank {
+        guard let record else {
+            return GameplayItemRank(priority: 1, dueAt: .distantPast, mistakeDebt: 0, tieBreak: stableTieBreak(item.id, seed: seed))
+        }
+        let isDue = record.dueAt <= now
+        let confidencePriority: Int
+        switch record.confidenceBand {
+        case .reviewNeeded: confidencePriority = 0
+        case .new: confidencePriority = 1
+        case .learning: confidencePriority = 2
+        case .steady: confidencePriority = 4
+        }
+        let duePenalty = isDue ? 0 : 5
+        return GameplayItemRank(
+            priority: duePenalty + confidencePriority,
+            dueAt: record.dueAt,
+            mistakeDebt: -record.mistakeCount,
+            tieBreak: stableTieBreak(item.id, seed: seed)
+        )
+    }
+
+    private static func confidenceBand(correctCount: Int, mistakeCount: Int) -> GameplayConfidenceBand {
+        if mistakeCount > 0 && mistakeCount >= correctCount { return .reviewNeeded }
+        if correctCount == 0 && mistakeCount == 0 { return .new }
+        if correctCount < 3 { return .learning }
+        return .steady
+    }
+
+    private static func dueDate(for record: GameplayExposureRecord, after date: Date, baseInterval: TimeInterval) -> Date {
+        switch record.confidenceBand {
+        case .reviewNeeded:
+            return date.addingTimeInterval(baseInterval / 24)
+        case .new, .learning:
+            return date.addingTimeInterval(baseInterval)
+        case .steady:
+            return date.addingTimeInterval(baseInterval * 5)
+        }
+    }
+
+    private static func stableTieBreak(_ id: String, seed: UInt64) -> UInt64 {
+        var hash = 14_695_981_039_346_656_037 ^ seed
+        for byte in id.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return hash
+    }
+}
+
+private struct GameplayItemRank: Comparable {
+    let priority: Int
+    let dueAt: Date
+    let mistakeDebt: Int
+    let tieBreak: UInt64
+
+    static func < (lhs: GameplayItemRank, rhs: GameplayItemRank) -> Bool {
+        if lhs.priority != rhs.priority { return lhs.priority < rhs.priority }
+        if lhs.dueAt != rhs.dueAt { return lhs.dueAt < rhs.dueAt }
+        if lhs.mistakeDebt != rhs.mistakeDebt { return lhs.mistakeDebt < rhs.mistakeDebt }
+        return lhs.tieBreak < rhs.tieBreak
+    }
+}

--- a/Tests/MatherTests/GameplaySchedulerTests.swift
+++ b/Tests/MatherTests/GameplaySchedulerTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import Mather
+
+struct GameplaySchedulerTests {
+    @Test
+    func defaultThreadStagesMatchIssue912Order() {
+        #expect(GameplayThreadDefinition.defaultStages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+    }
+
+    @Test
+    func schedulerPrioritizesMissedDueItemsBeforeMasteredItems() {
+        let thread = sampleThread()
+        let stage = GameplayStageDefinition(
+            id: "bond-blast",
+            kind: .bondBlast,
+            title: "Bond Blast",
+            prompt: "Match facts",
+            propertyTypeIDs: ["capital"],
+            maximumItemCount: 2
+        )
+        let now = Date(timeIntervalSince1970: 1_000)
+        let indiaKey = GameplayExposureKey(entityID: "country-india", propertyID: "country-india-capital", stageID: stage.id)
+        let japanKey = GameplayExposureKey(entityID: "country-japan", propertyID: "country-japan-capital", stageID: stage.id)
+        let records: [GameplayExposureKey: GameplayExposureRecord] = [
+            indiaKey: GameplayExposureRecord(key: indiaKey, correctCount: 0, mistakeCount: 2, dueAt: now.addingTimeInterval(-10), confidenceBand: .reviewNeeded),
+            japanKey: GameplayExposureRecord(key: japanKey, correctCount: 5, mistakeCount: 0, dueAt: now.addingTimeInterval(-10), confidenceBand: .steady)
+        ]
+
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, records: records, now: now, seed: 7)
+
+        #expect(round.items.first?.entityID == "country-india")
+        #expect(round.items.map(\.propertyTypeID).allSatisfy { $0 == "capital" })
+    }
+
+    @Test
+    func schedulerSelectionIsDeterministicForSeed() {
+        let thread = sampleThread()
+        let stage = GameplayStageDefinition(id: "easy", kind: .easyMemory, title: "Easy", prompt: "Match", maximumItemCount: 3)
+
+        let first = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 42)
+        let second = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 42)
+        let different = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 43)
+
+        #expect(first.items.map(\.id) == second.items.map(\.id))
+        #expect(first.items.map(\.id) != different.items.map(\.id))
+    }
+
+    @Test
+    func applyingUpdatesMovesMistakesToReviewNeeded() {
+        let key = GameplayExposureKey(entityID: "fruit-apple", propertyID: "fruit-apple-taste", stageID: "multiple-choice")
+        let now = Date(timeIntervalSince1970: 2_000)
+
+        let records = SpacedRepetitionScheduler.applying(
+            updates: [SpacedRepetitionUpdate(key: key, wasCorrect: false, occurredAt: now)],
+            to: [:]
+        )
+
+        #expect(records[key]?.confidenceBand == .reviewNeeded)
+        #expect(records[key]?.mistakeCount == 1)
+        #expect((records[key]?.dueAt ?? .distantFuture) < now.addingTimeInterval(60 * 60 * 2))
+    }
+
+    @Test
+    func scoreSummaryAggregatesAccuracyHintsAndStars() {
+        let now = Date(timeIntervalSince1970: 3_000)
+        let results = [
+            GameplayStageResult(id: "one", stageID: "easy", correctCount: 5, mistakeCount: 0, hintsUsed: 1, durationSeconds: 20, completedAt: now),
+            GameplayStageResult(id: "two", stageID: "quiz", correctCount: 4, mistakeCount: 1, hintsUsed: 0, durationSeconds: 25, completedAt: now)
+        ]
+
+        let summary = GameplayScoreSummary.summarize(results)
+
+        #expect(summary.correctCount == 9)
+        #expect(summary.mistakeCount == 1)
+        #expect(summary.durationSeconds == 45)
+        #expect(summary.stars == 3)
+    }
+
+    private func sampleThread() -> GameplayThreadDefinition {
+        GameplayThreadDefinition(
+            id: "countries",
+            title: "Countries",
+            category: GameplayCategory(id: "geography", title: "Geography", subtitle: "Places"),
+            propertyTypes: [
+                GameplayPropertyType(id: "capital", displayName: "Capital", prompt: "Which capital?"),
+                GameplayPropertyType(id: "currency", displayName: "Currency", prompt: "Which money?")
+            ],
+            entities: [
+                GameplayEntity(id: "country-india", name: "India", properties: [
+                    GameplayProperty(id: "country-india-capital", typeID: "capital", value: "New Delhi"),
+                    GameplayProperty(id: "country-india-currency", typeID: "currency", value: "Indian rupee")
+                ]),
+                GameplayEntity(id: "country-japan", name: "Japan", properties: [
+                    GameplayProperty(id: "country-japan-capital", typeID: "capital", value: "Tokyo"),
+                    GameplayProperty(id: "country-japan-currency", typeID: "currency", value: "yen")
+                ]),
+                GameplayEntity(id: "country-france", name: "France", properties: [
+                    GameplayProperty(id: "country-france-capital", typeID: "capital", value: "Paris"),
+                    GameplayProperty(id: "country-france-currency", typeID: "currency", value: "euro")
+                ])
+            ]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add reusable gameplay thread/category/entity/property models for the #912 staged recall flow
- Add spaced-repetition exposure records and deterministic round scheduling
- Add scoring summary logic and unit coverage for stage order, prioritization, deterministic selection, updates, and stars

## Slice
PR 1 of the #912 wave: domain models + scheduler foundation.

## Testing
- Not run locally: this Linux worker does not have `xcodebuild` or `swiftc`
- Attempted remote validation on `ganesh-mba`, but SSH alias currently fails DNS resolution: `Could not resolve hostname mba`

Closes part of #912.
