### PR TITLE
Add lab round timer and session score foundation

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -111,7 +111,7 @@ struct LaneRecallReviewAction: Equatable {
     let isCorrect: Bool
 }
 
-enum LabActivityID: String, CaseIterable, Hashable {
+enum LabActivityID: String, CaseIterable, Codable, Hashable {
     case sumSprint
     case roomQuest
     case symmetryFold
@@ -223,7 +223,7 @@ struct ExplorerPathPresentation: Identifiable, Equatable {
     ]
 }
 
-enum GuidedLabStage: String, CaseIterable, Hashable, Identifiable {
+enum GuidedLabStage: String, CaseIterable, Codable, Hashable, Identifiable {
     case learn = "Learn"
     case remember = "Remember"
     case play = "Play"
@@ -250,6 +250,141 @@ enum GuidedLabStage: String, CaseIterable, Hashable, Identifiable {
         case .blast: return "Fast round"
         case .score: return "Celebrate progress"
         }
+    }
+}
+
+
+enum RoundTimerPressurePolicy: String, CaseIterable, Codable, Equatable, Hashable {
+    case trackedOnly
+    case visibleElapsed
+    case personalBest
+    case countdownChallenge
+
+    var usesCountdownPressure: Bool { self == .countdownChallenge }
+}
+
+struct RoundTimer: Identifiable, Codable, Equatable, Hashable {
+    let id: String
+    let stage: GuidedLabStage
+    let startedAt: Date
+    private(set) var endedAt: Date?
+    let targetDuration: TimeInterval?
+    let pressurePolicy: RoundTimerPressurePolicy
+
+    init(
+        id: String = UUID().uuidString,
+        stage: GuidedLabStage,
+        startedAt: Date,
+        endedAt: Date? = nil,
+        targetDuration: TimeInterval? = nil,
+        pressurePolicy: RoundTimerPressurePolicy = .trackedOnly
+    ) {
+        self.id = id
+        self.stage = stage
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.targetDuration = targetDuration.map { max(0, $0) }
+        self.pressurePolicy = pressurePolicy
+    }
+
+    var isComplete: Bool { endedAt != nil }
+    var allowsCountdownPressure: Bool { pressurePolicy.usesCountdownPressure }
+
+    func elapsed(at now: Date = Date()) -> TimeInterval {
+        let effectiveEnd = endedAt ?? now
+        return max(0, effectiveEnd.timeIntervalSince(startedAt))
+    }
+
+    func remaining(at now: Date = Date()) -> TimeInterval? {
+        guard let targetDuration else { return nil }
+        return max(0, targetDuration - elapsed(at: now))
+    }
+
+    func completed(at date: Date) -> RoundTimer {
+        var copy = self
+        copy.endedAt = date
+        return copy
+    }
+}
+
+struct SessionScoreRecommendation: Codable, Equatable, Hashable {
+    let title: String
+    let detail: String
+}
+
+struct SessionScore: Identifiable, Codable, Equatable, Hashable {
+    let id: UUID
+    let laneID: CapabilityLaneID?
+    let activityID: LabActivityID?
+    let stageTimers: [RoundTimer]
+    let correctCount: Int
+    let mistakeCount: Int
+    let streak: Int
+    let mastery: ConceptConfidence
+    let weakAreas: [ConceptId]
+    let recommendedNextActivity: SessionScoreRecommendation?
+
+    init(
+        id: UUID = UUID(),
+        laneID: CapabilityLaneID? = nil,
+        activityID: LabActivityID? = nil,
+        stageTimers: [RoundTimer],
+        correctCount: Int,
+        mistakeCount: Int,
+        streak: Int = 0,
+        mastery: ConceptConfidence = .introduced,
+        weakAreas: [ConceptId] = [],
+        recommendedNextActivity: SessionScoreRecommendation? = nil
+    ) {
+        self.id = id
+        self.laneID = laneID
+        self.activityID = activityID
+        self.stageTimers = stageTimers
+        self.correctCount = max(0, correctCount)
+        self.mistakeCount = max(0, mistakeCount)
+        self.streak = max(0, streak)
+        self.mastery = mastery
+        self.weakAreas = weakAreas
+        self.recommendedNextActivity = recommendedNextActivity
+    }
+
+    var attemptedCount: Int { correctCount + mistakeCount }
+    var totalTime: TimeInterval { stageTimers.reduce(0) { $0 + $1.elapsed() } }
+
+    var stageTimes: [GuidedLabStage: TimeInterval] {
+        stageTimers.reduce(into: [:]) { partial, timer in
+            partial[timer.stage, default: 0] += timer.elapsed()
+        }
+    }
+
+    var accuracy: Double {
+        guard attemptedCount > 0 else { return 0 }
+        return Double(correctCount) / Double(attemptedCount)
+    }
+
+    var totalScore: Int {
+        max(0, correctCount * 10 + streak * 2 - mistakeCount * 4)
+    }
+
+    var childCelebrationLabel: String {
+        if mastery >= .steady { return "You powered up this idea!" }
+        if attemptedCount == 0 { return "Session saved — come back when you're ready." }
+        return "Nice practice — tricky parts can come back soon."
+    }
+
+    var formattedAccuracy: String {
+        "\(Int((accuracy * 100).rounded()))%"
+    }
+
+    var formattedTotalTime: String {
+        Self.formatDuration(totalTime)
+    }
+
+    static func formatDuration(_ duration: TimeInterval) -> String {
+        let seconds = max(0, Int(duration.rounded()))
+        let minutes = seconds / 60
+        let remainingSeconds = seconds % 60
+        return minutes > 0 ? "\(minutes)m \(remainingSeconds)s" : "\(remainingSeconds)s"
     }
 }
 

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -166,6 +166,55 @@ final class LabModelsTests: XCTestCase {
         XCTAssertTrue(entries.contains { $0.activity.id == .memoryMatch && $0.directRoute == .memory })
     }
 
+    func testRoundTimerTracksElapsedTimeWithoutDefaultPressure() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        let now = Date(timeIntervalSince1970: 1_075)
+        let timer = RoundTimer(stage: .learn, startedAt: start, targetDuration: 90)
+
+        XCTAssertEqual(timer.elapsed(at: now), 75)
+        XCTAssertEqual(timer.remaining(at: now), 15)
+        XCTAssertFalse(timer.isComplete)
+        XCTAssertFalse(timer.allowsCountdownPressure)
+        XCTAssertEqual(timer.pressurePolicy, .trackedOnly)
+    }
+
+    func testRoundTimerCompletionClampsNegativeElapsedTime() {
+        let start = Date(timeIntervalSince1970: 200)
+        let earlier = Date(timeIntervalSince1970: 150)
+        let timer = RoundTimer(stage: .remember, startedAt: start).completed(at: earlier)
+
+        XCTAssertTrue(timer.isComplete)
+        XCTAssertEqual(timer.elapsed(at: Date(timeIntervalSince1970: 250)), 0)
+    }
+
+    func testSessionScoreAggregatesStageTimesAndChildSafeSummary() {
+        let timers = [
+            RoundTimer(stage: .learn, startedAt: Date(timeIntervalSince1970: 0)).completed(at: Date(timeIntervalSince1970: 60)),
+            RoundTimer(stage: .remember, startedAt: Date(timeIntervalSince1970: 60)).completed(at: Date(timeIntervalSince1970: 90)),
+            RoundTimer(stage: .blast, startedAt: Date(timeIntervalSince1970: 90), pressurePolicy: .personalBest).completed(at: Date(timeIntervalSince1970: 105)),
+        ]
+        let score = SessionScore(
+            laneID: .numbers,
+            activityID: .sumSprint,
+            stageTimers: timers,
+            correctCount: 9,
+            mistakeCount: 1,
+            streak: 4,
+            mastery: .steady,
+            weakAreas: ["number-bond-8"]
+        )
+
+        XCTAssertEqual(score.totalTime, 105)
+        XCTAssertEqual(score.stageTimes[.learn], 60)
+        XCTAssertEqual(score.stageTimes[.remember], 30)
+        XCTAssertEqual(score.stageTimes[.blast], 15)
+        XCTAssertEqual(score.accuracy, 0.9)
+        XCTAssertEqual(score.formattedAccuracy, "90%")
+        XCTAssertEqual(score.formattedTotalTime, "1m 45s")
+        XCTAssertEqual(score.totalScore, 94)
+        XCTAssertEqual(score.childCelebrationLabel, "You powered up this idea!")
+    }
+
 }
 
 extension LabModelsTests {


### PR DESCRIPTION
## Summary
- Adds reusable `RoundTimer` model for Guided Lab stages with start/end tracking, target duration, remaining time, and explicit pressure policy.
- Adds reusable `SessionScore` model for Lab/Games session summaries: total/per-stage time, accuracy, streak, mastery band, weak areas, recommendation fields, and child-safe summary labels.
- Adds model tests for timer elapsed/remaining behavior, no-pressure defaults, completion clamping, score aggregation, formatting, accuracy, and score labels.

## Links
- Parent: #927
- Child: #929

## Test notes
- `git diff --check` passes locally.
- Attempted remote validation on `ganesh-mba` with:
  `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:MatherTests/LabModelsTests CODE_SIGNING_ALLOWED=NO`
- Build did not reach these tests because Swift 6.3.1 crashed while type-checking existing `Features/ParentSummary/SettingsView.swift` in a clean temp checkout. The crash is outside this slice; no diagnostics pointed at the changed files.
