### PR TITLE
Fix gameplay stage chrome and retry navigation

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -6,12 +6,20 @@ struct GameplayStageNavigationState: Equatable {
     var stageResults: [GameplayStageResult]
     var startedAt: Date
     var currentStageStartedAt: Date
+    var stageAttemptNonce: Int
 
-    init(activeStageIndex: Int = 0, stageResults: [GameplayStageResult] = [], startedAt: Date = Date(), currentStageStartedAt: Date = Date()) {
+    init(
+        activeStageIndex: Int = 0,
+        stageResults: [GameplayStageResult] = [],
+        startedAt: Date = Date(),
+        currentStageStartedAt: Date = Date(),
+        stageAttemptNonce: Int = 0
+    ) {
         self.activeStageIndex = max(0, activeStageIndex)
         self.stageResults = stageResults
         self.startedAt = startedAt
         self.currentStageStartedAt = currentStageStartedAt
+        self.stageAttemptNonce = max(0, stageAttemptNonce)
     }
 
     func activeStage(in thread: GameplayThreadDefinition) -> GameplayStageDefinition? {
@@ -25,6 +33,8 @@ struct GameplayStageNavigationState: Equatable {
     }
 
     var canGoBack: Bool { activeStageIndex > 0 }
+
+    var stageAttemptID: String { "stage-attempt-\(activeStageIndex)-\(stageAttemptNonce)" }
 
     func isComplete(for thread: GameplayThreadDefinition) -> Bool {
         guard !thread.stages.isEmpty else { return true }
@@ -40,10 +50,18 @@ struct GameplayStageNavigationState: Equatable {
         guard activeStageIndex > 0 else { return }
         activeStageIndex -= 1
         currentStageStartedAt = now
+        stageAttemptNonce += 1
     }
 
-    mutating func retryCurrentStage(now: Date = Date()) {
+    mutating func retryCurrentStage(in thread: GameplayThreadDefinition? = nil, now: Date = Date()) {
+        if let thread, isComplete(for: thread) {
+            activeStageIndex = max(thread.stages.count - 1, 0)
+        }
+        if let thread, let stage = activeStage(in: thread) {
+            stageResults.removeAll { $0.stageID == stage.id }
+        }
         currentStageStartedAt = now
+        stageAttemptNonce += 1
     }
 
     mutating func completeCurrentStage(
@@ -68,6 +86,7 @@ struct GameplayStageNavigationState: Equatable {
         if activeStageIndex < thread.stages.count - 1 {
             activeStageIndex += 1
             currentStageStartedAt = now
+            stageAttemptNonce += 1
         }
     }
 }

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -32,6 +32,7 @@ enum AppRoute: Hashable {
 @Observable
 final class VerticalSliceEngine {
     private(set) var route: AppRoute = .home
+    private(set) var gameplayReturnRoute: AppRoute?
     private(set) var config = SliceConfig()
     private(set) var problems: [SliceProblem] = []
     private(set) var currentProblemIndex = 0
@@ -121,30 +122,42 @@ final class VerticalSliceEngine {
     var concreteCount: Int { concreteWarmCount + concreteAccentCount }
     var sumSprintStageCardCount: Int { sumSprintBurstState?.totalPairs ?? 0 }
 
-    func show(_ route: AppRoute) { self.route = route }
-    func showSettings() { route = .settings }
-    func showHome() { route = .home }
-    func showParentSummary() { route = .parentSummary }
-    func showSessionConfig() { route = .sessionConfig }
-    func showRoomQuest() { route = .roomQuest }
-    func showSumSprint() { route = .sumSprint }
-    func showSymmetryFold() { route = .symmetryFold }
-    func showRectangleFactory() { route = .rectangleFactory }
-    func showFactoryCards() { route = .factoryCards }
-    func showAngleCannon() { route = .angleCannon }
-    func showTwoFingerProtractor() { route = .twoFingerProtractor }
-    func showGravityArtist() { route = .gravityArtist }
-    func showCompassAngles() { route = .compassAngles }
-    func showLab() { route = .lab }
-    func showLabLane(_ laneID: CapabilityLaneID) { route = .labLane(laneID) }
-    func showMemory() { route = .memory }
-    func showLabRememberStage(_ deckID: LabRememberStageDeckID) { route = .labRememberStage(deckID) }
-    func showCountriesGameplayThread() { route = .gameplayThread(.countries) }
-    func showWaterCycle() { route = .gameplayThread(.waterCycle) }
-    func showLegacyWaterCycleLab() { route = .waterCycle }
-    func showGameplayThread(_ id: GameplayThreadID) { route = .gameplayThread(id) }
-    func showSoundVolume() { route = .soundVolume }
-    func showShapeGeometry() { route = .shapeGeometry }
+    func show(_ route: AppRoute) {
+        gameplayReturnRoute = nil
+        self.route = route
+    }
+
+    func showSettings() { show(.settings) }
+    func showHome() { show(.home) }
+    func showParentSummary() { show(.parentSummary) }
+    func showSessionConfig() { show(.sessionConfig) }
+    func showRoomQuest() { show(.roomQuest) }
+    func showSumSprint() { show(.sumSprint) }
+    func showSymmetryFold() { show(.symmetryFold) }
+    func showRectangleFactory() { show(.rectangleFactory) }
+    func showFactoryCards() { show(.factoryCards) }
+    func showAngleCannon() { show(.angleCannon) }
+    func showTwoFingerProtractor() { show(.twoFingerProtractor) }
+    func showGravityArtist() { show(.gravityArtist) }
+    func showCompassAngles() { show(.compassAngles) }
+    func showLab() { show(.lab) }
+    func showLabLane(_ laneID: CapabilityLaneID) { show(.labLane(laneID)) }
+    func showMemory() { show(.memory) }
+    func showLabRememberStage(_ deckID: LabRememberStageDeckID) { show(.labRememberStage(deckID)) }
+    func showCountriesGameplayThread() { showGameplayThread(.countries) }
+    func showWaterCycle() { showGameplayThread(.waterCycle) }
+    func showLegacyWaterCycleLab() { show(.waterCycle) }
+    func showGameplayThread(_ id: GameplayThreadID, returnRoute: AppRoute? = nil) {
+        gameplayReturnRoute = returnRoute
+        route = .gameplayThread(id)
+    }
+
+    func returnFromGameplay(defaultRoute: AppRoute = .lab) {
+        route = gameplayReturnRoute ?? defaultRoute
+        gameplayReturnRoute = nil
+    }
+    func showSoundVolume() { show(.soundVolume) }
+    func showShapeGeometry() { show(.shapeGeometry) }
 
     func startBondBlastFinale(target: Int = 10) {
         updateConfig(problemCount: 1, minTarget: target, maxTarget: target)

--- a/Features/GameplayStages/GameplayThreadView.swift
+++ b/Features/GameplayStages/GameplayThreadView.swift
@@ -24,23 +24,36 @@ struct GameplayThreadView: View {
     let thread: GameplayThreadDefinition
     var actions: GameplayStageFeedbackActions
     var progressStore: GameplayProgressStore?
+    var onHome: @MainActor () -> Void
+    var onBackToStageSurface: @MainActor () -> Void
     @State private var navigation: GameplayStageNavigationState
 
     init(
         thread: GameplayThreadDefinition = GameplaySampleThreads.countries,
         actions: GameplayStageFeedbackActions = GameplayStageFeedbackActions(),
         progressStore: GameplayProgressStore? = nil,
-        now: Date = Date()
+        now: Date = Date(),
+        onHome: @escaping @MainActor () -> Void = {},
+        onBackToStageSurface: @escaping @MainActor () -> Void = {}
     ) {
         self.thread = thread
         self.actions = actions
         self.progressStore = progressStore
+        self.onHome = onHome
+        self.onBackToStageSurface = onBackToStageSurface
         _navigation = State(initialValue: GameplayStageNavigationState(startedAt: now, currentStageStartedAt: now))
     }
 
     @MainActor
     init(thread: GameplayThreadDefinition = GameplaySampleThreads.countries, appModel: AppModel, now: Date = Date()) {
-        self.init(thread: thread, actions: .appModel(appModel), progressStore: appModel.gameplayProgressStore, now: now)
+        self.init(
+            thread: thread,
+            actions: .appModel(appModel),
+            progressStore: appModel.gameplayProgressStore,
+            now: now,
+            onHome: { appModel.engine.showHome() },
+            onBackToStageSurface: { appModel.engine.returnFromGameplay(defaultRoute: .lab) }
+        )
     }
 
     var body: some View {
@@ -48,8 +61,10 @@ struct GameplayThreadView: View {
             let compact = GameplayStageRenderSupport.usesCompactStageLayout(width: proxy.size.width, height: proxy.size.height)
             ScrollView {
                 VStack(spacing: compact ? 12 : 20) {
+                    topChrome(compact: compact)
                     header(compact: compact)
                     activeStage(compact: compact)
+                        .id(navigation.stageAttemptID)
                         .frame(maxWidth: GameplayStageRenderSupport.maximumContentWidth(compact: compact))
                     controls(compact: compact)
                 }
@@ -145,6 +160,41 @@ struct GameplayThreadView: View {
         return [key: totalHints]
     }
 
+    private func topChrome(compact: Bool) -> some View {
+        HStack(spacing: 10) {
+            Button {
+                backAction()
+            } label: {
+                Label(navigation.canGoBack ? "Back" : "Stages", systemImage: "chevron.left")
+                    .labelStyle(.titleAndIcon)
+            }
+            .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
+            .accessibilityLabel(navigation.canGoBack ? "Back to previous stage" : "Back to stage details")
+            .accessibilityIdentifier("GameplayStageTopBackButton")
+
+            Spacer(minLength: 0)
+
+            Button {
+                onHome()
+            } label: {
+                Label("Home", systemImage: "house.fill")
+                    .labelStyle(.titleAndIcon)
+            }
+            .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
+            .accessibilityLabel("Home")
+            .accessibilityIdentifier("GameplayStageHomeButton")
+        }
+        .frame(maxWidth: GameplayStageRenderSupport.maximumContentWidth(compact: compact))
+    }
+
+    private func backAction() {
+        if navigation.canGoBack {
+            navigation.goBack()
+        } else {
+            onBackToStageSurface()
+        }
+    }
+
     private func header(compact: Bool) -> some View {
         VStack(alignment: .leading, spacing: compact ? 8 : 12) {
             HStack {
@@ -190,11 +240,14 @@ struct GameplayThreadView: View {
 
     private func controlButtons(compact: Bool) -> some View {
         HStack(spacing: 8) {
-            Button("Back") { navigation.goBack() }
+            Button(navigation.canGoBack ? "Back" : "Stages") { backAction() }
                 .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
-                .disabled(!navigation.canGoBack)
-            Button("Retry") { navigation.retryCurrentStage() }
+                .accessibilityLabel(navigation.canGoBack ? "Back to previous stage" : "Back to stage details")
+                .accessibilityIdentifier("GameplayStageBackButton")
+            Button("Retry") { navigation.retryCurrentStage(in: thread) }
                 .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
+                .accessibilityLabel("Retry current stage")
+                .accessibilityIdentifier("GameplayStageRetryButton")
         }
     }
 

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -758,7 +758,7 @@ struct LabLaneDetailView: View {
             if stage.stage == .blast {
                 appModel.engine.startBondBlastFinale(target: 10)
             } else {
-                appModel.engine.show(route)
+                showActivityRoute(route, returnLaneID: plan.laneID)
                 if route == .sumSprint {
                     appModel.sumSprintEngine.showDifficultyPick()
                 }
@@ -769,7 +769,8 @@ struct LabLaneDetailView: View {
     private func launch(_ activityID: LabActivityID) {
         appModel.pickProfileThenRun {
             appModel.clearLabGameplayCompletion()
-            appModel.engine.show(route(for: activityID, laneID: lane.id))
+            let activityRoute = route(for: activityID, laneID: lane.id)
+            showActivityRoute(activityRoute, returnLaneID: lane.id)
             switch activityID {
             case .sumSprint:
                 appModel.sumSprintEngine.showDifficultyPick()
@@ -777,6 +778,14 @@ struct LabLaneDetailView: View {
                  .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .fruitCards:
                 break
             }
+        }
+    }
+
+    private func showActivityRoute(_ route: AppRoute, returnLaneID: CapabilityLaneID) {
+        if case let .gameplayThread(threadID) = route {
+            appModel.engine.showGameplayThread(threadID, returnRoute: .labLane(returnLaneID))
+        } else {
+            appModel.engine.show(route)
         }
     }
 

--- a/Tests/MatherTests/GameplayStageViewModelsTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelsTests.swift
@@ -23,6 +23,50 @@ struct GameplayStageViewModelsTests {
     }
 
     @Test
+    func retryCurrentStageRebuildsAttemptAndClearsCompletedResult() {
+        let thread = GameplaySampleThreads.countries
+        let start = Date(timeIntervalSince1970: 200)
+        var state = GameplayStageNavigationState(startedAt: start, currentStageStartedAt: start)
+
+        state.completeCurrentStage(thread: thread, correctCount: 3, mistakeCount: 0, now: start.addingTimeInterval(10))
+        #expect(state.activeStageIndex == 1)
+        let attemptBeforeRetry = state.stageAttemptID
+
+        state.retryCurrentStage(in: thread, now: start.addingTimeInterval(12))
+
+        #expect(state.activeStageIndex == 1)
+        #expect(state.stageResults.map(\.stageID) == [thread.stages[0].id])
+        #expect(state.currentStageStartedAt == start.addingTimeInterval(12))
+        #expect(state.stageAttemptID != attemptBeforeRetry)
+    }
+
+    @Test
+    func retryAfterThreadCompleteReturnsToLastStage() {
+        let thread = GameplayThreadDefinition(
+            id: "short-thread",
+            title: "Short Thread",
+            category: GameplayCategory(id: "test", title: "Test", subtitle: ""),
+            propertyTypes: [],
+            entities: [],
+            stages: [
+                GameplayStageDefinition(id: "look", kind: .flashcards, title: "Look", prompt: "Look"),
+                GameplayStageDefinition(id: "quiz", kind: .multipleChoice, title: "Quiz", prompt: "Quiz")
+            ]
+        )
+        let start = Date(timeIntervalSince1970: 300)
+        var state = GameplayStageNavigationState(startedAt: start, currentStageStartedAt: start)
+        state.completeCurrentStage(thread: thread, correctCount: 1, mistakeCount: 0, now: start.addingTimeInterval(5))
+        state.completeCurrentStage(thread: thread, correctCount: 1, mistakeCount: 0, now: start.addingTimeInterval(10))
+        #expect(state.isComplete(for: thread))
+
+        state.retryCurrentStage(in: thread, now: start.addingTimeInterval(11))
+
+        #expect(!state.isComplete(for: thread))
+        #expect(state.activeStage(in: thread)?.id == "quiz")
+        #expect(state.stageResults.map(\.stageID) == ["look"])
+    }
+
+    @Test
     func contentBuilderCreatesPropertyPairsForRoundItems() {
         let thread = GameplaySampleThreads.countries
         let stage = thread.stages.first { $0.kind == .easyMemory }!
@@ -67,7 +111,6 @@ struct GameplayStageViewModelsTests {
         #expect(GameplayStageRenderSupport.cardMinimumWidth(availableWidth: 820, compact: false) == 180)
     }
 }
-
 
 struct GameplayThreadCatalogRegressionTests {
     @Test

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -87,6 +87,29 @@ struct LabRouteRegressionTests {
     }
 
     @Test
+    func gameplayThreadReturnRouteCanLandBackOnLaunchingLabLane() {
+        let engine = makeEngine()
+
+        engine.showGameplayThread(.countries, returnRoute: .labLane(.mapWorld))
+        #expect(engine.route == .gameplayThread(.countries))
+        #expect(engine.gameplayReturnRoute == .labLane(.mapWorld))
+
+        engine.returnFromGameplay(defaultRoute: .lab)
+        #expect(engine.route == .labLane(.mapWorld))
+        #expect(engine.gameplayReturnRoute == nil)
+    }
+
+    @Test
+    func directGameplayThreadLaunchStillHasNoLabProgressReturnContext() {
+        let engine = makeEngine()
+
+        engine.showCountriesGameplayThread()
+
+        #expect(engine.route == .gameplayThread(.countries))
+        #expect(engine.gameplayReturnRoute == nil)
+    }
+
+    @Test
     func discoveryChemistryAndElectronicsShellsStayRegistered() throws {
         let lanes = CapabilityLane.defaultExplorerLanes
         let discovery = try #require(lanes.first { $0.id == .discoveryCards })


### PR DESCRIPTION
## Summary
- Adds consistent child-safe gameplay chrome with Home plus Back/Stages controls and accessibility identifiers.
- Makes Retry deterministic by rebuilding the active stage attempt and clearing any completed result for that stage, including retry from thread-complete state.
- Preserves direct Games one-tap launches while carrying Lab launch context so Back/Stages returns to the launching Lab lane instead of dead-ending.

Fixes #947
Fixes #948
Refs #957

## Validation
- `git diff --check` ✅
- Focused iOS test attempt on ganesh-mba: `xcodebuild test -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:MatherTests/GameplayStageViewModelsTests -only-testing:MatherTests/LabRouteRegressionTests` hit known Swift frontend crash in `Features/ParentSummary/SettingsView.swift` during type checking; exact failure was SwiftCompile code 65 / frontend stack dump, unrelated to this slice. Relying on PR CI.