### PR TITLE
Add reusable gameplay thread foundation

### DIFF
--- a/Domain/GameplayStageModels.swift
+++ b/Domain/GameplayStageModels.swift
@@ -1,0 +1,304 @@
+import Foundation
+
+struct GameplayThreadDefinition: Identifiable, Equatable, Codable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let category: GameplayCategory
+    let entities: [GameplayEntity]
+    let propertyTypes: [GameplayPropertyType]
+    let stages: [GameplayStageDefinition]
+    let progressionPolicy: GameplayProgressionPolicy
+
+    init(
+        id: String,
+        title: String,
+        subtitle: String = "",
+        category: GameplayCategory,
+        entities: [GameplayEntity],
+        propertyTypes: [GameplayPropertyType],
+        stages: [GameplayStageDefinition] = GameplayStageKind.allCases.map { GameplayStageDefinition(kind: $0) },
+        progressionPolicy: GameplayProgressionPolicy = .standard
+    ) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.category = category
+        self.entities = entities
+        self.propertyTypes = propertyTypes.sorted { $0.learningPriority < $1.learningPriority }
+        self.stages = stages
+        self.progressionPolicy = progressionPolicy
+    }
+
+    func propertyType(for id: String) -> GameplayPropertyType? { propertyTypes.first { $0.id == id } }
+    func entity(for id: String) -> GameplayEntity? { entities.first { $0.id == id } }
+}
+
+enum GameplayCategory: String, CaseIterable, Equatable, Codable {
+    case flashcards
+    case countries
+    case fruits
+    case waterCycle
+    case shapes
+    case sounds
+    case custom
+}
+
+struct GameplayEntity: Identifiable, Equatable, Codable {
+    let id: String
+    let name: String
+    let visual: GameplayVisual
+    let audioCue: GameplayAudioCue?
+    let explanation: String
+    let properties: [GameplayProperty]
+
+    init(
+        id: String,
+        name: String,
+        visual: GameplayVisual,
+        audioCue: GameplayAudioCue? = nil,
+        explanation: String,
+        properties: [GameplayProperty] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.visual = visual
+        self.audioCue = audioCue
+        self.explanation = explanation
+        self.properties = properties
+    }
+
+    func properties(ofType typeID: String) -> [GameplayProperty] { properties.filter { $0.typeID == typeID } }
+}
+
+enum GameplayVisual: Equatable, Codable, Hashable {
+    case emoji(String)
+    case asset(String)
+    case systemImage(String)
+    case text(String)
+}
+
+struct GameplayAudioCue: Equatable, Codable, Hashable {
+    let text: String
+    let assetName: String?
+
+    init(text: String, assetName: String? = nil) {
+        self.text = text
+        self.assetName = assetName
+    }
+}
+
+struct GameplayPropertyType: Identifiable, Equatable, Codable, Hashable {
+    let id: String
+    let title: String
+    let icon: String?
+    let learningPriority: Int
+
+    init(id: String, title: String, icon: String? = nil, learningPriority: Int = 0) {
+        self.id = id
+        self.title = title
+        self.icon = icon
+        self.learningPriority = learningPriority
+    }
+}
+
+struct GameplayProperty: Identifiable, Equatable, Codable, Hashable {
+    let id: String
+    let typeID: String
+    let value: String
+    let visual: GameplayVisual?
+    let audioCue: GameplayAudioCue?
+    let explanation: String?
+
+    init(
+        id: String,
+        typeID: String,
+        value: String,
+        visual: GameplayVisual? = nil,
+        audioCue: GameplayAudioCue? = nil,
+        explanation: String? = nil
+    ) {
+        self.id = id
+        self.typeID = typeID
+        self.value = value
+        self.visual = visual
+        self.audioCue = audioCue
+        self.explanation = explanation
+    }
+}
+
+enum GameplayStageKind: String, CaseIterable, Equatable, Codable, Hashable {
+    case flashcards
+    case easyMemory
+    case flipMemory
+    case bondBlast
+    case multipleChoice
+
+    var title: String {
+        switch self {
+        case .flashcards: return "Flashcards"
+        case .easyMemory: return "Easy Memory"
+        case .flipMemory: return "Flip Memory"
+        case .bondBlast: return "Bond Blast"
+        case .multipleChoice: return "Quiz"
+        }
+    }
+}
+
+struct GameplayStageDefinition: Identifiable, Equatable, Codable {
+    let id: String
+    let kind: GameplayStageKind
+    let title: String
+    let pairCount: Int
+    let focusedPropertyTypeIDs: [String]
+    let allowsHints: Bool
+
+    init(
+        id: String? = nil,
+        kind: GameplayStageKind,
+        title: String? = nil,
+        pairCount: Int = 4,
+        focusedPropertyTypeIDs: [String] = [],
+        allowsHints: Bool = true
+    ) {
+        self.id = id ?? kind.rawValue
+        self.kind = kind
+        self.title = title ?? kind.title
+        self.pairCount = pairCount
+        self.focusedPropertyTypeIDs = focusedPropertyTypeIDs
+        self.allowsHints = allowsHints
+    }
+}
+
+struct GameplayRoundDefinition: Identifiable, Equatable, Codable {
+    let id: UUID
+    let stageKind: GameplayStageKind
+    let entityIDs: [String]
+    let propertyTypeIDs: [String]
+    let seed: UInt64?
+
+    init(id: UUID = UUID(), stageKind: GameplayStageKind, entityIDs: [String], propertyTypeIDs: [String] = [], seed: UInt64? = nil) {
+        self.id = id
+        self.stageKind = stageKind
+        self.entityIDs = entityIDs
+        self.propertyTypeIDs = propertyTypeIDs
+        self.seed = seed
+    }
+}
+
+struct GameplayProgressionPolicy: Equatable, Codable {
+    let requiredStageOrder: [GameplayStageKind]
+    let minimumAccuracyToAdvance: Double
+    let reviewWeakItemsBetweenStages: Bool
+    let newItemRatio: Double
+    let steadyReviewRatio: Double
+
+    static let standard = GameplayProgressionPolicy(
+        requiredStageOrder: GameplayStageKind.allCases,
+        minimumAccuracyToAdvance: 0.7,
+        reviewWeakItemsBetweenStages: true,
+        newItemRatio: 0.25,
+        steadyReviewRatio: 0.15
+    )
+}
+
+struct GameplayStageScore: Identifiable, Equatable, Codable {
+    let id: UUID
+    let sessionID: UUID
+    let stageKind: GameplayStageKind
+    let startedAt: Date
+    var endedAt: Date?
+    var correctCount: Int
+    var incorrectCount: Int
+    var attempts: Int
+    var hintsUsed: Int
+    var currentStreak: Int
+    var bestStreak: Int
+    var firstTryCorrectCount: Int
+
+    init(id: UUID = UUID(), sessionID: UUID, stageKind: GameplayStageKind, startedAt: Date) {
+        self.id = id
+        self.sessionID = sessionID
+        self.stageKind = stageKind
+        self.startedAt = startedAt
+        self.endedAt = nil
+        self.correctCount = 0
+        self.incorrectCount = 0
+        self.attempts = 0
+        self.hintsUsed = 0
+        self.currentStreak = 0
+        self.bestStreak = 0
+        self.firstTryCorrectCount = 0
+    }
+
+    var elapsedSeconds: TimeInterval { (endedAt ?? startedAt).timeIntervalSince(startedAt) }
+
+    var accuracy: Double {
+        let total = correctCount + incorrectCount
+        guard total > 0 else { return 0 }
+        return Double(correctCount) / Double(total)
+    }
+
+    var points: Int {
+        let firstTryPoints = firstTryCorrectCount * 10
+        let supportedCorrectPoints = max(0, correctCount - firstTryCorrectCount) * 6
+        let streakBonus = bestStreak * 2
+        let hintPenalty = hintsUsed * 2
+        return max(0, firstTryPoints + supportedCorrectPoints + streakBonus - hintPenalty)
+    }
+
+    mutating func recordAnswer(correct: Bool, firstTry: Bool, usedHint: Bool = false) {
+        attempts += 1
+        if usedHint { hintsUsed += 1 }
+
+        if correct {
+            correctCount += 1
+            if firstTry { firstTryCorrectCount += 1 }
+            currentStreak += 1
+            bestStreak = max(bestStreak, currentStreak)
+        } else {
+            incorrectCount += 1
+            currentStreak = 0
+        }
+    }
+
+    mutating func finish(at endedAt: Date) { self.endedAt = endedAt }
+}
+
+struct GameplaySessionScore: Identifiable, Equatable, Codable {
+    let id: UUID
+    let threadID: String
+    let startedAt: Date
+    var endedAt: Date?
+    var stageScores: [GameplayStageScore]
+
+    init(id: UUID = UUID(), threadID: String, startedAt: Date, endedAt: Date? = nil, stageScores: [GameplayStageScore] = []) {
+        self.id = id
+        self.threadID = threadID
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.stageScores = stageScores
+    }
+
+    var totalCorrect: Int { stageScores.reduce(0) { $0 + $1.correctCount } }
+    var totalIncorrect: Int { stageScores.reduce(0) { $0 + $1.incorrectCount } }
+    var totalAttempts: Int { stageScores.reduce(0) { $0 + $1.attempts } }
+    var hintsUsed: Int { stageScores.reduce(0) { $0 + $1.hintsUsed } }
+    var totalPoints: Int { stageScores.reduce(0) { $0 + $1.points } }
+    var totalElapsedSeconds: TimeInterval { stageScores.reduce(0) { $0 + $1.elapsedSeconds } }
+
+    var accuracy: Double {
+        let total = totalCorrect + totalIncorrect
+        guard total > 0 else { return 0 }
+        return Double(totalCorrect) / Double(total)
+    }
+
+    var starRating: Int {
+        switch accuracy {
+        case 0.9...: return 3
+        case 0.7..<0.9: return 2
+        case 0.45..<0.7: return 1
+        default: return 0
+        }
+    }
+}

