### PR TITLE
feat: add Numbers Lab staged quest foundation

### DIFF
--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -322,6 +322,11 @@ struct LabLaneDetailView: View {
                         .foregroundStyle(MatherTheme.ink)
                         .lineLimit(2)
                         .minimumScaleFactor(0.82)
+                    Text(activity.tagline)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .lineLimit(2)
+                    sensorAffordanceRow(activity, tint: tint)
                 }
 
                 Spacer(minLength: 6)

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -414,6 +414,73 @@ struct GuidedLabPath: Identifiable, Equatable {
     ]
 }
 
+struct RoundTimerSnapshot: Equatable {
+    let startedAt: Date
+    let now: Date
+    let limitSeconds: TimeInterval?
+    let timerPolicy: LabSessionTimerPolicy
+
+    init(startedAt: Date, now: Date, limitSeconds: TimeInterval? = nil, timerPolicy: LabSessionTimerPolicy) {
+        self.startedAt = startedAt
+        self.now = now
+        self.limitSeconds = limitSeconds
+        self.timerPolicy = timerPolicy
+    }
+
+    var elapsedSeconds: TimeInterval {
+        max(0, now.timeIntervalSince(startedAt))
+    }
+
+    var remainingSeconds: TimeInterval? {
+        guard timerPolicy.showsCountdown, let limitSeconds else { return nil }
+        return max(0, limitSeconds - elapsedSeconds)
+    }
+
+    var childFacingLabel: String {
+        if let remainingSeconds {
+            return "Final round: \(Self.format(remainingSeconds)) left"
+        }
+        return "Time spent: \(Self.format(elapsedSeconds))"
+    }
+
+    static func format(_ seconds: TimeInterval) -> String {
+        let clamped = max(0, Int(seconds.rounded()))
+        return "\(clamped / 60):" + String(format: "%02d", clamped % 60)
+    }
+}
+
+struct LabSessionScoreSummary: Equatable {
+    let conceptTitle: String
+    let stageDurations: [GuidedLabStage: TimeInterval]
+    let accuracy: Double
+    let streak: Int
+    let weakAreas: [String]
+    let nextRecommendation: String
+
+    var totalSeconds: TimeInterval {
+        stageDurations.values.reduce(0, +)
+    }
+
+    var childCelebrationLine: String {
+        if weakAreas.isEmpty {
+            return "Session Complete 🎉 You powered up \(conceptTitle)!"
+        }
+        return "Session Complete 🎉 \(weakAreas.count) tricky \(weakAreas.count == 1 ? "idea" : "ideas") will come back soon."
+    }
+
+    var parentDetailLines: [String] {
+        [
+            "Total time: \(RoundTimerSnapshot.format(totalSeconds))",
+            "Accuracy: \(Int((accuracy * 100).rounded()))%",
+            "Best streak: \(streak)",
+            "Next: \(nextRecommendation)",
+        ] + GuidedLabStage.allCases.compactMap { stage in
+            guard let seconds = stageDurations[stage] else { return nil }
+            return "\(stage.rawValue): \(RoundTimerSnapshot.format(seconds))"
+        } + (weakAreas.isEmpty ? ["Weak areas: none flagged"] : ["Coming back soon: \(weakAreas.joined(separator: ", "))"])
+    }
+}
+
 struct ExplorerGameEntry: Identifiable, Equatable {
     let laneID: CapabilityLaneID
     let activity: LabActivity

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -217,6 +217,39 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(entries.first { $0.activity.id == .factoryCards }?.directRoute, .factoryCards)
     }
 
