### PR TITLE
Polish Labs and Games artwork metadata

### DIFF
--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -268,7 +268,15 @@ struct LabLaneDetailView: View {
         let stageState = progressState(for: stage.stage, progress: progress)
         return VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
-                Text(stage.stage.emoji)
+                ZStack {
+                    Circle()
+                        .fill(tint.opacity(0.12))
+                    Image(systemName: stage.stage.symbolName)
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(tint)
+                }
+                .frame(width: 26, height: 26)
+                .accessibilityLabel(stage.stage.artworkAccessibilityLabel)
                 Text(stage.stage.rawValue)
                     .font(.caption.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
@@ -627,6 +635,7 @@ struct LabLaneDetailView: View {
                 .font(.system(size: 42))
         }
         .frame(width: 76, height: 76)
+        .accessibilityLabel("Lab artwork for \(lane.title)")
     }
 
     private func activityVisual(_ activity: LabActivity, tint: Color) -> some View {
@@ -639,7 +648,7 @@ struct LabLaneDetailView: View {
                 .offset(x: -18, y: -14)
         }
         .frame(width: 104, height: 96)
-        .accessibilityHidden(true)
+        .accessibilityLabel(activity.artworkAccessibilityLabel)
     }
 
     @ViewBuilder

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -348,6 +348,10 @@ struct LabActivity: Identifiable, Equatable {
         self.modes = modes
     }
 
+    var artworkAccessibilityLabel: String {
+        "Game artwork for \(title)"
+    }
+
     var accessibilityLabel: String {
         "\(title). \(tagline)"
     }
@@ -368,14 +372,22 @@ enum ExplorerPathID: String, CaseIterable, Hashable, Identifiable {
 struct ExplorerPathPresentation: Identifiable, Equatable {
     let id: ExplorerPathID
     let emoji: String
+    let symbolName: String
+    let artMotif: String
     let title: String
     let subtitle: String
     let callToAction: String
+
+    var artworkAccessibilityLabel: String {
+        "Decorative \(artMotif) artwork for \(title)"
+    }
 
     static let all: [ExplorerPathPresentation] = [
         ExplorerPathPresentation(
             id: .labs,
             emoji: "🧭",
+            symbolName: "sparkles.rectangle.stack.fill",
+            artMotif: "guided compass path",
             title: "Labs",
             subtitle: "Guided sessions that move from learning to remembering, playful practice, blast rounds, and score.",
             callToAction: "Start a learning path"
@@ -383,6 +395,8 @@ struct ExplorerPathPresentation: Identifiable, Equatable {
         ExplorerPathPresentation(
             id: .games,
             emoji: "🎮",
+            symbolName: "gamecontroller.fill",
+            artMotif: "arcade play portal",
             title: "Games",
             subtitle: "Jump straight into the games you already love — no staged lesson required.",
             callToAction: "Play now"
@@ -407,6 +421,30 @@ enum GuidedLabStage: String, CaseIterable, Codable, Hashable, Identifiable {
         case .blast: return "🚀"
         case .score: return "⭐"
         }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .learn: return "cube.transparent.fill"
+        case .remember: return "rectangle.on.rectangle.angled"
+        case .play: return "gamecontroller.fill"
+        case .blast: return "flame.fill"
+        case .score: return "star.circle.fill"
+        }
+    }
+
+    var artMotif: String {
+        switch self {
+        case .learn: return "hands-on blocks"
+        case .remember: return "memory cards"
+        case .play: return "practice game"
+        case .blast: return "celebration rocket"
+        case .score: return "progress star"
+        }
+    }
+
+    var artworkAccessibilityLabel: String {
+        "\(rawValue) stage artwork: \(artMotif)"
     }
 
     var microcopy: String {

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -121,8 +121,7 @@ struct LabView: View {
 
         return VStack(alignment: .leading, spacing: compact ? 8 : 10) {
             HStack(spacing: 10) {
-                Text(path.emoji)
-                    .font(.system(size: compact ? 30 : 38))
+                explorerArtwork(path, tint: tint, compact: compact)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(path.title)
                         .font(.system(size: compact ? 22 : 26, weight: .black, design: .rounded))
@@ -192,8 +191,7 @@ struct LabView: View {
         return LazyVGrid(columns: columns, spacing: compact ? 6 : 8) {
             ForEach(GuidedLabStage.allCases) { stage in
                 VStack(spacing: 4) {
-                    Text(stage.emoji)
-                        .font(.title3)
+                    stageArtwork(stage, tint: MatherTheme.accent, compact: compact)
                     Text(stage.rawValue)
                         .font(.caption2.weight(.black))
                         .foregroundStyle(MatherTheme.ink)
@@ -210,6 +208,39 @@ struct LabView: View {
         }
     }
 
+    private func explorerArtwork(_ path: ExplorerPathPresentation, tint: Color, compact: Bool) -> some View {
+        ZStack(alignment: .bottomTrailing) {
+            RoundedRectangle(cornerRadius: compact ? 16 : 18, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [tint.opacity(0.26), tint.opacity(0.08), MatherTheme.card.opacity(0.9)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            Image(systemName: path.symbolName)
+                .font(.system(size: compact ? 22 : 28, weight: .black))
+                .foregroundStyle(tint)
+            Text(path.emoji)
+                .font(.system(size: compact ? 16 : 20))
+                .offset(x: 3, y: 4)
+        }
+        .frame(width: compact ? 46 : 56, height: compact ? 46 : 56)
+        .accessibilityLabel(path.artworkAccessibilityLabel)
+    }
+
+    private func stageArtwork(_ stage: GuidedLabStage, tint: Color, compact: Bool) -> some View {
+        ZStack {
+            Circle()
+                .fill(tint.opacity(0.12))
+            Image(systemName: stage.symbolName)
+                .font(.system(size: compact ? 14 : 16, weight: .black))
+                .foregroundStyle(tint)
+        }
+        .frame(width: compact ? 30 : 34, height: compact ? 30 : 34)
+        .accessibilityLabel(stage.artworkAccessibilityLabel)
+    }
+
     private func guidedPathCard(_ path: GuidedLabPath) -> some View {
         let lane = lanes.first { $0.id == path.laneID }
         let tint = laneColor(path.laneID)
@@ -218,10 +249,18 @@ struct LabView: View {
             appModel.engine.showLabLane(path.laneID)
         } label: {
             HStack(spacing: 12) {
-                Text(lane?.emoji ?? "🧪")
-                    .font(.system(size: 34))
-                    .frame(width: 58, height: 58)
-                    .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                ZStack {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(tint.opacity(0.12))
+                    Image(systemName: "sparkles")
+                        .font(.title2.weight(.black))
+                        .foregroundStyle(tint)
+                    Text(lane?.emoji ?? "🧪")
+                        .font(.system(size: 24))
+                        .offset(x: 10, y: 10)
+                }
+                .frame(width: 58, height: 58)
+                .accessibilityLabel("Guided lab artwork for \(path.title)")
                 VStack(alignment: .leading, spacing: 4) {
                     Text(path.title)
                         .font(.headline.weight(.black))
@@ -284,10 +323,24 @@ struct LabView: View {
             launchDirectGame(entry)
         } label: {
             HStack(spacing: 12) {
-                Text(activity.emoji)
-                    .font(.system(size: 36))
-                    .frame(width: 62, height: 62)
-                    .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                ZStack {
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: [tint.opacity(0.18), MatherTheme.card.opacity(0.88)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                    Image(systemName: "play.circle.fill")
+                        .font(.title2.weight(.black))
+                        .foregroundStyle(tint.opacity(canLaunch ? 1 : 0.45))
+                    Text(activity.emoji)
+                        .font(.system(size: 24))
+                        .offset(x: 11, y: 11)
+                }
+                .frame(width: 62, height: 62)
+                .accessibilityLabel(activity.artworkAccessibilityLabel)
                 VStack(alignment: .leading, spacing: 4) {
                     Text(activity.title)
                         .font(.headline.weight(.black))

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -129,10 +129,26 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(labs.title, "Labs")
         XCTAssertTrue(labs.subtitle.contains("Guided sessions"))
         XCTAssertEqual(labs.callToAction, "Start a learning path")
+        XCTAssertEqual(labs.symbolName, "sparkles.rectangle.stack.fill")
+        XCTAssertTrue(labs.artworkAccessibilityLabel.contains("Labs"))
 
         XCTAssertEqual(games.title, "Games")
         XCTAssertTrue(games.subtitle.contains("Jump straight into"))
         XCTAssertEqual(games.callToAction, "Play now")
+        XCTAssertEqual(games.symbolName, "gamecontroller.fill")
+        XCTAssertTrue(games.artworkAccessibilityLabel.contains("Games"))
+    }
+
+    func testGuidedStageArtworkMetadataAvoidsEmbeddedTextDependency() {
+        XCTAssertEqual(GuidedLabStage.allCases.map(\.symbolName), [
+            "cube.transparent.fill",
+            "rectangle.on.rectangle.angled",
+            "gamecontroller.fill",
+            "flame.fill",
+            "star.circle.fill",
+        ])
+        XCTAssertTrue(GuidedLabStage.allCases.allSatisfy { !$0.artMotif.isEmpty })
+        XCTAssertTrue(GuidedLabStage.allCases.allSatisfy { $0.artworkAccessibilityLabel.contains($0.rawValue) })
     }
 
     func testPhaseOneGuidedLabPathShowsStagedLearningLoop() throws {


### PR DESCRIPTION
## Summary
- Adds explicit playful artwork metadata for top-level Labs/Games cards and Guided Lab stage checkpoints.
- Updates Labs/Games cards and stage badges to use layered SF Symbol + emoji artwork instead of plain emoji-only badges.
- Adds accessibility labels for path, stage, lane, and direct-game artwork.
- Keeps direct Games visually first-class and one-tap playable.

## Asset/source notes
- No generated bitmap assets were introduced in this PR.
- Artwork uses system SF Symbols plus existing emoji motifs, so there is no embedded text in the art layer and localization stays in SwiftUI `Text`.

## Validation
- `git diff --check`
- Attempted on `ganesh-mba`:
  `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:MatherTests/LabModelsTests CODE_SIGNING_ALLOWED=NO`
- Local remote validation is still blocked by the pre-existing Swift 6.3.1 frontend crash while type-checking `Features/ParentSummary/SettingsView.swift`; CI is the canonical validation path.

## Screenshots
- Not attached from local validation because the simulator build is blocked by the existing `SettingsView.swift` Swift frontend crash before the app can launch.

Closes #934
Refs #927
