### PR TITLE
feat: add fruits gameplay thread

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -96,6 +96,8 @@ struct RootView: View {
                     MemoryView(appModel: appModel, initialDeckKind: deckKind)
                 case .waterCycle:
                     WaterCycleLabView(appModel: appModel)
+                case .gameplayThread(let threadID):
+                    GameplayThreadView(thread: GameplayThreadCatalog.thread(for: threadID), appModel: appModel)
                 case .soundVolume:
                     SoundVolumeLabView(appModel: appModel)
                 case .shapeGeometry:

--- a/Domain/GameplayThreadCatalog.swift
+++ b/Domain/GameplayThreadCatalog.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+enum GameplayThreadID: String, Codable, CaseIterable, Hashable {
+    case countries
+    case fruits
+}
+
+enum GameplayThreadCatalog {
+    static func thread(for id: GameplayThreadID) -> GameplayThreadDefinition {
+        switch id {
+        case .countries:
+            return GameplaySampleThreads.countries
+        case .fruits:
+            return fruits
+        }
+    }
+
+    static let fruits: GameplayThreadDefinition = GameplayThreadDefinition(
+        id: "fruits",
+        title: "Fruit Cards",
+        category: GameplayCategory(
+            id: "chemistry",
+            title: "Chemistry",
+            subtitle: "Fruit properties: colors, tastes, seeds, skins, and where they grow"
+        ),
+        propertyTypes: [
+            GameplayPropertyType(id: "name", displayName: "Name", prompt: "Find the fruit name."),
+            GameplayPropertyType(id: "color", displayName: "Color", prompt: "Find the fruit color."),
+            GameplayPropertyType(id: "taste", displayName: "Taste", prompt: "Find the taste clue."),
+            GameplayPropertyType(id: "seed-skin", displayName: "Seed or Skin", prompt: "Find the seed or skin clue."),
+            GameplayPropertyType(id: "grows-on", displayName: "Grows On", prompt: "Find where it grows."),
+            GameplayPropertyType(id: "category", displayName: "Fruit Type", prompt: "Find the fruit family clue.")
+        ],
+        entities: [
+            GameplayEntity(id: "fruit-apple", name: "Apple", summary: "A crunchy fruit that can be red, green, or yellow.", visualKey: "🍎", properties: [
+                GameplayProperty(id: "fruit-apple-name", typeID: "name", value: "Apple", explanation: "Apple is the fruit's name.", visualKey: "🍎"),
+                GameplayProperty(id: "fruit-apple-color", typeID: "color", value: "Red, green, or yellow", explanation: "Apples can wear different colored skins."),
+                GameplayProperty(id: "fruit-apple-taste", typeID: "taste", value: "Sweet and crisp", explanation: "An apple often tastes sweet and makes a crisp crunch."),
+                GameplayProperty(id: "fruit-apple-seed-skin", typeID: "seed-skin", value: "Thin skin with small seeds inside", explanation: "Apple seeds hide in the core, and the skin is safe to eat after washing."),
+                GameplayProperty(id: "fruit-apple-grows-on", typeID: "grows-on", value: "Tree", explanation: "Apples grow on apple trees."),
+                GameplayProperty(id: "fruit-apple-category", typeID: "category", value: "Orchard fruit", explanation: "Orchards are places where many fruit trees grow.")
+            ]),
+            GameplayEntity(id: "fruit-banana", name: "Banana", summary: "A soft yellow fruit with a peel you remove.", visualKey: "🍌", properties: [
+                GameplayProperty(id: "fruit-banana-name", typeID: "name", value: "Banana", explanation: "Banana is the fruit's name.", visualKey: "🍌"),
+                GameplayProperty(id: "fruit-banana-color", typeID: "color", value: "Yellow", explanation: "Ripe bananas usually have yellow peels."),
+                GameplayProperty(id: "fruit-banana-taste", typeID: "taste", value: "Sweet and soft", explanation: "Bananas taste sweet and feel soft when ripe."),
+                GameplayProperty(id: "fruit-banana-seed-skin", typeID: "seed-skin", value: "Thick peel with tiny soft seeds", explanation: "The peel protects the banana. The tiny seeds are usually too small to notice."),
+                GameplayProperty(id: "fruit-banana-grows-on", typeID: "grows-on", value: "Large banana plant", explanation: "Bananas grow in bunches on tall banana plants."),
+                GameplayProperty(id: "fruit-banana-category", typeID: "category", value: "Tropical fruit", explanation: "Tropical fruits grow well in warm places.")
+            ]),
+            GameplayEntity(id: "fruit-mango", name: "Mango", summary: "A juicy tropical fruit with one big seed.", visualKey: "🥭", properties: [
+                GameplayProperty(id: "fruit-mango-name", typeID: "name", value: "Mango", explanation: "Mango is the fruit's name.", visualKey: "🥭"),
+                GameplayProperty(id: "fruit-mango-color", typeID: "color", value: "Yellow, orange, green, or red", explanation: "Mango skin can show many sunny colors."),
+                GameplayProperty(id: "fruit-mango-taste", typeID: "taste", value: "Very sweet and juicy", explanation: "A ripe mango is juicy and very sweet."),
+                GameplayProperty(id: "fruit-mango-seed-skin", typeID: "seed-skin", value: "Thin skin with one big flat seed", explanation: "A mango has one large seed in the middle."),
+                GameplayProperty(id: "fruit-mango-grows-on", typeID: "grows-on", value: "Tree", explanation: "Mangoes grow on mango trees."),
+                GameplayProperty(id: "fruit-mango-category", typeID: "category", value: "Tropical stone fruit", explanation: "A stone fruit has one big hard seed, or stone, inside.")
+            ]),
+            GameplayEntity(id: "fruit-orange", name: "Orange", summary: "A round citrus fruit with juicy sections.", visualKey: "🍊", properties: [
+                GameplayProperty(id: "fruit-orange-name", typeID: "name", value: "Orange", explanation: "Orange is both the fruit name and a color.", visualKey: "🍊"),
+                GameplayProperty(id: "fruit-orange-color", typeID: "color", value: "Orange", explanation: "Most ripe oranges have bright orange skin."),
+                GameplayProperty(id: "fruit-orange-taste", typeID: "taste", value: "Sweet and tangy", explanation: "Tangy means it has a bright little zing."),
+                GameplayProperty(id: "fruit-orange-seed-skin", typeID: "seed-skin", value: "Bumpy peel; some have seeds", explanation: "The peel comes off before eating the juicy parts."),
+                GameplayProperty(id: "fruit-orange-grows-on", typeID: "grows-on", value: "Tree", explanation: "Oranges grow on citrus trees."),
+                GameplayProperty(id: "fruit-orange-category", typeID: "category", value: "Citrus fruit", explanation: "Citrus fruits often smell fresh and taste tangy.")
+            ]),
+            GameplayEntity(id: "fruit-grape", name: "Grape", summary: "A small juicy fruit that grows in bunches.", visualKey: "🍇", properties: [
+                GameplayProperty(id: "fruit-grape-name", typeID: "name", value: "Grape", explanation: "Grape is the fruit's name.", visualKey: "🍇"),
+                GameplayProperty(id: "fruit-grape-color", typeID: "color", value: "Green, red, or purple", explanation: "Grapes can be green, red, or purple."),
+                GameplayProperty(id: "fruit-grape-taste", typeID: "taste", value: "Sweet and juicy", explanation: "Grapes pop with sweet juice."),
+                GameplayProperty(id: "fruit-grape-seed-skin", typeID: "seed-skin", value: "Thin skin; seeded or seedless", explanation: "Some grapes have tiny seeds, and some are grown seedless."),
+                GameplayProperty(id: "fruit-grape-grows-on", typeID: "grows-on", value: "Vine", explanation: "Grapes grow in bunches on vines."),
+                GameplayProperty(id: "fruit-grape-category", typeID: "category", value: "Vine fruit", explanation: "Vine fruits grow on long climbing stems.")
+            ]),
+            GameplayEntity(id: "fruit-watermelon", name: "Watermelon", summary: "A big melon with green rind and red juicy inside.", visualKey: "🍉", properties: [
+                GameplayProperty(id: "fruit-watermelon-name", typeID: "name", value: "Watermelon", explanation: "Watermelon is the fruit's name.", visualKey: "🍉"),
+                GameplayProperty(id: "fruit-watermelon-color", typeID: "color", value: "Green outside and red inside", explanation: "The rind is green, and the juicy middle is often red."),
+                GameplayProperty(id: "fruit-watermelon-taste", typeID: "taste", value: "Sweet and watery", explanation: "Watermelon is full of sweet juice."),
+                GameplayProperty(id: "fruit-watermelon-seed-skin", typeID: "seed-skin", value: "Hard rind with black or white seeds", explanation: "The rind protects the juicy fruit inside."),
+                GameplayProperty(id: "fruit-watermelon-grows-on", typeID: "grows-on", value: "Vine on the ground", explanation: "Watermelons grow on vines that spread along the ground."),
+                GameplayProperty(id: "fruit-watermelon-category", typeID: "category", value: "Melon", explanation: "Melons are large juicy fruits with rinds.")
+            ]),
+            GameplayEntity(id: "fruit-pineapple", name: "Pineapple", summary: "A tropical fruit with a spiky crown.", visualKey: "🍍", properties: [
+                GameplayProperty(id: "fruit-pineapple-name", typeID: "name", value: "Pineapple", explanation: "Pineapple is the fruit's name.", visualKey: "🍍"),
+                GameplayProperty(id: "fruit-pineapple-color", typeID: "color", value: "Gold and green", explanation: "Pineapple has golden fruit and green leaves."),
+                GameplayProperty(id: "fruit-pineapple-taste", typeID: "taste", value: "Sweet and tangy", explanation: "Pineapple tastes sweet with a bright tang."),
+                GameplayProperty(id: "fruit-pineapple-seed-skin", typeID: "seed-skin", value: "Tough spiky skin; tiny seeds", explanation: "The rough outside protects the sweet fruit."),
+                GameplayProperty(id: "fruit-pineapple-grows-on", typeID: "grows-on", value: "Low plant", explanation: "Pineapples grow from low plants near the ground."),
+                GameplayProperty(id: "fruit-pineapple-category", typeID: "category", value: "Tropical fruit", explanation: "Pineapples like warm tropical places." )
+            ]),
+            GameplayEntity(id: "fruit-strawberry", name: "Strawberry", summary: "A red berry-like fruit with tiny seeds on the outside.", visualKey: "🍓", properties: [
+                GameplayProperty(id: "fruit-strawberry-name", typeID: "name", value: "Strawberry", explanation: "Strawberry is the fruit's name.", visualKey: "🍓"),
+                GameplayProperty(id: "fruit-strawberry-color", typeID: "color", value: "Red", explanation: "Ripe strawberries are usually bright red."),
+                GameplayProperty(id: "fruit-strawberry-taste", typeID: "taste", value: "Sweet and a little tart", explanation: "Tart means a tiny sour sparkle with the sweet taste."),
+                GameplayProperty(id: "fruit-strawberry-seed-skin", typeID: "seed-skin", value: "Tiny seeds on the outside", explanation: "Strawberries carry many tiny seeds on their outside."),
+                GameplayProperty(id: "fruit-strawberry-grows-on", typeID: "grows-on", value: "Low plant", explanation: "Strawberries grow on low plants close to the ground."),
+                GameplayProperty(id: "fruit-strawberry-category", typeID: "category", value: "Berry-like fruit", explanation: "Kids often call it a berry because it is small, soft, and juicy.")
+            ])
+        ],
+        stages: [
+            GameplayStageDefinition(id: "fruit-flashcards", kind: .flashcards, title: "Look + Learn", prompt: "Meet each fruit and its clues.", maximumItemCount: 8),
+            GameplayStageDefinition(id: "fruit-easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Match each fruit to a friendly clue.", propertyTypeIDs: ["name", "color"], maximumItemCount: 6),
+            GameplayStageDefinition(id: "fruit-flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Remember fruit colors and tastes.", propertyTypeIDs: ["color", "taste"], maximumItemCount: 6),
+            GameplayStageDefinition(id: "fruit-bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect fruit names, tastes, seeds, skins, and grow clues.", propertyTypeIDs: ["taste", "seed-skin", "grows-on", "category"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "fruit-quiz", kind: .multipleChoice, title: "Fruit Quiz", prompt: "Pick the best fruit property.", propertyTypeIDs: ["color", "taste", "seed-skin", "grows-on"], maximumItemCount: 6)
+        ],
+        progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.72, retryMissedItemsFirst: true)
+    )
+}

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -22,6 +22,7 @@ enum AppRoute: Hashable {
     case memory
     case memoryDeck(MemoryDeckKind)
     case waterCycle
+    case gameplayThread(GameplayThreadID)
     case soundVolume
     case shapeGeometry
 }
@@ -135,6 +136,7 @@ final class VerticalSliceEngine {
     func showLabLane(_ laneID: CapabilityLaneID) { route = .labLane(laneID) }
     func showMemory() { route = .memory }
     func showWaterCycle() { route = .waterCycle }
+    func showGameplayThread(_ id: GameplayThreadID) { route = .gameplayThread(id) }
     func showSoundVolume() { route = .soundVolume }
     func showShapeGeometry() { route = .shapeGeometry }
 

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -597,7 +597,7 @@ struct LabLaneDetailView: View {
         guard activityID == .memoryMatch else { return activityID.appRoute }
         switch laneID {
         case .chemistry:
-            return .memoryDeck(.fruits)
+            return .gameplayThread(.fruits)
         case .mapWorld:
             return .memoryDeck(.countries)
         default:

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -161,7 +161,7 @@ extension LabActivityID {
         case .countryCards:
             return .memoryDeck(.countries)
         case .fruitCards:
-            return .memoryDeck(.fruits)
+            return .gameplayThread(.fruits)
         }
     }
 }

--- a/Mather.xcodeproj/project.pbxproj
+++ b/Mather.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		211111111111111111111113 /* SpacedRepetitionScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111111111111111111111113 /* SpacedRepetitionScheduler.swift */; };
 		211111111111111111111114 /* GameplaySchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111111111111111111111114 /* GameplaySchedulerTests.swift */; };
 		A912C0000000000000000011 /* GameplaySampleThreads.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000010 /* GameplaySampleThreads.swift */; };
