### PR TITLE
feat: hook Lab Bond Blast finale

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -95,6 +95,7 @@ final class AppModel {
     }
 
     func completePendingLabBondBlast(with summary: SessionSummaryDraft) {
+        guard pendingLabGameplayCompletionContext?.stage == .blast else { return }
         let context = pendingLabGameplayCompletionContext
         pendingLabGameplayCompletionContext = nil
 


### PR DESCRIPTION
## Summary
- route the Numbers Lab Blast stage into a Lab-contextual Bond Blast finale
- record Lab-launched Bond Blast completion into existing Lab progress/score summaries
- preserve standalone/direct game launches so direct Bond Blast/Sum Sprint do not mutate Lab progress

## Validation
- git diff --check
- remote ganesh-mba: xcodegen generate
- remote ganesh-mba: xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" -derivedDataPath /tmp/mather-927-dd-xcodegen -parallel-testing-enabled NO -only-testing:MatherTests/LabModelsTests -only-testing:MatherTests/VerticalSliceEngineTests/startBondBlastFinaleStartsDirectlyInBondMatchAndCompletesSummary

Refs #927
