### PR TITLE
Render gameplay card assets and map shapes (#949 #959)

### DIFF
--- a/Domain/CountryGameplayThread.swift
+++ b/Domain/CountryGameplayThread.swift
@@ -156,7 +156,7 @@ enum CountryGameplayThread {
                 property(entityID: id, typeID: "capital", value: capital, explanation: "The capital of \(name) is \(capital).", visualKey: "🏛️"),
                 property(entityID: id, typeID: "currency", value: currency, explanation: "\(name) uses \(currency).", visualKey: "💰"),
                 property(entityID: id, typeID: "flag", value: "\(name) flag", explanation: "This is the flag of \(name).", visualKey: flagEmoji, visualAssetName: flagAsset),
-                property(entityID: id, typeID: "map-shape", value: mapShape, explanation: "A map clue for \(name): \(mapShape).", visualKey: "🗺️"),
+                property(entityID: id, typeID: "map-shape", value: mapShape, explanation: "A map clue for \(name): \(mapShape).", visualKey: "🗺️", visualShapeKey: id),
                 property(entityID: id, typeID: "continent", value: continent, explanation: "\(name) is in \(continent).", visualKey: "🌍"),
                 property(entityID: id, typeID: "language", value: language, explanation: "A language clue for \(name): \(language).", visualKey: "🗣️"),
                 property(entityID: id, typeID: "clue", value: knownFor, explanation: "\(name) is \(knownFor).", visualKey: "✨")
@@ -170,7 +170,8 @@ enum CountryGameplayThread {
         value: String,
         explanation: String,
         visualKey: String? = nil,
-        visualAssetName: String? = nil
+        visualAssetName: String? = nil,
+        visualShapeKey: String? = nil
     ) -> GameplayProperty {
         GameplayProperty(
             id: "\(entityID)-\(typeID)",
@@ -178,7 +179,8 @@ enum CountryGameplayThread {
             value: value,
             explanation: explanation,
             visualKey: visualKey,
-            visualAssetName: visualAssetName
+            visualAssetName: visualAssetName,
+            visualShapeKey: visualShapeKey
         )
     }
 }

--- a/Domain/GameplayStageModels.swift
+++ b/Domain/GameplayStageModels.swift
@@ -27,6 +27,7 @@ struct GameplayProperty: Identifiable, Codable, Equatable, Hashable {
     let explanation: String
     let visualKey: String?
     let visualAssetName: String?
+    let visualShapeKey: String?
 
     init(
         id: String,
@@ -34,7 +35,8 @@ struct GameplayProperty: Identifiable, Codable, Equatable, Hashable {
         value: String,
         explanation: String = "",
         visualKey: String? = nil,
-        visualAssetName: String? = nil
+        visualAssetName: String? = nil,
+        visualShapeKey: String? = nil
     ) {
         self.id = id
         self.typeID = typeID
@@ -42,6 +44,7 @@ struct GameplayProperty: Identifiable, Codable, Equatable, Hashable {
         self.explanation = explanation
         self.visualKey = visualKey
         self.visualAssetName = visualAssetName
+        self.visualShapeKey = visualShapeKey
     }
 }
 
@@ -51,6 +54,7 @@ struct GameplayEntity: Identifiable, Codable, Equatable, Hashable {
     let summary: String
     let visualKey: String?
     let visualAssetName: String?
+    let visualShapeKey: String?
     let properties: [GameplayProperty]
 
     init(
@@ -59,6 +63,7 @@ struct GameplayEntity: Identifiable, Codable, Equatable, Hashable {
         summary: String = "",
         visualKey: String? = nil,
         visualAssetName: String? = nil,
+        visualShapeKey: String? = nil,
         properties: [GameplayProperty]
     ) {
         self.id = id
@@ -66,6 +71,7 @@ struct GameplayEntity: Identifiable, Codable, Equatable, Hashable {
         self.summary = summary
         self.visualKey = visualKey
         self.visualAssetName = visualAssetName
+        self.visualShapeKey = visualShapeKey
         self.properties = properties
     }
 }

--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -98,6 +98,7 @@ struct GameplayDisplayItem: Identifiable, Equatable, Hashable {
     let subtitle: String
     let visualKey: String?
     let visualAssetName: String?
+    let visualShapeKey: String?
 
     var spokenText: String {
         [title, subtitle].filter { !$0.isEmpty }.joined(separator: ". ")
@@ -309,7 +310,8 @@ enum GameplayStageContentBuilder {
                 title: entity.name,
                 subtitle: entity.summary,
                 visualKey: entity.visualKey,
-                visualAssetName: entity.visualAssetName
+                visualAssetName: entity.visualAssetName,
+                visualShapeKey: entity.visualShapeKey
             )
         }
     }
@@ -324,7 +326,8 @@ enum GameplayStageContentBuilder {
                 title: entity.name,
                 subtitle: entity.summary,
                 visualKey: entity.visualKey,
-                visualAssetName: entity.visualAssetName
+                visualAssetName: entity.visualAssetName,
+                visualShapeKey: entity.visualShapeKey
             )
             let right = GameplayDisplayItem(
                 id: "\(item.id)-right",
@@ -332,7 +335,8 @@ enum GameplayStageContentBuilder {
                 title: property?.value ?? entity.name,
                 subtitle: property.map { propertyTypeTitle($0.typeID, in: thread) } ?? "Name",
                 visualKey: property?.visualKey,
-                visualAssetName: property?.visualAssetName
+                visualAssetName: property?.visualAssetName,
+                visualShapeKey: property?.visualShapeKey
             )
             return GameplayMatchPair(id: item.id, left: left, right: right)
         }

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -63,11 +63,14 @@ struct GameplayDisplayCard: View {
 
     var body: some View {
         VStack(spacing: compact ? 6 : 10) {
-            Text(concealed ? "?" : item.visualKey ?? "✦")
-                .font(.system(size: visualSize, weight: concealed ? .black : .regular, design: .rounded))
-                .foregroundStyle(concealed ? MatherTheme.accent : MatherTheme.ink)
-                .frame(width: visualFrameWidth, height: visualFrameHeight)
-                .background(Circle().fill(MatherTheme.softBlue.opacity(0.45)))
+            GameplayDisplayVisual(
+                item: item,
+                concealed: concealed,
+                visualSize: visualSize,
+                visualFrameWidth: visualFrameWidth,
+                visualFrameHeight: visualFrameHeight,
+                cornerRadius: isFeatured ? 28 : 22
+            )
             Text(concealed ? "Hidden match" : item.title)
                 .font(prominence == .featured ? (compact ? .title3.bold() : .title.bold()) : (compact ? .headline.bold() : .title3.bold()))
                 .multilineTextAlignment(.center)
@@ -99,19 +102,19 @@ struct GameplayDisplayCard: View {
 
     private var isFeatured: Bool { prominence == .featured }
     private var visualSize: CGFloat {
-        if isFeatured { return compact ? 76 : 112 }
+        if isFeatured { return compact ? 104 : 140 }
         return compact ? 40 : 58
     }
     private var visualFrameWidth: CGFloat {
-        if isFeatured { return compact ? 118 : 156 }
+        if isFeatured { return compact ? 220 : 320 }
         return compact ? 64 : 86
     }
     private var visualFrameHeight: CGFloat {
-        if isFeatured { return compact ? 102 : 136 }
+        if isFeatured { return compact ? 170 : 240 }
         return compact ? 58 : 78
     }
     private var minimumHeight: CGFloat {
-        if isFeatured { return compact ? 220 : 280 }
+        if isFeatured { return compact ? 310 : 400 }
         return compact ? 132 : 164
     }
 }
@@ -119,6 +122,115 @@ struct GameplayDisplayCard: View {
 enum GameplayDisplayCardProminence {
     case normal
     case featured
+}
+
+private struct GameplayDisplayVisual: View {
+    let item: GameplayDisplayItem
+    let concealed: Bool
+    let visualSize: CGFloat
+    let visualFrameWidth: CGFloat
+    let visualFrameHeight: CGFloat
+    let cornerRadius: CGFloat
+
+    var body: some View {
+        Group {
+            if concealed {
+                Text("?")
+                    .font(.system(size: visualSize, weight: .black, design: .rounded))
+                    .foregroundStyle(MatherTheme.accent)
+            } else if let assetName = item.visualAssetName {
+                Image(assetName)
+                    .resizable()
+                    .scaledToFit()
+                    .accessibilityHidden(true)
+                    .padding(visualAssetPadding)
+            } else if let shapeKey = item.visualShapeKey {
+                CountryMapShapeArtwork(shapeKey: shapeKey)
+                    .accessibilityHidden(true)
+                    .padding(visualAssetPadding)
+            } else {
+                Text(item.visualKey ?? "✦")
+                    .font(.system(size: visualSize, weight: .regular, design: .rounded))
+                    .foregroundStyle(MatherTheme.ink)
+            }
+        }
+        .frame(width: visualFrameWidth, height: visualFrameHeight)
+        .background(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(MatherTheme.softBlue.opacity(0.45))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .strokeBorder(MatherTheme.panelDeep.opacity(concealed ? 0 : 0.12), lineWidth: 1)
+        )
+    }
+
+    private var visualAssetPadding: CGFloat {
+        max(4, min(14, visualFrameHeight * 0.08))
+    }
+}
+
+private struct CountryMapShapeArtwork: View {
+    let shapeKey: String
+
+    var body: some View {
+        CountryMapSilhouette(shapeKey: shapeKey)
+            .fill(
+                LinearGradient(
+                    colors: [MatherTheme.accent.opacity(0.95), MatherTheme.panelDeep.opacity(0.82)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .overlay(
+                CountryMapSilhouette(shapeKey: shapeKey)
+                    .stroke(MatherTheme.ink.opacity(0.18), lineWidth: 2)
+            )
+            .shadow(color: MatherTheme.panelDeep.opacity(0.18), radius: 4, x: 0, y: 3)
+    }
+}
+
+private struct CountryMapSilhouette: Shape {
+    let shapeKey: String
+
+    func path(in rect: CGRect) -> Path {
+        let points = normalizedPoints(for: shapeKey)
+        guard let first = points.first else { return Path() }
+        var path = Path()
+        path.move(to: point(first, in: rect))
+        for coordinate in points.dropFirst() {
+            path.addLine(to: point(coordinate, in: rect))
+        }
+        path.closeSubpath()
+        return path
+    }
+
+    private func point(_ coordinate: CGPoint, in rect: CGRect) -> CGPoint {
+        CGPoint(x: rect.minX + coordinate.x * rect.width, y: rect.minY + coordinate.y * rect.height)
+    }
+
+    private func normalizedPoints(for key: String) -> [CGPoint] {
+        switch key {
+        case "country-india":
+            return [CGPoint(x: 0.40, y: 0.08), CGPoint(x: 0.70, y: 0.22), CGPoint(x: 0.62, y: 0.52), CGPoint(x: 0.52, y: 0.92), CGPoint(x: 0.34, y: 0.58), CGPoint(x: 0.24, y: 0.24)]
+        case "country-japan":
+            return [CGPoint(x: 0.58, y: 0.06), CGPoint(x: 0.72, y: 0.18), CGPoint(x: 0.65, y: 0.36), CGPoint(x: 0.76, y: 0.56), CGPoint(x: 0.58, y: 0.92), CGPoint(x: 0.42, y: 0.76), CGPoint(x: 0.50, y: 0.52), CGPoint(x: 0.34, y: 0.30)]
+        case "country-france":
+            return [CGPoint(x: 0.34, y: 0.12), CGPoint(x: 0.66, y: 0.12), CGPoint(x: 0.82, y: 0.42), CGPoint(x: 0.66, y: 0.78), CGPoint(x: 0.36, y: 0.86), CGPoint(x: 0.16, y: 0.48)]
+        case "country-egypt":
+            return [CGPoint(x: 0.18, y: 0.18), CGPoint(x: 0.72, y: 0.18), CGPoint(x: 0.72, y: 0.56), CGPoint(x: 0.86, y: 0.72), CGPoint(x: 0.58, y: 0.74), CGPoint(x: 0.18, y: 0.72)]
+        case "country-brazil":
+            return [CGPoint(x: 0.34, y: 0.08), CGPoint(x: 0.70, y: 0.18), CGPoint(x: 0.88, y: 0.46), CGPoint(x: 0.70, y: 0.74), CGPoint(x: 0.54, y: 0.92), CGPoint(x: 0.24, y: 0.76), CGPoint(x: 0.12, y: 0.44)]
+        case "country-australia":
+            return [CGPoint(x: 0.20, y: 0.42), CGPoint(x: 0.40, y: 0.24), CGPoint(x: 0.76, y: 0.32), CGPoint(x: 0.88, y: 0.56), CGPoint(x: 0.66, y: 0.78), CGPoint(x: 0.32, y: 0.72), CGPoint(x: 0.12, y: 0.58)]
+        case "country-canada":
+            return [CGPoint(x: 0.06, y: 0.34), CGPoint(x: 0.22, y: 0.16), CGPoint(x: 0.42, y: 0.28), CGPoint(x: 0.58, y: 0.14), CGPoint(x: 0.86, y: 0.30), CGPoint(x: 0.94, y: 0.54), CGPoint(x: 0.72, y: 0.68), CGPoint(x: 0.42, y: 0.58), CGPoint(x: 0.20, y: 0.72)]
+        case "country-kenya":
+            return [CGPoint(x: 0.42, y: 0.10), CGPoint(x: 0.64, y: 0.18), CGPoint(x: 0.72, y: 0.46), CGPoint(x: 0.54, y: 0.90), CGPoint(x: 0.30, y: 0.70), CGPoint(x: 0.34, y: 0.34)]
+        default:
+            return [CGPoint(x: 0.30, y: 0.12), CGPoint(x: 0.74, y: 0.28), CGPoint(x: 0.66, y: 0.76), CGPoint(x: 0.24, y: 0.86), CGPoint(x: 0.16, y: 0.42)]
+        }
+    }
 }
 
 struct GameplayPairingStageShell: View {

--- a/Tests/MatherTests/CountryGameplayThreadTests.swift
+++ b/Tests/MatherTests/CountryGameplayThreadTests.swift
@@ -30,6 +30,7 @@ struct CountryGameplayThreadTests {
             #expect(entity.visualAssetName?.hasPrefix("MemoryFlag") == true)
             #expect(entity.properties.first { $0.typeID == "flag" }?.visualAssetName == entity.visualAssetName)
             #expect(!(entity.properties.first { $0.typeID == "map-shape" }?.value.isEmpty ?? true))
+            #expect(entity.properties.first { $0.typeID == "map-shape" }?.visualShapeKey == entity.id)
         }
     }
 
@@ -72,6 +73,20 @@ struct CountryGameplayThreadTests {
         let questions = GameplayStageContentBuilder.multipleChoiceQuestions(thread: thread, round: quiz)
         #expect(!questions.isEmpty)
         #expect(questions.allSatisfy { $0.choices.contains($0.answer) })
+    }
+
+
+    @Test
+    func mapShapeQuizItemsCarryDrawableShapeKeys() throws {
+        let thread = CountryGameplayThread.thread
+        let stage = try #require(thread.stages.first { $0.kind == .multipleChoice })
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 18)
+        let questions = GameplayStageContentBuilder.multipleChoiceQuestions(thread: thread, round: round)
+        let mapShapeAnswers = questions.map(\.answer).filter { $0.subtitle == "Map Shape" }
+
+        #expect(!mapShapeAnswers.isEmpty)
+        #expect(mapShapeAnswers.allSatisfy { $0.visualShapeKey == $0.entityID })
+        #expect(mapShapeAnswers.allSatisfy { $0.visualAssetName == nil })
     }
 
     @Test

--- a/Tests/MatherTests/WaterCycleGameplayThreadTests.swift
+++ b/Tests/MatherTests/WaterCycleGameplayThreadTests.swift
@@ -38,6 +38,19 @@ struct WaterCycleGameplayThreadTests {
         #expect(thread.entities[3].properties.first { $0.typeID == "whatHappens" }?.value.localizedCaseInsensitiveContains("ponds") == true)
     }
 
+
+    @Test
+    func waterCycleFlashcardsExposeLargeRenderableAssetMetadata() {
+        let thread = GameplayThreadCatalog.waterCycle
+        let stage = thread.stages[0]
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 5)
+        let cards = GameplayStageContentBuilder.flashcards(thread: thread, round: round)
+
+        #expect(cards.count == 4)
+        #expect(cards.allSatisfy { $0.visualAssetName?.hasPrefix("MemoryWaterCycle") == true })
+        #expect(cards.allSatisfy { $0.visualShapeKey == nil })
+    }
+
     @Test
     func waterCycleStagesGenerateFocusedRounds() {
         let thread = GameplayThreadCatalog.waterCycle


### PR DESCRIPTION
## Summary
- render gameplay display-card visualAssetName images instead of emoji placeholders
- enlarge featured/single-card flashcard visuals for Water Cycle Look + Learn
- add lightweight country map-shape metadata and SwiftUI silhouette rendering for map-shape cards
- cover Water Cycle asset metadata and Country map-shape display metadata in tests

## Validation
- ✅ git diff --check
- ⚠️ Remote focused Xcode test attempted on ganesh-mba: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,OS=18.3.1,name=iPhone 16' -only-testing:MatherTests/CountryGameplayThreadTests -only-testing:MatherTests/WaterCycleGameplayThreadTests`
  - blocked because ganesh-mba does not have xcodegen installed and the checked-in Mather.xcodeproj is stale/missing many generated source files (baseline build errors like CardReviewResult/KidProfileStore/CapabilityLaneID not found).
- ⏳ PR CI Build & Test is pending; CI post-clone should regenerate the project via xcodegen.

Fixes #949
Fixes #959
