### PR TITLE
feat: add Numbers Lab staged session plan

### DIFF
--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -13,6 +13,10 @@ struct LabLaneDetailView: View {
         CapabilityLane.defaultExplorerLanes.first { $0.id == laneID } ?? CapabilityLane.defaultExplorerLanes[0]
     }
 
+    private var sessionPlans: [LabConceptSessionPlan] {
+        GuidedLabPath.phaseOne.first { $0.laneID == laneID }?.sessionPlans ?? []
+    }
+
     var body: some View {
         let selectedLane = lane
         let tint = laneColor(selectedLane.id)
@@ -24,6 +28,7 @@ struct LabLaneDetailView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                     header(selectedLane, presentation: presentation, progress: progress, tint: tint)
+                    guidedSessionSection(tint: tint)
                     gamesSection(selectedLane, tint: tint)
                     supportPanel(selectedLane, progress: progress, tint: tint)
                     researchQuestSection(selectedLane, tint: tint)
@@ -174,6 +179,112 @@ struct LabLaneDetailView: View {
         .frame(maxWidth: .infinity, minHeight: 88, alignment: .topLeading)
         .padding(10)
         .background(tint.opacity(0.10), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    @ViewBuilder
+    private func guidedSessionSection(tint: Color) -> some View {
+        if !sessionPlans.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top, spacing: 10) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Guided path")
+                            .font(.title3.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text("Learn → Remember → Play → Blast → Score")
+                            .font(.caption.weight(.black))
+                            .foregroundStyle(tint)
+                    }
+                    Spacer(minLength: 0)
+                }
+
+                ForEach(sessionPlans) { plan in
+                    conceptSessionPlanCard(plan, tint: tint)
+                }
+            }
+            .padding(14)
+            .background(MatherTheme.card.opacity(0.86), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(tint.opacity(0.18), lineWidth: 1)
+            )
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Guided path for \(lane.title).")
+        }
+    }
+
+    private func conceptSessionPlanCard(_ plan: LabConceptSessionPlan, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(plan.title)
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text(plan.subtitle)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("\(plan.masteryStateLabel) • \(plan.estimatedLength) • Next: \(plan.recommendedNextActivity)")
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(tint)
+                }
+
+                Spacer(minLength: 0)
+
+                Button {
+                    start(plan)
+                } label: {
+                    Label(plan.startAffordanceLabel, systemImage: "play.fill")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(tint, in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Start \(plan.title)")
+                .accessibilityHint("Opens the first available stage. Games remain directly playable below.")
+            }
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 132), spacing: 8)], spacing: 8) {
+                ForEach(plan.stages) { stage in
+                    stagePlanCard(stage, tint: tint)
+                }
+            }
+        }
+        .padding(12)
+        .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(plan.title). \(plan.pathLabel).")
+    }
+
+    private func stagePlanCard(_ stage: LabSessionStagePlan, tint: Color) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text(stage.stage.emoji)
+                Text(stage.stage.rawValue)
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Spacer(minLength: 0)
+            }
+            Text(stage.title)
+                .font(.caption.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            Text(stage.childCopy)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .lineLimit(3)
+                .minimumScaleFactor(0.75)
+            Text(stage.timerPolicy.childCopy)
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(tint)
+                .lineLimit(2)
+                .minimumScaleFactor(0.72)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, minHeight: 138, alignment: .topLeading)
+        .background(MatherTheme.card.opacity(0.78), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(stage.accessibilityLabel)
     }
 
     private func gamesSection(_ lane: CapabilityLane, tint: Color) -> some View {
@@ -577,6 +688,19 @@ struct LabLaneDetailView: View {
             return "camera.viewfinder"
         case .haptics:
             return "waveform"
+        }
+    }
+
+    private func start(_ plan: LabConceptSessionPlan) {
+        guard let route = plan.startRoute else { return }
+        appModel.pickProfileThenRun {
+            if plan.id == LabConceptSessionPlan.numbersNumberBondsTo10.id {
+                appModel.engine.updateConfig(problemCount: 4, minTarget: 1, maxTarget: 10)
+            }
+            appModel.engine.show(route)
+            if route == .sumSprint {
+                appModel.sumSprintEngine.showDifficultyPick()
+            }
         }
     }
 

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -253,20 +253,163 @@ enum GuidedLabStage: String, CaseIterable, Hashable, Identifiable {
     }
 }
 
