### PR TITLE
feat: add gameplay repetition scoring foundation

### DIFF
--- a/Domain/GameplayStageModels.swift
+++ b/Domain/GameplayStageModels.swift
@@ -174,6 +174,15 @@ struct GameplayStageResult: Identifiable, Codable, Equatable, Hashable {
         guard attemptedCount > 0 else { return 0 }
         return Double(correctCount) / Double(attemptedCount)
     }
+
+    var scorePoints: Int {
+        max(0, correctCount * 10 - mistakeCount * 4 - hintsUsed * 2)
+    }
+
+    var averageSecondsPerAttempt: TimeInterval {
+        guard attemptedCount > 0 else { return durationSeconds }
+        return durationSeconds / Double(attemptedCount)
+    }
 }
 
 struct GameplayScoreSummary: Codable, Equatable, Hashable {
@@ -187,6 +196,15 @@ struct GameplayScoreSummary: Codable, Equatable, Hashable {
     var accuracy: Double {
         guard attemptedCount > 0 else { return 0 }
         return Double(correctCount) / Double(attemptedCount)
+    }
+
+    var scorePoints: Int {
+        max(0, correctCount * 10 - mistakeCount * 4 - hintsUsed * 2)
+    }
+
+    var averageSecondsPerAttempt: TimeInterval {
+        guard attemptedCount > 0 else { return durationSeconds }
+        return durationSeconds / Double(attemptedCount)
     }
 
     static func summarize(_ results: [GameplayStageResult]) -> GameplayScoreSummary {

--- a/Domain/SpacedRepetitionModels.swift
+++ b/Domain/SpacedRepetitionModels.swift
@@ -19,31 +19,55 @@ enum GameplayConfidenceBand: String, Codable, Equatable, Hashable, CaseIterable 
     case reviewNeeded
 }
 
+enum GameplayExposureOutcome: String, Codable, Equatable, Hashable, CaseIterable {
+    case correct
+    case supportedCorrect
+    case incorrect
+
+    var cardReviewResult: CardReviewResult {
+        switch self {
+        case .correct: return .correct
+        case .supportedCorrect: return .supportedCorrect
+        case .incorrect: return .incorrect
+        }
+    }
+}
+
 struct GameplayExposureRecord: Codable, Equatable, Hashable {
     let key: GameplayExposureKey
     var correctCount: Int
+    var supportedCorrectCount: Int
     var mistakeCount: Int
     var lastSeenAt: Date?
+    var lastOutcome: GameplayExposureOutcome?
     var dueAt: Date
     var confidenceBand: GameplayConfidenceBand
 
     init(
         key: GameplayExposureKey,
         correctCount: Int = 0,
+        supportedCorrectCount: Int = 0,
         mistakeCount: Int = 0,
         lastSeenAt: Date? = nil,
+        lastOutcome: GameplayExposureOutcome? = nil,
         dueAt: Date = .distantPast,
         confidenceBand: GameplayConfidenceBand = .new
     ) {
         self.key = key
         self.correctCount = correctCount
+        self.supportedCorrectCount = supportedCorrectCount
         self.mistakeCount = mistakeCount
         self.lastSeenAt = lastSeenAt
+        self.lastOutcome = lastOutcome
         self.dueAt = dueAt
         self.confidenceBand = confidenceBand
     }
 
-    var attemptCount: Int { correctCount + mistakeCount }
+    var attemptCount: Int { correctCount + supportedCorrectCount + mistakeCount }
+
+    var independentCorrectCount: Int { correctCount }
+
+    var totalSuccessfulCount: Int { correctCount + supportedCorrectCount }
 }
 
 struct SpacedRepetitionSelectionPolicy: Codable, Equatable, Hashable {
@@ -70,6 +94,18 @@ struct SpacedRepetitionSelectionPolicy: Codable, Equatable, Hashable {
 
 struct SpacedRepetitionUpdate: Codable, Equatable, Hashable {
     let key: GameplayExposureKey
-    let wasCorrect: Bool
+    let outcome: GameplayExposureOutcome
     let occurredAt: Date
+
+    var wasCorrect: Bool { outcome != .incorrect }
+
+    init(key: GameplayExposureKey, outcome: GameplayExposureOutcome, occurredAt: Date) {
+        self.key = key
+        self.outcome = outcome
+        self.occurredAt = occurredAt
+    }
+
+    init(key: GameplayExposureKey, wasCorrect: Bool, occurredAt: Date) {
+        self.init(key: key, outcome: wasCorrect ? .correct : .incorrect, occurredAt: occurredAt)
+    }
 }

--- a/Services/SpacedRepetitionScheduler.swift
+++ b/Services/SpacedRepetitionScheduler.swift
@@ -52,13 +52,17 @@ enum SpacedRepetitionScheduler {
         var next = records
         for update in updates {
             var record = next[update.key] ?? GameplayExposureRecord(key: update.key)
-            if update.wasCorrect {
+            switch update.outcome {
+            case .correct:
                 record.correctCount += 1
-            } else {
+            case .supportedCorrect:
+                record.supportedCorrectCount += 1
+            case .incorrect:
                 record.mistakeCount += 1
             }
             record.lastSeenAt = update.occurredAt
-            record.confidenceBand = confidenceBand(correctCount: record.correctCount, mistakeCount: record.mistakeCount)
+            record.lastOutcome = update.outcome
+            record.confidenceBand = confidenceBand(for: record)
             record.dueAt = dueDate(for: record, after: update.occurredAt, baseInterval: stageInterval)
             next[update.key] = record
         }
@@ -75,11 +79,18 @@ enum SpacedRepetitionScheduler {
         }
         let isDue = record.dueAt <= now
         let confidencePriority: Int
-        switch record.confidenceBand {
-        case .reviewNeeded: confidencePriority = 0
-        case .new: confidencePriority = 1
-        case .learning: confidencePriority = 2
-        case .steady: confidencePriority = 4
+        switch record.lastOutcome {
+        case .incorrect:
+            confidencePriority = 0
+        case .supportedCorrect:
+            confidencePriority = 1
+        case .correct, nil:
+            switch record.confidenceBand {
+            case .reviewNeeded: confidencePriority = 0
+            case .new: confidencePriority = 2
+            case .learning: confidencePriority = 3
+            case .steady: confidencePriority = 4
+            }
         }
         let duePenalty = isDue ? 0 : 5
         return GameplayItemRank(
@@ -90,22 +101,30 @@ enum SpacedRepetitionScheduler {
         )
     }
 
-    private static func confidenceBand(correctCount: Int, mistakeCount: Int) -> GameplayConfidenceBand {
-        if mistakeCount > 0 && mistakeCount >= correctCount { return .reviewNeeded }
-        if correctCount == 0 && mistakeCount == 0 { return .new }
-        if correctCount < 3 { return .learning }
-        return .steady
+    private static func confidenceBand(for record: GameplayExposureRecord) -> GameplayConfidenceBand {
+        if record.mistakeCount > 0 && record.mistakeCount >= record.totalSuccessfulCount { return .reviewNeeded }
+        if record.attemptCount == 0 { return .new }
+        if record.independentCorrectCount >= 3 && record.mistakeCount == 0 { return .steady }
+        return .learning
     }
 
     private static func dueDate(for record: GameplayExposureRecord, after date: Date, baseInterval: TimeInterval) -> Date {
-        switch record.confidenceBand {
-        case .reviewNeeded:
-            return date.addingTimeInterval(baseInterval / 24)
-        case .new, .learning:
-            return date.addingTimeInterval(baseInterval)
-        case .steady:
-            return date.addingTimeInterval(baseInterval * 5)
-        }
+        guard let outcome = record.lastOutcome else { return date }
+        let configuration = CardReviewScheduler.Configuration(
+            incorrectRetryDelay: baseInterval / 24,
+            supportedCorrectDelay: baseInterval / 2,
+            independentCorrectIntervals: [baseInterval, baseInterval * 3, baseInterval * 5],
+            interleaveWindow: baseInterval / 48
+        )
+        let progress = CardProgress(
+            timesSeen: record.attemptCount,
+            correctCount: record.totalSuccessfulCount,
+            incorrectCount: record.mistakeCount,
+            currentCorrectStreak: outcome == .correct ? max(1, record.independentCorrectCount) : 0,
+            lastReviewedAt: date,
+            lastReviewResult: outcome.cardReviewResult
+        )
+        return CardReviewScheduler(now: date, configuration: configuration).nextReviewDate(for: progress)
     }
 
     private static func stableTieBreak(_ id: String, seed: UInt64) -> UInt64 {

--- a/Tests/MatherTests/GameplaySchedulerTests.swift
+++ b/Tests/MatherTests/GameplaySchedulerTests.swift
@@ -46,6 +46,48 @@ struct GameplaySchedulerTests {
         #expect(first.items.map(\.id) != different.items.map(\.id))
     }
 
+
+    @Test
+    func schedulerPlacesSupportedCorrectBetweenIncorrectAndIndependentCorrect() {
+        let thread = sampleThread()
+        let stage = GameplayStageDefinition(
+            id: "multiple-choice",
+            kind: .multipleChoice,
+            title: "Quiz",
+            prompt: "Choose",
+            propertyTypeIDs: ["capital"],
+            maximumItemCount: 3
+        )
+        let now = Date(timeIntervalSince1970: 4_000)
+        let indiaKey = GameplayExposureKey(entityID: "country-india", propertyID: "country-india-capital", stageID: stage.id)
+        let japanKey = GameplayExposureKey(entityID: "country-japan", propertyID: "country-japan-capital", stageID: stage.id)
+        let franceKey = GameplayExposureKey(entityID: "country-france", propertyID: "country-france-capital", stageID: stage.id)
+        let records: [GameplayExposureKey: GameplayExposureRecord] = [
+            indiaKey: GameplayExposureRecord(key: indiaKey, correctCount: 0, supportedCorrectCount: 0, mistakeCount: 1, lastOutcome: .incorrect, dueAt: now, confidenceBand: .reviewNeeded),
+            japanKey: GameplayExposureRecord(key: japanKey, correctCount: 0, supportedCorrectCount: 1, mistakeCount: 0, lastOutcome: .supportedCorrect, dueAt: now, confidenceBand: .learning),
+            franceKey: GameplayExposureRecord(key: franceKey, correctCount: 3, supportedCorrectCount: 0, mistakeCount: 0, lastOutcome: .correct, dueAt: now, confidenceBand: .steady)
+        ]
+
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, records: records, now: now, seed: 11)
+
+        #expect(round.items.map(\.entityID) == ["country-india", "country-japan", "country-france"])
+    }
+
+    @Test
+    func applyingSupportedCorrectUsesMiddleReviewDelay() {
+        let key = GameplayExposureKey(entityID: "fruit-mango", propertyID: "fruit-mango-taste", stageID: "easy-memory")
+        let now = Date(timeIntervalSince1970: 5_000)
+
+        let records = SpacedRepetitionScheduler.applying(
+            updates: [SpacedRepetitionUpdate(key: key, outcome: .supportedCorrect, occurredAt: now)],
+            to: [:]
+        )
+
+        #expect(records[key]?.confidenceBand == .learning)
+        #expect(records[key]?.supportedCorrectCount == 1)
+        #expect(records[key]?.dueAt == now.addingTimeInterval(60 * 60 * 12))
+    }
+
     @Test
     func applyingUpdatesMovesMistakesToReviewNeeded() {
         let key = GameplayExposureKey(entityID: "fruit-apple", propertyID: "fruit-apple-taste", stageID: "multiple-choice")
@@ -75,6 +117,8 @@ struct GameplaySchedulerTests {
         #expect(summary.mistakeCount == 1)
         #expect(summary.durationSeconds == 45)
         #expect(summary.stars == 3)
+        #expect(summary.scorePoints == 84)
+        #expect(summary.averageSecondsPerAttempt == 4.5)
     }
 
     private func sampleThread() -> GameplayThreadDefinition {


### PR DESCRIPTION
## Summary
- Adds explicit gameplay exposure outcomes for incorrect, supported-correct, and independent-correct review events.
- Reuses `CardReviewScheduler` semantics for next-due timing so gameplay repetition does not silently diverge from card review behavior.
- Adds deterministic stage/total score point and timing aggregation helpers.

## Validation
- `git diff --check`
- Targeted Xcode test attempted on `ganesh-mba`, but SSH timed out before the Mac could run `MatherTests/GameplaySchedulerTests`.
- Linux host does not have Swift installed; relying on GitHub CI for full validation.

Refs #912
