### PR TITLE
feat: split Explorer into Labs and Games foundation

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -190,6 +190,101 @@ struct LabActivity: Identifiable, Equatable {
     }
 }
 
+
+enum ExplorerPathID: String, CaseIterable, Hashable, Identifiable {
+    case labs
+    case games
+
+    var id: String { rawValue }
+}
+
+struct ExplorerPathPresentation: Identifiable, Equatable {
+    let id: ExplorerPathID
+    let emoji: String
+    let title: String
+    let subtitle: String
+    let callToAction: String
+
+    static let all: [ExplorerPathPresentation] = [
+        ExplorerPathPresentation(
+            id: .labs,
+            emoji: "🧭",
+            title: "Labs",
+            subtitle: "Guided sessions that move from learning to remembering, playful practice, blast rounds, and score.",
+            callToAction: "Start a learning path"
+        ),
+        ExplorerPathPresentation(
+            id: .games,
+            emoji: "🎮",
+            title: "Games",
+            subtitle: "Jump straight into the games you already love — no staged lesson required.",
+            callToAction: "Play now"
+        ),
+    ]
+}
+
+enum GuidedLabStage: String, CaseIterable, Hashable, Identifiable {
+    case learn = "Learn"
+    case remember = "Remember"
+    case play = "Play"
+    case blast = "Blast"
+    case score = "Score"
+
+    var id: String { rawValue }
+
+    var emoji: String {
+        switch self {
+        case .learn: return "📖"
+        case .remember: return "🧠"
+        case .play: return "🕹️"
+        case .blast: return "🚀"
+        case .score: return "⭐"
+        }
+    }
+
+    var microcopy: String {
+        switch self {
+        case .learn: return "See the idea"
+        case .remember: return "Recall cards"
+        case .play: return "Practice calmly"
+        case .blast: return "Fast round"
+        case .score: return "Celebrate progress"
+        }
+    }
+}
+
+struct GuidedLabPath: Identifiable, Equatable {
+    let laneID: CapabilityLaneID
+    let title: String
+    let subtitle: String
+    let stages: [GuidedLabStage]
+
+    var id: CapabilityLaneID { laneID }
+
+    static let phaseOne: [GuidedLabPath] = [
+        GuidedLabPath(
+            laneID: .numbers,
+            title: "Numbers Path",
+            subtitle: "A first guided loop for number bonds and arrays.",
+            stages: GuidedLabStage.allCases
+        ),
+    ]
+}
+
+struct ExplorerGameEntry: Identifiable, Equatable {
+    let laneID: CapabilityLaneID
+    let activity: LabActivity
+
+    var id: LabActivityID { activity.id }
+    var directRoute: AppRoute { activity.id.appRoute }
+}
+
+enum ExplorerGameRegistry {
+    static let directLaunchEntries: [ExplorerGameEntry] = CapabilityLane.defaultExplorerLanes.flatMap { lane in
+        lane.activities.map { ExplorerGameEntry(laneID: lane.id, activity: $0) }
+    }
+}
+
 enum LabSensorNeed: CaseIterable, Equatable {
     case noSpecialSensor
     case motion

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -5,8 +5,11 @@ struct LabView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Bindable var appModel: AppModel
     @State private var playfulPulse = false
+    @State private var selectedPath: ExplorerPathID = .labs
 
     private let lanes = CapabilityLane.defaultExplorerLanes
+    private let guidedPaths = GuidedLabPath.phaseOne
+    private let gameEntries = ExplorerGameRegistry.directLaunchEntries
 
     var body: some View {
         ZStack {
@@ -19,11 +22,18 @@ struct LabView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: compactGrid ? 16 : 20) {
                         header
+                        pathSelector(compact: compactGrid)
 
-                        LazyVGrid(columns: labColumns(for: proxy.size.width), spacing: compactGrid ? 14 : 16) {
-                            ForEach(lanes) { lane in
-                                laneCard(lane, compact: compactGrid)
+                        if selectedPath == .labs {
+                            guidedLabsIntro(compact: compactGrid)
+
+                            LazyVGrid(columns: labColumns(for: proxy.size.width), spacing: compactGrid ? 14 : 16) {
+                                ForEach(lanes) { lane in
+                                    laneCard(lane, compact: compactGrid)
+                                }
                             }
+                        } else {
+                            directGamesSection(compact: compactGrid, width: proxy.size.width)
                         }
                     }
                     .padding(.horizontal, horizontalPadding)
@@ -80,6 +90,229 @@ struct LabView: View {
                     .frame(width: 56, height: 56)
             }
             .accessibilityLabel("Home")
+        }
+    }
+
+    private func pathSelector(compact: Bool) -> some View {
+        let columns = compact
+            ? [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
+            : [GridItem(.flexible(), spacing: 16), GridItem(.flexible(), spacing: 16)]
+
+        return LazyVGrid(columns: columns, spacing: compact ? 12 : 16) {
+            ForEach(ExplorerPathPresentation.all) { path in
+                Button {
+                    withAnimation(.spring(response: 0.28, dampingFraction: 0.88)) {
+                        selectedPath = path.id
+                    }
+                } label: {
+                    explorerPathCard(path, isSelected: selectedPath == path.id, compact: compact)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Explorer path: \(path.title). \(path.subtitle)")
+                .accessibilityHint(path.callToAction)
+            }
+        }
+    }
+
+    private func explorerPathCard(_ path: ExplorerPathPresentation, isSelected: Bool, compact: Bool) -> some View {
+        let tint = path.id == .labs ? MatherTheme.accent : MatherTheme.warm
+
+        return VStack(alignment: .leading, spacing: compact ? 8 : 10) {
+            HStack(spacing: 10) {
+                Text(path.emoji)
+                    .font(.system(size: compact ? 30 : 38))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(path.title)
+                        .font(.system(size: compact ? 22 : 26, weight: .black, design: .rounded))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text(path.callToAction)
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(tint)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.title3.weight(.black))
+                    .foregroundStyle(tint)
+            }
+
+            Text(path.subtitle)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .lineLimit(compact ? 3 : 2)
+        }
+        .padding(compact ? 12 : 16)
+        .frame(maxWidth: .infinity, minHeight: compact ? 146 : 136, alignment: .topLeading)
+        .background(
+            LinearGradient(
+                colors: [tint.opacity(isSelected ? 0.18 : 0.08), MatherTheme.card],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            ),
+            in: RoundedRectangle(cornerRadius: 22, style: .continuous)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .stroke(tint.opacity(isSelected ? 0.50 : 0.16), lineWidth: isSelected ? 2 : 1)
+        )
+    }
+
+    private func guidedLabsIntro(compact: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Labs build in stages")
+                        .font(.title3.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text("Learn → Remember → Play → Blast → Score")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(MatherTheme.accent)
+                }
+                Spacer(minLength: 0)
+            }
+
+            stageStrip(compact: compact)
+
+            ForEach(guidedPaths) { path in
+                guidedPathCard(path)
+            }
+        }
+        .padding(16)
+        .background(MatherTheme.card.opacity(0.86), in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .stroke(MatherTheme.accent.opacity(0.18), lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+    }
+
+    private func stageStrip(compact: Bool) -> some View {
+        let columns = Array(repeating: GridItem(.flexible(), spacing: compact ? 6 : 8), count: compact ? 3 : 5)
+        return LazyVGrid(columns: columns, spacing: compact ? 6 : 8) {
+            ForEach(GuidedLabStage.allCases) { stage in
+                VStack(spacing: 4) {
+                    Text(stage.emoji)
+                        .font(.title3)
+                    Text(stage.rawValue)
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text(stage.microcopy)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                }
+                .padding(8)
+                .frame(maxWidth: .infinity, minHeight: 82)
+                .background(MatherTheme.panel.opacity(0.62), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            }
+        }
+    }
+
+    private func guidedPathCard(_ path: GuidedLabPath) -> some View {
+        let lane = lanes.first { $0.id == path.laneID }
+        let tint = laneColor(path.laneID)
+
+        return Button {
+            appModel.engine.showLabLane(path.laneID)
+        } label: {
+            HStack(spacing: 12) {
+                Text(lane?.emoji ?? "🧪")
+                    .font(.system(size: 34))
+                    .frame(width: 58, height: 58)
+                    .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(path.title)
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text(path.subtitle)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                    Text(path.stages.map(\.rawValue).joined(separator: " → "))
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(tint)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right.circle.fill")
+                    .font(.title3.weight(.black))
+                    .foregroundStyle(tint)
+            }
+            .padding(12)
+            .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Open \(path.title). \(path.subtitle). Stages: \(path.stages.map(\.rawValue).joined(separator: ", "))")
+    }
+
+    private func directGamesSection(compact: Bool, width: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Games")
+                    .font(.title3.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text("Direct launch stays one tap away. Pick any game without entering a staged lab session.")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
+
+            LazyVGrid(columns: labColumns(for: width), spacing: compact ? 12 : 14) {
+                ForEach(gameEntries) { entry in
+                    directGameCard(entry)
+                }
+            }
+        }
+    }
+
+    private func directGameCard(_ entry: ExplorerGameEntry) -> some View {
+        let tint = laneColor(entry.laneID)
+        let activity = entry.activity
+
+        return Button {
+            launchDirectGame(entry)
+        } label: {
+            HStack(spacing: 12) {
+                Text(activity.emoji)
+                    .font(.system(size: 36))
+                    .frame(width: 62, height: 62)
+                    .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(activity.title)
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                        .lineLimit(2)
+                    Text(activity.tagline)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .lineLimit(2)
+                    Text("Direct game")
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(tint)
+                }
+                Spacer(minLength: 0)
+                Image(systemName: "play.circle.fill")
+                    .font(.title2.weight(.black))
+                    .foregroundStyle(tint)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, minHeight: 116, alignment: .leading)
+            .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .stroke(tint.opacity(0.16), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Launch game \(activity.title). \(activity.tagline)")
+        .accessibilityHint("Directly starts the existing game route without a staged lab session.")
+    }
+
+    private func launchDirectGame(_ entry: ExplorerGameEntry) {
+        appModel.pickProfileThenRun {
+            appModel.engine.show(entry.directRoute)
+            if entry.activity.id == .sumSprint {
+                appModel.sumSprintEngine.showDifficultyPick()
+            }
         }
     }
 

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -119,6 +119,53 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(LabActivityID.memoryMatch.appRoute, .memory)
     }
 
+    func testExplorerPathSplitKeepsLabsAndGamesAsTopLevelChoices() {
+        XCTAssertEqual(ExplorerPathID.allCases, [.labs, .games])
+        XCTAssertEqual(ExplorerPathPresentation.all.map(\.id), [.labs, .games])
+
+        let labs = ExplorerPathPresentation.all[0]
+        let games = ExplorerPathPresentation.all[1]
+
+        XCTAssertEqual(labs.title, "Labs")
+        XCTAssertTrue(labs.subtitle.contains("Guided sessions"))
+        XCTAssertEqual(labs.callToAction, "Start a learning path")
+
+        XCTAssertEqual(games.title, "Games")
+        XCTAssertTrue(games.subtitle.contains("Jump straight into"))
+        XCTAssertEqual(games.callToAction, "Play now")
+    }
+
+    func testPhaseOneGuidedLabPathShowsStagedLearningLoop() throws {
+        let path = try XCTUnwrap(GuidedLabPath.phaseOne.first)
+
+        XCTAssertEqual(path.laneID, .numbers)
+        XCTAssertEqual(path.title, "Numbers Path")
+        XCTAssertEqual(path.stages, [.learn, .remember, .play, .blast, .score])
+        XCTAssertEqual(path.stages.map(\.rawValue).joined(separator: " → "), "Learn → Remember → Play → Blast → Score")
+        XCTAssertEqual(GuidedLabStage.allCases.map(\.microcopy), [
+            "See the idea",
+            "Recall cards",
+            "Practice calmly",
+            "Fast round",
+            "Celebrate progress",
+        ])
+    }
+
+    func testExplorerGamesRegistryDirectlyLaunchesEveryCurrentExplorerActivity() {
+        let expectedEntries = CapabilityLane.defaultExplorerLanes.flatMap { lane in
+            lane.activities.map { (laneID: lane.id, activityID: $0.id, route: $0.id.appRoute) }
+        }
+        let entries = ExplorerGameRegistry.directLaunchEntries
+
+        XCTAssertEqual(entries.map(\.laneID), expectedEntries.map { $0.laneID })
+        XCTAssertEqual(entries.map { $0.activity.id }, expectedEntries.map { $0.activityID })
+        XCTAssertEqual(entries.map(\.directRoute), expectedEntries.map { $0.route })
+        XCTAssertEqual(Set(entries.map(\.id)).count, entries.count)
+        XCTAssertTrue(entries.contains { $0.activity.id == .sumSprint && $0.directRoute == .sumSprint })
+        XCTAssertTrue(entries.contains { $0.activity.id == .waterCycle && $0.directRoute == .gameplayThread(.waterCycle) })
+        XCTAssertTrue(entries.contains { $0.activity.id == .memoryMatch && $0.directRoute == .memory })
+    }
+
 }
 
 extension LabModelsTests {


### PR DESCRIPTION
## Summary
- Adds a first Explorer foundation split with two top-level paths: **Labs** and **Games**.
- Keeps Labs as the guided mastery path and introduces the visible `Learn → Remember → Play → Blast → Score` stage strip plus a Phase 1 Numbers Path entry.
- Adds a Games path that directly launches existing Explorer activities through a shared registry, preserving instant/free play without forcing a staged session.
- Adds model tests covering the Labs/Games split, staged learning loop, and direct-game registry routes.

## Phase 1 scope
This is intentionally a foundation PR for #927, not the whole epic. Follow-ups still needed:
- complete end-to-end Lab session orchestration and score screen
- shared per-stage timing policies
- reusable Remember/Bond Blast stage plumbing
- deeper age/readiness gates and visual asset pass

## Validation
- `git diff --check` ✅
- Attempted targeted Xcode validation on `ganesh-mba` with `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' -only-testing:MatherTests/LabModelsTests`; blocked by the checked-in/stale Xcode project path hitting an existing Swift compiler crash in `SettingsView.swift` before Lab files/tests compiled. CI regenerates the project with `xcodegen generate`, so PR CI should be the authoritative gate.

Closes #927 when the umbrella accepts Phase 1 as sufficient; otherwise this references #927 as the first implementation slice.