--- a/Domain/SpacedRepetitionModels.swift
+++ b/Domain/SpacedRepetitionModels.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+struct GameplayRepetitionKey: Hashable, Equatable, Codable, Comparable {
+    let entityID: String
+    let propertyTypeID: String?
+    let propertyValueID: String?
+
+    init(entityID: String, propertyTypeID: String? = nil, propertyValueID: String? = nil) {
+        self.entityID = entityID
+        self.propertyTypeID = propertyTypeID
+        self.propertyValueID = propertyValueID
+    }
+
+    static func < (lhs: GameplayRepetitionKey, rhs: GameplayRepetitionKey) -> Bool {
+        [lhs.entityID, lhs.propertyTypeID ?? "", lhs.propertyValueID ?? ""] < [rhs.entityID, rhs.propertyTypeID ?? "", rhs.propertyValueID ?? ""]
+    }
+}
+
+enum GameplayConfidenceBand: String, CaseIterable, Equatable, Codable {
+    case new
+    case learning
+    case steady
+    case reviewNeeded
+    case mastered
+}
+
+struct GameplayExposureEvent: Identifiable, Equatable, Codable {
+    let id: UUID
+    let key: GameplayRepetitionKey
+    let stageKind: GameplayStageKind
+    let sessionID: UUID
+    let seenAt: Date
+    let wasCorrect: Bool?
+    let attempts: Int
+    let usedHint: Bool
+    let responseTimeSeconds: TimeInterval?
+
+    init(
+        id: UUID = UUID(),
+        key: GameplayRepetitionKey,
+        stageKind: GameplayStageKind,
+        sessionID: UUID,
+        seenAt: Date,
+        wasCorrect: Bool? = nil,
+        attempts: Int = 0,
+        usedHint: Bool = false,
+        responseTimeSeconds: TimeInterval? = nil
+    ) {
+        self.id = id
+        self.key = key
+        self.stageKind = stageKind
+        self.sessionID = sessionID
+        self.seenAt = seenAt
+        self.wasCorrect = wasCorrect
+        self.attempts = attempts
+        self.usedHint = usedHint
+        self.responseTimeSeconds = responseTimeSeconds
+    }
+}
+
+struct GameplayRepetitionState: Identifiable, Equatable, Codable {
+    var id: GameplayRepetitionKey { key }
+    let key: GameplayRepetitionKey
+    var lastStageKind: GameplayStageKind?
+    var lastSessionID: UUID?
+    var exposureCount: Int
+    var correctCount: Int
+    var incorrectCount: Int
+    var lastSeenAt: Date?
+    var nextDueAt: Date
+    var confidenceBand: GameplayConfidenceBand
+
+    init(
+        key: GameplayRepetitionKey,
+        lastStageKind: GameplayStageKind? = nil,
+        lastSessionID: UUID? = nil,
+        exposureCount: Int = 0,
+        correctCount: Int = 0,
+        incorrectCount: Int = 0,
+        lastSeenAt: Date? = nil,
+        nextDueAt: Date = .distantPast,
+        confidenceBand: GameplayConfidenceBand = .new
+    ) {
+        self.key = key
+        self.lastStageKind = lastStageKind
+        self.lastSessionID = lastSessionID
+        self.exposureCount = exposureCount
+        self.correctCount = correctCount
+        self.incorrectCount = incorrectCount
+        self.lastSeenAt = lastSeenAt
+        self.nextDueAt = nextDueAt
+        self.confidenceBand = confidenceBand
+    }
+
+    var accuracy: Double {
+        guard exposureCount > 0 else { return 0 }
+        return Double(correctCount) / Double(exposureCount)
+    }
+
+    var isWeak: Bool { confidenceBand == .reviewNeeded || confidenceBand == .learning || incorrectCount > correctCount }
+    var isMastered: Bool { confidenceBand == .mastered }
+}
+
+protocol GameplayRepetitionStoring {
+    func states(for keys: [GameplayRepetitionKey]) -> [GameplayRepetitionKey: GameplayRepetitionState]
+    mutating func apply(_ events: [GameplayExposureEvent], at now: Date)
+}
+
+struct InMemoryGameplayRepetitionStore: GameplayRepetitionStoring {
+    private(set) var statesByKey: [GameplayRepetitionKey: GameplayRepetitionState]
+
+    init(states: [GameplayRepetitionState] = []) {
+        self.statesByKey = Dictionary(uniqueKeysWithValues: states.map { ($0.key, $0) })
+    }
+
+    func states(for keys: [GameplayRepetitionKey]) -> [GameplayRepetitionKey: GameplayRepetitionState] {
+        Dictionary(uniqueKeysWithValues: keys.map { key in
+            (key, statesByKey[key] ?? GameplayRepetitionState(key: key))
+        })
+    }
+
+    mutating func apply(_ events: [GameplayExposureEvent], at now: Date) {
+        let scheduler = SpacedRepetitionScheduler()
+        for event in events {
+            let previous = statesByKey[event.key] ?? GameplayRepetitionState(key: event.key)
+            statesByKey[event.key] = scheduler.updatedState(from: previous, with: event, at: now)
+        }
+    }
+}

