### PR TITLE
feat: add Lab session progress resume foundation

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -23,6 +23,7 @@ final class AppModel {
     let sumSprintEngine: SumSprintEngine
     let gameSessionStore: GameSessionStore
     let gameplayProgressStore: GameplayProgressStore
+    let labConceptSessionProgressStore: LabConceptSessionProgressStore
     let explorerLabMasteryStore: ExplorerLabMasteryStore
 
     var explorerLabMasteryProfile: ExplorerLabMasteryProfile
@@ -135,6 +136,7 @@ final class AppModel {
         let factStore = FactRecordStore(modelContext: modelContext, activeProfileIdProvider: { profileStore.activeProfileId })
         let gameSessionStore = GameSessionStore(modelContext: modelContext, activeProfileIdProvider: { profileStore.activeProfileId })
         let gameplayProgressStore = GameplayProgressStore(modelContext: modelContext, activeProfileIdProvider: { profileStore.activeProfileId })
+        let labConceptSessionProgressStore = LabConceptSessionProgressStore(activeProfileIdProvider: { profileStore.activeProfileId })
         let explorerLabMasteryStore = ExplorerLabMasteryStore()
         let explorerLabMasteryProfile = explorerLabMasteryStore.load()
         let sumSprintEngine = SumSprintEngine(
@@ -147,6 +149,7 @@ final class AppModel {
         self.factStore = factStore
         self.gameSessionStore = gameSessionStore
         self.gameplayProgressStore = gameplayProgressStore
+        self.labConceptSessionProgressStore = labConceptSessionProgressStore
         self.explorerLabMasteryStore = explorerLabMasteryStore
         self.explorerLabMasteryProfile = explorerLabMasteryProfile
         self.sumSprintEngine = sumSprintEngine

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -233,7 +233,7 @@ struct LabLaneDetailView: View {
                 Button {
                     start(plan)
                 } label: {
-                    Label(plan.startAffordanceLabel, systemImage: "play.fill")
+                    Label(startLabel(for: plan), systemImage: appModel.labConceptSessionProgressStore.hasProgress(for: plan) ? "arrow.clockwise.circle.fill" : "play.fill")
                         .font(.caption.weight(.black))
                         .foregroundStyle(.white)
                         .padding(.horizontal, 12)
@@ -241,13 +241,20 @@ struct LabLaneDetailView: View {
                         .background(tint, in: Capsule())
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Start \(plan.title)")
-                .accessibilityHint("Opens the first available stage. Games remain directly playable below.")
+                .accessibilityLabel("\(startLabel(for: plan)) \(plan.title)")
+                .accessibilityHint("Opens the guided stage in progress. Games remain directly playable below.")
+            }
+
+            if let progress = appModel.labConceptSessionProgressStore.progress(for: plan) {
+                Label(progress.resumeCopy, systemImage: "bookmark.fill")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(tint)
+                    .accessibilityLabel("Resume \(plan.title). \(progress.resumeCopy).")
             }
 
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 132), spacing: 8)], spacing: 8) {
                 ForEach(plan.stages) { stage in
-                    stagePlanCard(stage, tint: tint)
+                    stagePlanCard(stage, progress: appModel.labConceptSessionProgressStore.progress(for: plan), tint: tint)
                 }
             }
         }
@@ -257,14 +264,20 @@ struct LabLaneDetailView: View {
         .accessibilityLabel("\(plan.title). \(plan.pathLabel).")
     }
 
-    private func stagePlanCard(_ stage: LabSessionStagePlan, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
+    private func stagePlanCard(_ stage: LabSessionStagePlan, progress: LabConceptSessionProgress?, tint: Color) -> some View {
+        let stageState = progressState(for: stage.stage, progress: progress)
+        return VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
                 Text(stage.stage.emoji)
                 Text(stage.stage.rawValue)
                     .font(.caption.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
                 Spacer(minLength: 0)
+                if let stageState {
+                    Text(stageState)
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(tint)
+                }
             }
             Text(stage.title)
                 .font(.caption.weight(.black))
@@ -696,9 +709,23 @@ struct LabLaneDetailView: View {
         }
     }
 
+    private func startLabel(for plan: LabConceptSessionPlan) -> String {
+        appModel.labConceptSessionProgressStore.resumeLabel(for: plan)
+    }
+
+    private func progressState(for stage: GuidedLabStage, progress: LabConceptSessionProgress?) -> String? {
+        guard let progress else { return nil }
+        if progress.completedStages.contains(stage) { return "Done" }
+        if progress.currentStage == stage { return "Resume" }
+        return nil
+    }
+
     private func start(_ plan: LabConceptSessionPlan) {
-        guard let route = plan.startRoute else { return }
+        let progress = appModel.labConceptSessionProgressStore.progress(for: plan)
+        let stage = progress?.currentStagePlan(in: plan) ?? plan.stages.first(where: { $0.route != nil })
+        guard let stage, let route = stage.route else { return }
         appModel.pickProfileThenRun {
+            _ = appModel.labConceptSessionProgressStore.beginGuidedStage(stage.stage, in: plan)
             if plan.id == LabConceptSessionPlan.numbersNumberBondsTo10.id {
                 appModel.engine.updateConfig(problemCount: 4, minTarget: 1, maxTarget: 10)
             }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -223,7 +223,7 @@ struct ExplorerPathPresentation: Identifiable, Equatable {
     ]
 }
 
-enum GuidedLabStage: String, CaseIterable, Hashable, Identifiable {
+enum GuidedLabStage: String, CaseIterable, Codable, Hashable, Identifiable {
     case learn = "Learn"
     case remember = "Remember"
     case play = "Play"
@@ -449,7 +449,7 @@ struct RoundTimerSnapshot: Equatable {
     }
 }
 
-struct LabSessionScoreSummary: Equatable {
+struct LabSessionScoreSummary: Codable, Equatable {
     let conceptTitle: String
     let stageDurations: [GuidedLabStage: TimeInterval]
     let accuracy: Double
@@ -1113,4 +1113,93 @@ struct CapabilityLane: Identifiable, Equatable {
         ],
     ]
 
+}
+
+// MARK: - Lab concept session progress
+
+struct LabStageTimingScoreSummary: Codable, Equatable {
+    let durationSeconds: TimeInterval?
+    let scoreSummary: LabSessionScoreSummary?
+
+    init(durationSeconds: TimeInterval? = nil, scoreSummary: LabSessionScoreSummary? = nil) {
+        self.durationSeconds = durationSeconds
+        self.scoreSummary = scoreSummary
+    }
+}
+
+struct LabConceptSessionProgress: Codable, Equatable, Identifiable {
+    let conceptPlanID: String
+    var currentStage: GuidedLabStage
+    private(set) var completedStages: [GuidedLabStage]
+    var lastActivityAt: Date
+    var stageSummaries: [GuidedLabStage: LabStageTimingScoreSummary]
+
+    var id: String { conceptPlanID }
+    var hasStarted: Bool { true }
+
+    init(
+        conceptPlanID: String,
+        currentStage: GuidedLabStage,
+        completedStages: [GuidedLabStage] = [],
+        lastActivityAt: Date,
+        stageSummaries: [GuidedLabStage: LabStageTimingScoreSummary] = [:]
+    ) {
+        self.conceptPlanID = conceptPlanID
+        self.currentStage = currentStage
+        self.completedStages = Self.uniqueStages(completedStages)
+        self.lastActivityAt = lastActivityAt
+        self.stageSummaries = stageSummaries
+    }
+
+    init(plan: LabConceptSessionPlan, startedAt: Date) {
+        self.init(
+            conceptPlanID: plan.id,
+            currentStage: plan.stageOrder.first ?? .learn,
+            lastActivityAt: startedAt
+        )
+    }
+
+    var resumeCopy: String {
+        if completedStages.isEmpty {
+            return "Continue: \(currentStage.rawValue)"
+        }
+        return "Continue: \(currentStage.rawValue) next"
+    }
+
+    func currentStagePlan(in plan: LabConceptSessionPlan) -> LabSessionStagePlan? {
+        plan.stages.first { $0.stage == currentStage }
+    }
+
+    func nextIncompleteStage(in plan: LabConceptSessionPlan) -> GuidedLabStage? {
+        plan.stageOrder.first { !completedStages.contains($0) }
+    }
+
+    mutating func markLaunched(_ stage: GuidedLabStage, in plan: LabConceptSessionPlan, at date: Date) {
+        guard plan.stageOrder.contains(stage) else { return }
+        currentStage = stage
+        lastActivityAt = date
+    }
+
+    mutating func markCompleted(
+        _ stage: GuidedLabStage,
+        in plan: LabConceptSessionPlan,
+        at date: Date,
+        summary: LabStageTimingScoreSummary? = nil
+    ) {
+        guard plan.stageOrder.contains(stage) else { return }
+        if !completedStages.contains(stage) {
+            completedStages.append(stage)
+        }
+        completedStages = plan.stageOrder.filter { completedStages.contains($0) }
+        if let summary {
+            stageSummaries[stage] = summary
+        }
+        currentStage = nextIncompleteStage(in: plan) ?? stage
+        lastActivityAt = date
+    }
+
+    private static func uniqueStages(_ stages: [GuidedLabStage]) -> [GuidedLabStage] {
+        var seen = Set<GuidedLabStage>()
+        return stages.filter { seen.insert($0).inserted }
+    }
 }

--- a/Persistence/LabConceptSessionProgressStore.swift
+++ b/Persistence/LabConceptSessionProgressStore.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+final class LabConceptSessionProgressStore {
+    static let defaultStorageKey = "labConceptSessionProgress.v1"
+
+    private let storage: ExplorerLabMasteryKeyValueStore
+    private let storageKey: String
+    private let activeProfileIdProvider: () -> String
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(
+        storage: ExplorerLabMasteryKeyValueStore = UserDefaults.standard,
+        storageKey: String = LabConceptSessionProgressStore.defaultStorageKey,
+        activeProfileIdProvider: @escaping () -> String = { "default" },
+        encoder: JSONEncoder = JSONEncoder(),
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.storage = storage
+        self.storageKey = storageKey
+        self.activeProfileIdProvider = activeProfileIdProvider
+        self.encoder = encoder
+        self.decoder = decoder
+    }
+
+    func progress(for plan: LabConceptSessionPlan) -> LabConceptSessionProgress? {
+        loadProfile()[plan.id]
+    }
+
+    func hasProgress(for plan: LabConceptSessionPlan) -> Bool {
+        progress(for: plan) != nil
+    }
+
+    func currentStage(for plan: LabConceptSessionPlan) -> GuidedLabStage? {
+        progress(for: plan)?.currentStage
+    }
+
+    func resumeLabel(for plan: LabConceptSessionPlan) -> String {
+        progress(for: plan)?.resumeCopy ?? plan.startAffordanceLabel
+    }
+
+    @discardableResult
+    func beginGuidedStage(
+        _ stage: GuidedLabStage? = nil,
+        in plan: LabConceptSessionPlan,
+        at date: Date = Date()
+    ) -> LabConceptSessionProgress {
+        update(plan: plan, at: date) { progress in
+            let chosenStage = stage ?? progress.currentStage
+            progress.markLaunched(chosenStage, in: plan, at: date)
+        }
+    }
+
+    @discardableResult
+    func markCompleted(
+        _ stage: GuidedLabStage,
+        in plan: LabConceptSessionPlan,
+        at date: Date = Date(),
+        summary: LabStageTimingScoreSummary? = nil
+    ) -> LabConceptSessionProgress {
+        update(plan: plan, at: date) { progress in
+            progress.markCompleted(stage, in: plan, at: date, summary: summary)
+        }
+    }
+
+    func reset() {
+        var all = loadAll()
+        all[activeProfileIdProvider()] = [:]
+        saveAll(all)
+    }
+
+    private func update(
+        plan: LabConceptSessionPlan,
+        at date: Date,
+        mutation: (inout LabConceptSessionProgress) -> Void
+    ) -> LabConceptSessionProgress {
+        var all = loadAll()
+        let profileId = activeProfileIdProvider()
+        var profile = all[profileId] ?? [:]
+        var progress = profile[plan.id] ?? LabConceptSessionProgress(plan: plan, startedAt: date)
+        mutation(&progress)
+        profile[plan.id] = progress
+        all[profileId] = profile
+        saveAll(all)
+        return progress
+    }
+
+    private func loadProfile() -> [String: LabConceptSessionProgress] {
+        loadAll()[activeProfileIdProvider()] ?? [:]
+    }
+
+    private func loadAll() -> [String: [String: LabConceptSessionProgress]] {
+        guard let data = storage.data(forKey: storageKey),
+              let progress = try? decoder.decode([String: [String: LabConceptSessionProgress]].self, from: data)
+        else { return [:] }
+        return progress
+    }
+
+    private func saveAll(_ progress: [String: [String: LabConceptSessionProgress]]) {
+        guard let data = try? encoder.encode(progress) else { return }
+        storage.set(data, forKey: storageKey)
+    }
+}

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -265,6 +265,94 @@ final class LabModelsTests: XCTestCase {
         XCTAssertTrue(entries.contains { $0.activity.id == .memoryMatch && $0.directRoute == .memory })
     }
 
+
+    func testLabConceptProgressCreationAndResumeCopy() throws {
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        let progress = LabConceptSessionProgress(plan: plan, startedAt: startedAt)
+
+        XCTAssertEqual(progress.conceptPlanID, plan.id)
+        XCTAssertEqual(progress.currentStage, .learn)
+        XCTAssertEqual(progress.completedStages, [])
+        XCTAssertEqual(progress.lastActivityAt, startedAt)
+        XCTAssertEqual(progress.resumeCopy, "Continue: Learn")
+        XCTAssertEqual(progress.currentStagePlan(in: plan)?.route, .sessionConfig)
+    }
+
+    func testLabConceptProgressNextStageCalculationAndCompletedOrdering() {
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        var progress = LabConceptSessionProgress(
+            conceptPlanID: plan.id,
+            currentStage: .learn,
+            completedStages: [.play, .learn, .play],
+            lastActivityAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        progress.markCompleted(.remember, in: plan, at: Date(timeIntervalSince1970: 1_100))
+
+        XCTAssertEqual(progress.completedStages, [.learn, .remember, .play])
+        XCTAssertEqual(progress.nextIncompleteStage(in: plan), .blast)
+        XCTAssertEqual(progress.currentStage, .blast)
+        XCTAssertEqual(progress.resumeCopy, "Continue: Blast next")
+    }
+
+    func testLabConceptProgressStorePersistsGuidedLaunchWithoutFakingMastery() throws {
+        let storage = InMemoryLabConceptSessionProgressDefaults()
+        let store = LabConceptSessionProgressStore(
+            storage: storage,
+            storageKey: "test.lab-progress",
+            activeProfileIdProvider: { "profile-a" }
+        )
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        let launchedAt = Date(timeIntervalSince1970: 2_000)
+
+        let progress = store.beginGuidedStage(.learn, in: plan, at: launchedAt)
+        let reloaded = LabConceptSessionProgressStore(
+            storage: storage,
+            storageKey: "test.lab-progress",
+            activeProfileIdProvider: { "profile-a" }
+        )
+
+        XCTAssertEqual(progress.currentStage, .learn)
+        XCTAssertEqual(progress.completedStages, [])
+        XCTAssertEqual(progress.lastActivityAt, launchedAt)
+        XCTAssertEqual(reloaded.resumeLabel(for: plan), "Continue: Learn")
+        XCTAssertEqual(reloaded.progress(for: plan)?.completedStages, [])
+    }
+
+    func testLabConceptProgressStoreScopesByProfile() throws {
+        let storage = InMemoryLabConceptSessionProgressDefaults()
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        let first = LabConceptSessionProgressStore(
+            storage: storage,
+            storageKey: "test.lab-progress.profiles",
+            activeProfileIdProvider: { "profile-a" }
+        )
+        let second = LabConceptSessionProgressStore(
+            storage: storage,
+            storageKey: "test.lab-progress.profiles",
+            activeProfileIdProvider: { "profile-b" }
+        )
+
+        first.beginGuidedStage(.remember, in: plan, at: Date(timeIntervalSince1970: 3_000))
+
+        XCTAssertEqual(first.currentStage(for: plan), .remember)
+        XCTAssertNil(second.progress(for: plan))
+        XCTAssertEqual(second.resumeLabel(for: plan), "Start")
+    }
+
+    func testDirectGamesLaunchDoesNotMarkBlastOrScoreComplete() throws {
+        let storage = InMemoryLabConceptSessionProgressDefaults()
+        let store = LabConceptSessionProgressStore(storage: storage, storageKey: "test.direct-games")
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        let directSumSprint = try XCTUnwrap(ExplorerGameRegistry.directLaunchEntries.first { $0.activity.id == .sumSprint })
+
+        XCTAssertEqual(directSumSprint.directRoute, .sumSprint)
+        XCTAssertNil(store.progress(for: plan))
+        XCTAssertFalse(store.progress(for: plan)?.completedStages.contains(.blast) ?? false)
+        XCTAssertFalse(store.progress(for: plan)?.completedStages.contains(.score) ?? false)
+    }
+
 }
 
 extension LabModelsTests {
@@ -421,5 +509,22 @@ extension LabModelsTests {
             LabActivityID.twoFingerProtractor.sensorAffordances(with: capabilities).map(\.displayLabel),
             ["No special sensor needed"]
         )
+    }
+}
+
+
+private final class InMemoryLabConceptSessionProgressDefaults: ExplorerLabMasteryKeyValueStore {
+    var values: [String: Data] = [:]
+
+    func data(forKey defaultName: String) -> Data? {
+        values[defaultName]
+    }
+
+    func set(_ value: Data?, forKey defaultName: String) {
+        values[defaultName] = value
+    }
+
+    func removeObject(forKey defaultName: String) {
+        values.removeValue(forKey: defaultName)
     }
 }


### PR DESCRIPTION
## Summary
- Adds a reusable Lab concept session progress model/store scoped by active kid profile.
- Persists current guided stage, completed stages, last activity time, and optional per-stage timing summary.
- Updates Numbers Lab guided cards to show Start/Continue state and mark guided stage launches without faking mastery.
- Preserves direct Games launches; direct game registry remains independent of Lab progress.

## Validation
- `git diff --check` ✅
- `xcodegen generate && xcodebuild build-for-testing -project Mather.xcodeproj -scheme Mather -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` on `ganesh-mba` ✅
- Added model tests for progress creation, next stage calculation, persisted resume label, profile scoping, and direct Games not marking Blast/Score complete.

## Remaining #927 slices
- Full gameplay completion callbacks into Lab progress
- Reusable Remember stage execution/decks beyond model bindings
- Bond Blast finale hookup into actual staged flow
- Sensor capability/fallback UX pass
- Graphics/assets pass after session UX settles

Refs #927
