### PR TITLE
Fix gameplay memory turns and flip reveal

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -165,13 +165,18 @@ struct GameplayMatchStageViewModel: Equatable {
     let seed: UInt64
     var selectedLeftID: String?
     var inspectedItemID: String?
+    var revealedRightIDs: Set<String> = []
     var matchedPairIDs: Set<String> = []
     var mismatchCount = 0
     var hintCount = 0
     var activeTurnIndex = 0
 
     init(thread: GameplayThreadDefinition, round: GameplayRoundDefinition, mode: GameplayStageKind, turnItemCount: Int? = nil) {
-        self.pairs = GameplayStageContentBuilder.matchPairs(thread: thread, round: round)
+        self.pairs = GameplayStageContentBuilder.turnFriendlyOrder(
+            GameplayStageContentBuilder.matchPairs(thread: thread, round: round),
+            turnItemCount: turnItemCount ?? Self.defaultTurnItemCount(for: mode, itemCount: round.items.count),
+            seed: round.seed
+        )
         self.mode = mode
         self.turnItemCount = max(1, turnItemCount ?? Self.defaultTurnItemCount(for: mode, itemCount: round.items.count))
         self.seed = round.seed
@@ -208,7 +213,9 @@ struct GameplayMatchStageViewModel: Equatable {
     }
 
     func shouldConcealRight(_ item: GameplayDisplayItem) -> Bool {
-        mode == .flipMemory && !matchedPairIDs.contains(pairID(forRight: item))
+        guard mode == .flipMemory else { return false }
+        guard !matchedPairIDs.contains(pairID(forRight: item)) else { return false }
+        return !revealedRightIDs.contains(item.id) && inspectedItemID != item.id
     }
 
     func pairID(forRight item: GameplayDisplayItem) -> String {
@@ -223,9 +230,17 @@ struct GameplayMatchStageViewModel: Equatable {
 
     mutating func inspect(_ item: GameplayDisplayItem) {
         inspectedItemID = inspectedItemID == item.id ? nil : item.id
+        if mode == .flipMemory, activePairs.contains(where: { $0.right.id == item.id }) {
+            if revealedRightIDs.contains(item.id), inspectedItemID == nil {
+                revealedRightIDs.remove(item.id)
+            } else {
+                revealedRightIDs.insert(item.id)
+            }
+        }
     }
 
     mutating func chooseRight(_ right: GameplayDisplayItem) -> Bool {
+        revealedRightIDs.insert(right.id)
         guard let selectedLeftID, let pair = activePairs.first(where: { $0.id == selectedLeftID }) else {
             inspect(right)
             return false
@@ -235,9 +250,11 @@ struct GameplayMatchStageViewModel: Equatable {
             matchedPairIDs.insert(pair.id)
             self.selectedLeftID = nil
             inspectedItemID = right.id
+            revealedRightIDs.insert(right.id)
         } else {
             mismatchCount += 1
             inspectedItemID = right.id
+            revealedRightIDs = Set([right.id])
         }
         return correct
     }
@@ -247,6 +264,7 @@ struct GameplayMatchStageViewModel: Equatable {
         activeTurnIndex = min(activeTurnIndex + 1, turnCount - 1)
         selectedLeftID = nil
         inspectedItemID = nil
+        revealedRightIDs.removeAll()
     }
 
     private static func defaultTurnItemCount(for mode: GameplayStageKind, itemCount: Int) -> Int {
@@ -360,6 +378,31 @@ enum GameplayStageContentBuilder {
 
     static func sortedRights(_ pairs: [GameplayMatchPair], seed: UInt64) -> [GameplayDisplayItem] {
         deterministicOrder(pairs.map(\.right), seed: seed)
+    }
+
+    static func turnFriendlyOrder(_ pairs: [GameplayMatchPair], turnItemCount: Int, seed: UInt64) -> [GameplayMatchPair] {
+        let size = max(1, turnItemCount)
+        var remaining = deterministicOrder(pairs, seed: seed &+ 31)
+        var ordered: [GameplayMatchPair] = []
+        while !remaining.isEmpty {
+            var turn: [GameplayMatchPair] = []
+            var usedEntities = Set<String>()
+            var nextRemaining: [GameplayMatchPair] = []
+            for pair in remaining {
+                if turn.count < size && !usedEntities.contains(pair.left.entityID) {
+                    turn.append(pair)
+                    usedEntities.insert(pair.left.entityID)
+                } else {
+                    nextRemaining.append(pair)
+                }
+            }
+            while turn.count < size, !nextRemaining.isEmpty {
+                turn.append(nextRemaining.removeFirst())
+            }
+            ordered.append(contentsOf: turn)
+            remaining = nextRemaining
+        }
+        return ordered
     }
 
     private static func propertyTypeTitle(_ id: String, in thread: GameplayThreadDefinition) -> String {

--- a/Services/SpacedRepetitionScheduler.swift
+++ b/Services/SpacedRepetitionScheduler.swift
@@ -18,7 +18,11 @@ enum SpacedRepetitionScheduler {
             let rightRank = rank(item: rhs, record: rightRecord, now: now, seed: seed)
             return leftRank < rightRank
         }
-        let selected = Array(ranked.prefix(effectivePolicy.maximumItemCount))
+        let selected = childSafeSelection(
+            from: ranked,
+            maximumItemCount: effectivePolicy.maximumItemCount,
+            stageKind: stage.kind
+        )
         return GameplayRoundDefinition(
             id: "\(stage.id)-round-\(seed)",
             stageID: stage.id,
@@ -71,6 +75,33 @@ enum SpacedRepetitionScheduler {
 
     static func recordKey(for item: GameplayRoundItem, stageID: String) -> GameplayExposureKey {
         GameplayExposureKey(entityID: item.entityID, propertyID: item.propertyID, stageID: stageID)
+    }
+
+    private static func childSafeSelection(
+        from ranked: [GameplayRoundItem],
+        maximumItemCount: Int,
+        stageKind: GameplayStageKind
+    ) -> [GameplayRoundItem] {
+        let limit = max(1, maximumItemCount)
+        guard stageKind == .easyMemory || stageKind == .flipMemory else {
+            return Array(ranked.prefix(limit))
+        }
+
+        var selected: [GameplayRoundItem] = []
+        var selectedEntityIDs = Set<String>()
+        var deferred: [GameplayRoundItem] = []
+        for item in ranked {
+            guard selected.count < limit else { break }
+            if selectedEntityIDs.insert(item.entityID).inserted {
+                selected.append(item)
+            } else {
+                deferred.append(item)
+            }
+        }
+        for item in deferred where selected.count < limit {
+            selected.append(item)
+        }
+        return selected
     }
 
     private static func rank(item: GameplayRoundItem, record: GameplayExposureRecord?, now: Date, seed: UInt64) -> GameplayItemRank {

--- a/Tests/MatherTests/GameplaySchedulerTests.swift
+++ b/Tests/MatherTests/GameplaySchedulerTests.swift
@@ -47,6 +47,25 @@ struct GameplaySchedulerTests {
     }
 
 
+
+    @Test
+    func memoryRoundsPreferOneCardPerEntityBeforeRepeats() {
+        let thread = sampleThread()
+        let stage = GameplayStageDefinition(
+            id: "flip-memory",
+            kind: .flipMemory,
+            title: "Flip",
+            prompt: "Match",
+            propertyTypeIDs: ["capital", "currency"],
+            maximumItemCount: 3
+        )
+
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 23)
+
+        #expect(round.items.count == 3)
+        #expect(Set(round.items.map(\.entityID)).count == round.items.count)
+    }
+
     @Test
     func schedulerPlacesSupportedCorrectBetweenIncorrectAndIndependentCorrect() {
         let thread = sampleThread()

--- a/Tests/MatherTests/GameplayStageViewModelsTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelsTests.swift
@@ -85,6 +85,35 @@ struct GameplayStageViewModelsTests {
         #expect(allPairsUseCapitalSubtitle)
     }
 
+
+    @Test
+    func flipMemoryHiddenRightCardRevealsWhenTappedFirst() {
+        let thread = GameplaySampleThreads.countries
+        let stage = thread.stages.first { $0.kind == .flipMemory }!
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 77)
+        var viewModel = GameplayMatchStageViewModel(thread: thread, round: round, mode: .flipMemory, turnItemCount: 2)
+        let firstRight = viewModel.shuffledRights[0]
+
+        #expect(viewModel.shouldConcealRight(firstRight))
+        let correct = viewModel.chooseRight(firstRight)
+
+        #expect(!correct)
+        #expect(!viewModel.shouldConcealRight(firstRight))
+        #expect(viewModel.inspectedItemID == firstRight.id)
+        #expect(viewModel.mismatchCount == 0)
+    }
+
+    @Test
+    func matchTurnsAvoidDuplicateEntitiesWherePossible() {
+        let thread = GameplaySampleThreads.countries
+        let stage = thread.stages.first { $0.kind == .bondBlast }!
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 18)
+        let viewModel = GameplayMatchStageViewModel(thread: thread, round: round, mode: .bondBlast, turnItemCount: 3)
+
+        #expect(viewModel.activePairs.count <= 3)
+        #expect(Set(viewModel.activePairs.map { $0.left.entityID }).count == viewModel.activePairs.count)
+    }
+
     @Test
     func multipleChoiceQuestionsIncludeAnswerAndDistractors() {
         let thread = GameplaySampleThreads.countries


### PR DESCRIPTION
## Summary
- Makes Flip Memory taps on hidden/right cards visibly reveal the card instead of feeling like a silent miss.
- Keeps reusable matching/memory stages child-sized by ordering pairs into turn-friendly chunks and avoiding duplicate entities within the same visible turn where possible.
- Updates SR round selection for easy/flip memory to prefer one card per entity before repeating entity properties, preserving the same exposure/update keys for completed turns.
- Adds focused scheduler/view-model coverage for entity-unique memory rounds, hidden-card reveal, and duplicate-free visible turns.

Fixes #951
Fixes #952
Fixes #958
Fixes #960

## Validation
- `git diff --check` ✅
- Local Linux `swift test --filter GameplaySchedulerTests --filter GameplayStageViewModelsTests` blocked: `swift` is not installed on the worker host.
- Remote `ganesh-mba` Xcode focused test attempted:
  - `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:MatherTests/GameplaySchedulerTests -only-testing:MatherTests/GameplayStageViewModelsTests`
  - Blocked by Swift frontend crash while type-checking unrelated `Features/ParentSummary/SettingsView.swift` (`SettingsView.profilesCard.getter`, command exited 65). Changed gameplay files compiled before the frontend crashed.