--- a/Domain/SpacedRepetitionModels.swift
+++ b/Domain/SpacedRepetitionModels.swift
@@ -12,7 +12,11 @@ struct GameplayRepetitionKey: Hashable, Equatable, Codable, Comparable {
     }
 
     static func < (lhs: GameplayRepetitionKey, rhs: GameplayRepetitionKey) -> Bool {
-        [lhs.entityID, lhs.propertyTypeID ?? "", lhs.propertyValueID ?? ""] < [rhs.entityID, rhs.propertyTypeID ?? "", rhs.propertyValueID ?? ""]
+        if lhs.entityID != rhs.entityID { return lhs.entityID < rhs.entityID }
+        let lhsPropertyTypeID = lhs.propertyTypeID ?? ""
+        let rhsPropertyTypeID = rhs.propertyTypeID ?? ""
+        if lhsPropertyTypeID != rhsPropertyTypeID { return lhsPropertyTypeID < rhsPropertyTypeID }
+        return (lhs.propertyValueID ?? "") < (rhs.propertyValueID ?? "")
     }
 }
 

--- a/Services/SpacedRepetitionScheduler.swift
+++ b/Services/SpacedRepetitionScheduler.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+struct SpacedRepetitionScheduler {
+    struct Configuration: Equatable {
+        let dueWeakWeight: Double
+        let dueSteadyWeight: Double
+        let newItemWeight: Double
+        let masteredWeight: Double
+        let weakReviewInterval: TimeInterval
+        let learningInterval: TimeInterval
+        let steadyInterval: TimeInterval
+        let masteredInterval: TimeInterval
+
+        static let standard = Configuration(
+            dueWeakWeight: 1_000,
+            dueSteadyWeight: 600,
+            newItemWeight: 450,
+            masteredWeight: 50,
+            weakReviewInterval: 60 * 5,
+            learningInterval: 60 * 60,
+            steadyInterval: 60 * 60 * 24,
+            masteredInterval: 60 * 60 * 24 * 5
+        )
+    }
+
+    let configuration: Configuration
+
+    init(configuration: Configuration = .standard) {
+        self.configuration = configuration
+    }
+
+    func repetitionKeys(for thread: GameplayThreadDefinition) -> [GameplayRepetitionKey] {
+        thread.entities.flatMap { entity -> [GameplayRepetitionKey] in
+            let entityKey = GameplayRepetitionKey(entityID: entity.id)
+            let propertyKeys = entity.properties.map {
+                GameplayRepetitionKey(entityID: entity.id, propertyTypeID: $0.typeID, propertyValueID: $0.id)
+            }
+            return [entityKey] + propertyKeys
+        }.sorted()
+    }
+
+    func selectKeys(
+        from candidates: [GameplayRepetitionKey],
+        states: [GameplayRepetitionKey: GameplayRepetitionState],
+        limit: Int,
+        now: Date
+    ) -> [GameplayRepetitionKey] {
+        guard limit > 0 else { return [] }
+        return candidates
+            .sorted { lhs, rhs in
+                let lhsScore = priorityScore(for: states[lhs] ?? GameplayRepetitionState(key: lhs), now: now)
+                let rhsScore = priorityScore(for: states[rhs] ?? GameplayRepetitionState(key: rhs), now: now)
+                if lhsScore == rhsScore { return lhs < rhs }
+                return lhsScore > rhsScore
+            }
+            .prefix(limit)
+            .map { $0 }
+    }
+
+    func buildRound(
+        for thread: GameplayThreadDefinition,
+        stageKind: GameplayStageKind,
+        states: [GameplayRepetitionKey: GameplayRepetitionState],
+        itemLimit: Int,
+        now: Date,
+        seed: UInt64? = nil
+    ) -> GameplayRoundDefinition {
+        let selected = selectKeys(from: repetitionKeys(for: thread), states: states, limit: itemLimit, now: now)
+        let entityIDs = Array(Set(selected.map(\.entityID))).sorted()
+        let propertyTypeIDs = Array(Set(selected.compactMap(\.propertyTypeID))).sorted()
+        return GameplayRoundDefinition(stageKind: stageKind, entityIDs: entityIDs, propertyTypeIDs: propertyTypeIDs, seed: seed)
+    }
+
+    func updatedState(
+        from previous: GameplayRepetitionState,
+        with event: GameplayExposureEvent,
+        at now: Date
+    ) -> GameplayRepetitionState {
+        var state = previous
+        state.lastStageKind = event.stageKind
+        state.lastSessionID = event.sessionID
+        state.exposureCount += 1
+        state.lastSeenAt = event.seenAt
+
+        switch event.wasCorrect {
+        case .some(true): state.correctCount += 1
+        case .some(false): state.incorrectCount += 1
+        case .none: break
+        }
+
+        state.confidenceBand = confidenceBand(
+            exposureCount: state.exposureCount,
+            correctCount: state.correctCount,
+            incorrectCount: state.incorrectCount,
+            usedHint: event.usedHint,
+            attempts: event.attempts
+        )
+        state.nextDueAt = nextDueDate(for: state.confidenceBand, after: now)
+        return state
+    }
+
+    func priorityScore(for state: GameplayRepetitionState, now: Date) -> Double {
+        if state.exposureCount == 0 { return configuration.newItemWeight }
+
+        let isDue = state.nextDueAt <= now
+        let dueBoost = isDue ? dueUrgency(for: state, now: now) : 0
+        let weaknessBoost = Double(state.incorrectCount * 90) + max(0, 1 - state.accuracy) * 180
+
+        switch state.confidenceBand {
+        case .reviewNeeded:
+            return configuration.dueWeakWeight + dueBoost + weaknessBoost
+        case .learning:
+            return (isDue ? configuration.dueWeakWeight : configuration.dueSteadyWeight) + dueBoost + weaknessBoost
+        case .new:
+            return configuration.newItemWeight
+        case .steady:
+            return (isDue ? configuration.dueSteadyWeight : 200) + dueBoost + weaknessBoost
+        case .mastered:
+            return (isDue ? configuration.dueSteadyWeight / 2 : configuration.masteredWeight) + dueBoost
+        }
+    }
+
+    private func dueUrgency(for state: GameplayRepetitionState, now: Date) -> Double {
+        max(0, now.timeIntervalSince(state.nextDueAt) / 60)
+    }
+
+    private func confidenceBand(
+        exposureCount: Int,
+        correctCount: Int,
+        incorrectCount: Int,
+        usedHint: Bool,
+        attempts: Int
+    ) -> GameplayConfidenceBand {
+        guard exposureCount > 0 else { return .new }
+        if incorrectCount > 0 && (incorrectCount >= correctCount || usedHint || attempts > 1) {
+            return .reviewNeeded
+        }
+        if usedHint || attempts > 1 { return .reviewNeeded }
+        if exposureCount < 2 || correctCount < 2 { return .learning }
+        if correctCount >= 5 && incorrectCount == 0 { return .mastered }
+        return .steady
+    }
+
+    private func nextDueDate(for band: GameplayConfidenceBand, after date: Date) -> Date {
+        switch band {
+        case .new: return date
+        case .reviewNeeded: return date.addingTimeInterval(configuration.weakReviewInterval)
+        case .learning: return date.addingTimeInterval(configuration.learningInterval)
+        case .steady: return date.addingTimeInterval(configuration.steadyInterval)
+        case .mastered: return date.addingTimeInterval(configuration.masteredInterval)
+        }
+    }
+}

