### PR TITLE
feat: add countries gameplay thread

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -16,6 +16,15 @@ struct RootView: View {
         gameSessions.filter { $0.profileId == appModel.profileStore.activeProfileId }
     }
 
+    private static func gameplayThread(for id: String) -> GameplayThreadDefinition {
+        switch id {
+        case CountryGameplayThread.thread.id:
+            return CountryGameplayThread.thread
+        default:
+            return CountryGameplayThread.thread
+        }
+    }
+
     var body: some View {
         NavigationStack {
             Group {
@@ -94,6 +103,8 @@ struct RootView: View {
                     MemoryView(appModel: appModel)
                 case .memoryDeck(let deckKind):
                     MemoryView(appModel: appModel, initialDeckKind: deckKind)
+                case .gameplayThread(let threadID):
+                    GameplayThreadView(thread: Self.gameplayThread(for: threadID), appModel: appModel)
                 case .waterCycle:
                     WaterCycleLabView(appModel: appModel)
                 case .soundVolume:

--- a/Domain/CountryGameplayThread.swift
+++ b/Domain/CountryGameplayThread.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+enum CountryGameplayThread {
+    static let thread = GameplayThreadDefinition(
+        id: "countries",
+        title: "Country Cards",
+        category: GameplayCategory(
+            id: "geography",
+            title: "Geography",
+            subtitle: "Countries, flags, capitals, maps, languages, and money"
+        ),
+        propertyTypes: [
+            GameplayPropertyType(id: "capital", displayName: "Capital", prompt: "Which capital city belongs to this country?"),
+            GameplayPropertyType(id: "currency", displayName: "Currency", prompt: "Which money is used here?"),
+            GameplayPropertyType(id: "flag", displayName: "Flag", prompt: "Which flag belongs to this country?"),
+            GameplayPropertyType(id: "map-shape", displayName: "Map Shape", prompt: "Which map-shape clue fits this country?"),
+            GameplayPropertyType(id: "continent", displayName: "Continent", prompt: "Which continent is this country on?"),
+            GameplayPropertyType(id: "language", displayName: "Language", prompt: "Which language clue fits this country?"),
+            GameplayPropertyType(id: "known-for", displayName: "Known For", prompt: "Which clue is this country known for?")
+        ],
+        entities: [
+            country(
+                id: "country-india",
+                name: "India",
+                flagEmoji: "🇮🇳",
+                flagAsset: "MemoryFlagIndia",
+                summary: "India is a large country in Asia, home of the Taj Mahal.",
+                capital: "New Delhi",
+                currency: "Indian rupee",
+                mapShape: "wide triangle-like peninsula",
+                continent: "Asia",
+                language: "Hindi and English",
+                knownFor: "home of the Taj Mahal"
+            ),
+            country(
+                id: "country-japan",
+                name: "Japan",
+                flagEmoji: "🇯🇵",
+                flagAsset: "MemoryFlagJapan",
+                summary: "Japan is a long island chain in Asia.",
+                capital: "Tokyo",
+                currency: "yen",
+                mapShape: "long island chain",
+                continent: "Asia",
+                language: "Japanese",
+                knownFor: "known for cherry blossoms and bullet trains"
+            ),
+            country(
+                id: "country-france",
+                name: "France",
+                flagEmoji: "🇫🇷",
+                flagAsset: "MemoryFlagFrance",
+                summary: "France is a European country with a hexagon-like outline.",
+                capital: "Paris",
+                currency: "euro",
+                mapShape: "hexagon-like outline",
+                continent: "Europe",
+                language: "French",
+                knownFor: "home of the Eiffel Tower"
+            ),
+            country(
+                id: "country-egypt",
+                name: "Egypt",
+                flagEmoji: "🇪🇬",
+                flagAsset: "MemoryFlagEgypt",
+                summary: "Egypt is in Africa and is home of the Great Pyramids.",
+                capital: "Cairo",
+                currency: "Egyptian pound",
+                mapShape: "square-like shape with Sinai corner",
+                continent: "Africa",
+                language: "Arabic",
+                knownFor: "home of the Great Pyramids"
+            ),
+            country(
+                id: "country-brazil",
+                name: "Brazil",
+                flagEmoji: "🇧🇷",
+                flagAsset: "MemoryFlagBrazil",
+                summary: "Brazil is a large South American country with the Amazon rainforest.",
+                capital: "Brasília",
+                currency: "Brazilian real",
+                mapShape: "large east-bulging outline",
+                continent: "South America",
+                language: "Portuguese",
+                knownFor: "home of the Amazon rainforest"
+            ),
+            country(
+                id: "country-australia",
+                name: "Australia",
+                flagEmoji: "🇦🇺",
+                flagAsset: "MemoryFlagAustralia",
+                summary: "Australia is a big island continent with kangaroos and koalas.",
+                capital: "Canberra",
+                currency: "Australian dollar",
+                mapShape: "big island continent",
+                continent: "Australia",
+                language: "English",
+                knownFor: "home of kangaroos and koalas"
+            ),
+            country(
+                id: "country-canada",
+                name: "Canada",
+                flagEmoji: "🇨🇦",
+                flagAsset: "MemoryFlagCanada",
+                summary: "Canada is a very wide northern country in North America.",
+                capital: "Ottawa",
+                currency: "Canadian dollar",
+                mapShape: "very wide northern outline",
+                continent: "North America",
+                language: "English and French",
+                knownFor: "known for maple leaves and snowy winters"
+            ),
+            country(
+                id: "country-kenya",
+                name: "Kenya",
+                flagEmoji: "🇰🇪",
+                flagAsset: "MemoryFlagKenya",
+                summary: "Kenya is in east Africa by the Indian Ocean.",
+                capital: "Nairobi",
+                currency: "Kenyan shilling",
+                mapShape: "east Africa shape by the Indian Ocean",
+                continent: "Africa",
+                language: "Swahili and English",
+                knownFor: "known for savannas and wildlife parks"
+            )
+        ],
+        stages: [
+            GameplayStageDefinition(id: "flashcards", kind: .flashcards, title: "Look + Learn", prompt: "Meet each country, flag, capital, map clue, language, and money.", maximumItemCount: 8),
+            GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Start by matching countries to flags, capitals, and continents.", propertyTypeIDs: ["flag", "capital", "continent"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Flip and remember flags, capitals, and currencies.", propertyTypeIDs: ["flag", "capital", "currency"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect each country to mixed facts.", propertyTypeIDs: ["capital", "currency", "continent", "language", "map-shape"], maximumItemCount: 10),
+            GameplayStageDefinition(id: "multiple-choice", kind: .multipleChoice, title: "Quiz", prompt: "Pick the best country fact.", propertyTypeIDs: ["capital", "currency", "flag", "map-shape", "continent", "language"], maximumItemCount: 12)
+        ]
+    )
+
+    private static func country(
+        id: String,
+        name: String,
+        flagEmoji: String,
+        flagAsset: String,
+        summary: String,
+        capital: String,
+        currency: String,
+        mapShape: String,
+        continent: String,
+        language: String,
+        knownFor: String
+    ) -> GameplayEntity {
+        GameplayEntity(
+            id: id,
+            name: name,
+            summary: summary,
+            visualKey: flagEmoji,
+            visualAssetName: flagAsset,
+            properties: [
+                property(entityID: id, typeID: "capital", value: capital, explanation: "The capital of \(name) is \(capital).", visualKey: "🏛️"),
+                property(entityID: id, typeID: "currency", value: currency, explanation: "\(name) uses \(currency).", visualKey: "💰"),
+                property(entityID: id, typeID: "flag", value: "\(name) flag", explanation: "This is the flag of \(name).", visualKey: flagEmoji, visualAssetName: flagAsset),
+                property(entityID: id, typeID: "map-shape", value: mapShape, explanation: "A map clue for \(name): \(mapShape).", visualKey: "🗺️"),
+                property(entityID: id, typeID: "continent", value: continent, explanation: "\(name) is in \(continent).", visualKey: "🌍"),
+                property(entityID: id, typeID: "language", value: language, explanation: "A language clue for \(name): \(language).", visualKey: "🗣️"),
+                property(entityID: id, typeID: "known-for", value: knownFor, explanation: "\(name) is \(knownFor).", visualKey: "✨")
+            ]
+        )
+    }
+
+    private static func property(
+        entityID: String,
+        typeID: String,
+        value: String,
+        explanation: String,
+        visualKey: String? = nil,
+        visualAssetName: String? = nil
+    ) -> GameplayProperty {
+        GameplayProperty(
+            id: "\(entityID)-\(typeID)",
+            typeID: typeID,
+            value: value,
+            explanation: explanation,
+            visualKey: visualKey,
+            visualAssetName: visualAssetName
+        )
+    }
+}

--- a/Domain/CountryGameplayThread.swift
+++ b/Domain/CountryGameplayThread.swift
@@ -16,7 +16,7 @@ enum CountryGameplayThread {
             GameplayPropertyType(id: "map-shape", displayName: "Map Shape", prompt: "Which map-shape clue fits this country?"),
             GameplayPropertyType(id: "continent", displayName: "Continent", prompt: "Which continent is this country on?"),
             GameplayPropertyType(id: "language", displayName: "Language", prompt: "Which language clue fits this country?"),
-            GameplayPropertyType(id: "known-for", displayName: "Known For", prompt: "Which clue is this country known for?")
+            GameplayPropertyType(id: "clue", displayName: "Clue", prompt: "Which clue is this country known for?")
         ],
         entities: [
             country(
@@ -159,7 +159,7 @@ enum CountryGameplayThread {
                 property(entityID: id, typeID: "map-shape", value: mapShape, explanation: "A map clue for \(name): \(mapShape).", visualKey: "🗺️"),
                 property(entityID: id, typeID: "continent", value: continent, explanation: "\(name) is in \(continent).", visualKey: "🌍"),
                 property(entityID: id, typeID: "language", value: language, explanation: "A language clue for \(name): \(language).", visualKey: "🗣️"),
-                property(entityID: id, typeID: "known-for", value: knownFor, explanation: "\(name) is \(knownFor).", visualKey: "✨")
+                property(entityID: id, typeID: "clue", value: knownFor, explanation: "\(name) is \(knownFor).", visualKey: "✨")
             ]
         )
     }

--- a/Domain/GameplaySampleThreads.swift
+++ b/Domain/GameplaySampleThreads.swift
@@ -1,5 +1,43 @@
 import Foundation
 
 enum GameplaySampleThreads {
-    static let countries: GameplayThreadDefinition = CountryGameplayThread.thread
+    static let countries: GameplayThreadDefinition = GameplayThreadDefinition(
+        id: "sample-countries-gameplay-thread",
+        title: "Countries Quest",
+        category: GameplayCategory(id: "geography", title: "Geography", subtitle: "Countries and clues"),
+        propertyTypes: [
+            GameplayPropertyType(id: "capital", displayName: "Capital", prompt: "Find the capital."),
+            GameplayPropertyType(id: "continent", displayName: "Continent", prompt: "Find the continent."),
+            GameplayPropertyType(id: "currency", displayName: "Currency", prompt: "Find the money clue.")
+        ],
+        entities: [
+            GameplayEntity(id: "country-india", name: "India", summary: "A large country in Asia.", visualKey: "🇮🇳", properties: [
+                GameplayProperty(id: "country-india-capital", typeID: "capital", value: "New Delhi", explanation: "New Delhi is India’s capital city."),
+                GameplayProperty(id: "country-india-continent", typeID: "continent", value: "Asia"),
+                GameplayProperty(id: "country-india-currency", typeID: "currency", value: "Indian rupee")
+            ]),
+            GameplayEntity(id: "country-japan", name: "Japan", summary: "An island country in Asia.", visualKey: "🇯🇵", properties: [
+                GameplayProperty(id: "country-japan-capital", typeID: "capital", value: "Tokyo"),
+                GameplayProperty(id: "country-japan-continent", typeID: "continent", value: "Asia"),
+                GameplayProperty(id: "country-japan-currency", typeID: "currency", value: "Yen")
+            ]),
+            GameplayEntity(id: "country-france", name: "France", summary: "A country in Europe.", visualKey: "🇫🇷", properties: [
+                GameplayProperty(id: "country-france-capital", typeID: "capital", value: "Paris"),
+                GameplayProperty(id: "country-france-continent", typeID: "continent", value: "Europe"),
+                GameplayProperty(id: "country-france-currency", typeID: "currency", value: "Euro")
+            ]),
+            GameplayEntity(id: "country-brazil", name: "Brazil", summary: "A big country in South America.", visualKey: "🇧🇷", properties: [
+                GameplayProperty(id: "country-brazil-capital", typeID: "capital", value: "Brasília"),
+                GameplayProperty(id: "country-brazil-continent", typeID: "continent", value: "South America"),
+                GameplayProperty(id: "country-brazil-currency", typeID: "currency", value: "Brazilian real")
+            ])
+        ],
+        stages: [
+            GameplayStageDefinition(id: "flashcards", kind: .flashcards, title: "Look + Learn", prompt: "Meet each country.", maximumItemCount: 4),
+            GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Match countries to clues.", propertyTypeIDs: ["capital"], maximumItemCount: 4),
+            GameplayStageDefinition(id: "flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Flip and remember each match.", propertyTypeIDs: ["continent"], maximumItemCount: 4),
+            GameplayStageDefinition(id: "bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect every country to its fact.", propertyTypeIDs: ["capital", "currency"], maximumItemCount: 6),
+            GameplayStageDefinition(id: "multiple-choice", kind: .multipleChoice, title: "Quiz", prompt: "Pick the best answer.", propertyTypeIDs: ["capital"], maximumItemCount: 4)
+        ]
+    )
 }

--- a/Domain/GameplaySampleThreads.swift
+++ b/Domain/GameplaySampleThreads.swift
@@ -1,43 +1,5 @@
 import Foundation
 
 enum GameplaySampleThreads {
-    static let countries: GameplayThreadDefinition = GameplayThreadDefinition(
-        id: "sample-countries-gameplay-thread",
-        title: "Countries Quest",
-        category: GameplayCategory(id: "geography", title: "Geography", subtitle: "Countries and clues"),
-        propertyTypes: [
-            GameplayPropertyType(id: "capital", displayName: "Capital", prompt: "Find the capital."),
-            GameplayPropertyType(id: "continent", displayName: "Continent", prompt: "Find the continent."),
-            GameplayPropertyType(id: "currency", displayName: "Currency", prompt: "Find the money clue.")
-        ],
-        entities: [
-            GameplayEntity(id: "country-india", name: "India", summary: "A large country in Asia.", visualKey: "🇮🇳", properties: [
-                GameplayProperty(id: "country-india-capital", typeID: "capital", value: "New Delhi", explanation: "New Delhi is India’s capital city."),
-                GameplayProperty(id: "country-india-continent", typeID: "continent", value: "Asia"),
-                GameplayProperty(id: "country-india-currency", typeID: "currency", value: "Indian rupee")
-            ]),
-            GameplayEntity(id: "country-japan", name: "Japan", summary: "An island country in Asia.", visualKey: "🇯🇵", properties: [
-                GameplayProperty(id: "country-japan-capital", typeID: "capital", value: "Tokyo"),
-                GameplayProperty(id: "country-japan-continent", typeID: "continent", value: "Asia"),
-                GameplayProperty(id: "country-japan-currency", typeID: "currency", value: "Yen")
-            ]),
-            GameplayEntity(id: "country-france", name: "France", summary: "A country in Europe.", visualKey: "🇫🇷", properties: [
-                GameplayProperty(id: "country-france-capital", typeID: "capital", value: "Paris"),
-                GameplayProperty(id: "country-france-continent", typeID: "continent", value: "Europe"),
-                GameplayProperty(id: "country-france-currency", typeID: "currency", value: "Euro")
-            ]),
-            GameplayEntity(id: "country-brazil", name: "Brazil", summary: "A big country in South America.", visualKey: "🇧🇷", properties: [
-                GameplayProperty(id: "country-brazil-capital", typeID: "capital", value: "Brasília"),
-                GameplayProperty(id: "country-brazil-continent", typeID: "continent", value: "South America"),
-                GameplayProperty(id: "country-brazil-currency", typeID: "currency", value: "Brazilian real")
-            ])
-        ],
-        stages: [
-            GameplayStageDefinition(id: "flashcards", kind: .flashcards, title: "Look + Learn", prompt: "Meet each country.", maximumItemCount: 4),
-            GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Match countries to clues.", propertyTypeIDs: ["capital"], maximumItemCount: 4),
-            GameplayStageDefinition(id: "flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Flip and remember each match.", propertyTypeIDs: ["continent"], maximumItemCount: 4),
-            GameplayStageDefinition(id: "bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect every country to its fact.", propertyTypeIDs: ["capital", "currency"], maximumItemCount: 6),
-            GameplayStageDefinition(id: "multiple-choice", kind: .multipleChoice, title: "Quiz", prompt: "Pick the best answer.", propertyTypeIDs: ["capital"], maximumItemCount: 4)
-        ]
-    )
+    static let countries: GameplayThreadDefinition = CountryGameplayThread.thread
 }

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -21,6 +21,7 @@ enum AppRoute: Hashable {
     case labLane(CapabilityLaneID)
     case memory
     case memoryDeck(MemoryDeckKind)
+    case gameplayThread(String)
     case waterCycle
     case soundVolume
     case shapeGeometry
@@ -134,6 +135,8 @@ final class VerticalSliceEngine {
     func showLab() { route = .lab }
     func showLabLane(_ laneID: CapabilityLaneID) { route = .labLane(laneID) }
     func showMemory() { route = .memory }
+    func showGameplayThread(_ threadID: String) { route = .gameplayThread(threadID) }
+    func showCountriesGameplayThread() { route = .gameplayThread(CountryGameplayThread.thread.id) }
     func showWaterCycle() { route = .waterCycle }
     func showSoundVolume() { route = .soundVolume }
     func showShapeGeometry() { route = .shapeGeometry }

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -599,7 +599,7 @@ struct LabLaneDetailView: View {
         case .chemistry:
             return .memoryDeck(.fruits)
         case .mapWorld:
-            return .memoryDeck(.countries)
+            return .gameplayThread(CountryGameplayThread.thread.id)
         default:
             return .memory
         }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -159,7 +159,7 @@ extension LabActivityID {
         case .memoryMatch:
             return .memory
         case .countryCards:
-            return .memoryDeck(.countries)
+            return .gameplayThread(CountryGameplayThread.thread.id)
         case .fruitCards:
             return .memoryDeck(.fruits)
         }

--- a/Mather.xcodeproj/project.pbxproj
+++ b/Mather.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		211111111111111111111113 /* SpacedRepetitionScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111111111111111111111113 /* SpacedRepetitionScheduler.swift */; };
 		211111111111111111111114 /* GameplaySchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111111111111111111111114 /* GameplaySchedulerTests.swift */; };
 		A912C0000000000000000011 /* GameplaySampleThreads.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000010 /* GameplaySampleThreads.swift */; };
+		A912C0000000000000000013 /* CountryGameplayThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000012 /* CountryGameplayThread.swift */; };
 		A912C0000000000000000021 /* GameplayStageViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000020 /* GameplayStageViewModels.swift */; };
 		A912C0000000000000000031 /* GameplayThreadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000030 /* GameplayThreadView.swift */; };
 		A912C0000000000000000041 /* FlashcardStageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000040 /* FlashcardStageView.swift */; };
