### PR TITLE
feat: add gameplay progress persistence

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -22,6 +22,7 @@ final class AppModel {
     let factStore: FactRecordStore
     let sumSprintEngine: SumSprintEngine
     let gameSessionStore: GameSessionStore
+    let gameplayProgressStore: GameplayProgressStore
     let explorerLabMasteryStore: ExplorerLabMasteryStore
 
     var explorerLabMasteryProfile: ExplorerLabMasteryProfile
@@ -133,6 +134,7 @@ final class AppModel {
 
         let factStore = FactRecordStore(modelContext: modelContext, activeProfileIdProvider: { profileStore.activeProfileId })
         let gameSessionStore = GameSessionStore(modelContext: modelContext, activeProfileIdProvider: { profileStore.activeProfileId })
+        let gameplayProgressStore = GameplayProgressStore(modelContext: modelContext, activeProfileIdProvider: { profileStore.activeProfileId })
         let explorerLabMasteryStore = ExplorerLabMasteryStore()
         let explorerLabMasteryProfile = explorerLabMasteryStore.load()
         let sumSprintEngine = SumSprintEngine(
@@ -144,6 +146,7 @@ final class AppModel {
         )
         self.factStore = factStore
         self.gameSessionStore = gameSessionStore
+        self.gameplayProgressStore = gameplayProgressStore
         self.explorerLabMasteryStore = explorerLabMasteryStore
         self.explorerLabMasteryProfile = explorerLabMasteryProfile
         self.sumSprintEngine = sumSprintEngine

--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -14,7 +14,9 @@ struct MatherApp: App {
                 StoredFactRecord.self,
                 StoredKidProfile.self,
                 StoredTelemetryEvent.self,
-                StoredGameSession.self
+                StoredGameSession.self,
+                StoredGameplayProgressRecord.self,
+                StoredGameplayThreadSession.self
             )
             let appModel = AppModel(modelContext: container.mainContext)
             Self.seedSessionHistoryIfRequested(using: appModel)

--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -737,3 +737,116 @@ final class StoredGameSession {
         self.detail = detail
     }
 }
+
+// MARK: - StoredGameplayProgressRecord
+
+@Model
+final class StoredGameplayProgressRecord {
+    @Attribute(.unique) var uniqueKey: String
+    var profileId: String
+    var threadId: String
+    var entityId: String
+    var propertyId: String?
+    var propertyTypeId: String?
+    var propertyValue: String?
+    var relationId: String?
+    var stageId: String
+    var exposureCount: Int
+    var correctCount: Int
+    var incorrectCount: Int
+    var supportedCorrectCount: Int
+    var hintCount: Int
+    var firstSeenAt: Date
+    var lastSeenAt: Date?
+    var nextDueAt: Date
+    var confidenceBandRawValue: String
+    var lastOutcomeRawValue: String?
+    var lastStageId: String?
+    var lastResultMetadata: String?
+
+    init(
+        uniqueKey: String,
+        profileId: String,
+        threadId: String,
+        entityId: String,
+        propertyId: String? = nil,
+        propertyTypeId: String? = nil,
+        propertyValue: String? = nil,
+        relationId: String? = nil,
+        stageId: String,
+        exposureCount: Int = 0,
+        correctCount: Int = 0,
+        incorrectCount: Int = 0,
+        supportedCorrectCount: Int = 0,
+        hintCount: Int = 0,
+        firstSeenAt: Date = .now,
+        lastSeenAt: Date? = nil,
+        nextDueAt: Date = .distantPast,
+        confidenceBandRawValue: String = GameplayConfidenceBand.new.rawValue,
+        lastOutcomeRawValue: String? = nil,
+        lastStageId: String? = nil,
+        lastResultMetadata: String? = nil
+    ) {
+        self.uniqueKey = uniqueKey
+        self.profileId = profileId
+        self.threadId = threadId
+        self.entityId = entityId
+        self.propertyId = propertyId
+        self.propertyTypeId = propertyTypeId
+        self.propertyValue = propertyValue
+        self.relationId = relationId
+        self.stageId = stageId
+        self.exposureCount = exposureCount
+        self.correctCount = correctCount
+        self.incorrectCount = incorrectCount
+        self.supportedCorrectCount = supportedCorrectCount
+        self.hintCount = hintCount
+        self.firstSeenAt = firstSeenAt
+        self.lastSeenAt = lastSeenAt
+        self.nextDueAt = nextDueAt
+        self.confidenceBandRawValue = confidenceBandRawValue
+        self.lastOutcomeRawValue = lastOutcomeRawValue
+        self.lastStageId = lastStageId
+        self.lastResultMetadata = lastResultMetadata
+    }
+}
+
+// MARK: - StoredGameplayThreadSession
+
+@Model
+final class StoredGameplayThreadSession {
+    @Attribute(.unique) var id: String
+    var profileId: String
+    var threadId: String
+    var startedAt: Date
+    var endedAt: Date
+    var durationSeconds: Double
+    var completedStageIdsData: Data?
+    var totalScore: Int
+    var stars: Int
+    var stageSummaryData: Data?
+
+    init(
+        id: String = UUID().uuidString,
+        profileId: String,
+        threadId: String,
+        startedAt: Date,
+        endedAt: Date,
+        durationSeconds: Double,
+        completedStageIdsData: Data? = nil,
+        totalScore: Int,
+        stars: Int,
+        stageSummaryData: Data? = nil
+    ) {
+        self.id = id
+        self.profileId = profileId
+        self.threadId = threadId
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.durationSeconds = durationSeconds
+        self.completedStageIdsData = completedStageIdsData
+        self.totalScore = totalScore
+        self.stars = stars
+        self.stageSummaryData = stageSummaryData
+    }
+}

--- a/Features/GameplayStages/GameplayThreadView.swift
+++ b/Features/GameplayStages/GameplayThreadView.swift
@@ -23,21 +23,24 @@ struct GameplayStageFeedbackActions {
 struct GameplayThreadView: View {
     let thread: GameplayThreadDefinition
     var actions: GameplayStageFeedbackActions
+    var progressStore: GameplayProgressStore?
     @State private var navigation: GameplayStageNavigationState
 
     init(
         thread: GameplayThreadDefinition = GameplaySampleThreads.countries,
         actions: GameplayStageFeedbackActions = GameplayStageFeedbackActions(),
+        progressStore: GameplayProgressStore? = nil,
         now: Date = Date()
     ) {
         self.thread = thread
         self.actions = actions
+        self.progressStore = progressStore
         _navigation = State(initialValue: GameplayStageNavigationState(startedAt: now, currentStageStartedAt: now))
     }
 
     @MainActor
     init(thread: GameplayThreadDefinition = GameplaySampleThreads.countries, appModel: AppModel, now: Date = Date()) {
-        self.init(thread: thread, actions: .appModel(appModel), now: now)
+        self.init(thread: thread, actions: .appModel(appModel), progressStore: appModel.gameplayProgressStore, now: now)
     }
 
     var body: some View {
@@ -64,7 +67,8 @@ struct GameplayThreadView: View {
         if navigation.isComplete(for: thread) {
             GameplayThreadSummaryView(summary: navigation.summary(), stageCount: thread.stages.count)
         } else if let stage = navigation.activeStage(in: thread) {
-            let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: UInt64(navigation.activeStageIndex + 17))
+            let round = progressStore?.makeRound(thread: thread, stage: stage, seed: UInt64(navigation.activeStageIndex + 17))
+                ?? SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: UInt64(navigation.activeStageIndex + 17))
             switch stage.kind {
             case .flashcards:
                 FlashcardStageView(thread: thread, stage: stage, round: round, actions: actions, compact: compact) { correct, mistakes, hints in
@@ -96,6 +100,10 @@ struct GameplayThreadView: View {
 
     private func complete(correct: Int, mistakes: Int, hints: Int) {
         navigation.completeCurrentStage(thread: thread, correctCount: correct, mistakeCount: mistakes, hintsUsed: hints)
+        if navigation.isComplete(for: thread) {
+            let endedAt = navigation.stageResults.last?.completedAt ?? Date()
+            progressStore?.saveThreadSession(thread: thread, startedAt: navigation.startedAt, endedAt: endedAt, results: navigation.stageResults)
+        }
         actions.success()
     }
 

--- a/Mather.xcodeproj/project.pbxproj
+++ b/Mather.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		211111111111111111111112 /* SpacedRepetitionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111111111111111111111112 /* SpacedRepetitionModels.swift */; };
 		211111111111111111111113 /* SpacedRepetitionScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111111111111111111111113 /* SpacedRepetitionScheduler.swift */; };
 		211111111111111111111114 /* GameplaySchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111111111111111111111114 /* GameplaySchedulerTests.swift */; };
+		A912G0000000000000000011 /* GameplayProgressStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912G0000000000000000010 /* GameplayProgressStore.swift */; };
+		A912G0000000000000000021 /* GameplayProgressStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912G0000000000000000020 /* GameplayProgressStoreTests.swift */; };
 		A912C0000000000000000011 /* GameplaySampleThreads.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000010 /* GameplaySampleThreads.swift */; };
 		A912D0000000000000000011 /* GameplayThreadCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912D0000000000000000010 /* GameplayThreadCatalog.swift */; };
 		A912D0000000000000000021 /* GameplayThreadContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912D0000000000000000020 /* GameplayThreadContentTests.swift */; };
