### PR TITLE
Connect lab gameplay completions to progress

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -29,6 +29,7 @@ final class AppModel {
     var explorerLabMasteryProfile: ExplorerLabMasteryProfile
     var showingProfilePicker = false
     private var pendingGameAction: (() -> Void)?
+    private var pendingLabGameplayCompletionContext: LabGameplayCompletionContext?
 
     func pickProfileThenRun(_ action: @escaping () -> Void) {
         if featureFlags.skipProfilePicker {
@@ -64,6 +65,33 @@ final class AppModel {
             for: conceptID,
             laneID: laneID
         )
+    }
+
+    func prepareLabGameplayCompletion(plan: LabConceptSessionPlan, stage: GuidedLabStage) {
+        pendingLabGameplayCompletionContext = LabGameplayCompletionContext(plan: plan, stage: stage)
+    }
+
+    func clearLabGameplayCompletion() {
+        pendingLabGameplayCompletionContext = nil
+    }
+
+    func completePendingLabGameplay(with summary: SumSprintSessionSummary) {
+        let context = pendingLabGameplayCompletionContext
+        pendingLabGameplayCompletionContext = nil
+
+        let accuracy = summary.cards.isEmpty ? 0 : Double(summary.correctCount) / Double(summary.cards.count)
+        let stageSummary = LabStageTimingScoreSummary(
+            durationSeconds: summary.endedAt.timeIntervalSince(summary.startedAt),
+            scoreSummary: LabSessionScoreSummary(
+                conceptTitle: "Number Bonds to 10",
+                stageDurations: [.play: summary.endedAt.timeIntervalSince(summary.startedAt)],
+                accuracy: accuracy,
+                streak: summary.peakStreak,
+                weakAreas: summary.timeoutCount > 0 ? ["timed practice"] : [],
+                nextRecommendation: "Try Bond Blast when ready"
+            )
+        )
+        _ = labConceptSessionProgressStore.markLabLaunchedGameplayCompleted(context, summary: stageSummary)
     }
 
     init(modelContext: ModelContext) {
@@ -154,7 +182,7 @@ final class AppModel {
         self.explorerLabMasteryProfile = explorerLabMasteryProfile
         self.sumSprintEngine = sumSprintEngine
         sumSprintEngine.onExitToHome = { [weak vsEngine] in vsEngine?.showHome() }
-        sumSprintEngine.onSessionComplete = { [weak gameSessionStore] summary in
+        sumSprintEngine.onSessionComplete = { [weak self, weak gameSessionStore] summary in
             gameSessionStore?.save(
                 gameName: "Sum Sprint",
                 startedAt: summary.startedAt,
@@ -162,6 +190,7 @@ final class AppModel {
                 scoreLabel: "correct",
                 detail: summary.difficulty.rawValue
             )
+            self?.completePendingLabGameplay(with: summary)
         }
     }
 }

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -726,6 +726,11 @@ struct LabLaneDetailView: View {
         guard let stage, let route = stage.route else { return }
         appModel.pickProfileThenRun {
             _ = appModel.labConceptSessionProgressStore.beginGuidedStage(stage.stage, in: plan)
+            if stage.stage == .play {
+                appModel.prepareLabGameplayCompletion(plan: plan, stage: stage.stage)
+            } else {
+                appModel.clearLabGameplayCompletion()
+            }
             if plan.id == LabConceptSessionPlan.numbersNumberBondsTo10.id {
                 appModel.engine.updateConfig(problemCount: 4, minTarget: 1, maxTarget: 10)
             }
@@ -738,6 +743,7 @@ struct LabLaneDetailView: View {
 
     private func launch(_ activityID: LabActivityID) {
         appModel.pickProfileThenRun {
+            appModel.clearLabGameplayCompletion()
             appModel.engine.show(route(for: activityID, laneID: lane.id))
             switch activityID {
             case .sumSprint:

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -493,6 +493,13 @@ struct LabConceptSessionPlan: Identifiable, Equatable {
     var continueAffordanceLabel: String { "Continue" }
     var pathLabel: String { stageOrder.map(\.rawValue).joined(separator: " → ") }
 
+    static func plan(for id: String) -> LabConceptSessionPlan? {
+        if id == numbersNumberBondsTo10.id {
+            return .numbersNumberBondsTo10
+        }
+        return nil
+    }
+
     static let numbersNumberBondsTo10 = LabConceptSessionPlan(
         id: "numbers-number-bonds-to-10",
         laneID: .numbers,
@@ -1283,6 +1290,20 @@ struct CapabilityLane: Identifiable, Equatable {
 }
 
 // MARK: - Lab concept session progress
+
+struct LabGameplayCompletionContext: Codable, Equatable {
+    let conceptPlanID: String
+    let stage: GuidedLabStage
+
+    init(conceptPlanID: String, stage: GuidedLabStage) {
+        self.conceptPlanID = conceptPlanID
+        self.stage = stage
+    }
+
+    init(plan: LabConceptSessionPlan, stage: GuidedLabStage) {
+        self.init(conceptPlanID: plan.id, stage: stage)
+    }
+}
 
 struct LabStageTimingScoreSummary: Codable, Equatable {
     let durationSeconds: TimeInterval?

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -316,6 +316,7 @@ struct LabView: View {
 
     private func launchDirectGame(_ entry: ExplorerGameEntry) {
         appModel.pickProfileThenRun {
+            appModel.clearLabGameplayCompletion()
             appModel.engine.show(entry.directRoute)
             if entry.activity.id == .sumSprint {
                 appModel.sumSprintEngine.showDifficultyPick()

--- a/Persistence/LabConceptSessionProgressStore.swift
+++ b/Persistence/LabConceptSessionProgressStore.swift
@@ -63,6 +63,27 @@ final class LabConceptSessionProgressStore {
         }
     }
 
+    @discardableResult
+    func markLabLaunchedGameplayCompleted(
+        _ context: LabGameplayCompletionContext?,
+        at date: Date = Date(),
+        summary: LabStageTimingScoreSummary? = nil
+    ) -> LabConceptSessionProgress? {
+        guard let context,
+              context.stage == .play,
+              let plan = LabConceptSessionPlan.plan(for: context.conceptPlanID),
+              plan.stageOrder.contains(context.stage)
+        else { return nil }
+
+        return update(plan: plan, at: date) { progress in
+            progress.markCompleted(context.stage, in: plan, at: date, summary: summary)
+            if let completedIndex = plan.stageOrder.firstIndex(of: context.stage),
+               plan.stageOrder.indices.contains(completedIndex + 1) {
+                progress.currentStage = plan.stageOrder[completedIndex + 1]
+            }
+        }
+    }
+
     func reset() {
         var all = loadAll()
         all[activeProfileIdProvider()] = [:]

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -399,6 +399,71 @@ final class LabModelsTests: XCTestCase {
         XCTAssertTrue(deck.cards.contains { $0.prompt == "7 + 3" && $0.answer == "10" })
     }
 
+
+    func testLabLaunchedGameplayCompletionAdvancesPlayToBlastWithSummary() throws {
+        let storage = InMemoryLabConceptSessionProgressDefaults()
+        let store = LabConceptSessionProgressStore(
+            storage: storage,
+            storageKey: "test.lab-gameplay-complete",
+            activeProfileIdProvider: { "profile-a" }
+        )
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        let launchedAt = Date(timeIntervalSince1970: 4_000)
+        let completedAt = Date(timeIntervalSince1970: 4_120)
+        let context = LabGameplayCompletionContext(plan: plan, stage: .play)
+        let summary = LabStageTimingScoreSummary(durationSeconds: 120)
+
+        _ = store.beginGuidedStage(.play, in: plan, at: launchedAt)
+        let progress = try XCTUnwrap(store.markLabLaunchedGameplayCompleted(context, at: completedAt, summary: summary))
+
+        XCTAssertEqual(progress.completedStages, [.play])
+        XCTAssertEqual(progress.currentStage, .blast)
+        XCTAssertEqual(progress.lastActivityAt, completedAt)
+        XCTAssertEqual(progress.stageSummaries[.play], summary)
+    }
+
+    func testLabLaunchedGameplayCompletionIsProfileScoped() throws {
+        let storage = InMemoryLabConceptSessionProgressDefaults()
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        let context = LabGameplayCompletionContext(plan: plan, stage: .play)
+        let first = LabConceptSessionProgressStore(
+            storage: storage,
+            storageKey: "test.lab-gameplay-profile",
+            activeProfileIdProvider: { "profile-a" }
+        )
+        let second = LabConceptSessionProgressStore(
+            storage: storage,
+            storageKey: "test.lab-gameplay-profile",
+            activeProfileIdProvider: { "profile-b" }
+        )
+
+        _ = first.beginGuidedStage(.play, in: plan)
+        _ = first.markLabLaunchedGameplayCompleted(context)
+
+        XCTAssertEqual(first.progress(for: plan)?.completedStages, [.play])
+        XCTAssertNil(second.progress(for: plan))
+    }
+
+    func testDirectGameplayCompletionWithoutLabContextDoesNotMutateLabProgress() throws {
+        let storage = InMemoryLabConceptSessionProgressDefaults()
+        let store = LabConceptSessionProgressStore(storage: storage, storageKey: "test.direct-gameplay-complete")
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+
+        XCTAssertNil(store.markLabLaunchedGameplayCompleted(nil))
+        XCTAssertNil(store.progress(for: plan))
+    }
+
+    func testNonPlayLabCompletionContextDoesNotAdvanceGameplayProgress() throws {
+        let storage = InMemoryLabConceptSessionProgressDefaults()
+        let store = LabConceptSessionProgressStore(storage: storage, storageKey: "test.non-play-context")
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        _ = store.beginGuidedStage(.remember, in: plan)
+
+        XCTAssertNil(store.markLabLaunchedGameplayCompleted(LabGameplayCompletionContext(plan: plan, stage: .remember)))
+        XCTAssertEqual(store.currentStage(for: plan), .remember)
+        XCTAssertEqual(store.progress(for: plan)?.completedStages, [])
+    }
+
     func testDirectGamesLaunchDoesNotMarkBlastOrScoreComplete() throws {
         let storage = InMemoryLabConceptSessionProgressDefaults()
         let store = LabConceptSessionProgressStore(storage: storage, storageKey: "test.direct-games")


### PR DESCRIPTION
## Summary
- carry Lab-launched Play-stage context into Sum Sprint completion handling
- advance profile-scoped Lab progress from Play to Blast on gameplay completion
- clear Lab completion context for direct Games/free-play launches so they remain isolated
- add focused Lab progress tests for callbacks, profile scoping, and direct-game isolation

## Validation
- `git diff --check`
- Attempted: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MatherTests/LabModelsTests` on `ganesh-mba`
- Local remote validation was blocked by a Swift frontend crash while type-checking unchanged `Features/ParentSummary/SettingsView.swift` under `ganesh-mba` Xcode 26.4.1; GitHub CI is the canonical validation path.

Part of #927.