@@ -52,6 +53,7 @@
 		A912C0000000000000000091 /* GameplayStageSharedViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000090 /* GameplayStageSharedViews.swift */; };
 		A912C00000000000000000A1 /* GameplayStageViewModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C00000000000000000A0 /* GameplayStageViewModelsTests.swift */; };
 		A912C00000000000000000B1 /* GameplayStageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C00000000000000000B0 /* GameplayStageViewModelTests.swift */; };
+		A912C00000000000000000C1 /* CountryGameplayThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C00000000000000000C0 /* CountryGameplayThreadTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -103,6 +105,7 @@
 		111111111111111111111113 /* SpacedRepetitionScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacedRepetitionScheduler.swift; sourceTree = "<group>"; };
 		111111111111111111111114 /* GameplaySchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplaySchedulerTests.swift; sourceTree = "<group>"; };
 		A912C0000000000000000010 /* GameplaySampleThreads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplaySampleThreads.swift; sourceTree = "<group>"; };
+		A912C0000000000000000012 /* CountryGameplayThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryGameplayThread.swift; sourceTree = "<group>"; };
 		A912C0000000000000000020 /* GameplayStageViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayStageViewModels.swift; sourceTree = "<group>"; };
 		A912C0000000000000000030 /* GameplayThreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayThreadView.swift; sourceTree = "<group>"; };
 		A912C0000000000000000040 /* FlashcardStageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashcardStageView.swift; sourceTree = "<group>"; };
@@ -113,6 +116,7 @@
 		A912C0000000000000000090 /* GameplayStageSharedViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayStageSharedViews.swift; sourceTree = "<group>"; };
 		A912C00000000000000000A0 /* GameplayStageViewModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayStageViewModelsTests.swift; sourceTree = "<group>"; };
 		A912C00000000000000000B0 /* GameplayStageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayStageViewModelTests.swift; sourceTree = "<group>"; };
+		A912C00000000000000000C0 /* CountryGameplayThreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryGameplayThreadTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -150,6 +154,7 @@
 				111111111111111111111114 /* GameplaySchedulerTests.swift */,
 				A912C00000000000000000A0 /* GameplayStageViewModelsTests.swift */,
 				A912C00000000000000000B0 /* GameplayStageViewModelTests.swift */,