--- a/Tests/MatherTests/GameplayScoringTests.swift
+++ b/Tests/MatherTests/GameplayScoringTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import Mather
+
+struct GameplayScoringTests {
+    @Test
+    func stageScoreRewardsFirstTryAndTracksHintsStreakAndTime() {
+        let sessionID = UUID()
+        var score = GameplayStageScore(
+            sessionID: sessionID,
+            stageKind: .multipleChoice,
+            startedAt: Date(timeIntervalSince1970: 10)
+        )
+
+        score.recordAnswer(correct: true, firstTry: true)
+        score.recordAnswer(correct: true, firstTry: true)
+        score.recordAnswer(correct: false, firstTry: false)
+        score.recordAnswer(correct: true, firstTry: false, usedHint: true)
+        score.finish(at: Date(timeIntervalSince1970: 70))
+
+        #expect(score.correctCount == 3)
+        #expect(score.incorrectCount == 1)
+        #expect(score.attempts == 4)
+        #expect(score.hintsUsed == 1)
+        #expect(score.bestStreak == 2)
+        #expect(score.accuracy == 0.75)
+        #expect(score.elapsedSeconds == 60)
+        #expect(score.points == 28)
+    }
+
+    @Test
+    func sessionScoreAggregatesStageTotalsAndStars() {
+        let sessionID = UUID()
+        let startedAt = Date(timeIntervalSince1970: 100)
+        var flashcards = GameplayStageScore(sessionID: sessionID, stageKind: .flashcards, startedAt: startedAt)
+        flashcards.recordAnswer(correct: true, firstTry: true)
+        flashcards.recordAnswer(correct: true, firstTry: true)
+        flashcards.finish(at: startedAt.addingTimeInterval(30))
+
+        var quiz = GameplayStageScore(sessionID: sessionID, stageKind: .multipleChoice, startedAt: startedAt.addingTimeInterval(30))
+        quiz.recordAnswer(correct: true, firstTry: true)
+        quiz.recordAnswer(correct: false, firstTry: false)
+        quiz.finish(at: startedAt.addingTimeInterval(75))
+
+        let session = GameplaySessionScore(
+            id: sessionID,
+            threadID: "countries",
+            startedAt: startedAt,
+            stageScores: [flashcards, quiz]
+        )
+
+        #expect(session.totalCorrect == 3)
+        #expect(session.totalIncorrect == 1)
+        #expect(session.totalAttempts == 4)
+        #expect(session.totalElapsedSeconds == 75)
+        #expect(session.accuracy == 0.75)
+        #expect(session.starRating == 2)
+        #expect(session.totalPoints == flashcards.points + quiz.points)
+    }
+}

