### PR TITLE
Fix reusable Bond Blast test macro expansion

### DIFF
--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -196,7 +196,10 @@ struct GameplayStageParityRegressionTests {
 
         #expect(!active.isEmpty)
         #expect(active.count <= 3)
-        #expect(active.allSatisfy { !$0.left.title.isEmpty && !$0.right.title.isEmpty })
+        let activePairsHaveDisplayText = active.allSatisfy { pair in
+            !pair.left.title.isEmpty && !pair.right.title.isEmpty
+        }
+        #expect(activePairsHaveDisplayText)
 
         let pair = active[0]
         viewModel.selectLeft(pairID: pair.id)


### PR DESCRIPTION
## Summary
- Fixes the reusable Bond Blast regression test added in #972 so Swift Testing's `#expect` macro does not expand over an `allSatisfy` closure.
- Keeps the Bond Blast implementation from #972 intact on latest `origin/main`.

## Validation
- `git diff --check` ✅

Follow-up to #950 / #972.