+				A912C00000000000000000C0 /* CountryGameplayThreadTests.swift */,
 				000C9B49685F8A6A3703EB65 /* ProblemGeneratorTests.swift */,
 				A5C80ECCAE5D25201666CBD0 /* SliceStateMachineTests.swift */,
 				6312C329D7FA010DA974C358 /* VerticalSliceEngineTests.swift */,
@@ -163,6 +168,7 @@
 			children = (
 				111111111111111111111111 /* GameplayStageModels.swift */,
 				A912C0000000000000000010 /* GameplaySampleThreads.swift */,
+				A912C0000000000000000012 /* CountryGameplayThread.swift */,
 				A912C0000000000000000020 /* GameplayStageViewModels.swift */,
 				111111111111111111111112 /* SpacedRepetitionModels.swift */,
 				4BE99DB8FC85397C3E504E0B /* ProblemGenerator.swift */,
@@ -355,6 +361,7 @@
 				211111111111111111111114 /* GameplaySchedulerTests.swift in Sources */,
 				A912C00000000000000000A1 /* GameplayStageViewModelsTests.swift in Sources */,
 				A912C00000000000000000B1 /* GameplayStageViewModelTests.swift in Sources */,
+				A912C00000000000000000C1 /* CountryGameplayThreadTests.swift in Sources */,
 				D0FA2DF7DD9A64D4BB9C8080 /* ProblemGeneratorTests.swift in Sources */,
 				739452A890EDE3E9C9B6B9C4 /* SliceStateMachineTests.swift in Sources */,
 				7B95DE9FB34D4A152F5553FB /* VerticalSliceEngineTests.swift in Sources */,
@@ -369,6 +376,7 @@
 				211111111111111111111112 /* SpacedRepetitionModels.swift in Sources */,
 				211111111111111111111113 /* SpacedRepetitionScheduler.swift in Sources */,
 				A912C0000000000000000011 /* GameplaySampleThreads.swift in Sources */,
+				A912C0000000000000000013 /* CountryGameplayThread.swift in Sources */,
 				A912C0000000000000000021 /* GameplayStageViewModels.swift in Sources */,
 				A912C0000000000000000031 /* GameplayThreadView.swift in Sources */,
 				A912C0000000000000000041 /* FlashcardStageView.swift in Sources */,

--- a/Tests/MatherTests/CountryGameplayThreadTests.swift
+++ b/Tests/MatherTests/CountryGameplayThreadTests.swift
@@ -3,7 +3,7 @@ import Testing
 @testable import Mather
 
 struct CountryGameplayThreadTests {
-    private let requiredPropertyTypeIDs: Set<String> = ["capital", "currency", "flag", "map-shape", "continent", "language"]
+    private let requiredPropertyTypeIDs: Set<String> = ["capital", "currency", "flag", "map-shape", "continent", "language", "clue"]
 
     @Test
     func countriesThreadMigratesAllCurrentCountryCardsWithRequiredProperties() throws {

--- a/Tests/MatherTests/CountryGameplayThreadTests.swift
+++ b/Tests/MatherTests/CountryGameplayThreadTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import Mather
+
+struct CountryGameplayThreadTests {
+    private let requiredPropertyTypeIDs: Set<String> = ["capital", "currency", "flag", "map-shape", "continent", "language"]
+
+    @Test
+    func countriesThreadMigratesAllCurrentCountryCardsWithRequiredProperties() throws {
+        let thread = CountryGameplayThread.thread
+
+        #expect(thread.id == "countries")
+        #expect(thread.title == "Country Cards")
+        #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+        #expect(thread.entities.map(\.id) == [
+            "country-india",
+            "country-japan",
+            "country-france",
+            "country-egypt",
+            "country-brazil",
+            "country-australia",
+            "country-canada",
+            "country-kenya",
+        ])
+        #expect(Set(thread.propertyTypes.map(\.id)).isSuperset(of: requiredPropertyTypeIDs))
+
+        for entity in thread.entities {
+            let propertyTypeIDs = Set(entity.properties.map(\.typeID))
+            #expect(propertyTypeIDs.isSuperset(of: requiredPropertyTypeIDs), "\(entity.name) is missing a required country property")
+            #expect(entity.visualAssetName?.hasPrefix("MemoryFlag") == true)
+            #expect(entity.properties.first { $0.typeID == "flag" }?.visualAssetName == entity.visualAssetName)
+            #expect(!(entity.properties.first { $0.typeID == "map-shape" }?.value.isEmpty ?? true))
+        }
+    }
+
+    @Test
+    func specificCountryFactsMatchCurrentMemoryInventory() throws {
+        let entities = Dictionary(uniqueKeysWithValues: CountryGameplayThread.thread.entities.map { ($0.id, $0) })
+
+        try expectCountry(entities["country-india"], capital: "New Delhi", currency: "Indian rupee", continent: "Asia", language: "Hindi and English", flagAsset: "MemoryFlagIndia")
+        try expectCountry(entities["country-japan"], capital: "Tokyo", currency: "yen", continent: "Asia", language: "Japanese", flagAsset: "MemoryFlagJapan")
+        try expectCountry(entities["country-france"], capital: "Paris", currency: "euro", continent: "Europe", language: "French", flagAsset: "MemoryFlagFrance")
+        try expectCountry(entities["country-egypt"], capital: "Cairo", currency: "Egyptian pound", continent: "Africa", language: "Arabic", flagAsset: "MemoryFlagEgypt")
+        try expectCountry(entities["country-brazil"], capital: "Brasília", currency: "Brazilian real", continent: "South America", language: "Portuguese", flagAsset: "MemoryFlagBrazil")
+        try expectCountry(entities["country-australia"], capital: "Canberra", currency: "Australian dollar", continent: "Australia", language: "English", flagAsset: "MemoryFlagAustralia")
+        try expectCountry(entities["country-canada"], capital: "Ottawa", currency: "Canadian dollar", continent: "North America", language: "English and French", flagAsset: "MemoryFlagCanada")
+        try expectCountry(entities["country-kenya"], capital: "Nairobi", currency: "Kenyan shilling", continent: "Africa", language: "Swahili and English", flagAsset: "MemoryFlagKenya")
+    }
+
+    @Test
+    func countryStageRoundsUseReusableStageModels() throws {
+        let thread = CountryGameplayThread.thread
+
+        let flashcards = try round(kind: .flashcards, thread: thread)
+        #expect(flashcards.items.count == 8)
+        #expect(flashcards.items.allSatisfy { $0.propertyID == nil })
+        #expect(GameplayStageContentBuilder.flashcards(thread: thread, round: flashcards).count == 8)
+
+        let easy = try round(kind: .easyMemory, thread: thread)
+        #expect(!easy.items.isEmpty)
+        #expect(easy.items.allSatisfy { ["flag", "capital", "continent"].contains($0.propertyTypeID ?? "") })
+        #expect(!GameplayStageContentBuilder.matchPairs(thread: thread, round: easy).isEmpty)
+
+        let flip = try round(kind: .flipMemory, thread: thread)
+        #expect(flip.items.allSatisfy { ["flag", "capital", "currency"].contains($0.propertyTypeID ?? "") })
+
+        let bondBlast = try round(kind: .bondBlast, thread: thread)
+        #expect(bondBlast.items.count == 10)
+        #expect(bondBlast.items.allSatisfy { ["capital", "currency", "continent", "language", "map-shape"].contains($0.propertyTypeID ?? "") })
+
+        let quiz = try round(kind: .multipleChoice, thread: thread)
+        let questions = GameplayStageContentBuilder.multipleChoiceQuestions(thread: thread, round: quiz)
+        #expect(!questions.isEmpty)
+        #expect(questions.allSatisfy { $0.choices.contains($0.answer) })
+    }
+
+    @Test
+    @MainActor
+    func countryCardsLaunchesCountriesGameplayThreadDirectly() {
+        #expect(LabActivityID.countryCards.appRoute == .gameplayThread(CountryGameplayThread.thread.id))
+
+        let engine = makeEngine()
+        engine.showCountriesGameplayThread()
+        #expect(engine.route == .gameplayThread("countries"))
+    }
+
+    private func expectCountry(
+        _ entity: GameplayEntity?,
+        capital: String,
+        currency: String,
+        continent: String,
+        language: String,
+        flagAsset: String
+    ) throws {
+        let entity = try #require(entity)
+        #expect(entity.visualAssetName == flagAsset)
+        #expect(entity.properties.first { $0.typeID == "capital" }?.value == capital)
+        #expect(entity.properties.first { $0.typeID == "currency" }?.value == currency)
+        #expect(entity.properties.first { $0.typeID == "continent" }?.value == continent)
+        #expect(entity.properties.first { $0.typeID == "language" }?.value == language)
+        #expect(entity.properties.first { $0.typeID == "flag" }?.visualAssetName == flagAsset)
+    }
+
+    private func round(kind: GameplayStageKind, thread: GameplayThreadDefinition) throws -> GameplayRoundDefinition {
+        let stage = try #require(thread.stages.first { $0.kind == kind })
+        return SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 912)
+    }
+
+    @MainActor
+    private func makeEngine() -> VerticalSliceEngine {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: "CountryGameplayThreadTests")!)
+        flags.testModeEnabled = true
+        flags.audioEnabled = false
+        return VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+    }
+}

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -36,7 +36,7 @@ struct LabRouteRegressionTests {
             .waterCycle: .waterCycle,
             .soundVolume: .soundVolume,
             .memoryMatch: .memory,
-            .countryCards: .memoryDeck(.countries),
+            .countryCards: .gameplayThread(CountryGameplayThread.thread.id),
             .fruitCards: .memoryDeck(.fruits),
         ]
 


### PR DESCRIPTION
## Summary
- Adds a full `CountryGameplayThread` definition for the current 8 Memory countries with required #912 Slice D properties: capital, currency, flag, map-shape, continent, language, and clue.
- Routes Country Cards and the map-world Memory Match entry directly into the reusable staged gameplay thread while leaving generic Memory country decks available for cleanup later.
- Adds country coverage, stage round generation, multiple-choice availability, and direct-route tests while keeping the existing sample gameplay thread stable.

## Validation
- `git diff --check`
- GitHub CI: Build & Test, Analyze Actions Workflows, CodeQL, Dependency Review all passing on head `3c00c1f`.
- Targeted local xcodebuild attempt blocked: local Linux host has no `xcodebuild`/`swift`; `ganesh-mba` SSH timed out before tests could run.

Refs #912 (Slice D countries migration).