--- a/Tests/MatherTests/GameplayStageModelsTests.swift
+++ b/Tests/MatherTests/GameplayStageModelsTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import Mather
+
+struct GameplayStageModelsTests {
+    @Test
+    func threadDefinitionSupportsEntitiesPropertiesVisualsAudioAndStages() {
+        let capital = GameplayPropertyType(id: "capital", title: "Capital", icon: "building.columns", learningPriority: 2)
+        let flag = GameplayPropertyType(id: "flag", title: "Flag", icon: "flag", learningPriority: 1)
+        let india = GameplayEntity(
+            id: "india",
+            name: "India",
+            visual: .emoji("🇮🇳"),
+            audioCue: GameplayAudioCue(text: "India"),
+            explanation: "India is a country in Asia.",
+            properties: [
+                GameplayProperty(id: "india-flag", typeID: "flag", value: "Indian flag", visual: .emoji("🇮🇳")),
+                GameplayProperty(id: "india-capital", typeID: "capital", value: "New Delhi", explanation: "New Delhi is India's capital.")
+            ]
+        )
+
+        let thread = GameplayThreadDefinition(
+            id: "countries",
+            title: "Countries",
+            category: .countries,
+            entities: [india],
+            propertyTypes: [capital, flag]
+        )
+
+        #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+        #expect(thread.propertyTypes.map(\.id) == ["flag", "capital"])
+        #expect(thread.entity(for: "india")?.properties(ofType: "capital").first?.value == "New Delhi")
+        #expect(thread.entities.first?.audioCue?.text == "India")
+    }
+
+    @Test
+    func progressionPolicyDefaultsToFullGameplayThreadOrder() {
+        let policy = GameplayProgressionPolicy.standard
+        #expect(policy.requiredStageOrder == GameplayStageKind.allCases)
+        #expect(policy.minimumAccuracyToAdvance == 0.7)
+        #expect(policy.reviewWeakItemsBetweenStages)
+    }
+}

