### PR TITLE
feat: add water cycle gameplay thread

### DIFF
--- a/Domain/GameplayThreadContent+WaterCycle.swift
+++ b/Domain/GameplayThreadContent+WaterCycle.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+enum GameplayThreadCatalog {
+    static let waterCycle: GameplayThreadDefinition = GameplayThreadDefinition(
+        id: "water-cycle",
+        title: "Water Cycle",
+        category: GameplayCategory(
+            id: "physics",
+            title: "Physics",
+            subtitle: "Water moves up, gathers, falls, and collects again."
+        ),
+        propertyTypes: waterCyclePropertyTypes,
+        entities: waterCycleEntities,
+        stages: waterCycleStages,
+        progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.75)
+    )
+
+    private static let waterCyclePropertyTypes: [GameplayPropertyType] = [
+        GameplayPropertyType(id: "order", displayName: "Order", prompt: "Which step comes here in the cycle?"),
+        GameplayPropertyType(id: "simpleExplanation", displayName: "Simple Explanation", prompt: "Say the step in kid-friendly words."),
+        GameplayPropertyType(id: "cause", displayName: "Cause", prompt: "What makes this step happen?"),
+        GameplayPropertyType(id: "whatHappens", displayName: "What Happens", prompt: "What changes during this step?"),
+        GameplayPropertyType(id: "visualClue", displayName: "Visual Clue", prompt: "What can you look for in the picture?")
+    ]
+
+    private static let waterCycleEntities: [GameplayEntity] = [
+        GameplayEntity(
+            id: "water-cycle-evaporation",
+            name: "Evaporation",
+            summary: "Warm water changes into vapor and rises into the air.",
+            visualKey: "☀️💧⬆️",
+            visualAssetName: "MemoryWaterCycleEvaporation",
+            properties: properties(
+                for: "water-cycle-evaporation",
+                order: "1 of 4",
+                simpleExplanation: "Water goes up as vapor.",
+                cause: "The sun warms ponds, lakes, rivers, puddles, and wet ground.",
+                whatHappens: "Liquid water changes into tiny vapor particles that float upward.",
+                visualClue: "Look for mist or rising drops above warm water."
+            )
+        ),
+        GameplayEntity(
+            id: "water-cycle-condensation",
+            name: "Condensation",
+            summary: "Vapor cools and gathers into tiny drops that make clouds.",
+            visualKey: "☁️💧",
+            visualAssetName: "MemoryWaterCycleCondensation",
+            properties: properties(
+                for: "water-cycle-condensation",
+                order: "2 of 4",
+                simpleExplanation: "Tiny water drops gather into clouds.",
+                cause: "Rising water vapor reaches cooler air high above the ground.",
+                whatHappens: "Vapor changes back into liquid droplets and bunches together.",
+                visualClue: "Look for small drops packed inside a cloud."
+            )
+        ),
+        GameplayEntity(
+            id: "water-cycle-precipitation",
+            name: "Precipitation",
+            summary: "Cloud drops get heavy enough to fall as rain, snow, sleet, or hail.",
+            visualKey: "🌧️⬇️",
+            visualAssetName: "MemoryWaterCyclePrecipitation",
+            properties: properties(
+                for: "water-cycle-precipitation",
+                order: "3 of 4",
+                simpleExplanation: "Water falls from clouds.",
+                cause: "Cloud drops grow too heavy for the air to hold.",
+                whatHappens: "Water falls back toward Earth as rain, snow, sleet, or hail.",
+                visualClue: "Look for rain streaks falling under a dark cloud."
+            )
+        ),
+        GameplayEntity(
+            id: "water-cycle-collection",
+            name: "Collection",
+            summary: "Fallen water gathers in places like ponds, lakes, rivers, puddles, and the ground.",
+            visualKey: "🏞️💧",
+            visualAssetName: "MemoryWaterCycleCollection",
+            properties: properties(
+                for: "water-cycle-collection",
+                order: "4 of 4",
+                simpleExplanation: "Water gathers again on Earth.",
+                cause: "Gravity pulls fallen water into low places and into the ground.",
+                whatHappens: "Water waits in ponds, lakes, rivers, puddles, oceans, snow, ice, or soil until it can rise again.",
+                visualClue: "Look for water collecting in a pond, river, puddle, or lake."
+            )
+        )
+    ]
+
+    private static let waterCycleStages: [GameplayStageDefinition] = [
+        GameplayStageDefinition(
+            id: "water-cycle-flashcards",
+            kind: .flashcards,
+            title: "Look + Learn",
+            prompt: "Meet each water cycle step in order.",
+            maximumItemCount: 4
+        ),
+        GameplayStageDefinition(
+            id: "water-cycle-easy-memory",
+            kind: .easyMemory,
+            title: "Order Match",
+            prompt: "Match each process to its cycle order clue.",
+            propertyTypeIDs: ["order"],
+            maximumItemCount: 4
+        ),
+        GameplayStageDefinition(
+            id: "water-cycle-flip-memory",
+            kind: .flipMemory,
+            title: "What Happens?",
+            prompt: "Flip and remember what changes in each step.",
+            propertyTypeIDs: ["whatHappens"],
+            maximumItemCount: 4
+        ),
+        GameplayStageDefinition(
+            id: "water-cycle-bond-blast",
+            kind: .bondBlast,
+            title: "Cause + Clue Blast",
+            prompt: "Connect steps to causes and picture clues.",
+            propertyTypeIDs: ["cause", "visualClue"],
+            maximumItemCount: 8
+        ),
+        GameplayStageDefinition(
+            id: "water-cycle-multiple-choice",
+            kind: .multipleChoice,
+            title: "Cycle Quiz",
+            prompt: "Pick the best explanation for each water cycle step.",
+            propertyTypeIDs: ["simpleExplanation"],
+            maximumItemCount: 4
+        )
+    ]
+
+    private static func properties(
+        for entityID: String,
+        order: String,
+        simpleExplanation: String,
+        cause: String,
+        whatHappens: String,
+        visualClue: String
+    ) -> [GameplayProperty] {
+        [
+            GameplayProperty(id: "\(entityID)-order", typeID: "order", value: order, explanation: "Cycle order clue for \(entityID)."),
+            GameplayProperty(id: "\(entityID)-simpleExplanation", typeID: "simpleExplanation", value: simpleExplanation),
+            GameplayProperty(id: "\(entityID)-cause", typeID: "cause", value: cause),
+            GameplayProperty(id: "\(entityID)-whatHappens", typeID: "whatHappens", value: whatHappens),
+            GameplayProperty(id: "\(entityID)-visualClue", typeID: "visualClue", value: visualClue)
+        ]
+    }
+}