+enum LabSessionTimerPressure: String, Equatable {
+    case trackedOnly
+    case none
+    case readinessGated
+}
+
+struct LabSessionTimerPolicy: Equatable {
+    let pressure: LabSessionTimerPressure
+    let tracksElapsedTime: Bool
+    let showsCountdown: Bool
+    let isPunitive: Bool
+    let childCopy: String
+
+    static let learnTrackedOnly = LabSessionTimerPolicy(
+        pressure: .trackedOnly,
+        tracksElapsedTime: true,
+        showsCountdown: false,
+        isPunitive: false,
+        childCopy: "No rush — I’ll just remember how long you explored."
+    )
+
+    static let calmNoCountdown = LabSessionTimerPolicy(
+        pressure: .none,
+        tracksElapsedTime: true,
+        showsCountdown: false,
+        isPunitive: false,
+        childCopy: "Take your time. Memory grows with calm practice."
+    )
+
+    static let readinessGatedBlast = LabSessionTimerPolicy(
+        pressure: .readinessGated,
+        tracksElapsedTime: true,
+        showsCountdown: false,
+        isPunitive: false,
+        childCopy: "Blast is a celebration after you feel ready — not a test."
+    )
+}
+
+struct LabSessionStagePlan: Identifiable, Equatable {
+    let stage: GuidedLabStage
+    let title: String
+    let childCopy: String
+    let parentCopy: String
+    let timerPolicy: LabSessionTimerPolicy
+    let route: AppRoute?
+
+    var id: GuidedLabStage { stage }
+
+    var actionLabel: String {
+        route == nil ? "Preview" : (stage == .learn ? "Start" : "Continue")
+    }
+
+    var accessibilityLabel: String {
+        "\(stage.rawValue). \(title). \(childCopy)"
+    }
+}
+
+struct LabConceptSessionPlan: Identifiable, Equatable {
+    let id: String
+    let laneID: CapabilityLaneID
+    let title: String
+    let subtitle: String
+    let estimatedLength: String
+    let masteryStateLabel: String
+    let recommendedNextActivity: String
+    let stages: [LabSessionStagePlan]
+
+    var stageOrder: [GuidedLabStage] { stages.map(\.stage) }
+    var startRoute: AppRoute? { stages.first(where: { $0.route != nil })?.route }
+    var startAffordanceLabel: String { "Start" }
+    var continueAffordanceLabel: String { "Continue" }
+    var pathLabel: String { stageOrder.map(\.rawValue).joined(separator: " → ") }
+
+    static let numbersNumberBondsTo10 = LabConceptSessionPlan(
+        id: "numbers-number-bonds-to-10",
+        laneID: .numbers,
+        title: "Number Bonds to 10",
+        subtitle: "Build pairs that make ten, remember friendly facts, then celebrate with Bond Blast.",
+        estimatedLength: "8–10 min",
+        masteryStateLabel: "Recommended first",
+        recommendedNextActivity: "Make & Break warm-up",
+        stages: [
+            LabSessionStagePlan(
+                stage: .learn,
+                title: "Build ten",
+                childCopy: "Move counters and see two parts make one ten.",
+                parentCopy: "Concrete/pictorial discovery before symbols; elapsed time is tracked only.",
+                timerPolicy: .learnTrackedOnly,
+                route: .sessionConfig
+            ),
+            LabSessionStagePlan(
+                stage: .remember,
+                title: "Bring pairs back",
+                childCopy: "Use friendly picture clues to remember ten pairs.",
+                parentCopy: "Soft retrieval with visual support; no punitive countdown.",
+                timerPolicy: .calmNoCountdown,
+                route: .memory
+            ),
+            LabSessionStagePlan(
+                stage: .play,
+                title: "Try it for real",
+                childCopy: "Practice bonds inside playful number games.",
+                parentCopy: "Application stays calm before any readiness-gated speed round.",
+                timerPolicy: .calmNoCountdown,
+                route: .sumSprint
+            ),
+            LabSessionStagePlan(
+                stage: .blast,
+                title: "Bond Blast",
+                childCopy: "A rocket round appears when you’re ready to celebrate.",
+                parentCopy: "Blast is celebratory and readiness gated; countdown pressure is not default.",
+                timerPolicy: .readinessGatedBlast,
+                route: nil
+            ),
+            LabSessionStagePlan(
+                stage: .score,
+                title: "Spark score",
+                childCopy: "See what grew and pick the next tiny quest.",
+                parentCopy: "Child score stays encouraging; richer analytics can live in parent detail later.",
+                timerPolicy: .calmNoCountdown,
+                route: nil
+            ),
+        ]
+    )
+}
+
 struct GuidedLabPath: Identifiable, Equatable {
     let laneID: CapabilityLaneID
     let title: String
     let subtitle: String
     let stages: [GuidedLabStage]
+    let sessionPlans: [LabConceptSessionPlan]
 
     var id: CapabilityLaneID { laneID }
+    var primaryPlan: LabConceptSessionPlan? { sessionPlans.first }
+
+    init(
+        laneID: CapabilityLaneID,
+        title: String,
+        subtitle: String,
+        stages: [GuidedLabStage],
+        sessionPlans: [LabConceptSessionPlan] = []
+    ) {
+        self.laneID = laneID
+        self.title = title
+        self.subtitle = subtitle
+        self.stages = stages
+        self.sessionPlans = sessionPlans
+    }
 
     static let phaseOne: [GuidedLabPath] = [
         GuidedLabPath(
             laneID: .numbers,
             title: "Numbers Path",
-            subtitle: "A first guided loop for number bonds and arrays.",
-            stages: GuidedLabStage.allCases
+            subtitle: "A first guided loop for Number Bonds to 10.",
+            stages: LabConceptSessionPlan.numbersNumberBondsTo10.stageOrder,
+            sessionPlans: [.numbersNumberBondsTo10]
         ),
     ]
 }

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -227,6 +227,13 @@ struct LabView: View {
                     Text(path.subtitle)
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(MatherTheme.cardSubtitle)
+                    if let primaryPlan = path.primaryPlan {
+                        Text("First quest: \(primaryPlan.title) • \(primaryPlan.estimatedLength)")
+                            .font(.caption2.weight(.black))
+                            .foregroundStyle(tint)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.72)
+                    }
                     Text(path.stages.map(\.rawValue).joined(separator: " → "))
                         .font(.caption2.weight(.black))
                         .foregroundStyle(tint)

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -151,6 +151,72 @@ final class LabModelsTests: XCTestCase {
         ])
     }
 