--- a/Tests/MatherTests/SpacedRepetitionSchedulerTests.swift
+++ b/Tests/MatherTests/SpacedRepetitionSchedulerTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import Mather
+
+struct SpacedRepetitionSchedulerTests {
+    private let now = Date(timeIntervalSince1970: 1_000)
+
+    @Test
+    func schedulerPrioritizesDueWeakItemsBeforeNewSteadyAndMasteredItems() {
+        let weak = GameplayRepetitionKey(entityID: "weak")
+        let new = GameplayRepetitionKey(entityID: "new")
+        let steady = GameplayRepetitionKey(entityID: "steady")
+        let mastered = GameplayRepetitionKey(entityID: "mastered")
+        let candidates = [mastered, steady, new, weak]
+        let states: [GameplayRepetitionKey: GameplayRepetitionState] = [
+            weak: GameplayRepetitionState(
+                key: weak,
+                exposureCount: 3,
+                correctCount: 1,
+                incorrectCount: 2,
+                nextDueAt: now.addingTimeInterval(-60),
+                confidenceBand: .reviewNeeded
+            ),
+            steady: GameplayRepetitionState(
+                key: steady,
+                exposureCount: 3,
+                correctCount: 3,
+                incorrectCount: 0,
+                nextDueAt: now.addingTimeInterval(-60),
+                confidenceBand: .steady
+            ),
+            mastered: GameplayRepetitionState(
+                key: mastered,
+                exposureCount: 6,
+                correctCount: 6,
+                incorrectCount: 0,
+                nextDueAt: now.addingTimeInterval(86_400),
+                confidenceBand: .mastered
+            )
+        ]
+
+        let selected = SpacedRepetitionScheduler().selectKeys(
+            from: candidates,
+            states: states,
+            limit: 4,
+            now: now
+        )
+
+        #expect(selected == [weak, steady, new, mastered])
+    }
+
+    @Test
+    func updatingStateMovesIncorrectOrHintedWorkIntoReviewNeeded() {
+        let key = GameplayRepetitionKey(entityID: "india", propertyTypeID: "capital", propertyValueID: "india-capital")
+        let sessionID = UUID()
+        let event = GameplayExposureEvent(
+            key: key,
+            stageKind: .easyMemory,
+            sessionID: sessionID,
+            seenAt: now,
+            wasCorrect: true,
+            attempts: 2,
+            usedHint: true
+        )
+
+        let state = SpacedRepetitionScheduler().updatedState(
+            from: GameplayRepetitionState(key: key),
+            with: event,
+            at: now
+        )
+
+        #expect(state.exposureCount == 1)
+        #expect(state.correctCount == 1)
+        #expect(state.confidenceBand == .reviewNeeded)
+        #expect(state.nextDueAt > now)
+        #expect(state.lastStageKind == .easyMemory)
+        #expect(state.lastSessionID == sessionID)
+    }
+
+    @Test
+    func buildRoundReturnsDeterministicEntityAndPropertySelection() {
+        let thread = GameplayThreadDefinition.sampleForSchedulerTests()
+        let scheduler = SpacedRepetitionScheduler()
+        let allKeys = scheduler.repetitionKeys(for: thread)
+        let weakKey = GameplayRepetitionKey(entityID: "india", propertyTypeID: "capital", propertyValueID: "india-capital")
+        let states = Dictionary(uniqueKeysWithValues: allKeys.map { key in
+            (
+                key,
+                GameplayRepetitionState(
+                    key: key,
+                    exposureCount: key == weakKey ? 3 : 5,
+                    correctCount: key == weakKey ? 1 : 5,
+                    incorrectCount: key == weakKey ? 2 : 0,
+                    nextDueAt: key == weakKey ? now.addingTimeInterval(-60) : now.addingTimeInterval(86_400),
+                    confidenceBand: key == weakKey ? .reviewNeeded : .mastered
+                )
+            )
+        })
+
+        let round = scheduler.buildRound(
+            for: thread,
+            stageKind: .bondBlast,
+            states: states,
+            itemLimit: 2,
+            now: now,
+            seed: 42
+        )
+
+        #expect(round.stageKind == .bondBlast)
+        #expect(round.entityIDs.contains("india"))
+        #expect(round.propertyTypeIDs.contains("capital"))
+        #expect(round.seed == 42)
+    }
+
+    @Test
+    func inMemoryStoreAppliesExposureEvents() {
+        let key = GameplayRepetitionKey(entityID: "mango")
+        let sessionID = UUID()
+        var store = InMemoryGameplayRepetitionStore()
+        store.apply([
+            GameplayExposureEvent(
+                key: key,
+                stageKind: .flashcards,
+                sessionID: sessionID,
+                seenAt: now,
+                wasCorrect: nil
+            )
+        ], at: now)
+
+        let state = store.states(for: [key])[key]
+        #expect(state?.exposureCount == 1)
+        #expect(state?.lastStageKind == .flashcards)
+    }
+}
+
+private extension GameplayThreadDefinition {
+    static func sampleForSchedulerTests() -> GameplayThreadDefinition {
+        let capital = GameplayPropertyType(id: "capital", title: "Capital", learningPriority: 1)
+        let currency = GameplayPropertyType(id: "currency", title: "Currency", learningPriority: 2)
+        return GameplayThreadDefinition(
+            id: "countries",
+            title: "Countries",
+            category: .countries,
+            entities: [
+                GameplayEntity(
+                    id: "india",
+                    name: "India",
+                    visual: .emoji("🇮🇳"),
+                    explanation: "India is in Asia.",
+                    properties: [
+                        GameplayProperty(id: "india-capital", typeID: "capital", value: "New Delhi"),
+                        GameplayProperty(id: "india-currency", typeID: "currency", value: "Rupee")
+                    ]
+                ),
+                GameplayEntity(
+                    id: "japan",
+                    name: "Japan",
+                    visual: .emoji("🇯🇵"),
+                    explanation: "Japan is an island country.",
+                    properties: [
+                        GameplayProperty(id: "japan-capital", typeID: "capital", value: "Tokyo")
+                    ]
+                )
+            ],
+            propertyTypes: [capital, currency]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds reusable gameplay thread domain models for entities, properties, visuals/audio cues, stages, rounds, progression policy, scoring, and timing.
- Adds spaced repetition keys/events/state plus an in-memory progress store.
- Adds a deterministic scheduler that prioritizes due/weak items ahead of steady/new/mastered work and builds foundation rounds for later UI slices.

## Validation
- `git diff --check`
- GitHub CI Build & Test passed: https://github.com/ganesh47/mather/actions/runs/25280805191/job/74117689306

Refs #912 (Slice A foundation; follow-up migration/view slices remain in the lane wave).
