### PR TITLE
Fix Water Cycle screenshot legacy route

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -444,7 +444,7 @@ final class ScreenshotTests: XCTestCase {
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
             "-feature.skipProfilePicker", "YES",
-            "-uiTest.startRoute", "waterCycle"
+            "-uiTest.startRoute", "waterCycleLab"
         ])
     }
 


### PR DESCRIPTION
## Summary
- updates the Water Cycle compact screenshot test to launch the legacy Water Cycle lab route explicitly
- keeps the newer reusable water-cycle gameplay thread behavior intact for normal \ route aliases

## Validation
- ✅ xcodebuild build-for-testing -project Mather.xcodeproj -scheme Mather -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO

Unblocks main iOS UI Review failure from run 25320086952 after #940.