--- a/Tests/MatherTests/WaterCycleGameplayThreadTests.swift
+++ b/Tests/MatherTests/WaterCycleGameplayThreadTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import Mather
+
+struct WaterCycleGameplayThreadTests {
+    @Test
+    func waterCycleThreadModelsCoreProcessStepsWithRequiredProperties() {
+        let thread = GameplayThreadCatalog.waterCycle
+
+        #expect(thread.id == "water-cycle")
+        #expect(thread.entities.map(\.id) == [
+            "water-cycle-evaporation",
+            "water-cycle-condensation",
+            "water-cycle-precipitation",
+            "water-cycle-collection"
+        ])
+        #expect(Set(thread.propertyTypes.map(\.id)) == ["order", "simpleExplanation", "cause", "whatHappens", "visualClue"])
+
+        for entity in thread.entities {
+            let propertyTypeIDs = Set(entity.properties.map(\.typeID))
+            #expect(propertyTypeIDs == ["order", "simpleExplanation", "cause", "whatHappens", "visualClue"])
+            #expect(entity.visualAssetName?.hasPrefix("MemoryWaterCycle") == true)
+            #expect(entity.properties.allSatisfy { !$0.value.isEmpty })
+        }
+    }
+
+    @Test
+    func waterCycleOrderCluesFollowEvaporationToCollectionSequence() {
+        let thread = GameplayThreadCatalog.waterCycle
+        let orderValues = thread.entities.compactMap { entity in
+            entity.properties.first { $0.typeID == "order" }?.value
+        }
+
+        #expect(orderValues == ["1 of 4", "2 of 4", "3 of 4", "4 of 4"])
+        #expect(thread.entities[0].properties.first { $0.typeID == "cause" }?.value.localizedCaseInsensitiveContains("sun") == true)
+        #expect(thread.entities[1].properties.first { $0.typeID == "whatHappens" }?.value.localizedCaseInsensitiveContains("droplets") == true)
+        #expect(thread.entities[2].properties.first { $0.typeID == "visualClue" }?.value.localizedCaseInsensitiveContains("rain") == true)
+        #expect(thread.entities[3].properties.first { $0.typeID == "whatHappens" }?.value.localizedCaseInsensitiveContains("ponds") == true)
+    }
+
+    @Test
+    func waterCycleStagesGenerateFocusedRounds() {
+        let thread = GameplayThreadCatalog.waterCycle
+
+        #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+
+        let flashcardStage = thread.stages[0]
+        let flashcardRound = SpacedRepetitionScheduler.makeRound(thread: thread, stage: flashcardStage, seed: 912)
+        #expect(flashcardRound.items.count == 4)
+        #expect(flashcardRound.items.allSatisfy { $0.propertyID == nil && $0.propertyTypeID == nil })
+
+        let orderStage = thread.stages[1]
+        let orderRound = SpacedRepetitionScheduler.makeRound(thread: thread, stage: orderStage, seed: 912)
+        #expect(orderRound.items.count == 4)
+        #expect(orderRound.items.allSatisfy { $0.propertyTypeID == "order" })
+
+        let bondStage = thread.stages[3]
+        let bondRound = SpacedRepetitionScheduler.makeRound(thread: thread, stage: bondStage, seed: 912)
+        #expect(bondRound.items.count == 8)
+        #expect(Set(bondRound.items.compactMap(\.propertyTypeID)) == ["cause", "visualClue"])
+
+        let quizStage = thread.stages[4]
+        let quizRound = SpacedRepetitionScheduler.makeRound(thread: thread, stage: quizStage, seed: 912)
+        let quizViewModel = GameplayMultipleChoiceStageViewModel(thread: thread, round: quizRound)
+        #expect(quizViewModel.questions.count == 4)
+        #expect(quizViewModel.questions.allSatisfy { $0.choices.contains($0.answer) })
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a curated `GameplayThreadCatalog.waterCycle` definition for issue #912 using reusable gameplay stages.
- Models evaporation, condensation, precipitation, and collection as process entities with order, simple explanation, cause, what happens, and visual clue properties.
- Adds Water Cycle gameplay tests for content coverage, order clues, and stage/round generation.

## Route note
- I did not replace the existing Water Cycle Lab route in this slice; routing should be a follow-up once the unified gameplay thread migration is ready to avoid disrupting the current lab/lesson flow.

## Validation
- `git diff --check --cached` before commit
- Attempted targeted iOS test on `ganesh-mba`, but SSH connection timed out before the job could start.

Refs #912

## Notes
- This is the water-cycle content slice only.
- #912 should remain open after this PR unless the full lane wave acceptance criteria are complete.