@@ -108,6 +110,8 @@
 		111111111111111111111112 /* SpacedRepetitionModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacedRepetitionModels.swift; sourceTree = "<group>"; };
 		111111111111111111111113 /* SpacedRepetitionScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacedRepetitionScheduler.swift; sourceTree = "<group>"; };
 		111111111111111111111114 /* GameplaySchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplaySchedulerTests.swift; sourceTree = "<group>"; };
+		A912G0000000000000000010 /* GameplayProgressStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayProgressStore.swift; sourceTree = "<group>"; };
+		A912G0000000000000000020 /* GameplayProgressStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayProgressStoreTests.swift; sourceTree = "<group>"; };
 		A912C0000000000000000010 /* GameplaySampleThreads.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplaySampleThreads.swift; sourceTree = "<group>"; };
 		A912D0000000000000000010 /* GameplayThreadCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayThreadCatalog.swift; sourceTree = "<group>"; };
 		A912D0000000000000000020 /* GameplayThreadContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayThreadContentTests.swift; sourceTree = "<group>"; };
@@ -141,6 +145,7 @@
 			isa = PBXGroup;
 			children = (
 				111111111111111111111113 /* SpacedRepetitionScheduler.swift */,
+				A912G0000000000000000010 /* GameplayProgressStore.swift */,
 				C12E4243979B82D1D254C7BF /* HapticsService.swift */,
 				57321A0556CEB2A30DE5A7A7 /* SpeechService.swift */,
 			);
