### PR TITLE
Fix gameplay thread recovery controls

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -6,12 +6,20 @@ struct GameplayStageNavigationState: Equatable {
     var stageResults: [GameplayStageResult]
     var startedAt: Date
     var currentStageStartedAt: Date
+    var stageAttemptToken: Int
 
-    init(activeStageIndex: Int = 0, stageResults: [GameplayStageResult] = [], startedAt: Date = Date(), currentStageStartedAt: Date = Date()) {
+    init(
+        activeStageIndex: Int = 0,
+        stageResults: [GameplayStageResult] = [],
+        startedAt: Date = Date(),
+        currentStageStartedAt: Date = Date(),
+        stageAttemptToken: Int = 0
+    ) {
         self.activeStageIndex = max(0, activeStageIndex)
         self.stageResults = stageResults
         self.startedAt = startedAt
         self.currentStageStartedAt = currentStageStartedAt
+        self.stageAttemptToken = max(0, stageAttemptToken)
     }
 
     func activeStage(in thread: GameplayThreadDefinition) -> GameplayStageDefinition? {
@@ -40,10 +48,30 @@ struct GameplayStageNavigationState: Equatable {
         guard activeStageIndex > 0 else { return }
         activeStageIndex -= 1
         currentStageStartedAt = now
+        stageAttemptToken += 1
+    }
+
+    mutating func goBack(in thread: GameplayThreadDefinition, now: Date = Date()) {
+        guard activeStageIndex > 0 else { return }
+        activeStageIndex -= 1
+        if let stage = activeStage(in: thread) {
+            stageResults.removeAll { $0.stageID == stage.id }
+        }
+        currentStageStartedAt = now
+        stageAttemptToken += 1
     }
 
     mutating func retryCurrentStage(now: Date = Date()) {
         currentStageStartedAt = now
+        stageAttemptToken += 1
+    }
+
+    mutating func retryCurrentStage(in thread: GameplayThreadDefinition, now: Date = Date()) {
+        if let stage = activeStage(in: thread) {
+            stageResults.removeAll { $0.stageID == stage.id }
+        }
+        currentStageStartedAt = now
+        stageAttemptToken += 1
     }
 
     mutating func completeCurrentStage(

--- a/Features/GameplayStages/GameplayThreadView.swift
+++ b/Features/GameplayStages/GameplayThreadView.swift
@@ -24,23 +24,32 @@ struct GameplayThreadView: View {
     let thread: GameplayThreadDefinition
     var actions: GameplayStageFeedbackActions
     var progressStore: GameplayProgressStore?
+    var onExitHome: (() -> Void)?
     @State private var navigation: GameplayStageNavigationState
 
     init(
         thread: GameplayThreadDefinition = GameplaySampleThreads.countries,
         actions: GameplayStageFeedbackActions = GameplayStageFeedbackActions(),
         progressStore: GameplayProgressStore? = nil,
+        onExitHome: (@escaping () -> Void)? = nil,
         now: Date = Date()
     ) {
         self.thread = thread
         self.actions = actions
         self.progressStore = progressStore
+        self.onExitHome = onExitHome
         _navigation = State(initialValue: GameplayStageNavigationState(startedAt: now, currentStageStartedAt: now))
     }
 
     @MainActor
     init(thread: GameplayThreadDefinition = GameplaySampleThreads.countries, appModel: AppModel, now: Date = Date()) {
-        self.init(thread: thread, actions: .appModel(appModel), progressStore: appModel.gameplayProgressStore, now: now)
+        self.init(
+            thread: thread,
+            actions: .appModel(appModel),
+            progressStore: appModel.gameplayProgressStore,
+            onExitHome: { appModel.engine.showHome() },
+            now: now
+        )
     }
 
     var body: some View {
@@ -67,9 +76,11 @@ struct GameplayThreadView: View {
         if navigation.isComplete(for: thread) {
             GameplayThreadSummaryView(summary: navigation.summary(), stageCount: thread.stages.count)
         } else if let stage = navigation.activeStage(in: thread) {
-            let round = progressStore?.makeRound(thread: thread, stage: stage, seed: UInt64(navigation.activeStageIndex + 17))
-                ?? SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: UInt64(navigation.activeStageIndex + 17))
-            switch stage.kind {
+            let roundSeed = UInt64(max(0, navigation.activeStageIndex + 17 + navigation.stageAttemptToken * 7_919))
+            let round = progressStore?.makeRound(thread: thread, stage: stage, seed: roundSeed)
+                ?? SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: roundSeed)
+            Group {
+                switch stage.kind {
             case .flashcards:
                 FlashcardStageView(thread: thread, stage: stage, round: round, actions: actions, compact: compact) { correct, mistakes, hints in
                     complete(stage: stage, round: round, correct: correct, mistakes: mistakes, hints: hints)
@@ -90,7 +101,9 @@ struct GameplayThreadView: View {
                 MultipleChoiceStageView(thread: thread, stage: stage, round: round, actions: actions, compact: compact) { correct, mistakes, hints in
                     complete(stage: stage, round: round, correct: correct, mistakes: mistakes, hints: hints)
                 }
+                }
             }
+            .id("\(stage.id)-\(navigation.stageAttemptToken)")
         } else {
             Text("No stage is available yet.")
                 .font(.headline)
@@ -190,11 +203,15 @@ struct GameplayThreadView: View {
 
     private func controlButtons(compact: Bool) -> some View {
         HStack(spacing: 8) {
-            Button("Back") { navigation.goBack() }
+            Button("Back") { navigation.goBack(in: thread) }
                 .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
                 .disabled(!navigation.canGoBack)
-            Button("Retry") { navigation.retryCurrentStage() }
+            Button("Retry") { navigation.retryCurrentStage(in: thread) }
                 .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
+            if let onExitHome {
+                Button("Home") { onExitHome() }
+                    .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
+            }
         }
     }
 

--- a/Features/GameplayStages/GameplayThreadView.swift
+++ b/Features/GameplayStages/GameplayThreadView.swift
@@ -31,7 +31,7 @@ struct GameplayThreadView: View {
         thread: GameplayThreadDefinition = GameplaySampleThreads.countries,
         actions: GameplayStageFeedbackActions = GameplayStageFeedbackActions(),
         progressStore: GameplayProgressStore? = nil,
-        onExitHome: (@escaping () -> Void)? = nil,
+        onExitHome: (() -> Void)? = nil,
         now: Date = Date()
     ) {
         self.thread = thread

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -27,6 +27,56 @@ struct GameplayStageViewModelTests {
     }
 
     @Test
+    func retryReopensCompletedCurrentStageWithFreshAttemptToken() {
+        let thread = GameplaySampleThreads.countries
+        let start = Date(timeIntervalSince1970: 20)
+        var navigation = GameplayStageNavigationState(startedAt: start, currentStageStartedAt: start)
+
+        for index in thread.stages.indices {
+            navigation.completeCurrentStage(
+                thread: thread,
+                correctCount: 2,
+                mistakeCount: 0,
+                now: start.addingTimeInterval(Double(index + 1) * 5)
+            )
+        }
+
+        #expect(navigation.isComplete(for: thread))
+        let previousToken = navigation.stageAttemptToken
+
+        navigation.retryCurrentStage(in: thread, now: start.addingTimeInterval(100))
+
+        #expect(!navigation.isComplete(for: thread))
+        #expect(navigation.activeStage(in: thread)?.id == thread.stages.last?.id)
+        #expect(!navigation.stageResults.contains { $0.stageID == thread.stages.last?.id })
+        #expect(navigation.stageAttemptToken == previousToken + 1)
+    }
+
+    @Test
+    func backFromCompletedSummaryReopensPreviousStage() {
+        let thread = GameplaySampleThreads.countries
+        let start = Date(timeIntervalSince1970: 30)
+        var navigation = GameplayStageNavigationState(startedAt: start, currentStageStartedAt: start)
+
+        for index in thread.stages.indices {
+            navigation.completeCurrentStage(
+                thread: thread,
+                correctCount: 2,
+                mistakeCount: 0,
+                now: start.addingTimeInterval(Double(index + 1) * 5)
+            )
+        }
+
+        #expect(navigation.isComplete(for: thread))
+
+        navigation.goBack(in: thread, now: start.addingTimeInterval(100))
+
+        #expect(!navigation.isComplete(for: thread))
+        #expect(navigation.activeStage(in: thread)?.id == thread.stages[thread.stages.count - 2].id)
+        #expect(!navigation.stageResults.contains { $0.stageID == thread.stages[thread.stages.count - 2].id })
+    }
+
+    @Test
     func flashcardListenAgainAccessibilityNamesActiveCardAndTracksExposure() {
         let thread = GameplaySampleThreads.countries
         let stage = thread.stages[0]
@@ -59,7 +109,6 @@ struct GameplayStageViewModelTests {
         #expect(correctResult)
         #expect(viewModel.correctCount == 1)
     }
-
 
     @Test
     func flipMemoryConcealsUnmatchedAnswerCardsUntilMatched() {

--- a/wiki/Specs/Mather-Build78-81-Lane-Wave-Enrichment-2026-05-04.md
+++ b/wiki/Specs/Mather-Build78-81-Lane-Wave-Enrichment-2026-05-04.md
@@ -1,0 +1,155 @@
+# Mather build 78–81 lane wave enrichment — open issues #946–#965
+
+Created: 2026-05-04 18:05 UTC  
+Repo: `ganesh47/mather`  
+Base inspected: `origin/main` at `de47b6b` (`feat: polish labs games artwork metadata (#956)`)  
+Raw issue snapshot: `artifacts/mather-build78-81-wave-20260504/open-issues-full.json`  
+Readable issue snapshot: `artifacts/mather-build78-81-wave-20260504/open-issues-readable.md`  
+Downloaded screenshots: `artifacts/mather-build78-81-wave-20260504/screenshots/issue-946-1.jpg` … `issue-964-1.jpg`
+
+## 0. Executive read
+
+This queue is mostly one coherent TestFlight theme: **the new cross-domain gameplay-thread/lab experience is useful, but it must inherit the product’s standard stage model, visible recovery controls, visual card treatment, and compact child-friendly pacing.**
+
+The safest immediate implementation slice is the navigation/recovery cluster:
+
+- #947 — Retry does not actually reset the stage; no Home route.
+- #948 — Back from completed summary does not return to playable stage.
+- #957 — Gameplay thread lacks an obvious Home escape hatch.
+
+Those share a small surface (`GameplayStageNavigationState` + `GameplayThreadView`) and can be fixed without disturbing domain content or stage model decisions.
+
+## 1. Issue inventory and enriched classification
+
+| Issue | Build | Visible / inferred area | Feedback | Cluster | Likely root cause | Acceptance summary |
+| --- | --- | --- | --- | --- | --- | --- |
+| #965 | n/a | VS1 milestone progress check | VS1 milestone says 35/35 closed, 0 open | Tracking / umbrella | Not a product bug; useful coordinator anchor | Use as tracking comment surface; do not close product bugs through it |
+| #964 | 81 | Shape Lab / ShapeGeometry | Shape Lab UX diverges from standard stages/cards | Geometry labs stage unification | `ShapeGeometryLabView` uses local `ShapeGeometryStage`, bespoke picker/progress/card UI, not `GameplayThreadDefinition`/shared cards | Shape Lab either wraps into shared stage model or has explicit adapter using shared stage strip, card components, retry/back/home conventions |
+| #963 | 81 | Symmetry Fold / Symmetry Lab | Symmetry Lab does not follow stage pattern | Geometry labs stage unification | `RootView` routes directly to standalone `SymmetryFoldView`; no shared staged thread/session plan | Symmetry Lab shows a multi-stage path: learn/look, memory/recognize, fold play, challenge, score; current fold remains core Play stage |
+| #962 | 81 | Angle Cannon / Angle Lab | Angle Cannon should become Angle Lab with lessons/stages | Geometry labs stage unification | `RootView` routes directly to `AngleCannonView`; angle tools are separate, not a staged lab | Angle Lab staged wrapper exists with vocabulary/visual matching, cannon play, protractor practice, score |
+| #961 | 81 | Gameplay thread first stage | Need to show all stages, not just first stage | Gameplay stage overview | `GameplayThreadView` only renders current active stage; header says Stage X/Y but no full stage overview/list | Add standard stage strip/overview showing all stages with locked/current/done/replay states |
+| #960 | 81 | Country Cards gameplay | Countries repeat in the round | Gameplay round diversification | `SpacedRepetitionScheduler` samples entity-property pairs; same country appears with different facts but left title stays generic country name | One property per country per turn, or visually label property focus when an entity repeats |
+| #959 | 81 | Single-card / flashcard display | Card images should be bigger; one card can be large | Shared card visuals | `GameplayDisplayCard` renders `visualKey` text only in small circle; ignores `visualAssetName`; flashcards reuse grid-sized card | Render `Image(visualAssetName)` when present and add hero/single-card visual sizing for flashcards |
+| #958 | 81 | Water Cycle thread stage | Stage is buggy/not working in Water Cycle | Shared pairing shell / Water Cycle content | Water Cycle uses shared pairing shell; known defects: hidden right cards do not flip, generic Bond Blast shell, possible repeated step names in 8-item mixed stage | Fix shared pairing mechanics first, then Water Cycle-specific turn sizing/visual cycle diagram if needed |
+| #957 | 81 | Gameplay thread controls | No way to navigate Home | Navigation/recovery | `GameplayThreadView` controls are Back/Retry/score only; appModel route home action not exposed | Home/Done control visible in active and summary states; routes through `appModel.engine.showHome()` |
+| #955 | 78 | Top-level / Labs menu | Menu options are crowded | IA / compact menu hierarchy | `HomeView` exposes two large feature cards plus secondary actions; `LabView` and lane cards carry dense copy | Top-level uses two primary choices `Labs` and `Games`; secondary parent/settings de-emphasized; compact copy reduced |
+| #954 | 78 | Lab lane detail / plan cards | Screen crowded and too detailed | Lab progressive disclosure | `LabLaneDetailView` shows title/subtitle/mastery/length/next/resume + every stage card with parent and timing copy | Default child view shows one recommended action + compact stage strip; parent/timing details behind disclosure |
+| #953 | 78 | Labs landing | Missing streams: Physics, Geometry, Chemistry, Geography | Labs breadth visibility | `CapabilityLaneID` and default lanes include streams, but `GuidedLabPath.phaseOne` only has Numbers path, making breadth feel absent | Add first-class guided paths or make lane grid primary; learner-facing `Map & World`/Geography label clear |
+| #952 | 78 | Pairing / flip-memory stage | Too much scrolling; use multiple turns and spaced repetition | Gameplay turn chunking | `GameplayPairingStageShell` renders all left/right cards in two `LazyVGrid`s; Country stages allow 8–10 items | Pairing stages paginate into 3–4 pair turns; misses requeue later; no compact-device scrolling through a full grid |
+| #951 | 78 | Flip Memory | Tap does not open hidden card | Flip-memory interaction bug | `chooseRight` immediately returns false when no left card is selected; `shouldConcealRight` stays true | Hidden right-card tap previews/reveals in flip mode; matching evaluates only when a left prompt is selected |
+| #950 | 78 | Bond Blast stage | Generic stage is not Numbers Bond Blast | Bond Blast consistency | `BondBlastStageView` uses generic pairing shell, while VS1 uses bespoke `BondMatchView` | Shared/domain-adaptable Bond Blast interaction preserves Numbers mental model with non-number content |
+| #949 | 78 | Country map-shape cards | Draw country outline instead of textual description | Geography visual assets | `map-shape` property values are text; `visualKey` is `🗺️`; no outline asset rendering | Add map-outline/vector assets; card primary visual is silhouette; text moves to subtitle/accessibility |
+| #948 | 78 | Gameplay summary / Back | Back does not go to stage play | Navigation/recovery | `isComplete` remains true because all stage results remain after `goBack`; summary keeps rendering | Back from summary reopens previous playable stage or stage replay mode; regression test exists |
+| #947 | 78 | Gameplay summary / controls | Retry does not work; no Home | Navigation/recovery | `retryCurrentStage()` only resets timestamp; child view state/result not reset; no Home action | Retry increments stage instance/seed and removes current result when needed; Home visible; regression test exists |
+| #946 | 78 | Main menu | Main menu should have two streams, Labs and Games | IA / compact menu hierarchy | `HomeView` has `Make & Break` and `Explorer Lab` as peer top-level tiles; Labs/Games split exists deeper in `LabView` | Home IA promotes `Labs` and `Games`; Make & Break becomes entry under suitable stream |
+
+## 2. Duplicate / dependency clusters
+
+### A. Navigation and recovery — #947, #948, #957
+
+**Intent:** Gameplay threads must never trap child/parent users in a stage or summary. Back, Retry, and Home should reverse/restart/exit predictably.
+
+**Implementation surface:**
+
+- `Domain/GameplayStageViewModels.swift`
+  - `GameplayStageNavigationState.goBack`
+  - `GameplayStageNavigationState.retryCurrentStage`
+  - `isComplete(for:)`
+- `Features/GameplayStages/GameplayThreadView.swift`
+  - app-model initializer
+  - controls row
+  - active stage view identity/seed
+- Tests: `Tests/MatherTests/GameplayStageViewModelTests.swift`
+
+**Root cause:** Navigation state tracks completed stage results, but Back/Retry do not alter those results or force a fresh child stage instance. Since `activeStage` is hidden when `isComplete` is true, summary stays visible.
+
+**Acceptance:**
+
+- Active stage and summary both expose a Home/Done route to the app home.
+- Retry resets the current playable stage, including child `@State` and round seed/identity.
+- Retry from summary reopens the last stage instead of staying on summary.
+- Back from complete summary reopens the previous playable stage or explicit replay mode.
+- Regression tests cover retry/back state transitions.
+
+### B. Shared gameplay shell quality — #951, #952, #958, #960, #961
+
+**Intent:** Country/Water Cycle/Fruit gameplay threads should feel like stage-based, turn-based children’s activities, not large static grids.
+
+**Root causes:**
+
+- `GameplayThreadView` has no stage overview (#961).
+- `GameplayPairingStageShell` lays out all pairs at once (#952).
+- Flip memory conceals answer cards but does not support preview reveal (#951).
+- Round selection works at entity-property level, so country names repeat without context (#960).
+- Water Cycle inherits every shell problem and adds sequential science semantics (#958).
+
+**Acceptance:**
+
+- Stage overview/strip shows the entire thread.
+- Pairing stages use compact turns (3–4 pairs) with miss requeue.
+- Flip cards reveal on tap before match evaluation.
+- Country rounds avoid unlabelled duplicate country prompts in one turn.
+- Water Cycle is regression-tested after shell fixes, ideally with a cycle-order visual.
+
+### C. Card visual asset use — #949, #959
+
+**Intent:** Visual concepts should be visual. When a card has art, the art should dominate the card, especially on single-card flashcard screens.
+
+**Root causes:**
+
+- `GameplayDisplayCard` ignores `visualAssetName` and renders `visualKey` text/emoji in a small circular area.
+- Country `map-shape` currently has text descriptions instead of outline assets.
+
+**Acceptance:**
+
+- Shared card supports image assets with text/emoji fallback.
+- Flashcard/single-card stage uses a hero card variant.
+- Country map-shape property has silhouette assets or vector outlines and keeps descriptions for accessibility/subtitle.
+
+### D. Geometry lab stage unification — #962, #963, #964
+
+**Intent:** Angle, Symmetry, and Shape should feel like coherent Labs with lessons/stages, not standalone one-off games.
+
+**Root causes:** standalone views (`AngleCannonView`, `SymmetryFoldView`, `ShapeGeometryLabView`) bypass the shared gameplay/lab stage model.
+
+**Acceptance:**
+
+- Angle Lab: vocabulary/lesson → visual matching → Angle Cannon play → protractor practice → quiz/score.
+- Symmetry Lab: learn/look → recognition/memory → fold play → challenge → score.
+- Shape Lab: uses shared stage/card chrome or a deliberate adapter with the same controls and stage strip.
+
+**Risk:** bigger product-design slice. Should run after navigation/shared-card primitives unless the user wants a dedicated geometry wave.
+
+### E. Information architecture / compact density — #946, #953, #954, #955
+
+**Intent:** The product hierarchy should be simple at the top and progressively disclose detail.
+
+**Root causes:** Home/Labs screens expose too much explanatory and planning copy at once, while guided paths underrepresent non-number streams.
+
+**Acceptance:**
+
+- Home primary IA is `Labs` and `Games`.
+- Parent/settings actions move to secondary chrome.
+- Labs clearly show Geometry, Physics, Chemistry, Geography/Map World, Numbers.
+- Lab lane detail defaults to one next action + stage strip; parent/timing copy is disclosed.
+
+## 3. Asset / screenshot opportunities
+
+- Keep downloaded screenshots in the workspace artifact bundle while Apple signed URLs remain valid.
+- Add/confirm asset inventory for:
+  - country map silhouettes (`map-shape`, #949), ideally vector/PDF or SwiftUI shape fallback;
+  - flag/country images already referenced through `visualAssetName`;
+  - Water Cycle art already referenced by `MemoryWaterCycle*` assets;
+  - larger flashcard hero render path (#959).
+- Screenshot regression candidates:
+  - compact gameplay thread summary with Home/Back/Retry (#947/#948/#957);
+  - flip-memory hidden-card preview (#951);
+  - pair-turn pagination on compact device (#952);
+  - Home menu Labs/Games (#946/#955).
+
+## 4. Suggested first-wave acceptance gates
+
+- Unit tests: navigation state back/retry transitions; flip-card preview; round diversification if implemented.
+- Swift/Xcode: Build & Test on macOS runner if available.
+- UI smoke: iPhone compact screenshots for Home, gameplay active stage, gameplay summary, Water Cycle flip/pairing.
+- GitHub: do not close issues until PR merged and validation evidence is posted.

--- a/wiki/Specs/Mather-Build78-81-Lane-Wave-Plan-2026-05-04.md
+++ b/wiki/Specs/Mather-Build78-81-Lane-Wave-Plan-2026-05-04.md
@@ -1,0 +1,167 @@
+# Mather build 78–81 lane wave plan — 2026-05-04
+
+Repo: `ganesh47/mather`  
+Issue set: #946–#955, #957–#965  
+Enrichment: `artifacts/mather-build78-81-wave-20260504/enrichment.md`
+
+## Coordination principles
+
+- Keep implementation slices dependency-safe and PR-sized.
+- Use isolated worktrees under `/mnt/data/openclaw-parallel-workers/mather/build78-81-wave-20260504/`.
+- Push branches/PRs early; use GitHub comments/PRs as durable progress surface.
+- Do not close issues until fixes merge and validation is credible.
+- If Xcode hits the known Swift compiler crash in `SettingsView.swift`, record exact evidence and still push safe branches with Linux/static checks plus Mac blocker notes.
+
+## Wave 1 — safe independent / low product ambiguity
+
+### Slice 1A — Gameplay navigation recovery
+
+Issues: #947, #948, #957  
+Branch/worktree: `fix/build78-81-gameplay-nav-retry-home` at `/mnt/data/openclaw-parallel-workers/mather/build78-81-wave-20260504/nav-retry-home`  
+Parallelism: can run independently of all other slices.
+
+Scope:
+
+- Add Home/Done escape hatch to `GameplayThreadView` when launched with `AppModel`.
+- Make Retry force a fresh active-stage instance and remove current completed result when replaying.
+- Make Back from completed summary reopen a playable previous stage instead of rendering summary forever.
+- Add navigation-state regression tests.
+
+Validation:
+
+- `GameplayStageViewModelTests` targeted test suite.
+- Full Build & Test on macOS if runner is stable.
+
+Status: implementation started.
+
+### Slice 1B — Flip-memory preview bug
+
+Issues: #951; helps #958  
+Parallelism: can run with 1A, but validate after 1A if both touch shared gameplay shell.
+
+Scope:
+
+- Add flip/preview state for right-side cards in `.flipMemory` mode.
+- Right-card tap with no selected left card reveals/holds preview without mismatch haptic.
+- Right-card tap with selected left evaluates match.
+- Update accessibility labels and tests.
+
+Validation:
+
+- `GameplayStageViewModelTests.flipMemory...` regression expanded.
+- UI smoke on Country/Water Cycle flip-memory.
+
+### Slice 1C — Shared card asset rendering / hero flashcard
+
+Issues: #959; partial prerequisite for #949  
+Parallelism: can run independently after code owner decides image sizing defaults.
+
+Scope:
+
+- `GameplayDisplayCard` renders `Image(visualAssetName)` when present.
+- Flashcard stage passes a hero/single-card variant so one-card screens use available space.
+- Keep emoji/text fallback and accessibility.
+
+Validation:
+
+- Tests assert card model preserves visual asset names.
+- Snapshot/screenshot smoke for Water Cycle/Country flashcard.
+
+## Wave 2 — shared shell improvements / needs one validation lane
+
+### Slice 2A — Stage overview strip
+
+Issues: #961; supports geometry unification later.
+
+Scope:
+
+- Add stage strip to `GameplayThreadView` showing all stages and done/current/locked states.
+- Decide whether stage taps replay completed stages or are preview-only.
+- Ensure compact layout stays readable.
+
+Needs validation lane because it changes chrome on every gameplay thread.
+
+### Slice 2B — Pairing turns and spaced-repetition chunking
+
+Issues: #952; helps #958 and #960.
+
+Scope:
+
+- Present 3–4 pair turns instead of all pairs at once.
+- Track per-turn matched/missed; requeue misses later in session.
+- Keep progress store updates accurate.
+
+Needs careful validation across Country, Fruit, Water Cycle, Easy Memory, Flip Memory, Bond Blast.
+
+### Slice 2C — Country duplicate diversification
+
+Issue: #960.
+
+Scope:
+
+- Prefer unique `entityID` within a turn.
+- If an entity must repeat, annotate property focus on the prompt card.
+- Add scheduler/content-builder tests.
+
+Can run after 2B or alongside if merge coordination is tight.
+
+## Wave 3 — product design / larger refactors
+
+### Slice 3A — Bond Blast interaction consistency
+
+Issue: #950.
+
+Scope:
+
+- Extract or adapt Numbers `BondMatchView` mechanics into shared `BondBlastInteraction`.
+- Support domain-specific display items.
+- Replace generic pairing-shell Bond Blast for gameplay threads.
+
+Needs design/validation: named stage behavior changes across domains.
+
+### Slice 3B — Map-shape country silhouettes
+
+Issue: #949; depends on or benefits from Slice 1C.
+
+Scope:
+
+- Add vector/image silhouette assets or SwiftUI outline renderer.
+- Replace textual map-shape primary visual with actual country outline.
+- Keep text as subtitle/accessibility.
+
+Needs asset work; likely separate PR.
+
+### Slice 3C — Geometry labs stage unification
+
+Issues: #962, #963, #964.
+
+Scope:
+
+- Angle Lab wrapper: lesson/vocab → visual matching → Angle Cannon → protractor → quiz/score.
+- Symmetry Lab wrapper: learn/look → memory/recognition → fold play → challenge → score.
+- Shape Lab adapter/shared-stage conversion.
+
+Needs one focused coordinator because these are product-architecture changes, not simple bug fixes.
+
+### Slice 3D — Home/Labs IA and progressive disclosure
+
+Issues: #946, #953, #954, #955.
+
+Scope:
+
+- Promote Home primary choices to Labs/Games.
+- Reduce top-level copy density.
+- Surface guided/browse streams: Numbers, Geometry, Physics, Chemistry, Geography/Map World.
+- Collapse parent/timing details in lab detail cards.
+
+Needs design confirmation only for labels/order; implementation can then split into Home IA and Lab detail sub-PRs.
+
+## Tracking issue usage
+
+Use #965 as the concise coordinator-tracking surface because it is the umbrella-like VS1 progress/check issue in this inventory. The comment should link to:
+
+- this enrichment/plan artifact location,
+- the first implementation PR,
+- issue clusters and status.
+
+Do not mark #965 as fixing the TestFlight issues unless a dedicated tracking/meta convention is desired.


### PR DESCRIPTION
## Summary
- Restores gameplay-thread recovery controls for the build 78/81 feedback cluster: Home/Done escape hatch, retry reset, and Back-from-summary replay behavior.
- Adds regression coverage for navigation state retry/back transitions.
- Adds durable lane-wave enrichment and implementation-plan artifacts for the current open issue inventory (#946-#955, #957-#965).

## Links
- Wave tracker: #965
- Fixes #947
- Fixes #948
- Fixes #957
- Enrichment/plan supports #946-#955 and #957-#965

## Validation
- Local `git diff --check` passed before commit.
- Remote Xcode targeted validation was attempted on `ganesh-mba` with `GameplayStageViewModelTests`, but the build failed before reaching the targeted tests due to the existing Swift 6.3.1 compiler crash while type-checking `Features/ParentSummary/SettingsView.swift`.
- The crash reproduces in a temp checkout path and is not in the changed files for this slice.
