### PR TITLE
Polish Labs and Games shell

### DIFF
--- a/Domain/CapabilityLane.swift
+++ b/Domain/CapabilityLane.swift
@@ -24,7 +24,7 @@ enum CapabilityLaneID: String, CaseIterable, Codable, Hashable, Identifiable {
         case .physics:
             return "Physics Lab"
         case .mapWorld:
-            return "Map & World Lab"
+            return "Geography Lab"
         case .discoveryCards:
             return "Discovery Cards"
         case .chemistry:

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -389,8 +389,8 @@ struct ExplorerPathPresentation: Identifiable, Equatable {
             symbolName: "sparkles.rectangle.stack.fill",
             artMotif: "guided compass path",
             title: "Labs",
-            subtitle: "Guided sessions that move from learning to remembering, playful practice, blast rounds, and score.",
-            callToAction: "Start a learning path"
+            subtitle: "Pick a subject stream, then follow a calm staged path when one is ready.",
+            callToAction: "Choose a subject"
         ),
         ExplorerPathPresentation(
             id: .games,
@@ -398,7 +398,7 @@ struct ExplorerPathPresentation: Identifiable, Equatable {
             symbolName: "gamecontroller.fill",
             artMotif: "arcade play portal",
             title: "Games",
-            subtitle: "Jump straight into the games you already love — no staged lesson required.",
+            subtitle: "Jump straight into playable games — no lab progress changes unless a Lab starts them.",
             callToAction: "Play now"
         ),
     ]
@@ -873,12 +873,12 @@ struct LabLaneCardPresentation: Equatable {
 
     init(lane: CapabilityLane, progress: CapabilityLaneProgress) {
         self.laneID = lane.id
-        title = lane.title
+        title = lane.subjectStreamLabel
         promiseLine = lane.promise
         progressMicrocopy = "\(progress.progressSummaryLabel) • \(progress.nextRecommendedModeLabel)"
         openAffordanceLabel = "Enter world"
-        accessibilityLabel = "\(lane.title). \(lane.ageBandHint). \(lane.promise)"
-        accessibilityHint = "Opens \(lane.title) to choose missions, review cards, play styles, and sensor options."
+        accessibilityLabel = "\(lane.subjectStreamLabel) subject stream. \(lane.ageBandHint). \(lane.promise)"
+        accessibilityHint = "Opens \(lane.subjectStreamLabel) to choose missions, review cards, play styles, and sensor options."
         sections = [
             .visualSummary,
             .promise,
@@ -1088,6 +1088,43 @@ struct CapabilityLane: Identifiable, Equatable {
 
     var emptyProgress: CapabilityLaneProgress {
         CapabilityLaneProgress(laneID: id, availableModes: modes)
+    }
+
+    var isLabSubjectStream: Bool {
+        Self.labSubjectStreamIDs.contains(id)
+    }
+
+    var subjectStreamLabel: String {
+        switch id {
+        case .numbers:
+            return "Numbers & Arithmetic"
+        case .geometry:
+            return "Geometry"
+        case .physics:
+            return "Physics"
+        case .mapWorld:
+            return "Geography"
+        case .chemistry:
+            return "Chemistry"
+        case .discoveryCards:
+            return "Discovery Cards"
+        case .electronics:
+            return "Electronics"
+        }
+    }
+
+    static let labSubjectStreamIDs: [CapabilityLaneID] = [
+        .numbers,
+        .geometry,
+        .physics,
+        .mapWorld,
+        .chemistry,
+    ]
+
+    static var labSubjectStreams: [CapabilityLane] {
+        labSubjectStreamIDs.compactMap { streamID in
+            defaultExplorerLanes.first { $0.id == streamID }
+        }
     }
 
     static let defaultExplorerLanes: [CapabilityLane] = [

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -8,7 +8,7 @@ struct LabView: View {
     @State private var selectedPath: ExplorerPathID = .labs
     @State private var sensorCapabilities = DeviceSensorCapabilities.unavailable
 
-    private let lanes = CapabilityLane.defaultExplorerLanes
+    private let lanes = CapabilityLane.labSubjectStreams
     private let guidedPaths = GuidedLabPath.phaseOne
     private let gameEntries = ExplorerGameRegistry.directLaunchEntries
 
@@ -75,10 +75,10 @@ struct LabView: View {
                 Text("Explorer Lab")
                     .font(.system(size: 36, weight: .black, design: .rounded))
                     .foregroundStyle(MatherTheme.ink)
-                Text("Choose a world to explore")
+                Text("Labs and Games")
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(MatherTheme.cardSubtitle)
-                Text("Missions, mini cards, and sensor-powered experiments wait inside")
+                Text("Choose a subject stream, or jump straight into a game")
                     .font(.caption.weight(.bold))
                     .foregroundStyle(MatherTheme.accent)
             }
@@ -161,10 +161,10 @@ struct LabView: View {
         VStack(alignment: .leading, spacing: 14) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Labs build in stages")
+                    Text("Subject streams")
                         .font(.title3.weight(.black))
                         .foregroundStyle(MatherTheme.ink)
-                    Text("Learn → Remember → Play → Blast → Score")
+                    Text("Numbers & Arithmetic · Geometry · Physics · Geography · Chemistry")
                         .font(.caption.weight(.black))
                         .foregroundStyle(MatherTheme.accent)
                 }
@@ -269,17 +269,12 @@ struct LabView: View {
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(MatherTheme.cardSubtitle)
                     if let primaryPlan = path.primaryPlan {
-                        Text("First quest: \(primaryPlan.title) • \(primaryPlan.estimatedLength)")
+                        Text("First: \(primaryPlan.title) • \(primaryPlan.estimatedLength)")
                             .font(.caption2.weight(.black))
                             .foregroundStyle(tint)
                             .lineLimit(1)
                             .minimumScaleFactor(0.72)
                     }
-                    Text(path.stages.map(\.rawValue).joined(separator: " → "))
-                        .font(.caption2.weight(.black))
-                        .foregroundStyle(tint)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.72)
                 }
                 Spacer(minLength: 0)
                 Image(systemName: "chevron.right.circle.fill")
@@ -350,13 +345,15 @@ struct LabView: View {
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(MatherTheme.cardSubtitle)
                         .lineLimit(2)
-                    Text(canLaunch ? "Direct game" : "Needs a sensor on this device")
+                    Text(canLaunch ? "Tap to play" : "Needs a sensor")
                         .font(.caption2.weight(.black))
                         .foregroundStyle(canLaunch ? tint : MatherTheme.cardSubtitle)
-                    Text(capabilitySummary)
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .lineLimit(2)
+                    if !canLaunch || activity.id.sensorNeeds != [.noSpecialSensor] {
+                        Text(capabilitySummary)
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .lineLimit(1)
+                    }
                 }
                 Spacer(minLength: 0)
                 Image(systemName: canLaunch ? "play.circle.fill" : "exclamationmark.triangle.fill")

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -170,10 +170,10 @@ struct HomeView: View {
                             .font(.system(size: 48))
 
                         VStack(alignment: .leading, spacing: 2) {
-                            Text("Explorer Lab")
+                            Text("Labs + Games")
                                 .font(.title3.weight(.black))
                                 .foregroundStyle(.white)
-                            Text("8 games inside")
+                            Text("Subjects + one-tap play")
                                 .font(.subheadline.weight(.semibold))
                                 .foregroundStyle(.white.opacity(0.85))
                         }
@@ -194,10 +194,10 @@ struct HomeView: View {
 
                 HStack {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Physics · Geometry · Angles")
+                        Text("Numbers · Geometry · Physics · Geography")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(.secondary)
-                        Text("Tap to explore all activities")
+                        Text("Choose Labs or Games")
                             .font(.headline.weight(.bold))
                             .foregroundStyle(MatherTheme.ink)
                             .fixedSize(horizontal: false, vertical: true)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Mather is built around:
   - Numbers Lab
   - Geometry Lab
   - Physics Lab
-  - Map & World Lab
+  - Geography Lab
   - Discovery Cards / recall substrate
   - future Chemistry Lab
   - future Electronics Lab

--- a/Tests/MatherTests/CapabilityLaneTests.swift
+++ b/Tests/MatherTests/CapabilityLaneTests.swift
@@ -42,7 +42,7 @@ struct CapabilityLaneTests {
         #expect(CapabilityLaneID.numbers.title == "Numbers Lab")
         #expect(CapabilityLaneID.geometry.title == "Geometry Lab")
         #expect(CapabilityLaneID.physics.title == "Physics Lab")
-        #expect(CapabilityLaneID.mapWorld.title == "Map & World Lab")
+        #expect(CapabilityLaneID.mapWorld.title == "Geography Lab")
         #expect(CapabilityLaneID.discoveryCards.title == "Discovery Cards")
         #expect(CapabilityLaneID.chemistry.title == "Chemistry Lab")
         #expect(CapabilityLaneID.electronics.title == "Electronics Lab")

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -17,6 +17,16 @@ final class LabModelsTests: XCTestCase {
         }
     }
 
+    func testLabSubjectStreamsExposeFocusedSubjectPickerSeparateFromGames() throws {
+        let streams = CapabilityLane.labSubjectStreams
+
+        XCTAssertEqual(streams.map(\.id), [.numbers, .geometry, .physics, .mapWorld, .chemistry])
+        XCTAssertEqual(streams.map(\.subjectStreamLabel), ["Numbers & Arithmetic", "Geometry", "Physics", "Geography", "Chemistry"])
+        XCTAssertTrue(streams.allSatisfy(\.isLabSubjectStream))
+        XCTAssertFalse(CapabilityLane.defaultExplorerLanes.first { $0.id == .discoveryCards }?.isLabSubjectStream ?? true)
+        XCTAssertTrue(ExplorerGameRegistry.directLaunchEntries.contains { $0.activity.id == .memoryMatch })
+    }
+
     func testMemoryMatchIsEmbeddedInDiscoveryCardsInsteadOfTopLevelLane() throws {
         let lanes = CapabilityLane.defaultExplorerLanes
         let discovery = try XCTUnwrap(lanes.first { $0.id == .discoveryCards })
@@ -73,7 +83,7 @@ final class LabModelsTests: XCTestCase {
             progress: numbers.emptyProgress
         )
 
-        XCTAssertEqual(presentation.title, "Numbers Lab")
+        XCTAssertEqual(presentation.title, "Numbers & Arithmetic")
         XCTAssertEqual(presentation.openAffordanceLabel, "Enter world")
         XCTAssertEqual(
             presentation.sections,
@@ -84,7 +94,7 @@ final class LabModelsTests: XCTestCase {
         XCTAssertFalse(presentation.sections.contains(.ageEntries))
         XCTAssertFalse(presentation.sections.contains(.recall))
         XCTAssertFalse(presentation.sections.contains(.activities))
-        XCTAssertTrue(presentation.accessibilityHint.contains("Opens Numbers Lab"))
+        XCTAssertTrue(presentation.accessibilityHint.contains("Opens Numbers & Arithmetic"))
     }
 
     func testLaneDetailPresentationRestoresDetailsWithoutDroppingLaunches() throws {
@@ -127,13 +137,14 @@ final class LabModelsTests: XCTestCase {
         let games = ExplorerPathPresentation.all[1]
 
         XCTAssertEqual(labs.title, "Labs")
-        XCTAssertTrue(labs.subtitle.contains("Guided sessions"))
-        XCTAssertEqual(labs.callToAction, "Start a learning path")
+        XCTAssertTrue(labs.subtitle.contains("Pick a subject stream"))
+        XCTAssertEqual(labs.callToAction, "Choose a subject")
         XCTAssertEqual(labs.symbolName, "sparkles.rectangle.stack.fill")
         XCTAssertTrue(labs.artworkAccessibilityLabel.contains("Labs"))
 
         XCTAssertEqual(games.title, "Games")
-        XCTAssertTrue(games.subtitle.contains("Jump straight into"))
+        XCTAssertTrue(games.subtitle.contains("Jump straight into playable games"))
+        XCTAssertTrue(games.subtitle.contains("no lab progress changes"))
         XCTAssertEqual(games.callToAction, "Play now")
         XCTAssertEqual(games.symbolName, "gamecontroller.fill")
         XCTAssertTrue(games.artworkAccessibilityLabel.contains("Games"))


### PR DESCRIPTION
## Summary
- makes the Explorer shell explicitly split Labs vs Games
- narrows the Labs picker to subject streams: Numbers & Arithmetic, Geometry, Physics, Geography, Chemistry
- keeps Discovery Cards and other playable activities available through direct Games launch
- shortens crowded Labs/Games card copy and direct game sensor copy

## Issue refs
Refs #946 #953 #954 #955

## Validation
- `git diff --check` ✅
- Focused Xcode test attempt on `ganesh-mba`: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:MatherTests/LabModelsTests -only-testing:MatherTests/CapabilityLaneTests` ❌ blocked by known Swift frontend crash while type-checking `Features/ParentSummary/SettingsView.swift:162` (`ConstraintGraph::removeConstraint`, Xcode Swift 6.3.1). No failures from changed test assertions were reached.

## Notes
Direct Games/free play still calls `appModel.clearLabGameplayCompletion()` before routing, so it remains isolated from Lab progress unless launched with Lab context.
