### PR TITLE
Fix flip memory hidden country matches

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -159,7 +159,18 @@ struct GameplayMatchStageViewModel: Equatable {
 
     func accessibilityLabel(for item: GameplayDisplayItem, side: GameplayMatchSide) -> String {
         let role = side == .left ? "prompt" : "answer"
+        if side == .right && shouldConcealRight(item) {
+            return "hidden \(role) card"
+        }
         return "\(role): \(item.title), \(item.subtitle)"
+    }
+
+    func shouldConcealRight(_ item: GameplayDisplayItem) -> Bool {
+        mode == .flipMemory && !matchedPairIDs.contains(pairID(forRight: item))
+    }
+
+    private func pairID(forRight item: GameplayDisplayItem) -> String {
+        pairs.first(where: { $0.right.id == item.id })?.id ?? item.id
     }
 
     mutating func selectLeft(pairID: String) {

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -58,21 +58,24 @@ struct GameplayDisplayCard: View {
     var showsSubtitle = true
     var selected = false
     var matched = false
+    var concealed = false
 
     var body: some View {
         VStack(spacing: compact ? 6 : 10) {
-            Text(item.visualKey ?? "✦")
-                .font(.system(size: compact ? 40 : 58))
+            Text(concealed ? "?" : item.visualKey ?? "✦")
+                .font(.system(size: compact ? 40 : 58, weight: concealed ? .black : .regular, design: .rounded))
+                .foregroundStyle(concealed ? MatherTheme.accent : MatherTheme.ink)
                 .frame(width: compact ? 64 : 86, height: compact ? 58 : 78)
                 .background(Circle().fill(MatherTheme.softBlue.opacity(0.45)))
-            Text(item.title)
+            Text(concealed ? "Hidden match" : item.title)
                 .font(compact ? .headline.bold() : .title3.bold())
                 .multilineTextAlignment(.center)
                 .foregroundStyle(MatherTheme.ink)
                 .lineLimit(2)
                 .minimumScaleFactor(0.76)
-            if showsSubtitle && !item.subtitle.isEmpty {
-                Text(item.subtitle)
+            let subtitle = concealed ? "Tap to check" : item.subtitle
+            if showsSubtitle && !subtitle.isEmpty {
+                Text(subtitle)
                     .font(.caption.weight(.semibold))
                     .multilineTextAlignment(.center)
                     .foregroundStyle(MatherTheme.ink.opacity(0.68))
@@ -128,7 +131,13 @@ struct GameplayPairingStageShell: View {
                         if correct { actions.success() } else { actions.failure() }
                         if viewModel.isComplete { onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount) }
                     } label: {
-                        GameplayDisplayCard(item: item, compact: compact, showsSubtitle: true, matched: viewModel.matchedPairIDs.contains(pairID(for: item)))
+                        GameplayDisplayCard(
+                            item: item,
+                            compact: compact,
+                            showsSubtitle: true,
+                            matched: viewModel.matchedPairIDs.contains(pairID(for: item)),
+                            concealed: viewModel.shouldConcealRight(item)
+                        )
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(viewModel.accessibilityLabel(for: item, side: .right))

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -60,6 +60,26 @@ struct GameplayStageViewModelTests {
         #expect(viewModel.correctCount == 1)
     }
 
+
+    @Test
+    func flipMemoryConcealsUnmatchedAnswerCardsUntilMatched() {
+        let thread = CountryGameplayThread.thread
+        let stage = thread.stages.first { $0.kind == .flipMemory }!
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 923)
+        var viewModel = GameplayMatchStageViewModel(thread: thread, round: round, mode: .flipMemory)
+        let firstPair = viewModel.pairs[0]
+
+        #expect(viewModel.shouldConcealRight(firstPair.right))
+        #expect(viewModel.accessibilityLabel(for: firstPair.right, side: .right) == "hidden answer card")
+
+        viewModel.selectLeft(pairID: firstPair.id)
+        let didMatch = viewModel.chooseRight(firstPair.right)
+        #expect(didMatch)
+
+        #expect(!viewModel.shouldConcealRight(firstPair.right))
+        #expect(viewModel.accessibilityLabel(for: firstPair.right, side: .right).contains(firstPair.right.title))
+    }
+
     @Test
     func multipleChoiceQuestionsKeepVisibleAnswerAndDeterministicChoices() {
         let thread = GameplaySampleThreads.countries


### PR DESCRIPTION
## Summary
- Conceal unmatched answer cards in Flip Memory behind a generic hidden-match face
- Reveal answer details after the pair is matched so matched progress remains clear
- Add regression coverage for country Flip Memory answer concealment and accessibility

Fixes #923.

## Tests
- `git diff --check`
- Attempted targeted xcodebuild on ganesh-mba, but SSH to ganesh-mba timed out from this environment before the test could start.