### PR TITLE
feat: hook Lab blast stage to Bond Blast finale

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -94,6 +94,25 @@ final class AppModel {
         _ = labConceptSessionProgressStore.markLabLaunchedGameplayCompleted(context, summary: stageSummary)
     }
 
+    func completePendingLabBondBlast(with summary: SessionSummaryDraft) {
+        let context = pendingLabGameplayCompletionContext
+        pendingLabGameplayCompletionContext = nil
+
+        let duration = summary.endedAt.timeIntervalSince(summary.startedAt)
+        let stageSummary = LabStageTimingScoreSummary(
+            durationSeconds: duration,
+            scoreSummary: LabSessionScoreSummary(
+                conceptTitle: summary.objectiveTitle,
+                stageDurations: [.blast: duration],
+                accuracy: summary.firstAttemptAccuracy,
+                streak: summary.transferCorrectCount,
+                weakAreas: [],
+                nextRecommendation: "Celebrate the spark score"
+            )
+        )
+        _ = labConceptSessionProgressStore.markLabLaunchedGameplayCompleted(context, summary: stageSummary)
+    }
+
     init(modelContext: ModelContext) {
         let profileStore = KidProfileStore(modelContext: modelContext)
         let featureFlags = FeatureFlagService()
@@ -182,6 +201,9 @@ final class AppModel {
         self.explorerLabMasteryProfile = explorerLabMasteryProfile
         self.sumSprintEngine = sumSprintEngine
         sumSprintEngine.onExitToHome = { [weak vsEngine] in vsEngine?.showHome() }
+        vsEngine.onSessionComplete = { [weak self] summary in
+            self?.completePendingLabBondBlast(with: summary)
+        }
         sumSprintEngine.onSessionComplete = { [weak self, weak gameSessionStore] summary in
             gameSessionStore?.save(
                 gameName: "Sum Sprint",

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -65,6 +65,8 @@ final class VerticalSliceEngine {
     private let speechService: SpeechService
     private let hapticsService: HapticsService
     private let saveSummary: (SessionSummaryDraft) -> Void
+    var onSessionComplete: ((SessionSummaryDraft) -> Void)?
+    private var initialStageOverride: SliceStage?
     // Injected so unit tests can pass 0 to skip the animation delay.
     let celebrationDuration: TimeInterval
     // Frozen at startSession(); never changes mid-session.
@@ -144,6 +146,12 @@ final class VerticalSliceEngine {
     func showSoundVolume() { route = .soundVolume }
     func showShapeGeometry() { route = .shapeGeometry }
 
+    func startBondBlastFinale(target: Int = 10) {
+        updateConfig(problemCount: 1, minTarget: target, maxTarget: target)
+        initialStageOverride = .bondMatch
+        startSession()
+    }
+
     func startSession() {
         // Freeze the active theme from the user's current selection — unless a custom
         // theme was injected at init time (e.g. in unit tests using an arbitrary theme).
@@ -179,6 +187,7 @@ final class VerticalSliceEngine {
         }
         currentProblemIndex = 0
         currentStage = initialStageForCurrentRoute()
+        initialStageOverride = nil
         currentProblemState = ProblemState(stage: currentStage)
         currentSession = SliceSession(
             sessionId: UUID(),
@@ -204,7 +213,9 @@ final class VerticalSliceEngine {
         sessionStartedAt = .now
         problemStartedAt = .now
         speechService.resetSession()
-        if currentStage == .storyAnchor, let currentStoryPrompt {
+        if currentStage == .bondMatch {
+            prepareForStage(currentStage)
+        } else if currentStage == .storyAnchor, let currentStoryPrompt {
             speechService.speak(currentStoryPrompt.spokenIntro, enabled: featureFlags.audioEnabled)
         } else {
             speechService.speakSessionIntro(activeTheme.sessionIntroPhrase())
@@ -695,6 +706,7 @@ final class VerticalSliceEngine {
             exportFileName: "swiftdata://session/\(currentSession.sessionId.uuidString)"
         )
         saveSummary(summary)
+        onSessionComplete?(summary)
         completedSummary = summary
         feedbackMessage = activeTheme.sessionEndPhrase()
         route = .sessionSummary
@@ -995,7 +1007,7 @@ final class VerticalSliceEngine {
     }
 
     private func initialStageForCurrentRoute() -> SliceStage {
-        featureFlags.makeBreakLoopV2Enabled ? .storyAnchor : .concrete
+        initialStageOverride ?? (featureFlags.makeBreakLoopV2Enabled ? .storyAnchor : .concrete)
     }
 
 }

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -726,7 +726,7 @@ struct LabLaneDetailView: View {
         guard let stage, let route = stage.route else { return }
         appModel.pickProfileThenRun {
             _ = appModel.labConceptSessionProgressStore.beginGuidedStage(stage.stage, in: plan)
-            if stage.stage == .play {
+            if stage.stage == .play || stage.stage == .blast {
                 appModel.prepareLabGameplayCompletion(plan: plan, stage: stage.stage)
             } else {
                 appModel.clearLabGameplayCompletion()
@@ -734,9 +734,13 @@ struct LabLaneDetailView: View {
             if plan.id == LabConceptSessionPlan.numbersNumberBondsTo10.id {
                 appModel.engine.updateConfig(problemCount: 4, minTarget: 1, maxTarget: 10)
             }
-            appModel.engine.show(route)
-            if route == .sumSprint {
-                appModel.sumSprintEngine.showDifficultyPick()
+            if stage.stage == .blast {
+                appModel.engine.startBondBlastFinale(target: 10)
+            } else {
+                appModel.engine.show(route)
+                if route == .sumSprint {
+                    appModel.sumSprintEngine.showDifficultyPick()
+                }
             }
         }
     }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -539,7 +539,7 @@ struct LabConceptSessionPlan: Identifiable, Equatable {
                 childCopy: "A rocket round appears when you’re ready to celebrate.",
                 parentCopy: "Blast is celebratory and readiness gated; countdown pressure is not default.",
                 timerPolicy: .readinessGatedBlast,
-                route: nil
+                route: .session
             ),
             LabSessionStagePlan(
                 stage: .score,

--- a/Persistence/LabConceptSessionProgressStore.swift
+++ b/Persistence/LabConceptSessionProgressStore.swift
@@ -70,7 +70,7 @@ final class LabConceptSessionProgressStore {
         summary: LabStageTimingScoreSummary? = nil
     ) -> LabConceptSessionProgress? {
         guard let context,
-              context.stage == .play,
+              [.play, .blast].contains(context.stage),
               let plan = LabConceptSessionPlan.plan(for: context.conceptPlanID),
               plan.stageOrder.contains(context.stage)
         else { return nil }

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -204,7 +204,7 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(plan.masteryStateLabel, "Recommended first")
         XCTAssertEqual(plan.recommendedNextActivity, "Make & Break warm-up")
         XCTAssertTrue(plan.stages.allSatisfy { !$0.accessibilityLabel.isEmpty })
-        XCTAssertEqual(plan.stages.map(\.actionLabel), ["Start", "Continue", "Continue", "Preview", "Preview"])
+        XCTAssertEqual(plan.stages.map(\.actionLabel), ["Start", "Continue", "Continue", "Continue", "Preview"])
     }
 
     func testNumbersLabPlanDoesNotChangeDirectGamesRegistry() {
@@ -390,7 +390,10 @@ final class LabModelsTests: XCTestCase {
         let rememberStage = try XCTUnwrap(plan.stages.first { $0.stage == .remember })
         let deck = LabRememberStageDeck.numbersNumberBondsTo10
 
+        let blastStage = try XCTUnwrap(plan.stages.first { $0.stage == .blast })
+
         XCTAssertEqual(rememberStage.route, .labRememberStage(.numbersNumberBondsTo10))
+        XCTAssertEqual(blastStage.route, .session)
         XCTAssertEqual(rememberStage.timerPolicy, .calmNoCountdown)
         XCTAssertFalse(rememberStage.timerPolicy.showsCountdown)
         XCTAssertFalse(rememberStage.timerPolicy.isPunitive)
@@ -399,6 +402,40 @@ final class LabModelsTests: XCTestCase {
         XCTAssertTrue(deck.cards.contains { $0.prompt == "7 + 3" && $0.answer == "10" })
     }
 
+
+
+    func testLabBlastStageLaunchesBondBlastFinaleRoute() throws {
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        let blast = try XCTUnwrap(plan.stages.first { $0.stage == .blast })
+
+        XCTAssertEqual(blast.title, "Bond Blast")
+        XCTAssertEqual(blast.route, .session)
+        XCTAssertEqual(blast.timerPolicy, .readinessGatedBlast)
+        XCTAssertFalse(blast.timerPolicy.showsCountdown)
+        XCTAssertFalse(blast.timerPolicy.isPunitive)
+    }
+
+    func testLabLaunchedBlastCompletionAdvancesToScoreWithSummary() throws {
+        let storage = InMemoryLabConceptSessionProgressDefaults()
+        let store = LabConceptSessionProgressStore(
+            storage: storage,
+            storageKey: "test.lab-blast-complete",
+            activeProfileIdProvider: { "profile-a" }
+        )
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        let launchedAt = Date(timeIntervalSince1970: 5_000)
+        let completedAt = Date(timeIntervalSince1970: 5_045)
+        let context = LabGameplayCompletionContext(plan: plan, stage: .blast)
+        let summary = LabStageTimingScoreSummary(durationSeconds: 45)
+
+        _ = store.beginGuidedStage(.blast, in: plan, at: launchedAt)
+        let progress = try XCTUnwrap(store.markLabLaunchedGameplayCompleted(context, at: completedAt, summary: summary))
+
+        XCTAssertEqual(progress.completedStages, [.blast])
+        XCTAssertEqual(progress.currentStage, .score)
+        XCTAssertEqual(progress.lastActivityAt, completedAt)
+        XCTAssertEqual(progress.stageSummaries[.blast], summary)
+    }
 
     func testLabLaunchedGameplayCompletionAdvancesPlayToBlastWithSummary() throws {
         let storage = InMemoryLabConceptSessionProgressDefaults()

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -51,6 +51,38 @@ struct VerticalSliceEngineTests {
         Issue.record("Timed out waiting for \(description)")
     }
 
+
+    @Test
+    func startBondBlastFinaleStartsDirectlyInBondMatchAndCompletesSummary() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = true
+
+        var completedSummary: SessionSummaryDraft?
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { completedSummary = $0 }
+        )
+
+        engine.startBondBlastFinale(target: 10)
+
+        #expect(engine.route == .session)
+        #expect(engine.currentStage == .bondMatch)
+        #expect(engine.currentProblem?.target == 10)
+        #expect(engine.bondMatchState?.target == 10)
+        #expect(engine.bondMatchState?.pairs.isEmpty == false)
+
+        for id in engine.bondMatchState?.pairs.map(\.id) ?? [] {
+            engine.matchPair(id: id)
+        }
+
+        await waitFor("bond blast finale summary") { engine.route == .sessionSummary }
+        #expect(completedSummary?.problemsCompleted == 1)
+    }
+
     @Test
     func loopV2RoutesConcreteToGravitySplitToSumSprintToBondBlast() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)


### PR DESCRIPTION
## Summary
- make the Numbers Lab Blast stage launch a Bond Blast finale session instead of staying as a placeholder
- carry Lab-launched Blast context through completion so profile-scoped Lab progress advances to Score
- preserve standalone/direct game isolation by only mutating Lab progress when Lab context exists
- add focused Lab model and VerticalSliceEngine tests for Blast routing/progress behavior

## Validation
- `git diff --check`
- Attempted: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MatherTests/LabModelsTests -only-testing:MatherTests/VerticalSliceEngineTests/startBondBlastFinaleStartsDirectlyInBondMatchAndCompletesSummary` on `ganesh-mba`
- Local remote validation was blocked by a Swift frontend crash while type-checking unchanged `Features/ParentSummary/SettingsView.swift` under Xcode 26.4.1; GitHub CI is the canonical validation path.

Part of #927.