@@ -160,6 +165,7 @@
 			isa = PBXGroup;
 			children = (
 				111111111111111111111114 /* GameplaySchedulerTests.swift */,
+				A912G0000000000000000020 /* GameplayProgressStoreTests.swift */,
 				A912D0000000000000000020 /* GameplayThreadContentTests.swift */,
 				A912E0000000000000000020 /* WaterCycleGameplayThreadTests.swift */,
 				A912C00000000000000000A0 /* GameplayStageViewModelsTests.swift */,
@@ -371,6 +377,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				211111111111111111111114 /* GameplaySchedulerTests.swift in Sources */,
+				A912G0000000000000000021 /* GameplayProgressStoreTests.swift in Sources */,
 				A912D0000000000000000021 /* GameplayThreadContentTests.swift in Sources */,
 				A912E0000000000000000021 /* WaterCycleGameplayThreadTests.swift in Sources */,
 				A912C00000000000000000A1 /* GameplayStageViewModelsTests.swift in Sources */,
@@ -389,6 +396,7 @@
 				211111111111111111111111 /* GameplayStageModels.swift in Sources */,
 				211111111111111111111112 /* SpacedRepetitionModels.swift in Sources */,
 				211111111111111111111113 /* SpacedRepetitionScheduler.swift in Sources */,
+				A912G0000000000000000011 /* GameplayProgressStore.swift in Sources */,
 				A912C0000000000000000011 /* GameplaySampleThreads.swift in Sources */,
 				A912D0000000000000000011 /* GameplayThreadCatalog.swift in Sources */,
 				A912C0000000000000000013 /* CountryGameplayThread.swift in Sources */,

--- a/Services/GameplayProgressStore.swift
+++ b/Services/GameplayProgressStore.swift
@@ -1,0 +1,212 @@
+import Foundation
+import Observation
+import SwiftData
+
+@MainActor
+@Observable
+final class GameplayProgressStore {
+    private let modelContext: ModelContext
+    private let activeProfileIdProvider: () -> String
+    private let encoder = JSONEncoder()
+
+    init(modelContext: ModelContext, activeProfileIdProvider: @escaping () -> String) {
+        self.modelContext = modelContext
+        self.activeProfileIdProvider = activeProfileIdProvider
+    }
+
+    convenience init(modelContext: ModelContext) {
+        self.init(modelContext: modelContext, activeProfileIdProvider: { KidProfileStore.defaultProfileId })
+    }
+
+    func records(forThread threadID: String, stageID: String? = nil) -> [GameplayExposureKey: GameplayExposureRecord] {
+        let profileId = activeProfileIdProvider()
+        let descriptor = FetchDescriptor<StoredGameplayProgressRecord>(
+            predicate: #Predicate { $0.profileId == profileId && $0.threadId == threadID }
+        )
+        let stored = ((try? modelContext.fetch(descriptor)) ?? [])
+            .filter { stageID == nil || $0.stageId == stageID }
+        return Dictionary(uniqueKeysWithValues: stored.map { ($0.exposureKey, $0.exposureRecord) })
+    }
+
+    func storedRecords(forThread threadID: String) -> [StoredGameplayProgressRecord] {
+        let profileId = activeProfileIdProvider()
+        let descriptor = FetchDescriptor<StoredGameplayProgressRecord>(
+            predicate: #Predicate { $0.profileId == profileId && $0.threadId == threadID },
+            sortBy: [SortDescriptor(\StoredGameplayProgressRecord.nextDueAt)]
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
+    func makeRound(
+        thread: GameplayThreadDefinition,
+        stage: GameplayStageDefinition,
+        now: Date = Date(),
+        seed: UInt64 = 0,
+        policy: SpacedRepetitionSelectionPolicy? = nil
+    ) -> GameplayRoundDefinition {
+        SpacedRepetitionScheduler.makeRound(
+            thread: thread,
+            stage: stage,
+            records: records(forThread: thread.id, stageID: stage.id),
+            now: now,
+            seed: seed,
+            policy: policy
+        )
+    }
+
+    func markExposed(thread: GameplayThreadDefinition, stage: GameplayStageDefinition, items: [GameplayRoundItem], at date: Date = Date()) {
+        for item in items {
+            let key = SpacedRepetitionScheduler.recordKey(for: item, stageID: stage.id)
+            let stored = progressRecord(for: key, threadID: thread.id) ?? makeStoredRecord(for: key, thread: thread, stage: stage, firstSeenAt: date)
+            stored.exposureCount += 1
+            stored.lastSeenAt = date
+            if stored.firstSeenAt > date { stored.firstSeenAt = date }
+            if stored.modelContext == nil { modelContext.insert(stored) }
+        }
+        try? modelContext.save()
+    }
+
+    func apply(
+        updates: [SpacedRepetitionUpdate],
+        thread: GameplayThreadDefinition,
+        stageInterval: TimeInterval = 60 * 60 * 24,
+        hintsByKey: [GameplayExposureKey: Int] = [:],
+        metadataByKey: [GameplayExposureKey: String] = [:]
+    ) {
+        var current = records(forThread: thread.id)
+        for update in updates {
+            current = SpacedRepetitionScheduler.applying(updates: [update], to: current, stageInterval: stageInterval)
+            guard let record = current[update.key] else { continue }
+            let stage = thread.stages.first { $0.id == update.key.stageID } ?? GameplayStageDefinition(id: update.key.stageID, kind: .flashcards, title: update.key.stageID, prompt: "")
+            let stored = progressRecord(for: update.key, threadID: thread.id) ?? makeStoredRecord(for: update.key, thread: thread, stage: stage, firstSeenAt: update.occurredAt)
+            stored.apply(record: record)
+            stored.exposureCount = max(stored.exposureCount + 1, record.attemptCount)
+            stored.hintCount += hintsByKey[update.key] ?? 0
+            stored.lastStageId = update.key.stageID
+            stored.lastResultMetadata = metadataByKey[update.key]
+            if stored.modelContext == nil { modelContext.insert(stored) }
+        }
+        try? modelContext.save()
+    }
+
+    func dueAndWeakRecords(threadID: String, now: Date = Date(), limit: Int = 12) -> [StoredGameplayProgressRecord] {
+        storedRecords(forThread: threadID)
+            .filter { $0.nextDueAt <= now || $0.confidenceBand == .reviewNeeded || $0.confidenceBand == .learning }
+            .sorted { lhs, rhs in
+                if lhs.confidencePriority != rhs.confidencePriority { return lhs.confidencePriority < rhs.confidencePriority }
+                if lhs.nextDueAt != rhs.nextDueAt { return lhs.nextDueAt < rhs.nextDueAt }
+                return lhs.uniqueKey < rhs.uniqueKey
+            }
+            .prefix(max(0, limit))
+            .map { $0 }
+    }
+
+    @discardableResult
+    func saveThreadSession(
+        thread: GameplayThreadDefinition,
+        startedAt: Date,
+        endedAt: Date = Date(),
+        results: [GameplayStageResult]
+    ) -> StoredGameplayThreadSession {
+        let summary = GameplayScoreSummary.summarize(results)
+        let completedStageIDs = results.map(\.stageID)
+        let session = StoredGameplayThreadSession(
+            profileId: activeProfileIdProvider(),
+            threadId: thread.id,
+            startedAt: startedAt,
+            endedAt: endedAt,
+            durationSeconds: endedAt.timeIntervalSince(startedAt),
+            completedStageIdsData: try? encoder.encode(completedStageIDs),
+            totalScore: summary.scorePoints,
+            stars: summary.stars,
+            stageSummaryData: try? encoder.encode(results)
+        )
+        modelContext.insert(session)
+        try? modelContext.save()
+        return session
+    }
+
+    func threadSessions(forThread threadID: String) -> [StoredGameplayThreadSession] {
+        let profileId = activeProfileIdProvider()
+        let descriptor = FetchDescriptor<StoredGameplayThreadSession>(
+            predicate: #Predicate { $0.profileId == profileId && $0.threadId == threadID },
+            sortBy: [SortDescriptor(\StoredGameplayThreadSession.startedAt, order: .reverse)]
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
+    private func progressRecord(for key: GameplayExposureKey, threadID: String) -> StoredGameplayProgressRecord? {
+        let profileId = activeProfileIdProvider()
+        let uniqueKey = Self.uniqueKey(profileId: profileId, threadID: threadID, key: key)
+        var descriptor = FetchDescriptor<StoredGameplayProgressRecord>(
+            predicate: #Predicate { $0.uniqueKey == uniqueKey }
+        )
+        descriptor.fetchLimit = 1
+        return try? modelContext.fetch(descriptor).first
+    }
+
+    private func makeStoredRecord(for key: GameplayExposureKey, thread: GameplayThreadDefinition, stage: GameplayStageDefinition, firstSeenAt: Date) -> StoredGameplayProgressRecord {
+        let profileId = activeProfileIdProvider()
+        let entity = thread.entities.first { $0.id == key.entityID }
+        let property = entity?.properties.first { $0.id == key.propertyID }
+        return StoredGameplayProgressRecord(
+            uniqueKey: Self.uniqueKey(profileId: profileId, threadID: thread.id, key: key),
+            profileId: profileId,
+            threadId: thread.id,
+            entityId: key.entityID,
+            propertyId: key.propertyID,
+            propertyTypeId: property?.typeID,
+            propertyValue: property?.value,
+            stageId: stage.id,
+            firstSeenAt: firstSeenAt,
+            lastSeenAt: nil,
+            nextDueAt: .distantPast
+        )
+    }
+
+    static func uniqueKey(profileId: String, threadID: String, key: GameplayExposureKey) -> String {
+        [profileId, threadID, key.stageID, key.entityID, key.propertyID ?? "entity"].joined(separator: "::")
+    }
+}
+
+extension StoredGameplayProgressRecord {
+    var exposureKey: GameplayExposureKey {
+        GameplayExposureKey(entityID: entityId, propertyID: propertyId, stageID: stageId)
+    }
+
+    var confidenceBand: GameplayConfidenceBand {
+        GameplayConfidenceBand(rawValue: confidenceBandRawValue) ?? .new
+    }
+
+    var exposureRecord: GameplayExposureRecord {
+        GameplayExposureRecord(
+            key: exposureKey,
+            correctCount: correctCount,
+            supportedCorrectCount: supportedCorrectCount,
+            mistakeCount: incorrectCount,
+            lastSeenAt: lastSeenAt,
+            lastOutcome: lastOutcomeRawValue.flatMap(GameplayExposureOutcome.init(rawValue:)),
+            dueAt: nextDueAt,
+            confidenceBand: confidenceBand
+        )
+    }
+
+    func apply(record: GameplayExposureRecord) {
+        correctCount = record.correctCount
+        supportedCorrectCount = record.supportedCorrectCount
+        incorrectCount = record.mistakeCount
+        lastSeenAt = record.lastSeenAt
+        lastOutcomeRawValue = record.lastOutcome?.rawValue
+        nextDueAt = record.dueAt
+        confidenceBandRawValue = record.confidenceBand.rawValue
+    }
+
+    fileprivate var confidencePriority: Int {
+        switch confidenceBand {
+        case .reviewNeeded: return 0
+        case .learning: return 1
+        case .new: return 2
+        case .steady: return 3
+        }
+    }
+}

--- a/Tests/MatherTests/GameplayProgressStoreTests.swift
+++ b/Tests/MatherTests/GameplayProgressStoreTests.swift
@@ -49,7 +49,7 @@ struct GameplayProgressStoreTests {
         #expect(weak?.entityId == "country-japan")
         #expect(weak?.confidenceBand == .reviewNeeded)
 
-        let round = store.makeRound(thread: thread, stage: stage, now: now, seed: 7)
+        let round = store.makeRound(thread: thread, stage: stage, now: now.addingTimeInterval(60 * 60 + 1), seed: 7)
         #expect(round.items.first?.entityID == "country-japan")
     }
 

--- a/Tests/MatherTests/GameplayProgressStoreTests.swift
+++ b/Tests/MatherTests/GameplayProgressStoreTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import Mather
+
+@MainActor
+struct GameplayProgressStoreTests {
+    @Test
+    func exposuresPersistAcrossStoreLifecycle() throws {
+        let (context, profileId) = try makeGameplayProgressContext()
+        let thread = sampleThread()
+        let stage = thread.stages[0]
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 912)
+
+        var store: GameplayProgressStore? = GameplayProgressStore(modelContext: context, activeProfileIdProvider: { profileId })
+        store?.markExposed(thread: thread, stage: stage, items: Array(round.items.prefix(1)), at: Date(timeIntervalSince1970: 100))
+        store = nil
+
+        let reloaded = GameplayProgressStore(modelContext: context, activeProfileIdProvider: { profileId })
+        let fetched = reloaded.storedRecords(forThread: thread.id)
+
+        #expect(fetched.count == 1)
+        #expect(fetched[0].exposureCount == 1)
+        #expect(fetched[0].profileId == profileId)
+        #expect(fetched[0].threadId == thread.id)
+    }
+
+    @Test
+    func updatesPersistAndFeedSchedulerOrdering() throws {
+        let (context, profileId) = try makeGameplayProgressContext()
+        let store = GameplayProgressStore(modelContext: context, activeProfileIdProvider: { profileId })
+        let thread = sampleThread()
+        let stage = thread.stages.first { $0.id == "easy-memory" }!
+        let now = Date(timeIntervalSince1970: 2_000)
+        let weakKey = GameplayExposureKey(entityID: "country-japan", propertyID: "country-japan-capital", stageID: stage.id)
+        let strongKey = GameplayExposureKey(entityID: "country-india", propertyID: "country-india-capital", stageID: stage.id)
+
+        store.apply(
+            updates: [
+                SpacedRepetitionUpdate(key: strongKey, outcome: .correct, occurredAt: now.addingTimeInterval(-60)),
+                SpacedRepetitionUpdate(key: strongKey, outcome: .correct, occurredAt: now.addingTimeInterval(-30)),
+                SpacedRepetitionUpdate(key: strongKey, outcome: .correct, occurredAt: now),
+                SpacedRepetitionUpdate(key: weakKey, outcome: .incorrect, occurredAt: now)
+            ],
+            thread: thread
+        )
+
+        let weak = store.dueAndWeakRecords(threadID: thread.id, now: now).first
+        #expect(weak?.entityId == "country-japan")
+        #expect(weak?.confidenceBand == .reviewNeeded)
+
+        let round = store.makeRound(thread: thread, stage: stage, now: now, seed: 7)
+        #expect(round.items.first?.entityID == "country-japan")
+    }
+
+    @Test
+    func threadSessionsDoNotMutateStoredGameSessionSummaries() throws {
+        let (context, profileId) = try makeGameplayProgressContext()
+        let progressStore = GameplayProgressStore(modelContext: context, activeProfileIdProvider: { profileId })
+        let gameSessionStore = GameSessionStore(modelContext: context, activeProfileIdProvider: { profileId })
+        let thread = sampleThread()
+        let started = Date(timeIntervalSince1970: 5_000)
+
+        gameSessionStore.save(
+            gameName: "Sum Sprint",
+            startedAt: started,
+            scoreValue: 8,
+            scoreLabel: "correct",
+            detail: "warmup"
+        )
+        progressStore.saveThreadSession(
+            thread: thread,
+            startedAt: started,
+            endedAt: started.addingTimeInterval(45),
+            results: [GameplayStageResult(id: "r1", stageID: "flashcards", correctCount: 3, mistakeCount: 0, hintsUsed: 0, durationSeconds: 45, completedAt: started.addingTimeInterval(45))]
+        )
+
+        #expect(progressStore.threadSessions(forThread: thread.id).count == 1)
+        let gameSessions = gameSessionStore.sessions(forGame: "Sum Sprint")
+        #expect(gameSessions.count == 1)
+        #expect(gameSessions[0].scoreValue == 8)
+        #expect(gameSessions[0].detail == "warmup")
+    }
+
+    @Test
+    func appSchemaIncludesGameplayProgressModels() throws {
+        let schema = Schema([
+            StoredSessionSummary.self,
+            StoredRoomQuestStationReference.self,
+            StoredFactRecord.self,
+            StoredKidProfile.self,
+            StoredTelemetryEvent.self,
+            StoredGameSession.self,
+            StoredGameplayProgressRecord.self,
+            StoredGameplayThreadSession.self
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        _ = try ModelContainer(for: schema, configurations: config)
+    }
+
+    private func makeGameplayProgressContext() throws -> (ModelContext, String) {
+        let schema = Schema([
+            StoredGameplayProgressRecord.self,
+            StoredGameplayThreadSession.self,
+            StoredGameSession.self
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: config)
+        return (ModelContext(container), "kid-progress")
+    }
+
+    private func sampleThread() -> GameplayThreadDefinition {
+        GameplayThreadDefinition(
+            id: "countries",
+            title: "Countries",
+            category: GameplayCategory(id: "geography", title: "Geography", subtitle: "Places"),
+            propertyTypes: [
+                GameplayPropertyType(id: "capital", displayName: "Capital", prompt: "Which capital?"),
+                GameplayPropertyType(id: "currency", displayName: "Currency", prompt: "Which money?")
+            ],
+            entities: [
+                GameplayEntity(id: "country-india", name: "India", properties: [
+                    GameplayProperty(id: "country-india-capital", typeID: "capital", value: "New Delhi"),
+                    GameplayProperty(id: "country-india-currency", typeID: "currency", value: "Indian rupee")
+                ]),
+                GameplayEntity(id: "country-japan", name: "Japan", properties: [
+                    GameplayProperty(id: "country-japan-capital", typeID: "capital", value: "Tokyo"),
+                    GameplayProperty(id: "country-japan-currency", typeID: "currency", value: "yen")
+                ]),
+                GameplayEntity(id: "country-france", name: "France", properties: [
+                    GameplayProperty(id: "country-france-capital", typeID: "capital", value: "Paris"),
+                    GameplayProperty(id: "country-france-currency", typeID: "currency", value: "euro")
+                ])
+            ]
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add SwiftData models for gameplay exposure progress and gameplay thread session summaries
- wire `GameplayProgressStore` into the app model/container and gameplay thread view round/session paths
- cover persistence lifecycle, due/weak scheduler input, schema launch, and StoredGameSession summary intactness

## Validation
- `git diff --check`
- Not run locally: Linux workspace lacks Xcode/Swift tooling; ganesh-mba SSH timed out during validation attempt. Relying on GitHub CI for iOS tests.

Refs #912