+
+    func testRoundTimerFoundationTracksTimeWithoutDefaultPressure() {
+        let startedAt = Date(timeIntervalSince1970: 100)
+        let now = Date(timeIntervalSince1970: 175)
+        let gentleTimer = RoundTimerSnapshot(startedAt: startedAt, now: now, limitSeconds: 90, timerPolicy: .calmNoCountdown)
+
+        XCTAssertEqual(gentleTimer.elapsedSeconds, 75)
+        XCTAssertNil(gentleTimer.remainingSeconds)
+        XCTAssertEqual(gentleTimer.childFacingLabel, "Time spent: 1:15")
+
+        let blastTimer = RoundTimerSnapshot(startedAt: startedAt, now: now, limitSeconds: 90, timerPolicy: .readinessGatedBlast)
+        XCTAssertNil(blastTimer.remainingSeconds)
+        XCTAssertEqual(blastTimer.childFacingLabel, "Time spent: 1:15")
+    }
+
+    func testSessionScoreSummaryKeepsChildCopyEncouragingAndParentDetailSpecific() {
+        let score = LabSessionScoreSummary(
+            conceptTitle: "number bonds",
+            stageDurations: [.learn: 72, .remember: 45, .play: 90, .blast: 30, .score: 15],
+            accuracy: 0.82,
+            streak: 4,
+            weakAreas: ["6 + 4", "7 + 3"],
+            nextRecommendation: "Review number bonds tomorrow"
+        )
+
+        XCTAssertEqual(score.totalSeconds, 252)
+        XCTAssertEqual(score.childCelebrationLine, "Session Complete 🎉 2 tricky ideas will come back soon.")
+        XCTAssertTrue(score.parentDetailLines.contains("Total time: 4:12"))
+        XCTAssertTrue(score.parentDetailLines.contains("Accuracy: 82%"))
+        XCTAssertTrue(score.parentDetailLines.contains("Remember: 0:45"))
+        XCTAssertTrue(score.parentDetailLines.contains("Coming back soon: 6 + 4, 7 + 3"))
+    }
+
     func testExplorerGamesRegistryDirectlyLaunchesEveryCurrentExplorerActivity() {
         let expectedEntries = CapabilityLane.defaultExplorerLanes.flatMap { lane in
             lane.activities.map { (laneID: lane.id, activityID: $0.id, route: $0.id.appRoute) }


### PR DESCRIPTION
## Summary
- add a Numbers Lab vertical-slice concept model for Number Bonds to 10, Sums to 20, and Arrays / Factors
- expose optional guided quest cards in the Lab lane detail while keeping the Games section and direct launch cards intact
- add RoundTimerSnapshot and LabSessionScoreSummary foundations for gentle elapsed-time tracking and encouraging score copy
- cover the staged Numbers Lab path, timer policy, and session score copy in LabModelsTests

## Issue #927 decomposition / current slice map
- Explorer top-level Labs/Games shell: partially complete in #928; this PR fills the main Lab detail follow-up gap with concept-level guided quest cards.
- Preserve Games grid/direct launch: #928 already preserved route registry; this PR keeps Games below guided quests and retains direct route cards.
- Numbers Lab v1 vertical slice: started here with concept data and Learn → Remember → Play → Blast → Score plans.
- RoundTimer + SessionScore foundation: added here as model-layer primitives with tests.
- Remember stage reuse: represented by Memory Match activity bindings in the Numbers plans; deeper spaced-retrieval execution remains follow-up.
- Bond Blast finale reuse: represented in stage plans; reusable gameplay-thread hookup remains follow-up.
- Sensor capability guardrails: #928 has capability copy; this PR surfaces activity fallback copy in game cards.
- Graphics/assets pass: not done; remains follow-up.

## Validation
- Attempted: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,id=C1AB8073-7A56-4F2A-BA02-795EFC4F41C0' -only-testing:MatherTests/LabModelsTests CODE_SIGNING_ALLOWED=NO`
- Result: blocked by Swift 6.3.1 frontend crash while type-checking existing `Features/ParentSummary/SettingsView.swift` (`SettingsView.profilesCard`), before tests could run. Retried with `SWIFT_COMPILATION_MODE=wholemodule COMPILER_INDEX_STORE_ENABLE=NO`; same compiler crash.