+		A912D0000000000000000011 /* GameplayThreadCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912D0000000000000000010 /* GameplayThreadCatalog.swift */; };
+		A912D0000000000000000021 /* GameplayThreadContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912D0000000000000000020 /* GameplayThreadContentTests.swift */; };
 		A912C0000000000000000021 /* GameplayStageViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000020 /* GameplayStageViewModels.swift */; };
 		A912C0000000000000000031 /* GameplayThreadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000030 /* GameplayThreadView.swift */; };
 		A912C0000000000000000041 /* FlashcardStageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000040 /* FlashcardStageView.swift */; };
@@ -103,6 +105,8 @@
 		111111111111111111111113 /* SpacedRepetitionScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacedRepetitionScheduler.swift; sourceTree = "<group>"; };
 		111111111111111111111114 /* GameplaySchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplaySchedulerTests.swift; sourceTree = "<group>"; };
 		A912C0000000000000000010 /* GameplaySampleThreads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplaySampleThreads.swift; sourceTree = "<group>"; };
+		A912D0000000000000000010 /* GameplayThreadCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayThreadCatalog.swift; sourceTree = "<group>"; };
+		A912D0000000000000000020 /* GameplayThreadContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayThreadContentTests.swift; sourceTree = "<group>"; };
 		A912C0000000000000000020 /* GameplayStageViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayStageViewModels.swift; sourceTree = "<group>"; };
 		A912C0000000000000000030 /* GameplayThreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayThreadView.swift; sourceTree = "<group>"; };
 		A912C0000000000000000040 /* FlashcardStageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashcardStageView.swift; sourceTree = "<group>"; };
@@ -148,6 +152,7 @@
 			isa = PBXGroup;
 			children = (
 				111111111111111111111114 /* GameplaySchedulerTests.swift */,