+
+    func testNumbersLabNumberBondsPlanDefinesReusableStageOrder() throws {
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+
+        XCTAssertEqual(plan.id, "numbers-number-bonds-to-10")
+        XCTAssertEqual(plan.laneID, .numbers)
+        XCTAssertEqual(plan.title, "Number Bonds to 10")
+        XCTAssertEqual(plan.stageOrder, [.learn, .remember, .play, .blast, .score])
+        XCTAssertEqual(plan.pathLabel, "Learn → Remember → Play → Blast → Score")
+        XCTAssertEqual(plan.startRoute, .sessionConfig)
+        XCTAssertEqual(plan.startAffordanceLabel, "Start")
+        XCTAssertEqual(plan.continueAffordanceLabel, "Continue")
+    }
+
+    func testNumbersLabStageTimerPoliciesStayChildSafe() throws {
+        let stages = Dictionary(
+            uniqueKeysWithValues: LabConceptSessionPlan.numbersNumberBondsTo10.stages.map { ($0.stage, $0) }
+        )
+
+        let learn = try XCTUnwrap(stages[.learn])
+        XCTAssertEqual(learn.timerPolicy.pressure, .trackedOnly)
+        XCTAssertTrue(learn.timerPolicy.tracksElapsedTime)
+        XCTAssertFalse(learn.timerPolicy.showsCountdown)
+        XCTAssertFalse(learn.timerPolicy.isPunitive)
+        XCTAssertTrue(learn.timerPolicy.childCopy.contains("No rush"))
+
+        let remember = try XCTUnwrap(stages[.remember])
+        XCTAssertEqual(remember.timerPolicy.pressure, .none)
+        XCTAssertTrue(remember.timerPolicy.tracksElapsedTime)
+        XCTAssertFalse(remember.timerPolicy.showsCountdown)
+        XCTAssertFalse(remember.timerPolicy.isPunitive)
+        XCTAssertTrue(remember.parentCopy.contains("no punitive countdown"))
+
+        let blast = try XCTUnwrap(stages[.blast])
+        XCTAssertEqual(blast.timerPolicy.pressure, .readinessGated)
+        XCTAssertFalse(blast.timerPolicy.showsCountdown)
+        XCTAssertFalse(blast.timerPolicy.isPunitive)
+        XCTAssertTrue(blast.childCopy.contains("when you’re ready"))
+        XCTAssertTrue(blast.parentCopy.contains("readiness gated"))
+    }
+
+    func testNumbersPathCarriesNumberBondsPlanPresentationCopy() throws {
+        let path = try XCTUnwrap(GuidedLabPath.phaseOne.first { $0.laneID == .numbers })
+        let plan = try XCTUnwrap(path.primaryPlan)
+
+        XCTAssertEqual(path.title, "Numbers Path")
+        XCTAssertTrue(path.subtitle.contains("Number Bonds to 10"))
+        XCTAssertEqual(path.stages, plan.stageOrder)
+        XCTAssertEqual(plan.subtitle, "Build pairs that make ten, remember friendly facts, then celebrate with Bond Blast.")
+        XCTAssertEqual(plan.estimatedLength, "8–10 min")
+        XCTAssertEqual(plan.masteryStateLabel, "Recommended first")
+        XCTAssertEqual(plan.recommendedNextActivity, "Make & Break warm-up")
+        XCTAssertTrue(plan.stages.allSatisfy { !$0.accessibilityLabel.isEmpty })
+        XCTAssertEqual(plan.stages.map(\.actionLabel), ["Start", "Continue", "Continue", "Preview", "Preview"])
+    }
+
+    func testNumbersLabPlanDoesNotChangeDirectGamesRegistry() {
+        let entries = ExplorerGameRegistry.directLaunchEntries
+        let entryIDs = entries.map(\.activity.id)
+
+        XCTAssertEqual(entryIDs, CapabilityLane.defaultExplorerLanes.flatMap { $0.activities.map(\.id) })
+        XCTAssertEqual(entries.first { $0.activity.id == .sumSprint }?.directRoute, .sumSprint)
+        XCTAssertEqual(entries.first { $0.activity.id == .rectangleFactory }?.directRoute, .rectangleFactory)
+        XCTAssertEqual(entries.first { $0.activity.id == .factoryCards }?.directRoute, .factoryCards)
+    }
+
     func testExplorerGamesRegistryDirectlyLaunchesEveryCurrentExplorerActivity() {
         let expectedEntries = CapabilityLane.defaultExplorerLanes.flatMap { lane in
             lane.activities.map { (laneID: lane.id, activityID: $0.id, route: $0.id.appRoute) }


### PR DESCRIPTION
## Summary
- Adds a reusable Lab session plan foundation for **Numbers Lab: Number Bonds to 10**.
- Defines staged Learn → Remember → Play → Blast → Score model data with child-safe timer-pressure policies.
- Surfaces the Numbers guided plan in Lab detail UI with stage cards and a Start affordance that routes into the existing Make & Break/VS1 entry point.
- Keeps direct Games launch registry unchanged.

## Validation
- `git diff --check` ✅
- Added model tests covering stage order, timer policy guardrails, presentation copy, and unchanged direct-game routes.
- Attempted targeted Xcode validation on `ganesh-mba`; the checked-in/stale project hit the existing Swift compiler crash in `Features/ParentSummary/SettingsView.swift` before reaching the new Lab tests. CI regenerates the Xcode project with XcodeGen and remains the authoritative gate.

## Remaining #927 slices
- Shared round timer + persisted session score
- Reusable Remember stage runner/decks
- Reusable Bond Blast finale variants
- Full Lab session runner/resume flow
- Sensor fallback/permission policy UI
- Graphics/assets pass

Refs #927
