### PR TITLE
Fix gameplay stage parity chunking

### DIFF
--- a/Domain/GameplayStageModels.swift
+++ b/Domain/GameplayStageModels.swift
@@ -78,6 +78,23 @@ struct GameplayStageDefinition: Identifiable, Codable, Equatable, Hashable {
     let propertyTypeIDs: [String]
     let maximumItemCount: Int
 
+    /// Pairing/card stages may review several items in one stage while only
+    /// showing a child-sized turn at a time. This keeps Lab/Gameplay stages
+    /// aligned with the Numbers Bond Blast tap-to-select rhythm without forcing
+    /// a long scrolling board.
+    var recommendedTurnItemCount: Int {
+        switch kind {
+        case .flashcards:
+            return 1
+        case .easyMemory, .flipMemory:
+            return min(maximumItemCount, 2)
+        case .bondBlast:
+            return min(maximumItemCount, 3)
+        case .multipleChoice:
+            return 1
+        }
+    }
+
     init(
         id: String,
         kind: GameplayStageKind,
@@ -137,10 +154,10 @@ struct GameplayThreadDefinition: Identifiable, Codable, Equatable {
     }
 
     static let defaultStages: [GameplayStageDefinition] = [
-        GameplayStageDefinition(id: "flashcards", kind: .flashcards, title: "Look + Learn", prompt: "Meet each card."),
-        GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Match with the cards still visible."),
-        GameplayStageDefinition(id: "flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Remember where the matches are."),
-        GameplayStageDefinition(id: "bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect names, pictures, and facts."),
+        GameplayStageDefinition(id: "flashcards", kind: .flashcards, title: "Look + Learn", prompt: "Meet each card.", maximumItemCount: 6),
+        GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Match with the cards still visible.", maximumItemCount: 6),
+        GameplayStageDefinition(id: "flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Remember where the matches are.", maximumItemCount: 6),
+        GameplayStageDefinition(id: "bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect names, pictures, and facts.", maximumItemCount: 6),
         GameplayStageDefinition(id: "multiple-choice", kind: .multipleChoice, title: "Quiz", prompt: "Pick the best answer.")
     ]
 }

--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -154,7 +154,7 @@ struct GameplayMatchStageViewModel: Equatable {
     init(thread: GameplayThreadDefinition, round: GameplayRoundDefinition, mode: GameplayStageKind, turnItemCount: Int? = nil) {
         self.pairs = GameplayStageContentBuilder.matchPairs(thread: thread, round: round)
         self.mode = mode
-        self.turnItemCount = max(1, turnItemCount ?? defaultTurnItemCount(for: mode, itemCount: round.items.count))
+        self.turnItemCount = max(1, turnItemCount ?? Self.defaultTurnItemCount(for: mode, itemCount: round.items.count))
         self.seed = round.seed
     }
 

--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -142,20 +142,43 @@ struct GameplayFlashcardStageViewModel: Equatable {
 struct GameplayMatchStageViewModel: Equatable {
     let pairs: [GameplayMatchPair]
     let mode: GameplayStageKind
-    let shuffledRights: [GameplayDisplayItem]
+    let turnItemCount: Int
+    let seed: UInt64
     var selectedLeftID: String?
+    var inspectedItemID: String?
     var matchedPairIDs: Set<String> = []
     var mismatchCount = 0
     var hintCount = 0
+    var activeTurnIndex = 0
 
-    init(thread: GameplayThreadDefinition, round: GameplayRoundDefinition, mode: GameplayStageKind) {
+    init(thread: GameplayThreadDefinition, round: GameplayRoundDefinition, mode: GameplayStageKind, turnItemCount: Int? = nil) {
         self.pairs = GameplayStageContentBuilder.matchPairs(thread: thread, round: round)
         self.mode = mode
-        self.shuffledRights = GameplayStageContentBuilder.sortedRights(pairs, seed: round.seed)
+        self.turnItemCount = max(1, turnItemCount ?? defaultTurnItemCount(for: mode, itemCount: round.items.count))
+        self.seed = round.seed
     }
 
     var correctCount: Int { matchedPairIDs.count }
     var isComplete: Bool { !pairs.isEmpty && matchedPairIDs.count == pairs.count }
+    var turnCount: Int { max(1, Int(ceil(Double(max(pairs.count, 1)) / Double(turnItemCount)))) }
+    var turnProgressText: String { "Turn \(min(activeTurnIndex + 1, turnCount))/\(turnCount)" }
+    var activePairs: [GameplayMatchPair] {
+        let start = activeTurnIndex * turnItemCount
+        guard pairs.indices.contains(start) else { return [] }
+        let end = min(start + turnItemCount, pairs.count)
+        return Array(pairs[start..<end])
+    }
+    var shuffledRights: [GameplayDisplayItem] {
+        GameplayStageContentBuilder.sortedRights(activePairs, seed: seed &+ UInt64(activeTurnIndex * 97))
+    }
+    var isTurnComplete: Bool {
+        !activePairs.isEmpty && activePairs.allSatisfy { matchedPairIDs.contains($0.id) }
+    }
+    var canAdvanceTurn: Bool { isTurnComplete && !isComplete }
+    var inspectedItem: GameplayDisplayItem? {
+        guard let inspectedItemID else { return nil }
+        return (activePairs.map(\.left) + activePairs.map(\.right)).first { $0.id == inspectedItemID }
+    }
 
     func accessibilityLabel(for item: GameplayDisplayItem, side: GameplayMatchSide) -> String {
         let role = side == .left ? "prompt" : "answer"
@@ -169,25 +192,53 @@ struct GameplayMatchStageViewModel: Equatable {
         mode == .flipMemory && !matchedPairIDs.contains(pairID(forRight: item))
     }
 
-    private func pairID(forRight item: GameplayDisplayItem) -> String {
+    func pairID(forRight item: GameplayDisplayItem) -> String {
         pairs.first(where: { $0.right.id == item.id })?.id ?? item.id
     }
 
     mutating func selectLeft(pairID: String) {
-        guard !matchedPairIDs.contains(pairID) else { return }
+        guard activePairs.contains(where: { $0.id == pairID }), !matchedPairIDs.contains(pairID) else { return }
         selectedLeftID = pairID
+        inspectedItemID = activePairs.first(where: { $0.id == pairID })?.left.id
+    }
+
+    mutating func inspect(_ item: GameplayDisplayItem) {
+        inspectedItemID = inspectedItemID == item.id ? nil : item.id
     }
 
     mutating func chooseRight(_ right: GameplayDisplayItem) -> Bool {
-        guard let selectedLeftID, let pair = pairs.first(where: { $0.id == selectedLeftID }) else { return false }
+        guard let selectedLeftID, let pair = activePairs.first(where: { $0.id == selectedLeftID }) else {
+            inspect(right)
+            return false
+        }
         let correct = pair.right.id == right.id
         if correct {
             matchedPairIDs.insert(pair.id)
             self.selectedLeftID = nil
+            inspectedItemID = right.id
         } else {
             mismatchCount += 1
+            inspectedItemID = right.id
         }
         return correct
+    }
+
+    mutating func advanceTurn() {
+        guard canAdvanceTurn else { return }
+        activeTurnIndex = min(activeTurnIndex + 1, turnCount - 1)
+        selectedLeftID = nil
+        inspectedItemID = nil
+    }
+
+    private static func defaultTurnItemCount(for mode: GameplayStageKind, itemCount: Int) -> Int {
+        switch mode {
+        case .easyMemory, .flipMemory:
+            return min(max(itemCount, 1), 2)
+        case .bondBlast:
+            return min(max(itemCount, 1), 3)
+        default:
+            return max(itemCount, 1)
+        }
     }
 }
 

--- a/Features/GameplayStages/BondBlastStageView.swift
+++ b/Features/GameplayStages/BondBlastStageView.swift
@@ -12,10 +12,10 @@ struct BondBlastStageView: View {
         self.actions = actions
         self.compact = compact
         self.onComplete = onComplete
-        _viewModel = State(initialValue: GameplayMatchStageViewModel(thread: thread, round: round, mode: .bondBlast))
+        _viewModel = State(initialValue: GameplayMatchStageViewModel(thread: thread, round: round, mode: .bondBlast, turnItemCount: stage.recommendedTurnItemCount))
     }
 
     var body: some View {
-        GameplayPairingStageShell(title: stage.title, prompt: "Blast through the matching bonds.", compact: compact, viewModel: $viewModel, actions: actions, onComplete: onComplete)
+        GameplayPairingStageShell(title: stage.title, prompt: stage.prompt.isEmpty ? "Tap a card, then tap its matching bond." : stage.prompt, compact: compact, viewModel: $viewModel, actions: actions, onComplete: onComplete)
     }
 }

--- a/Features/GameplayStages/FlashcardStageView.swift
+++ b/Features/GameplayStages/FlashcardStageView.swift
@@ -20,8 +20,18 @@ struct FlashcardStageView: View {
         VStack(spacing: compact ? 12 : 18) {
             GameplayStageTitle(stage: stage, detail: viewModel.progressText)
             if let card = viewModel.activeCard {
-                GameplayDisplayCard(item: card, compact: compact)
-                    .accessibilityLabel("Flashcard: \(card.title), \(card.subtitle)")
+                Button {
+                    viewModel.markExposure()
+                    speak(card)
+                } label: {
+                    GameplayDisplayCard(
+                        item: card,
+                        compact: compact,
+                        prominence: viewModel.cards.count == 1 ? .featured : .normal
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open flashcard: \(card.title), \(card.subtitle)")
                 HStack(spacing: 10) {
                     Button("Listen again") {
                         viewModel.markExposure()

--- a/Features/GameplayStages/FlipMemoryStageView.swift
+++ b/Features/GameplayStages/FlipMemoryStageView.swift
@@ -12,7 +12,7 @@ struct FlipMemoryStageView: View {
         self.actions = actions
         self.compact = compact
         self.onComplete = onComplete
-        _viewModel = State(initialValue: GameplayMatchStageViewModel(thread: thread, round: round, mode: .flipMemory))
+        _viewModel = State(initialValue: GameplayMatchStageViewModel(thread: thread, round: round, mode: .flipMemory, turnItemCount: stage.recommendedTurnItemCount))
     }
 
     var body: some View {

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -59,16 +59,17 @@ struct GameplayDisplayCard: View {
     var selected = false
     var matched = false
     var concealed = false
+    var prominence: GameplayDisplayCardProminence = .normal
 
     var body: some View {
         VStack(spacing: compact ? 6 : 10) {
             Text(concealed ? "?" : item.visualKey ?? "✦")
-                .font(.system(size: compact ? 40 : 58, weight: concealed ? .black : .regular, design: .rounded))
+                .font(.system(size: visualSize, weight: concealed ? .black : .regular, design: .rounded))
                 .foregroundStyle(concealed ? MatherTheme.accent : MatherTheme.ink)
-                .frame(width: compact ? 64 : 86, height: compact ? 58 : 78)
+                .frame(width: visualFrameWidth, height: visualFrameHeight)
                 .background(Circle().fill(MatherTheme.softBlue.opacity(0.45)))
             Text(concealed ? "Hidden match" : item.title)
-                .font(compact ? .headline.bold() : .title3.bold())
+                .font(prominence == .featured ? (compact ? .title3.bold() : .title.bold()) : (compact ? .headline.bold() : .title3.bold()))
                 .multilineTextAlignment(.center)
                 .foregroundStyle(MatherTheme.ink)
                 .lineLimit(2)
@@ -84,7 +85,7 @@ struct GameplayDisplayCard: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .frame(minHeight: compact ? 132 : 164)
+        .frame(minHeight: minimumHeight)
         .padding(compact ? 10 : 14)
         .background(
             RoundedRectangle(cornerRadius: 20, style: .continuous)
@@ -95,6 +96,29 @@ struct GameplayDisplayCard: View {
                 .strokeBorder(selected ? MatherTheme.accent : .clear, lineWidth: 3)
         )
     }
+
+    private var isFeatured: Bool { prominence == .featured }
+    private var visualSize: CGFloat {
+        if isFeatured { return compact ? 76 : 112 }
+        return compact ? 40 : 58
+    }
+    private var visualFrameWidth: CGFloat {
+        if isFeatured { return compact ? 118 : 156 }
+        return compact ? 64 : 86
+    }
+    private var visualFrameHeight: CGFloat {
+        if isFeatured { return compact ? 102 : 136 }
+        return compact ? 58 : 78
+    }
+    private var minimumHeight: CGFloat {
+        if isFeatured { return compact ? 220 : 280 }
+        return compact ? 132 : 164
+    }
+}
+
+enum GameplayDisplayCardProminence {
+    case normal
+    case featured
 }
 
 struct GameplayPairingStageShell: View {
@@ -107,9 +131,9 @@ struct GameplayPairingStageShell: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 12 : 18) {
-            GameplayStageTitle(title: title, prompt: prompt, detail: "\(viewModel.correctCount)/\(viewModel.pairs.count)")
+            GameplayStageTitle(title: title, prompt: prompt, detail: "\(viewModel.turnProgressText) • \(viewModel.correctCount)/\(viewModel.pairs.count)")
             LazyVGrid(columns: columns, spacing: 12) {
-                ForEach(viewModel.pairs) { pair in
+                ForEach(viewModel.activePairs) { pair in
                     Button {
                         viewModel.selectLeft(pairID: pair.id)
                     } label: {
@@ -117,7 +141,8 @@ struct GameplayPairingStageShell: View {
                             item: pair.left,
                             compact: compact,
                             selected: viewModel.selectedLeftID == pair.id,
-                            matched: viewModel.matchedPairIDs.contains(pair.id)
+                            matched: viewModel.matchedPairIDs.contains(pair.id),
+                            prominence: viewModel.activePairs.count == 1 ? .featured : .normal
                         )
                     }
                     .buttonStyle(.plain)
@@ -127,29 +152,41 @@ struct GameplayPairingStageShell: View {
             LazyVGrid(columns: columns, spacing: 12) {
                 ForEach(viewModel.shuffledRights) { item in
                     Button {
+                        let wasMatching = viewModel.selectedLeftID != nil
                         let correct = viewModel.chooseRight(item)
-                        if correct { actions.success() } else { actions.failure() }
+                        if correct { actions.success() }
+                        else if wasMatching { actions.failure() }
                         if viewModel.isComplete { onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount) }
                     } label: {
                         GameplayDisplayCard(
                             item: item,
                             compact: compact,
                             showsSubtitle: true,
+                            selected: viewModel.inspectedItemID == item.id,
                             matched: viewModel.matchedPairIDs.contains(pairID(for: item)),
-                            concealed: viewModel.shouldConcealRight(item)
+                            concealed: viewModel.shouldConcealRight(item),
+                            prominence: viewModel.activePairs.count == 1 ? .featured : .normal
                         )
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(viewModel.accessibilityLabel(for: item, side: .right))
                 }
             }
+            if let item = viewModel.inspectedItem, !viewModel.shouldConcealRight(item) {
+                GameplayCardDetailCallout(item: item, compact: compact)
+            }
             HStack {
                 Button("Hint") { viewModel.hintCount += 1 }
                     .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
                 Spacer()
-                Button("Finish stage") { onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount) }
-                    .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
-                    .disabled(!viewModel.isComplete)
+                if viewModel.canAdvanceTurn {
+                    Button("Next turn") { viewModel.advanceTurn() }
+                        .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
+                } else {
+                    Button("Finish stage") { onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount) }
+                        .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
+                        .disabled(!viewModel.isComplete)
+                }
             }
         }
         .padding(compact ? 14 : 20)
@@ -161,6 +198,32 @@ struct GameplayPairingStageShell: View {
     }
 
     private func pairID(for item: GameplayDisplayItem) -> String {
-        viewModel.pairs.first(where: { $0.right.id == item.id })?.id ?? item.id
+        viewModel.pairID(forRight: item)
+    }
+}
+
+private struct GameplayCardDetailCallout: View {
+    let item: GameplayDisplayItem
+    let compact: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(item.visualKey ?? "✦")
+                .font(.system(size: compact ? 24 : 30, weight: .semibold, design: .rounded))
+            VStack(alignment: .leading, spacing: 3) {
+                Text(item.title)
+                    .font(.headline.bold())
+                if !item.subtitle.isEmpty {
+                    Text(item.subtitle)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.ink.opacity(0.72))
+                }
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 18, style: .continuous).fill(MatherTheme.softBlue.opacity(0.5)))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Card details: \(item.title), \(item.subtitle)")
     }
 }

--- a/Features/GameplayStages/MemoryStageView.swift
+++ b/Features/GameplayStages/MemoryStageView.swift
@@ -12,7 +12,7 @@ struct MemoryStageView: View {
         self.actions = actions
         self.compact = compact
         self.onComplete = onComplete
-        _viewModel = State(initialValue: GameplayMatchStageViewModel(thread: thread, round: round, mode: .easyMemory))
+        _viewModel = State(initialValue: GameplayMatchStageViewModel(thread: thread, round: round, mode: .easyMemory, turnItemCount: stage.recommendedTurnItemCount))
     }
 
     var body: some View {

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -104,3 +104,81 @@ struct GameplayStageViewModelTests {
         #expect(GameplayStageRenderSupport.maximumContentWidth(compact: false) == 920)
     }
 }
+
+struct GameplayStageParityRegressionTests {
+    @Test
+    func memoryStagesChunkPairsIntoSmallTurns() {
+        let thread = GameplaySampleThreads.countries
+        let stage = thread.stages.first { $0.kind == .easyMemory }!
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 44)
+        var viewModel = GameplayMatchStageViewModel(
+            thread: thread,
+            round: round,
+            mode: .easyMemory,
+            turnItemCount: stage.recommendedTurnItemCount
+        )
+
+        #expect(viewModel.pairs.count == 4)
+        #expect(viewModel.activePairs.count == 2)
+        #expect(viewModel.turnCount == 2)
+        #expect(viewModel.turnProgressText == "Turn 1/2")
+
+        for pair in viewModel.activePairs {
+            viewModel.selectLeft(pairID: pair.id)
+            #expect(viewModel.chooseRight(pair.right))
+        }
+
+        #expect(viewModel.canAdvanceTurn)
+        viewModel.advanceTurn()
+        #expect(viewModel.activeTurnIndex == 1)
+        #expect(viewModel.activePairs.count == 2)
+        #expect(viewModel.turnProgressText == "Turn 2/2")
+    }
+
+    @Test
+    func rightCardTapWithoutSelectedPromptOpensDetailsWithoutMistake() {
+        let thread = GameplaySampleThreads.countries
+        let stage = thread.stages.first { $0.kind == .easyMemory }!
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 45)
+        var viewModel = GameplayMatchStageViewModel(thread: thread, round: round, mode: .easyMemory, turnItemCount: 2)
+        let right = viewModel.shuffledRights[0]
+
+        let matched = viewModel.chooseRight(right)
+
+        #expect(!matched)
+        #expect(viewModel.mismatchCount == 0)
+        #expect(viewModel.inspectedItem == right)
+    }
+
+    @Test
+    func bondBlastUsesNumbersStyleTapSelectThenMatchAcrossReadinessTurns() {
+        let thread = GameplaySampleThreads.countries
+        let stage = thread.stages.first { $0.kind == .bondBlast }!
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 46)
+        var viewModel = GameplayMatchStageViewModel(
+            thread: thread,
+            round: round,
+            mode: .bondBlast,
+            turnItemCount: stage.recommendedTurnItemCount
+        )
+        let pair = viewModel.activePairs[0]
+
+        #expect(viewModel.activePairs.count <= 3)
+        viewModel.selectLeft(pairID: pair.id)
+        #expect(viewModel.selectedLeftID == pair.id)
+        #expect(viewModel.inspectedItem == pair.left)
+        #expect(viewModel.chooseRight(pair.right))
+        #expect(viewModel.correctCount == 1)
+    }
+
+    @Test
+    func stageDefinitionsKeepSingleCardAndPairTurnsChildSized() {
+        let flashcard = GameplayStageDefinition(id: "learn", kind: .flashcards, title: "Learn", prompt: "Look", maximumItemCount: 8)
+        let memory = GameplayStageDefinition(id: "remember", kind: .easyMemory, title: "Remember", prompt: "Match", maximumItemCount: 8)
+        let blast = GameplayStageDefinition(id: "blast", kind: .bondBlast, title: "Bond Blast", prompt: "Match", maximumItemCount: 10)
+
+        #expect(flashcard.recommendedTurnItemCount == 1)
+        #expect(memory.recommendedTurnItemCount == 2)
+        #expect(blast.recommendedTurnItemCount == 3)
+    }
+}

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -125,7 +125,8 @@ struct GameplayStageParityRegressionTests {
 
         for pair in viewModel.activePairs {
             viewModel.selectLeft(pairID: pair.id)
-            #expect(viewModel.chooseRight(pair.right))
+            let matched = viewModel.chooseRight(pair.right)
+            #expect(matched)
         }
 
         #expect(viewModel.canAdvanceTurn)
@@ -167,7 +168,8 @@ struct GameplayStageParityRegressionTests {
         viewModel.selectLeft(pairID: pair.id)
         #expect(viewModel.selectedLeftID == pair.id)
         #expect(viewModel.inspectedItem == pair.left)
-        #expect(viewModel.chooseRight(pair.right))
+        let matched = viewModel.chooseRight(pair.right)
+        #expect(matched)
         #expect(viewModel.correctCount == 1)
     }
 


### PR DESCRIPTION
## Summary
- Align Gameplay Bond Blast with Numbers Bond Blast tap/select/match semantics: select a prompt card, tap the matching answer, use success/failure feedback only on attempted matches.
- Split memory/card pairing stages into small child-sized turns to reduce scrolling and support spaced repetition within the stage.
- Make single-card layouts promote card art/visuals and let flashcard/card taps open details/listen behavior consistently.

Fixes #950.
Fixes #951.
Fixes #952.
Fixes #959.

## Validation
- `git diff --check` ✅
- Focused remote Xcode validation attempted on `ganesh-mba`:
  - `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:MatherTests/GameplayStageViewModelTests -quiet`
  - blocked by known Swift frontend crash while type-checking `Features/ParentSummary/SettingsView.swift` (`SettingsView.profilesCard.getter`, Xcode 26.4 / Swift 6.3.1), before focused tests could run. Relying on PR CI as canonical.
