### PR TITLE
feat: polish reusable gameplay thread completion

### DIFF
--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -58,8 +58,10 @@ private extension MatherApp {
         switch arguments[flagIndex + 1].lowercased() {
         case "lab", "explorerlab", "explorer-lab":
             appModel.engine.showLab()
-        case "watercycle", "water-cycle", "watercyclelab", "water-cycle-lab":
+        case "watercycle", "water-cycle", "watercyclethread", "water-cycle-thread":
             appModel.engine.showWaterCycle()
+        case "watercyclelab", "water-cycle-lab", "legacy-watercycle", "legacy-water-cycle":
+            appModel.engine.showLegacyWaterCycleLab()
         default:
             break
         }

--- a/Domain/GameplayStageModels.swift
+++ b/Domain/GameplayStageModels.swift
@@ -207,6 +207,17 @@ struct GameplayScoreSummary: Codable, Equatable, Hashable {
         return durationSeconds / Double(attemptedCount)
     }
 
+    var formattedAccuracy: String {
+        "\(Int((accuracy * 100).rounded()))%"
+    }
+
+    var formattedDuration: String {
+        let seconds = max(0, Int(durationSeconds.rounded()))
+        let minutes = seconds / 60
+        let remainingSeconds = seconds % 60
+        return minutes > 0 ? "\(minutes)m \(remainingSeconds)s" : "\(remainingSeconds)s"
+    }
+
     static func summarize(_ results: [GameplayStageResult]) -> GameplayScoreSummary {
         let correct = results.reduce(0) { $0 + $1.correctCount }
         let mistakes = results.reduce(0) { $0 + $1.mistakeCount }

--- a/Domain/GameplayThreadCatalog.swift
+++ b/Domain/GameplayThreadCatalog.swift
@@ -3,6 +3,7 @@ import Foundation
 enum GameplayThreadID: String, Codable, CaseIterable, Hashable {
     case countries
     case fruits
+    case waterCycle = "water-cycle"
 }
 
 extension GameplayThreadCatalog {
@@ -12,6 +13,8 @@ extension GameplayThreadCatalog {
             return CountryGameplayThread.thread
         case .fruits:
             return fruits
+        case .waterCycle:
+            return waterCycle
         }
     }
 

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -136,7 +136,8 @@ final class VerticalSliceEngine {
     func showLabLane(_ laneID: CapabilityLaneID) { route = .labLane(laneID) }
     func showMemory() { route = .memory }
     func showCountriesGameplayThread() { route = .gameplayThread(.countries) }
-    func showWaterCycle() { route = .waterCycle }
+    func showWaterCycle() { route = .gameplayThread(.waterCycle) }
+    func showLegacyWaterCycleLab() { route = .waterCycle }
     func showGameplayThread(_ id: GameplayThreadID) { route = .gameplayThread(id) }
     func showSoundVolume() { route = .soundVolume }
     func showShapeGeometry() { route = .shapeGeometry }

--- a/Features/GameplayStages/FlashcardStageView.swift
+++ b/Features/GameplayStages/FlashcardStageView.swift
@@ -6,6 +6,7 @@ struct FlashcardStageView: View {
     let compact: Bool
     let onComplete: (Int, Int, Int) -> Void
     @State private var viewModel: GameplayFlashcardStageViewModel
+    @State private var lastSpokenCardID: String?
 
     init(thread: GameplayThreadDefinition, stage: GameplayStageDefinition, round: GameplayRoundDefinition, actions: GameplayStageFeedbackActions, compact: Bool, onComplete: @escaping (Int, Int, Int) -> Void) {
         self.stage = stage
@@ -24,7 +25,7 @@ struct FlashcardStageView: View {
                 HStack(spacing: 10) {
                     Button("Listen again") {
                         viewModel.markExposure()
-                        actions.speak(card.spokenText)
+                        speak(card)
                     }
                     .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
                     .accessibilityLabel(viewModel.listenAgainAccessibilityLabel)
@@ -33,7 +34,7 @@ struct FlashcardStageView: View {
                         if viewModel.advance() {
                             onComplete(max(1, viewModel.cards.count), 0, 0)
                         } else if let active = viewModel.activeCard {
-                            actions.speak(active.spokenText)
+                            speak(active)
                         }
                     }
                     .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
@@ -42,5 +43,16 @@ struct FlashcardStageView: View {
         }
         .padding(compact ? 14 : 20)
         .background(GameplayStagePanel())
+        .onAppear { speakActiveCardIfNeeded() }
+    }
+
+    private func speakActiveCardIfNeeded() {
+        guard let card = viewModel.activeCard, lastSpokenCardID != card.id else { return }
+        speak(card)
+    }
+
+    private func speak(_ card: GameplayDisplayItem) {
+        lastSpokenCardID = card.id
+        actions.speak(card.spokenText)
     }
 }

--- a/Features/GameplayStages/GameplayThreadView.swift
+++ b/Features/GameplayStages/GameplayThreadView.swift
@@ -72,23 +72,23 @@ struct GameplayThreadView: View {
             switch stage.kind {
             case .flashcards:
                 FlashcardStageView(thread: thread, stage: stage, round: round, actions: actions, compact: compact) { correct, mistakes, hints in
-                    complete(correct: correct, mistakes: mistakes, hints: hints)
+                    complete(stage: stage, round: round, correct: correct, mistakes: mistakes, hints: hints)
                 }
             case .easyMemory:
                 MemoryStageView(thread: thread, stage: stage, round: round, actions: actions, compact: compact) { correct, mistakes, hints in
-                    complete(correct: correct, mistakes: mistakes, hints: hints)
+                    complete(stage: stage, round: round, correct: correct, mistakes: mistakes, hints: hints)
                 }
             case .flipMemory:
                 FlipMemoryStageView(thread: thread, stage: stage, round: round, actions: actions, compact: compact) { correct, mistakes, hints in
-                    complete(correct: correct, mistakes: mistakes, hints: hints)
+                    complete(stage: stage, round: round, correct: correct, mistakes: mistakes, hints: hints)
                 }
             case .bondBlast:
                 BondBlastStageView(thread: thread, stage: stage, round: round, actions: actions, compact: compact) { correct, mistakes, hints in
-                    complete(correct: correct, mistakes: mistakes, hints: hints)
+                    complete(stage: stage, round: round, correct: correct, mistakes: mistakes, hints: hints)
                 }
             case .multipleChoice:
                 MultipleChoiceStageView(thread: thread, stage: stage, round: round, actions: actions, compact: compact) { correct, mistakes, hints in
-                    complete(correct: correct, mistakes: mistakes, hints: hints)
+                    complete(stage: stage, round: round, correct: correct, mistakes: mistakes, hints: hints)
                 }
             }
         } else {
@@ -98,13 +98,51 @@ struct GameplayThreadView: View {
         }
     }
 
-    private func complete(correct: Int, mistakes: Int, hints: Int) {
-        navigation.completeCurrentStage(thread: thread, correctCount: correct, mistakeCount: mistakes, hintsUsed: hints)
+    private func complete(stage: GameplayStageDefinition, round: GameplayRoundDefinition, correct: Int, mistakes: Int, hints: Int) {
+        let occurredAt = Date()
+        navigation.completeCurrentStage(thread: thread, correctCount: correct, mistakeCount: mistakes, hintsUsed: hints, now: occurredAt)
+        persistProgress(stage: stage, round: round, correct: correct, mistakes: mistakes, hints: hints, at: occurredAt)
         if navigation.isComplete(for: thread) {
-            let endedAt = navigation.stageResults.last?.completedAt ?? Date()
+            let endedAt = navigation.stageResults.last?.completedAt ?? occurredAt
             progressStore?.saveThreadSession(thread: thread, startedAt: navigation.startedAt, endedAt: endedAt, results: navigation.stageResults)
         }
         actions.success()
+    }
+
+    private func persistProgress(stage: GameplayStageDefinition, round: GameplayRoundDefinition, correct: Int, mistakes: Int, hints: Int, at date: Date) {
+        guard let progressStore else { return }
+        progressStore.markExposed(thread: thread, stage: stage, items: round.items, at: date)
+        progressStore.apply(
+            updates: repetitionUpdates(for: round, stage: stage, correct: correct, mistakes: mistakes, at: date),
+            thread: thread,
+            hintsByKey: hintsByKey(for: round, stage: stage, totalHints: hints),
+            metadataByKey: Dictionary(uniqueKeysWithValues: round.items.map { item in
+                let key = SpacedRepetitionScheduler.recordKey(for: item, stageID: stage.id)
+                return (key, "stage=\(stage.kind.rawValue);score=\(correct);mistakes=\(mistakes)")
+            })
+        )
+    }
+
+    private func repetitionUpdates(for round: GameplayRoundDefinition, stage: GameplayStageDefinition, correct: Int, mistakes: Int, at date: Date) -> [SpacedRepetitionUpdate] {
+        let correctLimit = max(0, correct)
+        let mistakeLimit = max(0, mistakes)
+        return round.items.enumerated().map { index, item in
+            let outcome: GameplayExposureOutcome
+            if index < correctLimit {
+                outcome = mistakeLimit == 0 ? .correct : .supportedCorrect
+            } else if index < correctLimit + mistakeLimit {
+                outcome = .incorrect
+            } else {
+                outcome = .supportedCorrect
+            }
+            return SpacedRepetitionUpdate(key: SpacedRepetitionScheduler.recordKey(for: item, stageID: stage.id), outcome: outcome, occurredAt: date)
+        }
+    }
+
+    private func hintsByKey(for round: GameplayRoundDefinition, stage: GameplayStageDefinition, totalHints: Int) -> [GameplayExposureKey: Int] {
+        guard totalHints > 0, !round.items.isEmpty else { return [:] }
+        let key = SpacedRepetitionScheduler.recordKey(for: round.items[0], stageID: stage.id)
+        return [key: totalHints]
     }
 
     private func header(compact: Bool) -> some View {
@@ -133,18 +171,38 @@ struct GameplayThreadView: View {
     }
 
     private func controls(compact: Bool) -> some View {
+        ViewThatFits(in: .horizontal) {
+            controlRow(compact: compact)
+            VStack(alignment: .leading, spacing: 8) {
+                controlButtons(compact: compact)
+                scoreText
+            }
+        }
+    }
+
+    private func controlRow(compact: Bool) -> some View {
         HStack(spacing: 10) {
+            controlButtons(compact: compact)
+            Spacer(minLength: 0)
+            scoreText
+        }
+    }
+
+    private func controlButtons(compact: Bool) -> some View {
+        HStack(spacing: 8) {
             Button("Back") { navigation.goBack() }
                 .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
                 .disabled(!navigation.canGoBack)
             Button("Retry") { navigation.retryCurrentStage() }
                 .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
-            Spacer(minLength: 0)
-            Text("Score \(navigation.summary().correctCount)")
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(MatherTheme.ink.opacity(0.8))
-                .accessibilityLabel("Current score \(navigation.summary().correctCount)")
         }
+    }
+
+    private var scoreText: some View {
+        Text("Score \(navigation.summary().scorePoints)")
+            .font(.subheadline.weight(.semibold).monospacedDigit())
+            .foregroundStyle(MatherTheme.ink.opacity(0.8))
+            .accessibilityLabel("Current score \(navigation.summary().scorePoints)")
     }
 }
 
@@ -161,9 +219,12 @@ private struct GameplayThreadSummaryView: View {
             Text("Thread complete")
                 .font(.title.bold())
                 .foregroundStyle(MatherTheme.ink)
-            Text("\(summary.correctCount) correct • \(summary.mistakeCount) review items • \(stageCount) stages")
+            Text("Score \(summary.scorePoints) • \(summary.correctCount)/\(summary.attemptedCount) correct • \(summary.formattedDuration)")
                 .font(.headline)
                 .foregroundStyle(MatherTheme.ink.opacity(0.78))
+            Text("Accuracy \(summary.formattedAccuracy) • \(summary.mistakeCount) review items • \(stageCount) stages")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.ink.opacity(0.68))
         }
         .padding(24)
         .frame(maxWidth: .infinity)

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -153,7 +153,7 @@ extension LabActivityID {
         case .shapeGeometry:
             return .shapeGeometry
         case .waterCycle:
-            return .waterCycle
+            return .gameplayThread(.waterCycle)
         case .soundVolume:
             return .soundVolume
         case .memoryMatch:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Current Explorer Lab/gameplay work includes:
 - **Angle Cannon / Gravity Artist** — physics prediction and motion intuition
 - **Two-Finger Protractor / Compass Walk** — embodied angles, direction, and measurement
 - **Memory / Mix-Match** — moving from standalone play into embedded recall cards
+- **Reusable five-stage gameplay threads** — countries, fruits, and water cycle now share the same Flashcards → Easy Memory → Flip Memory → Bond Blast → Multiple Choice flow, with direct Explorer Lab entries, score/time summaries, and persisted spaced-repetition progress
 
 Useful specs and research live under `wiki/`, especially:
 
@@ -99,9 +100,15 @@ xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=
 
 CI and workflow work should preserve the security posture documented in `.github/workflows/` and active PRs/issues.
 
+## Release readiness notes
+
+- Issue #912 Slice H polish routes country cards, fruit cards, and water cycle through the reusable gameplay-thread surface.
+- The legacy water-cycle lab route remains intentionally available for explicit legacy/UI-test launches, while Explorer Lab and direct water-cycle launches delegate to `GameplayThreadView`.
+- Release screenshots should cover `-uiTest.startRoute waterCycle`, country cards, and fruit cards on compact phone and iPad layouts once CI/simulator infrastructure is available.
+
 ## Current near-term gaps
 
-- Implement the capability-lane Explorer Lab shell.
+- Continue expanding the capability-lane Explorer Lab shell.
 - Extract reusable Bond Blast-style pairing and Mix-Match recall components.
 - Embed recall cards inside capability lanes instead of keeping Memory Match as a primary standalone play mode.
 - Add play-mode choice: Learn, Explore, Challenge, Timed, Review.

--- a/Tests/MatherTests/GameplayStageViewModelsTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelsTests.swift
@@ -67,3 +67,17 @@ struct GameplayStageViewModelsTests {
         #expect(GameplayStageRenderSupport.cardMinimumWidth(availableWidth: 820, compact: false) == 180)
     }
 }
+
+
+struct GameplayThreadCatalogRegressionTests {
+    @Test
+    func allDirectGameplayEntriesUseFiveStageReusableThread() {
+        let directEntries: [GameplayThreadID] = [.countries, .fruits, .waterCycle]
+
+        for id in directEntries {
+            let thread = GameplayThreadCatalog.thread(for: id)
+            #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+            #expect(!thread.entities.isEmpty)
+        }
+    }
+}

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -114,7 +114,7 @@ final class LabModelsTests: XCTestCase {
         XCTAssertNotEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.numbers))
         XCTAssertEqual(LabActivityID.sumSprint.appRoute, .sumSprint)
         XCTAssertEqual(LabActivityID.shapeGeometry.appRoute, .shapeGeometry)
-        XCTAssertEqual(LabActivityID.waterCycle.appRoute, .waterCycle)
+        XCTAssertEqual(LabActivityID.waterCycle.appRoute, .gameplayThread(.waterCycle))
         XCTAssertEqual(LabActivityID.soundVolume.appRoute, .soundVolume)
         XCTAssertEqual(LabActivityID.memoryMatch.appRoute, .memory)
     }

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -33,7 +33,7 @@ struct LabRouteRegressionTests {
             .gravityArtist: .gravityArtist,
             .compassAngles: .compassAngles,
             .shapeGeometry: .shapeGeometry,
-            .waterCycle: .waterCycle,
+            .waterCycle: .gameplayThread(.waterCycle),
             .soundVolume: .soundVolume,
             .memoryMatch: .memory,
             .countryCards: .gameplayThread(.countries),
@@ -45,6 +45,31 @@ struct LabRouteRegressionTests {
             let expectedRoute = try #require(expectedRoutes[activityID])
             #expect(activityID.appRoute == expectedRoute)
         }
+    }
+
+    @Test
+    func explorerLabContentRoutesUseReusableGameplayThreads() {
+        let reusableThreadRoutes: [LabActivityID: GameplayThreadID] = [
+            .countryCards: .countries,
+            .fruitCards: .fruits,
+            .waterCycle: .waterCycle,
+        ]
+
+        for (activityID, threadID) in reusableThreadRoutes {
+            #expect(activityID.appRoute == .gameplayThread(threadID))
+            #expect(GameplayThreadCatalog.thread(for: threadID).stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+        }
+    }
+
+    @Test
+    func legacyWaterCycleRouteRemainsAvailableButExplorerLabDelegatesToGameplayThread() {
+        let engine = makeEngine()
+
+        engine.showWaterCycle()
+        #expect(engine.route == .gameplayThread(.waterCycle))
+
+        engine.showLegacyWaterCycleLab()
+        #expect(engine.route == .waterCycle)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- routes Water Cycle’s Explorer Lab/direct entry through the reusable five-stage gameplay thread while keeping the legacy Water Cycle lab route available for explicit legacy launches
- polishes gameplay thread completion with persisted per-stage repetition updates, compact controls, score/accuracy/duration summary text, haptics on completion, and flashcard audio replay behavior
- adds regression coverage that countries, fruits, and water cycle all use reusable five-stage gameplay threads, plus release-readiness notes in README

## Validation
- `git diff --check origin/main...HEAD`
- GitHub CI: Build & Test passed
- GitHub CI: Analyze Actions Workflows passed
- GitHub CI: Dependency Review passed
- GitHub CI: CodeQL passed

Refs #912