+				A912D0000000000000000020 /* GameplayThreadContentTests.swift */,
 				A912C00000000000000000A0 /* GameplayStageViewModelsTests.swift */,
 				A912C00000000000000000B0 /* GameplayStageViewModelTests.swift */,
 				000C9B49685F8A6A3703EB65 /* ProblemGeneratorTests.swift */,
@@ -163,6 +168,7 @@
 			children = (
 				111111111111111111111111 /* GameplayStageModels.swift */,
 				A912C0000000000000000010 /* GameplaySampleThreads.swift */,
+				A912D0000000000000000010 /* GameplayThreadCatalog.swift */,
 				A912C0000000000000000020 /* GameplayStageViewModels.swift */,
 				111111111111111111111112 /* SpacedRepetitionModels.swift */,
 				4BE99DB8FC85397C3E504E0B /* ProblemGenerator.swift */,
@@ -353,6 +359,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				211111111111111111111114 /* GameplaySchedulerTests.swift in Sources */,
+				A912D0000000000000000021 /* GameplayThreadContentTests.swift in Sources */,
 				A912C00000000000000000A1 /* GameplayStageViewModelsTests.swift in Sources */,
 				A912C00000000000000000B1 /* GameplayStageViewModelTests.swift in Sources */,
 				D0FA2DF7DD9A64D4BB9C8080 /* ProblemGeneratorTests.swift in Sources */,
@@ -369,6 +376,7 @@
 				211111111111111111111112 /* SpacedRepetitionModels.swift in Sources */,
 				211111111111111111111113 /* SpacedRepetitionScheduler.swift in Sources */,
 				A912C0000000000000000011 /* GameplaySampleThreads.swift in Sources */,
+				A912D0000000000000000011 /* GameplayThreadCatalog.swift in Sources */,
 				A912C0000000000000000021 /* GameplayStageViewModels.swift in Sources */,
 				A912C0000000000000000031 /* GameplayThreadView.swift in Sources */,
 				A912C0000000000000000041 /* FlashcardStageView.swift in Sources */,

--- a/Tests/MatherTests/CountryGameplayThreadTests.swift
+++ b/Tests/MatherTests/CountryGameplayThreadTests.swift
@@ -81,7 +81,7 @@ struct CountryGameplayThreadTests {
 
         let engine = makeEngine()
         engine.showCountriesGameplayThread()
-        #expect(engine.route == .gameplayThread("countries"))
+        #expect(engine.route == .gameplayThread(.countries))
     }
 
     private func expectCountry(

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import Mather
+
+struct GameplayThreadContentTests {
+    @Test
+    func fruitsThreadHasCuratedEntityAndPropertyCoverage() {
+        let thread = GameplayThreadCatalog.fruits
+
+        #expect(thread.id == "fruits")
+        #expect(thread.category.id == "chemistry")
+        #expect(thread.entities.count == 8)
+        #expect(Set(thread.propertyTypes.map(\.id)) == Set(["name", "color", "taste", "seed-skin", "grows-on", "category"]))
+        #expect(thread.entities.allSatisfy { $0.id.hasPrefix("fruit-") })
+        #expect(thread.entities.allSatisfy { $0.visualKey?.isEmpty == false })
+        #expect(thread.entities.allSatisfy { $0.visualAssetName == nil })
+
+        for fruit in thread.entities {
+            let propertyTypes = Set(fruit.properties.map(\.typeID))
+            #expect(propertyTypes == Set(["name", "color", "taste", "seed-skin", "grows-on", "category"]), "\(fruit.id) should expose every fruit property type")
+            #expect(fruit.properties.allSatisfy { !$0.value.isEmpty && !$0.explanation.isEmpty }, "\(fruit.id) properties should be kid-readable")
+        }
+    }
+
+    @Test
+    func fruitStagesUseReusableIssue912StageKindsAndFilters() {
+        let thread = GameplayThreadCatalog.fruits
+
+        #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+        #expect(thread.stages.allSatisfy { $0.maximumItemCount >= 6 })
+        #expect(thread.stages[0].propertyTypeIDs.isEmpty)
+        #expect(thread.stages[1].propertyTypeIDs == ["name", "color"])
+        #expect(thread.stages[2].propertyTypeIDs == ["color", "taste"])
+        #expect(thread.stages[3].propertyTypeIDs.contains("seed-skin"))
+        #expect(thread.stages[4].propertyTypeIDs.contains("grows-on"))
+    }
+
+    @Test
+    func fruitsThreadGeneratesRoundsForEachStage() {
+        let thread = GameplayThreadCatalog.fruits
+
+        for stage in thread.stages {
+            let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 912)
+            #expect(round.stageID == stage.id)
+            #expect(round.kind == stage.kind)
+            #expect(!round.items.isEmpty, "\(stage.id) should generate playable items")
+            #expect(round.items.count <= stage.maximumItemCount)
+
+            if !stage.propertyTypeIDs.isEmpty {
+                let allowed = Set(stage.propertyTypeIDs)
+                #expect(round.items.allSatisfy { item in
+                    guard let propertyTypeID = item.propertyTypeID else { return false }
+                    return allowed.contains(propertyTypeID)
+                }, "\(stage.id) should only select allowed fruit properties")
+            }
+        }
+    }
+
+    @Test
+    func fruitMultipleChoiceQuestionsHaveSamePropertyDistractors() throws {
+        let thread = GameplayThreadCatalog.fruits
+        let stage = try #require(thread.stages.first { $0.kind == .multipleChoice })
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 45)
+        let questions = GameplayStageContentBuilder.multipleChoiceQuestions(thread: thread, round: round)
+
+        #expect(questions.count == round.items.count)
+        for question in questions {
+            #expect(question.choices.count >= 2)
+            #expect(question.choices.contains(question.answer))
+            #expect(question.choices.allSatisfy { !$0.title.isEmpty })
+        }
+    }
+}

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -37,7 +37,7 @@ struct LabRouteRegressionTests {
             .soundVolume: .soundVolume,
             .memoryMatch: .memory,
             .countryCards: .memoryDeck(.countries),
-            .fruitCards: .memoryDeck(.fruits),
+            .fruitCards: .gameplayThread(.fruits),
         ]
 
         #expect(Set(expectedRoutes.keys) == Set(LabActivityID.allCases))


### PR DESCRIPTION
## Summary
- Adds a reusable `GameplayThreadCatalog` with a curated Fruits gameplay thread for issue #912.
- Defines 8 fruit entities using stable `fruit-*` IDs, emoji fallbacks, kid-friendly summaries, and name/color/taste/seed-skin/grows-on/category properties.
- Routes Fruit Cards to the generic gameplay thread entry while leaving old Memory fruit deck available as fallback content.
- Adds content and round-generation tests for fruit property coverage, stage filters, and MCQ generation.

## Validation
- `git diff --check`
- Targeted Xcode tests not run locally: this worker has no Swift/Xcode toolchain, and `ganesh-mba` SSH timed out during validation attempt.

Refs #912

## Notes
- This is the fruits migration slice only.
- #912 should remain open after this PR unless the full lane wave acceptance criteria are complete.
