### PR TITLE
Add Lab Remember stage foundation

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -98,6 +98,8 @@ struct RootView: View {
                     MemoryView(appModel: appModel)
                 case .memoryDeck(let deckKind):
                     MemoryView(appModel: appModel, initialDeckKind: deckKind)
+                case .labRememberStage(let deckID):
+                    LabRememberStageView(appModel: appModel, deckID: deckID)
                 case .waterCycle:
                     WaterCycleLabView(appModel: appModel)
                 case .gameplayThread(let threadID):

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -21,6 +21,7 @@ enum AppRoute: Hashable {
     case labLane(CapabilityLaneID)
     case memory
     case memoryDeck(MemoryDeckKind)
+    case labRememberStage(LabRememberStageDeckID)
     case waterCycle
     case gameplayThread(GameplayThreadID)
     case soundVolume
@@ -135,6 +136,7 @@ final class VerticalSliceEngine {
     func showLab() { route = .lab }
     func showLabLane(_ laneID: CapabilityLaneID) { route = .labLane(laneID) }
     func showMemory() { route = .memory }
+    func showLabRememberStage(_ deckID: LabRememberStageDeckID) { route = .labRememberStage(deckID) }
     func showCountriesGameplayThread() { route = .gameplayThread(.countries) }
     func showWaterCycle() { route = .gameplayThread(.waterCycle) }
     func showLegacyWaterCycleLab() { route = .waterCycle }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -78,6 +78,173 @@ struct MixMatchReviewSampler: Equatable {
     }
 }
 
+
+
+// MARK: - Guided Remember stage foundation
+
+enum LabRememberStageDeckID: String, Codable, Hashable, Identifiable {
+    case numbersNumberBondsTo10 = "numbers-number-bonds-to-10-remember"
+
+    var id: String { rawValue }
+}
+
+struct LabRememberStageCard: Codable, Equatable, Identifiable, Hashable {
+    let id: String
+    let laneID: CapabilityLaneID
+    let concept: String
+    let prompt: String
+    let answer: String
+    let supportCopy: String
+
+    init(
+        id: String,
+        laneID: CapabilityLaneID,
+        concept: String,
+        prompt: String,
+        answer: String,
+        supportCopy: String
+    ) {
+        self.id = id
+        self.laneID = laneID
+        self.concept = concept
+        self.prompt = prompt
+        self.answer = answer
+        self.supportCopy = supportCopy
+    }
+
+    init(mixMatchCard: MixMatchCard, supportCopy: String) {
+        self.init(
+            id: mixMatchCard.id,
+            laneID: mixMatchCard.laneID,
+            concept: mixMatchCard.concept,
+            prompt: mixMatchCard.prompt,
+            answer: mixMatchCard.match,
+            supportCopy: supportCopy
+        )
+    }
+
+    var accessibilityLabel: String {
+        "Remember card. \(prompt), answer \(answer). \(supportCopy)"
+    }
+}
+
+struct LabRememberStageDeck: Equatable, Identifiable {
+    let id: LabRememberStageDeckID
+    let planID: String
+    let stage: GuidedLabStage
+    let laneID: CapabilityLaneID
+    let concept: String
+    let title: String
+    let subtitle: String
+    let timerPolicy: LabSessionTimerPolicy
+    let cards: [LabRememberStageCard]
+
+    var route: AppRoute { .labRememberStage(id) }
+    var hasPunitiveCountdown: Bool { timerPolicy.showsCountdown || timerPolicy.isPunitive }
+
+    static func deck(for id: LabRememberStageDeckID) -> LabRememberStageDeck {
+        switch id {
+        case .numbersNumberBondsTo10:
+            return .numbersNumberBondsTo10
+        }
+    }
+
+    static let numbersNumberBondsTo10 = LabRememberStageDeck(
+        id: .numbersNumberBondsTo10,
+        planID: "numbers-number-bonds-to-10",
+        stage: .remember,
+        laneID: .numbers,
+        concept: "number-bond",
+        title: "Remember pairs to 10",
+        subtitle: "Flip friendly bond facts back into memory — no countdown, no penalty.",
+        timerPolicy: .calmNoCountdown,
+        cards: Self.numberBondCardsTo10()
+    )
+
+    private static func numberBondCardsTo10() -> [LabRememberStageCard] {
+        let mixMatchSupport = "Picture the two parts snapping into one full ten-frame."
+        let existingNumberBondCards = CapabilityLane.starterMixMatchCardsByLane[.numbers, default: []]
+            .filter { $0.concept == "number-bond" && $0.match == "10" }
+            .map { LabRememberStageCard(mixMatchCard: $0, supportCopy: mixMatchSupport) }
+        let existingIDs = Set(existingNumberBondCards.map(\.id))
+        let supplementalPairs: [(String, String)] = [
+            ("0 + 10", "empty and full ten-frame"),
+            ("1 + 9", "one dot plus nine more fills ten"),
+            ("2 + 8", "two dots need eight friends"),
+            ("3 + 7", "three and seven make a full row pair"),
+            ("4 + 6", "four dots need six to make ten"),
+            ("5 + 5", "five-frame plus five-frame makes ten"),
+            ("6 + 4", "six and four are switch partners"),
+            ("7 + 3", "seven and three are switch partners"),
+            ("8 + 2", "eight and two are switch partners"),
+            ("9 + 1", "nine needs one more"),
+            ("10 + 0", "full ten-frame plus none stays ten"),
+        ]
+        let supplemental = supplementalPairs.map { prompt, clue in
+            LabRememberStageCard(
+                id: "numbers-number-bond-\(prompt.replacingOccurrences(of: " + ", with: "-plus-"))",
+                laneID: .numbers,
+                concept: "number-bond",
+                prompt: prompt,
+                answer: "10",
+                supportCopy: clue
+            )
+        }
+        return existingNumberBondCards + supplemental.filter { !existingIDs.contains($0.id) }
+    }
+}
+
+struct LabRememberStageExecution: Equatable {
+    let deck: LabRememberStageDeck
+    private(set) var currentIndex: Int
+    private(set) var reviewedCardIDs: [String]
+    private(set) var correctCardIDs: Set<String>
+    private(set) var selectedAnswer: String?
+
+    init(deck: LabRememberStageDeck, currentIndex: Int = 0, reviewedCardIDs: [String] = [], correctCardIDs: Set<String> = []) {
+        self.deck = deck
+        self.currentIndex = deck.cards.isEmpty ? 0 : min(max(currentIndex, 0), deck.cards.count - 1)
+        self.reviewedCardIDs = reviewedCardIDs
+        self.correctCardIDs = correctCardIDs
+        self.selectedAnswer = nil
+    }
+
+    var currentCard: LabRememberStageCard? {
+        guard deck.cards.indices.contains(currentIndex) else { return nil }
+        return deck.cards[currentIndex]
+    }
+
+    var progressLabel: String {
+        guard !deck.cards.isEmpty else { return "0 / 0" }
+        return "\(min(currentIndex + 1, deck.cards.count)) / \(deck.cards.count)"
+    }
+
+    var isComplete: Bool {
+        !deck.cards.isEmpty && Set(reviewedCardIDs).isSuperset(of: deck.cards.map(\.id))
+    }
+
+    var usesPunitiveCountdown: Bool { deck.hasPunitiveCountdown }
+
+    mutating func submit(answer: String) -> Bool {
+        guard let card = currentCard else { return false }
+        selectedAnswer = answer
+        if !reviewedCardIDs.contains(card.id) {
+            reviewedCardIDs.append(card.id)
+        }
+        let isCorrect = answer.trimmingCharacters(in: .whitespacesAndNewlines) == card.answer
+        if isCorrect {
+            correctCardIDs.insert(card.id)
+        }
+        return isCorrect
+    }
+
+    mutating func advance() {
+        selectedAnswer = nil
+        guard !deck.cards.isEmpty else { return }
+        currentIndex = min(currentIndex + 1, deck.cards.count - 1)
+    }
+}
+
 struct LaneRecallEntry: Identifiable, Equatable {
     let laneID: CapabilityLaneID
     let card: LearningCard
@@ -349,7 +516,7 @@ struct LabConceptSessionPlan: Identifiable, Equatable {
                 childCopy: "Use friendly picture clues to remember ten pairs.",
                 parentCopy: "Soft retrieval with visual support; no punitive countdown.",
                 timerPolicy: .calmNoCountdown,
-                route: .memory
+                route: .labRememberStage(.numbersNumberBondsTo10)
             ),
             LabSessionStagePlan(
                 stage: .play,

--- a/Features/Lab/LabRememberStageView.swift
+++ b/Features/Lab/LabRememberStageView.swift
@@ -1,0 +1,135 @@
+import SwiftUI
+
+struct LabRememberStageView: View {
+    @Bindable var appModel: AppModel
+    let deckID: LabRememberStageDeckID
+
+    @State private var execution: LabRememberStageExecution
+    @State private var feedback: String = "Choose the match when you remember it."
+
+    init(appModel: AppModel, deckID: LabRememberStageDeckID) {
+        self.appModel = appModel
+        self.deckID = deckID
+        _execution = State(initialValue: LabRememberStageExecution(deck: LabRememberStageDeck.deck(for: deckID)))
+    }
+
+    var body: some View {
+        let deck = execution.deck
+        ZStack {
+            MatherTheme.background.ignoresSafeArea()
+            VStack(alignment: .leading, spacing: 18) {
+                HStack {
+                    Button {
+                        appModel.engine.showLabLane(deck.laneID)
+                    } label: {
+                        Label("Back", systemImage: "chevron.left")
+                            .font(.headline.weight(.black))
+                            .foregroundStyle(MatherTheme.accent)
+                    }
+                    .buttonStyle(.plain)
+                    Spacer()
+                    Text(execution.progressLabel)
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("🧠 Remember")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(MatherTheme.accent)
+                    Text(deck.title)
+                        .font(.system(size: 34, weight: .black, design: .rounded))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text(deck.subtitle)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                    Label(deck.timerPolicy.childCopy, systemImage: "timer")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(MatherTheme.accent)
+                }
+
+                if let card = execution.currentCard {
+                    rememberCard(card)
+                }
+
+                Text(feedback)
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(MatherTheme.ink)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Spacer(minLength: 0)
+
+                Button {
+                    finishRemember(deck)
+                } label: {
+                    Label(execution.isComplete ? "Finish Remember" : "Save and continue later", systemImage: "checkmark.circle.fill")
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity, minHeight: 56)
+                        .background(MatherTheme.accent, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(20)
+        }
+        .accessibilityLabel("Remember stage. No countdown. \(deck.title).")
+    }
+
+    private func rememberCard(_ card: LabRememberStageCard) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(card.prompt)
+                .font(.system(size: 52, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+                .frame(maxWidth: .infinity, minHeight: 140)
+                .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+
+            Text(card.supportCopy)
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 96), spacing: 10)], spacing: 10) {
+                ForEach(answerChoices(for: card), id: \.self) { choice in
+                    Button {
+                        answer(choice)
+                    } label: {
+                        Text(choice)
+                            .font(.title2.weight(.black))
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity, minHeight: 56)
+                            .background(MatherTheme.accent, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Answer \(choice)")
+                }
+            }
+        }
+        .padding(16)
+        .background(MatherTheme.card.opacity(0.86), in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(card.accessibilityLabel)
+    }
+
+    private func answer(_ choice: String) {
+        let correct = execution.submit(answer: choice)
+        feedback = correct ? "Yes — that pair makes 10." : "Try again calmly. Look for the pair that fills ten."
+        if correct {
+            execution.advance()
+        }
+    }
+
+    private func answerChoices(for card: LabRememberStageCard) -> [String] {
+        var choices = [card.answer, "9", "11"]
+        if card.answer != "10" { choices.append("10") }
+        return Array(Set(choices)).sorted()
+    }
+
+    private func finishRemember(_ deck: LabRememberStageDeck) {
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        if execution.isComplete {
+            _ = appModel.labConceptSessionProgressStore.markCompleted(deck.stage, in: plan)
+        } else {
+            _ = appModel.labConceptSessionProgressStore.beginGuidedStage(deck.stage, in: plan)
+        }
+        appModel.engine.showLabLane(deck.laneID)
+    }
+}

--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -13,7 +13,7 @@ struct MemoryFactCard: Equatable, Hashable {
     let value: String
 }
 
-enum MemoryDeckKind: String, Equatable {
+enum MemoryDeckKind: String, Equatable, Hashable {
     case domesticAnimals
     case birds
     case vehicles
@@ -24,6 +24,7 @@ enum MemoryDeckKind: String, Equatable {
     case indiaStates
     case waterCycle
     case fruits
+    case numberBondsTo10
 
     var displayName: String {
         switch self {
@@ -37,6 +38,7 @@ enum MemoryDeckKind: String, Equatable {
         case .indiaStates: return "Indian States & Capitals"
         case .waterCycle: return "Water Cycle"
         case .fruits: return "Fruits"
+        case .numberBondsTo10: return "Number Bonds to 10"
         }
     }
 }
@@ -391,6 +393,19 @@ enum MemoryDeck {
         indiaStateCapital("state-rajasthan", state: "Rajasthan", capital: "Jaipur", region: "northwest India", clue: "pink city and desert forts"),
         indiaStateCapital("state-kerala", state: "Kerala", capital: "Thiruvananthapuram", region: "south India", clue: "backwaters and coconut trees"),
         indiaStateCapital("state-assam", state: "Assam", capital: "Dispur", region: "northeast India", clue: "tea gardens and one-horned rhinos")
+    ]
+
+    static let numberBondsTo10: [MemoryAnimal] = [
+        numberBondTo10("bond-1-9", prompt: "1 + 9", match: "10", clue: "One and nine fill the ten-frame."),
+        numberBondTo10("bond-2-8", prompt: "2 + 8", match: "10", clue: "Two and eight make a full ten."),
+        numberBondTo10("bond-3-7", prompt: "3 + 7", match: "10", clue: "Three and seven are friendly ten partners."),
+        numberBondTo10("bond-4-6", prompt: "4 + 6", match: "10", clue: "Four and six snap together to ten."),
+        numberBondTo10("bond-5-5", prompt: "5 + 5", match: "10", clue: "Five and five are doubles that make ten."),
+        numberBondTo10("bond-6-4", prompt: "6 + 4", match: "10", clue: "Six needs four more to make ten."),
+        numberBondTo10("bond-7-3", prompt: "7 + 3", match: "10", clue: "Seven needs three more to make ten."),
+        numberBondTo10("bond-8-2", prompt: "8 + 2", match: "10", clue: "Eight and two complete the ten-frame."),
+        numberBondTo10("bond-9-1", prompt: "9 + 1", match: "10", clue: "Nine needs one more to make ten."),
+        numberBondTo10("bond-10-0", prompt: "10 + 0", match: "10", clue: "Ten and zero stay ten."),
     ]
 
     static let fruits: [MemoryAnimal] = [
@@ -817,6 +832,26 @@ enum MemoryDeck {
             )
         )
     }
+
+    private static func numberBondTo10(_ id: String, prompt: String, match: String, clue: String) -> MemoryAnimal {
+        MemoryAnimal(
+            id: id,
+            name: match,
+            canonicalName: "\(prompt) = \(match)",
+            picture: .text(prompt),
+            metadata: MemoryCardMetadata(
+                deck: .numberBondsTo10,
+                category: "number bond",
+                kind: "number bond to 10",
+                factCards: [
+                    MemoryFactCard(title: "Prompt", value: prompt),
+                    MemoryFactCard(title: "Match", value: match),
+                    MemoryFactCard(title: "Clue", value: clue),
+                    MemoryFactCard(title: "Stage", value: "Remember — calm retrieval, no countdown")
+                ]
+            )
+        )
+    }
 }
 
 // MARK: - Game difficulty
@@ -893,7 +928,7 @@ struct MemoryView: View {
     }
 
     enum DeckSelection: CaseIterable {
-        case domestic, birds, vehicles, planets, fishes, countries, countryFlags, indiaStates, waterCycle, fruits
+        case domestic, birds, vehicles, planets, fishes, countries, countryFlags, indiaStates, waterCycle, fruits, numberBondsTo10
 
         init(kind: MemoryDeckKind?) {
             switch kind {
@@ -907,6 +942,7 @@ struct MemoryView: View {
             case .indiaStates: self = .indiaStates
             case .waterCycle: self = .waterCycle
             case .fruits: self = .fruits
+            case .numberBondsTo10: self = .numberBondsTo10
             case nil: self = .domestic
             }
         }
@@ -923,6 +959,7 @@ struct MemoryView: View {
             case .indiaStates: return "📍 India States & Capitals"
             case .waterCycle: return "💧 Water Cycle"
             case .fruits: return "🍎 Fruits"
+            case .numberBondsTo10: return "🔟 Number Bonds"
             }
         }
 
@@ -938,6 +975,7 @@ struct MemoryView: View {
             case .indiaStates: return "India States & Capitals"
             case .waterCycle: return "Water Cycle"
             case .fruits: return "Fruits"
+            case .numberBondsTo10: return "Number Bonds to 10"
             }
         }
 
@@ -953,6 +991,7 @@ struct MemoryView: View {
             case .indiaStates: return MemoryDeck.indiaStates
             case .waterCycle: return MemoryDeck.waterCycle
             case .fruits: return MemoryDeck.fruits
+            case .numberBondsTo10: return MemoryDeck.numberBondsTo10
             }
         }
     }
@@ -1382,7 +1421,7 @@ struct MemoryView: View {
 
     static func directStagedEntryKind(for initialDeckKind: MemoryDeckKind?) -> MemoryDeckKind? {
         switch initialDeckKind {
-        case .fruits, .countries:
+        case .fruits, .countries, .numberBondsTo10:
             return initialDeckKind
         case .domesticAnimals, .birds, .vehicles, .planets, .fishes, .countryFlags, .indiaStates, .waterCycle, nil:
             return nil
@@ -1766,6 +1805,8 @@ struct MemoryView: View {
             deckLabel = "Water Cycle Guide"
         case .fruits:
             deckLabel = "Fruit Guide"
+        case .numberBondsTo10:
+            deckLabel = "Number Bond Guide"
         }
 
         switch source {

--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -235,10 +235,17 @@ final class MemoryCardDescribeService {
             } else {
                 firstSentence = "\(animal.canonicalName) is a fruit with shape, color, taste, and smell clues."
             }
+        case .numberBondsTo10:
+            firstSentence = "\(animal.canonicalName) is a number bond to ten."
         }
 
         let secondParts: [String]
-        if metadata.deck == .waterCycle {
+        if metadata.deck == .numberBondsTo10 {
+            secondParts = [
+                animal.detailCards.first { $0.title == "Clue" }.map(\.value),
+                animal.detailCards.first { $0.title == "Stage" }.map(\.value)
+            ].compactMap { $0 }
+        } else if metadata.deck == .waterCycle {
             secondParts = [
                 metadata.habitat.map { "You can notice it \($0.lowercased())" },
                 animal.detailCards.first { $0.title == "Everyday Words" }.map(\.value)

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -266,6 +266,50 @@ final class LabModelsTests: XCTestCase {
     }
 
 
+    func testRememberStageDeckReusesNumberBondMixMatchAndKeepsCalmPolicy() throws {
+        let deck = LabRememberStageDeck.numbersNumberBondsTo10
+
+        XCTAssertEqual(deck.id, .numbersNumberBondsTo10)
+        XCTAssertEqual(deck.planID, LabConceptSessionPlan.numbersNumberBondsTo10.id)
+        XCTAssertEqual(deck.stage, .remember)
+        XCTAssertEqual(deck.laneID, .numbers)
+        XCTAssertFalse(deck.hasPunitiveCountdown)
+        XCTAssertEqual(deck.timerPolicy, .calmNoCountdown)
+        XCTAssertGreaterThanOrEqual(deck.cards.count, 10)
+        XCTAssertTrue(deck.cards.contains { $0.id == "numbers-number-bond-6 + 4" || ($0.prompt == "6 + 4" && $0.answer == "10") })
+        XCTAssertTrue(deck.cards.contains { $0.prompt == "7 + 3" && $0.answer == "10" })
+        XCTAssertTrue(deck.cards.allSatisfy { $0.concept == "number-bond" && $0.laneID == .numbers })
+    }
+
+    func testRememberStageExecutionTracksRecallWithoutCountdownPressure() throws {
+        let deck = LabRememberStageDeck.numbersNumberBondsTo10
+        var execution = LabRememberStageExecution(deck: deck)
+        let first = try XCTUnwrap(execution.currentCard)
+
+        XCTAssertEqual(execution.progressLabel, "1 / \(deck.cards.count)")
+        XCTAssertFalse(execution.usesPunitiveCountdown)
+        XCTAssertFalse(execution.submit(answer: "9"))
+        XCTAssertEqual(execution.reviewedCardIDs, [first.id])
+        XCTAssertFalse(execution.correctCardIDs.contains(first.id))
+        XCTAssertTrue(execution.submit(answer: first.answer))
+        XCTAssertTrue(execution.correctCardIDs.contains(first.id))
+
+        execution.advance()
+
+        XCTAssertEqual(execution.progressLabel, "2 / \(deck.cards.count)")
+    }
+
+    func testNumbersRememberStageRoutesToReusableRememberDeck() throws {
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        let remember = try XCTUnwrap(plan.stages.first { $0.stage == .remember })
+
+        XCTAssertEqual(remember.route, .labRememberStage(.numbersNumberBondsTo10))
+        XCTAssertEqual(LabRememberStageDeck.deck(for: .numbersNumberBondsTo10).route, remember.route)
+        XCTAssertFalse(remember.timerPolicy.showsCountdown)
+        XCTAssertFalse(remember.timerPolicy.isPunitive)
+    }
+
+
     func testLabConceptProgressCreationAndResumeCopy() throws {
         let plan = LabConceptSessionPlan.numbersNumberBondsTo10
         let startedAt = Date(timeIntervalSince1970: 1_000)
@@ -339,6 +383,20 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(first.currentStage(for: plan), .remember)
         XCTAssertNil(second.progress(for: plan))
         XCTAssertEqual(second.resumeLabel(for: plan), "Start")
+    }
+
+    func testRememberStageDeckUsesNumberBondRouteWithoutCountdown() throws {
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        let rememberStage = try XCTUnwrap(plan.stages.first { $0.stage == .remember })
+        let deck = LabRememberStageDeck.numbersNumberBondsTo10
+
+        XCTAssertEqual(rememberStage.route, .labRememberStage(.numbersNumberBondsTo10))
+        XCTAssertEqual(rememberStage.timerPolicy, .calmNoCountdown)
+        XCTAssertFalse(rememberStage.timerPolicy.showsCountdown)
+        XCTAssertFalse(rememberStage.timerPolicy.isPunitive)
+        XCTAssertEqual(deck.route, .labRememberStage(.numbersNumberBondsTo10))
+        XCTAssertTrue(deck.cards.contains { $0.prompt == "6 + 4" && $0.answer == "10" })
+        XCTAssertTrue(deck.cards.contains { $0.prompt == "7 + 3" && $0.answer == "10" })
     }
 
     func testDirectGamesLaunchDoesNotMarkBlastOrScoreComplete() throws {

--- a/Tests/MatherTests/MemoryVarietyTests.swift
+++ b/Tests/MatherTests/MemoryVarietyTests.swift
@@ -13,6 +13,7 @@ struct MemoryVarietyTests {
         #expect(MemoryDeck.countryFlags.count >= 8)
         #expect(MemoryDeck.indiaStates.count >= 8)
         #expect(MemoryDeck.waterCycle.count >= 8)
+        #expect(MemoryDeck.numberBondsTo10.count == 10)
     }
 
     @MainActor @Test func preferredRoundAnimalsAvoidsRecentHistoryWhenFreshPoolIsLargeEnough() {
@@ -34,7 +35,7 @@ struct MemoryVarietyTests {
     }
 
     @MainActor @Test func buildCardsCreatesExactPictureAndLabelPairs() {
-        let round = Array(MemoryDeck.birds.prefix(4))
+        let round = Array(MemoryDeck.numberBondsTo10.prefix(4))
         let cards = MemoryView.buildCards(for: round)
 
         #expect(cards.count == 8)


### PR DESCRIPTION
## Summary
- adds a reusable Lab Remember stage route and execution model for the Numbers number-bonds-to-10 plan
- adds a calm, no-countdown Remember UI that records progress back to Lab session progress
- adds a number-bonds-to-10 memory deck and speech/learning fallback support

## Validation
- ✅ xcodebuild build-for-testing -project Mather.xcodeproj -scheme Mather -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO
- ✅ xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'id=E336EF23-FAE3-45B3-927B-9DE4FF250F72' -only-testing:MatherTests/LabModelsTests -only-testing:MatherTests/LabRouteRegressionTests -only-testing:MatherTests/MemoryVarietyTests CODE_SIGNING_ALLOWED=NO

Part of #927.