### PR TITLE
Add sensor fallback readiness metadata

### DIFF
--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -323,7 +323,9 @@ struct LabLaneDetailView: View {
     }
 
     private func activityCard(_ activity: LabActivity, lane: CapabilityLane, tint: Color) -> some View {
-        Button {
+        let canLaunch = activity.id.canDirectLaunch(with: sensorCapabilities)
+
+        return Button {
             launch(activity.id)
         } label: {
             HStack(alignment: .center, spacing: 14) {
@@ -332,7 +334,7 @@ struct LabLaneDetailView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(activity.title)
                         .font(.title3.weight(.black))
-                        .foregroundStyle(MatherTheme.ink)
+                        .foregroundStyle(canLaunch ? MatherTheme.ink : MatherTheme.ink.opacity(0.55))
                         .lineLimit(2)
                         .minimumScaleFactor(0.82)
                     Text(activity.tagline)
@@ -340,17 +342,23 @@ struct LabLaneDetailView: View {
                         .foregroundStyle(MatherTheme.cardSubtitle)
                         .lineLimit(2)
                     sensorAffordanceRow(activity, tint: tint)
+                    if !canLaunch {
+                        Text("Try this on a device with motion sensing. Nothing is counted as wrong.")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
 
                 Spacer(minLength: 6)
 
                 ZStack {
                     Circle()
-                        .fill(tint)
-                    Image(systemName: "play.fill")
+                        .fill(canLaunch ? tint : MatherTheme.cardSubtitle.opacity(0.35))
+                    Image(systemName: canLaunch ? "play.fill" : "lock.open.trianglebadge.exclamationmark")
                         .font(.title2.weight(.black))
                         .foregroundStyle(.white)
-                        .offset(x: 2)
+                        .offset(x: canLaunch ? 2 : 0)
                 }
                 .frame(width: 64, height: 64)
                 .accessibilityHidden(true)
@@ -360,12 +368,14 @@ struct LabLaneDetailView: View {
             .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .stroke(tint.opacity(0.16), lineWidth: 1)
+                    .stroke((canLaunch ? tint : MatherTheme.cardSubtitle).opacity(0.16), lineWidth: 1)
             )
+            .opacity(canLaunch ? 1 : 0.78)
         }
         .buttonStyle(.plain)
+        .disabled(!canLaunch)
         .accessibilityLabel("Launch \(activity.title). \(activity.tagline)")
-        .accessibilityHint("Starts this \(lane.title) game. Modes: \(activity.modes.map(\.rawValue).joined(separator: ", ")). \(sensorAccessibilitySummary(for: activity)).")
+        .accessibilityHint(canLaunch ? "Starts this \(lane.title) game. Modes: \(activity.modes.map(\.rawValue).joined(separator: ", ")). \(sensorAccessibilitySummary(for: activity))." : "This game needs a sensor that is not available on this device. Nothing is marked wrong.")
     }
 
     private func recallSection(_ lane: CapabilityLane, tint: Color) -> some View {
@@ -704,6 +714,8 @@ struct LabLaneDetailView: View {
             return "location.north.line.fill"
         case .cameraMarkerMode:
             return "camera.viewfinder"
+        case .stepCounting:
+            return "figure.walk"
         case .haptics:
             return "waveform"
         }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -669,10 +669,44 @@ enum ExplorerGameRegistry {
     }
 }
 
+enum LabSensorFallback: Equatable {
+    case none
+    case sameRoute(copy: String, actionTitle: String)
+    case visualOnly(copy: String)
+
+    var copy: String? {
+        switch self {
+        case .none:
+            return nil
+        case .sameRoute(let copy, _), .visualOnly(let copy):
+            return copy
+        }
+    }
+
+    var actionTitle: String? {
+        switch self {
+        case .sameRoute(_, let actionTitle):
+            return actionTitle
+        case .none, .visualOnly:
+            return nil
+        }
+    }
+
+    var permitsLaunch: Bool {
+        switch self {
+        case .none:
+            return false
+        case .sameRoute, .visualOnly:
+            return true
+        }
+    }
+}
+
 enum LabSensorNeed: CaseIterable, Equatable {
     case noSpecialSensor
     case motion
     case compass
+    case stepCounting
     case cameraMarkerMode
     case haptics
 
@@ -680,10 +714,10 @@ enum LabSensorNeed: CaseIterable, Equatable {
         switch self {
         case .noSpecialSensor:
             return true
-        case .motion:
+        case .motion, .compass:
             return capabilities.supportsMotion
-        case .compass:
-            return capabilities.supportsHeading
+        case .stepCounting:
+            return capabilities.supportsStepCounting
         case .cameraMarkerMode:
             return capabilities.supportsCamera
         case .haptics:
@@ -698,36 +732,49 @@ enum LabSensorNeed: CaseIterable, Equatable {
             return LabSensorAffordance(
                 need: self,
                 isAvailable: true,
-                label: "No special sensor needed",
-                fallback: nil
+                label: "Touch ready",
+                permissionCopy: "No sensor permission needed.",
+                fallback: .sameRoute(copy: "Works with touch only", actionTitle: "Play")
             )
         case .motion:
             return LabSensorAffordance(
                 need: self,
                 isAvailable: available,
-                label: available ? "Motion ready" : "Motion unavailable",
-                fallback: available ? nil : "Touch fallback available"
+                label: available ? "Tilt ready" : "Tilt not available",
+                permissionCopy: "Tilt sensing does not ask for a child permission prompt.",
+                fallback: .none
             )
         case .compass:
             return LabSensorAffordance(
                 need: self,
                 isAvailable: available,
-                label: available ? "Compass ready" : "Compass unavailable",
-                fallback: available ? nil : "Use on-screen turns"
+                label: available ? "Body turns ready" : "Body turns not available",
+                permissionCopy: "Uses gentle body-relative motion, not a precise compass reading.",
+                fallback: .none
+            )
+        case .stepCounting:
+            return LabSensorAffordance(
+                need: self,
+                isAvailable: available,
+                label: available ? "Step sensing ready" : "Step sensing unavailable",
+                permissionCopy: "If Motion & Fitness is not allowed, the game switches to tap-to-count steps.",
+                fallback: .sameRoute(copy: "Tap each small step instead", actionTitle: "Use tap count")
             )
         case .cameraMarkerMode:
             return LabSensorAffordance(
                 need: self,
                 isAvailable: available,
                 label: available ? "Camera marker mode ready" : "Camera marker mode unavailable",
-                fallback: available ? nil : "Use tap-to-place stations"
+                permissionCopy: "Camera is only for local station checks; a grown-up can choose same-place fallback.",
+                fallback: .sameRoute(copy: "Use same-place setup", actionTitle: "Use setup fallback")
             )
         case .haptics:
             return LabSensorAffordance(
                 need: self,
                 isAvailable: available,
                 label: available ? "Haptics ready" : "Haptics unavailable",
-                fallback: available ? nil : "Visual feedback stays available"
+                permissionCopy: "No permission prompt needed for haptics.",
+                fallback: .visualOnly(copy: "Visual feedback stays available")
             )
         }
     }
@@ -738,11 +785,15 @@ struct LabSensorAffordance: Identifiable, Equatable {
     let need: LabSensorNeed
     let isAvailable: Bool
     let label: String
-    let fallback: String?
+    let permissionCopy: String
+    let fallback: LabSensorFallback
+
+    var fallbackCopy: String? { fallback.copy }
+    var permitsLaunch: Bool { isAvailable || fallback.permitsLaunch }
 
     var displayLabel: String {
-        guard let fallback else { return label }
-        return "\(label): \(fallback)"
+        guard !isAvailable, let fallbackCopy else { return label }
+        return "\(label): \(fallbackCopy)"
     }
 
     var accessibilityLabel: String {
@@ -750,16 +801,13 @@ struct LabSensorAffordance: Identifiable, Equatable {
     }
 
     var accessibilityHint: String {
-        if need == .noSpecialSensor {
-            return "Works with touch only."
-        }
         if isAvailable {
-            return "Sensor is ready for this activity."
+            return permissionCopy
         }
-        guard let fallback else {
-            return "This activity still works without extra setup."
+        guard let fallbackCopy else {
+            return "This game needs this sensor on the device. Try another game for now."
         }
-        return fallback
+        return fallbackCopy
     }
 }
 
@@ -838,12 +886,20 @@ extension LabActivityID {
         case .roomQuest:
             return [.cameraMarkerMode, .haptics]
         case .compassAngles:
-            return [.compass]
+            return [.compass, .stepCounting]
         }
     }
 
     func sensorAffordances(with capabilities: DeviceSensorCapabilities) -> [LabSensorAffordance] {
         sensorNeeds.map { $0.copy(with: capabilities) }
+    }
+
+    func canDirectLaunch(with capabilities: DeviceSensorCapabilities) -> Bool {
+        sensorAffordances(with: capabilities).allSatisfy(\.permitsLaunch)
+    }
+
+    func capabilitySummary(with capabilities: DeviceSensorCapabilities) -> String {
+        sensorAffordances(with: capabilities).map(\.displayLabel).joined(separator: " • ")
     }
 }
 

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -6,6 +6,7 @@ struct LabView: View {
     @Bindable var appModel: AppModel
     @State private var playfulPulse = false
     @State private var selectedPath: ExplorerPathID = .labs
+    @State private var sensorCapabilities = DeviceSensorCapabilities.unavailable
 
     private let lanes = CapabilityLane.defaultExplorerLanes
     private let guidedPaths = GuidedLabPath.phaseOne
@@ -42,6 +43,7 @@ struct LabView: View {
             }
         }
         .onAppear {
+            sensorCapabilities = SensorCapabilityService().currentCapabilities()
             withAnimation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true)) {
                 playfulPulse = true
             }
@@ -275,6 +277,9 @@ struct LabView: View {
         let tint = laneColor(entry.laneID)
         let activity = entry.activity
 
+        let canLaunch = activity.id.canDirectLaunch(with: sensorCapabilities)
+        let capabilitySummary = activity.id.capabilitySummary(with: sensorCapabilities)
+
         return Button {
             launchDirectGame(entry)
         } label: {
@@ -286,32 +291,38 @@ struct LabView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(activity.title)
                         .font(.headline.weight(.black))
-                        .foregroundStyle(MatherTheme.ink)
+                        .foregroundStyle(canLaunch ? MatherTheme.ink : MatherTheme.ink.opacity(0.55))
                         .lineLimit(2)
                     Text(activity.tagline)
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(MatherTheme.cardSubtitle)
                         .lineLimit(2)
-                    Text("Direct game")
+                    Text(canLaunch ? "Direct game" : "Needs a sensor on this device")
                         .font(.caption2.weight(.black))
-                        .foregroundStyle(tint)
+                        .foregroundStyle(canLaunch ? tint : MatherTheme.cardSubtitle)
+                    Text(capabilitySummary)
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .lineLimit(2)
                 }
                 Spacer(minLength: 0)
-                Image(systemName: "play.circle.fill")
+                Image(systemName: canLaunch ? "play.circle.fill" : "exclamationmark.triangle.fill")
                     .font(.title2.weight(.black))
-                    .foregroundStyle(tint)
+                    .foregroundStyle(canLaunch ? tint : MatherTheme.cardSubtitle)
             }
             .padding(14)
-            .frame(maxWidth: .infinity, minHeight: 116, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 126, alignment: .leading)
             .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .stroke(tint.opacity(0.16), lineWidth: 1)
+                    .stroke((canLaunch ? tint : MatherTheme.cardSubtitle).opacity(0.16), lineWidth: 1)
             )
+            .opacity(canLaunch ? 1 : 0.78)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Launch game \(activity.title). \(activity.tagline)")
-        .accessibilityHint("Directly starts the existing game route without a staged lab session.")
+        .disabled(!canLaunch)
+        .accessibilityLabel("Launch game \(activity.title). \(activity.tagline). \(capabilitySummary)")
+        .accessibilityHint(canLaunch ? "Directly starts the existing game route without a staged lab session." : "This game needs a device sensor that is not available here; no score is lost.")
     }
 
     private func launchDirectGame(_ entry: ExplorerGameEntry) {

--- a/Services/SensorCapabilityService.swift
+++ b/Services/SensorCapabilityService.swift
@@ -16,6 +16,7 @@ struct DeviceSensorCapabilities: Equatable, Sendable {
     let supportsMicrophone: Bool
     let supportsHaptics: Bool
     let supportsBarometer: Bool
+    let supportsStepCounting: Bool
 
     /// LiDAR is currently only a readiness signal for future Explorer Lab lanes.
     let supportsLiDAR: Bool
@@ -31,6 +32,7 @@ struct DeviceSensorCapabilities: Equatable, Sendable {
         supportsMicrophone: false,
         supportsHaptics: false,
         supportsBarometer: false,
+        supportsStepCounting: false,
         supportsLiDAR: false,
         supportsApplePencil: false
     )
@@ -67,6 +69,7 @@ struct SystemDeviceSensorCapabilityInspector: DeviceSensorCapabilityInspecting {
             supportsMicrophone: AVAudioSession.sharedInstance().isInputAvailable,
             supportsHaptics: CHHapticEngine.capabilitiesForHardware().supportsHaptics,
             supportsBarometer: CMAltimeter.isRelativeAltitudeAvailable(),
+            supportsStepCounting: CMPedometer.isStepCountingAvailable(),
             supportsLiDAR: ARWorldTrackingConfiguration.supportsSceneReconstruction(.mesh),
             supportsApplePencil: false
         )

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -621,7 +621,7 @@ extension LabModelsTests {
         XCTAssertEqual(LabActivityID.shapeGeometry.sensorNeeds, [.noSpecialSensor])
         XCTAssertEqual(LabActivityID.angleCannon.sensorNeeds, [.motion])
         XCTAssertEqual(LabActivityID.gravityArtist.sensorNeeds, [.motion])
-        XCTAssertEqual(LabActivityID.compassAngles.sensorNeeds, [.compass])
+        XCTAssertEqual(LabActivityID.compassAngles.sensorNeeds, [.compass, .stepCounting])
         XCTAssertEqual(LabActivityID.roomQuest.sensorNeeds, [.cameraMarkerMode, .haptics])
         XCTAssertEqual(LabActivityID.soundVolume.sensorNeeds, [.noSpecialSensor])
         XCTAssertEqual(LabActivityID.memoryMatch.sensorNeeds, [.noSpecialSensor])
@@ -633,11 +633,11 @@ extension LabModelsTests {
         XCTAssertEqual(
             affordances.map(\.displayLabel),
             [
-                "Camera marker mode unavailable: Use tap-to-place stations",
+                "Camera marker mode unavailable: Use same-place setup",
                 "Haptics unavailable: Visual feedback stays available",
             ]
         )
-        XCTAssertEqual(affordances.map(\.accessibilityHint), ["Use tap-to-place stations", "Visual feedback stays available"])
+        XCTAssertEqual(affordances.map(\.accessibilityHint), ["Use same-place setup", "Visual feedback stays available"])
         XCTAssertTrue(affordances.allSatisfy { !$0.isAvailable })
     }
 
@@ -649,17 +649,18 @@ extension LabModelsTests {
             supportsMicrophone: false,
             supportsHaptics: true,
             supportsBarometer: false,
+            supportsStepCounting: true,
             supportsLiDAR: false,
             supportsApplePencil: false
         )
 
         XCTAssertEqual(
             LabActivityID.angleCannon.sensorAffordances(with: capabilities).map(\.displayLabel),
-            ["Motion ready"]
+            ["Tilt ready"]
         )
         XCTAssertEqual(
             LabActivityID.compassAngles.sensorAffordances(with: capabilities).map(\.displayLabel),
-            ["Compass ready"]
+            ["Body turns ready", "Step sensing ready"]
         )
         XCTAssertEqual(
             LabActivityID.roomQuest.sensorAffordances(with: capabilities).map(\.displayLabel),
@@ -667,9 +668,32 @@ extension LabModelsTests {
         )
         XCTAssertEqual(
             LabActivityID.twoFingerProtractor.sensorAffordances(with: capabilities).map(\.displayLabel),
-            ["No special sensor needed"]
+            ["Touch ready"]
         )
     }
+
+    func testSensorLaunchPolicyKeepsFallbackGamesPlayableButDisablesSensorOnlyRoutes() {
+        XCTAssertTrue(LabActivityID.sumSprint.canDirectLaunch(with: .unavailable))
+        XCTAssertTrue(LabActivityID.roomQuest.canDirectLaunch(with: .unavailable))
+        XCTAssertFalse(LabActivityID.angleCannon.canDirectLaunch(with: .unavailable))
+        XCTAssertFalse(LabActivityID.gravityArtist.canDirectLaunch(with: .unavailable))
+        XCTAssertFalse(LabActivityID.compassAngles.canDirectLaunch(with: .unavailable))
+
+        let roomQuestCopy = LabActivityID.roomQuest.capabilitySummary(with: .unavailable)
+        XCTAssertTrue(roomQuestCopy.contains("Use same-place setup"))
+        XCTAssertTrue(roomQuestCopy.contains("Visual feedback stays available"))
+    }
+
+    func testSensorAffordancesExposePermissionAwareChildSafeCopy() {
+        let unavailableTilt = LabActivityID.angleCannon.sensorAffordances(with: .unavailable)
+        XCTAssertEqual(unavailableTilt.first?.accessibilityHint, "This game needs this sensor on the device. Try another game for now.")
+
+        let stepFallback = LabSensorNeed.stepCounting.copy(with: .unavailable)
+        XCTAssertEqual(stepFallback.displayLabel, "Step sensing unavailable: Tap each small step instead")
+        XCTAssertEqual(stepFallback.accessibilityHint, "Tap each small step instead")
+        XCTAssertTrue(stepFallback.permitsLaunch)
+    }
+
 }
 
 

--- a/Tests/MatherTests/SensorCapabilityServiceTests.swift
+++ b/Tests/MatherTests/SensorCapabilityServiceTests.swift
@@ -13,6 +13,7 @@ struct SensorCapabilityServiceTests {
             supportsMicrophone: false,
             supportsHaptics: true,
             supportsBarometer: false,
+            supportsStepCounting: true,
             supportsLiDAR: false,
             supportsApplePencil: false
         )


### PR DESCRIPTION
## Summary
Adds Lab/Games sensor capability and fallback readiness metadata so sensor-dependent games are honest about availability, permissions, and safe fallback routes.

## Linked Issues
Refs #927

## Type of Change
- [x] New feature (ready to ship)
- [x] Bug fix

## Trunk-Based Dev Checklist
- [x] Branch is short-lived (< 2 days from `main`)
- [x] Incomplete features are behind a feature flag
- [ ] CI passes (build + tests)
- [x] New code has tests (or explain why not)
- [x] No new secrets, unsafe workflow permissions, or unpinned automation were introduced

## Testing
- `git diff --check`
- Attempted on `ganesh-mba`: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MatherTests/LabModelsTests -only-testing:MatherTests/SensorCapabilityServiceTests` — blocked by Swift 6.3.1 / Xcode 26.4 frontend crash while type-checking pre-existing `Features/ParentSummary/SettingsView.swift` `profilesCard`.
- Attempted with `SWIFT_COMPILATION_MODE=wholemodule` and CI-style `build-for-testing`; same unrelated frontend crash. CI on macos-15 should provide canonical validation.

## Screenshots / Screen Recording
Not captured; UI copy/model pass only.
