### PR TITLE
Refine Labs and Games information architecture

### DIFF
--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -91,7 +91,9 @@ struct RootView: View {
                 case .compassAngles:
                     CompassAnglesView(appModel: appModel)
                 case .lab:
-                    LabView(appModel: appModel)
+                    LabView(appModel: appModel, initialPath: .labs)
+                case .labGames:
+                    LabView(appModel: appModel, initialPath: .games)
                 case .labLane(let laneID):
                     LabLaneDetailView(appModel: appModel, laneID: laneID)
                 case .memory:

--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -18,6 +18,7 @@ enum AppRoute: Hashable {
     case gravityArtist
     case compassAngles
     case lab
+    case labGames
     case labLane(CapabilityLaneID)
     case memory
     case memoryDeck(MemoryDeckKind)
@@ -141,6 +142,7 @@ final class VerticalSliceEngine {
     func showGravityArtist() { show(.gravityArtist) }
     func showCompassAngles() { show(.compassAngles) }
     func showLab() { show(.lab) }
+    func showLabGames() { show(.labGames) }
     func showLabLane(_ laneID: CapabilityLaneID) { show(.labLane(laneID)) }
     func showMemory() { show(.memory) }
     func showLabRememberStage(_ deckID: LabRememberStageDeckID) { show(.labRememberStage(deckID)) }

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -7,6 +7,7 @@ struct LabLaneDetailView: View {
 
     @State private var expandedReview = false
     @State private var expandedSupport = false
+    @State private var expandedPlanDetails: Set<String> = []
     @State private var sensorCapabilities = DeviceSensorCapabilities.unavailable
 
     private var lane: CapabilityLane {
@@ -213,8 +214,11 @@ struct LabLaneDetailView: View {
     }
 
     private func conceptSessionPlanCard(_ plan: LabConceptSessionPlan, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top, spacing: 10) {
+        let progress = appModel.labConceptSessionProgressStore.progress(for: plan)
+        let detailsExpanded = expandedPlanDetails.contains(plan.id)
+
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(plan.title)
                         .font(.headline.weight(.black))
@@ -222,8 +226,9 @@ struct LabLaneDetailView: View {
                     Text(plan.subtitle)
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(MatherTheme.cardSubtitle)
+                        .lineLimit(2)
                         .fixedSize(horizontal: false, vertical: true)
-                    Text("\(plan.masteryStateLabel) • \(plan.estimatedLength) • Next: \(plan.recommendedNextActivity)")
+                    Text(plan.masteryStateLabel)
                         .font(.caption2.weight(.black))
                         .foregroundStyle(tint)
                 }
@@ -242,70 +247,79 @@ struct LabLaneDetailView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("\(startLabel(for: plan)) \(plan.title)")
-                .accessibilityHint("Opens the guided stage in progress. Games remain directly playable below.")
+                .accessibilityHint("This is the primary next action for the guided path. Games remain directly playable below.")
             }
 
-            if let progress = appModel.labConceptSessionProgressStore.progress(for: plan) {
+            if let progress {
                 Label(progress.resumeCopy, systemImage: "bookmark.fill")
                     .font(.caption.weight(.black))
                     .foregroundStyle(tint)
                     .accessibilityLabel("Resume \(plan.title). \(progress.resumeCopy).")
             }
 
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 132), spacing: 8)], spacing: 8) {
-                ForEach(plan.stages) { stage in
-                    stagePlanCard(stage, progress: appModel.labConceptSessionProgressStore.progress(for: plan), tint: tint)
+            stageSummaryStrip(plan, progress: progress, tint: tint)
+
+            Button {
+                withAnimation(.spring(response: 0.28, dampingFraction: 0.9)) {
+                    if detailsExpanded {
+                        expandedPlanDetails.remove(plan.id)
+                    } else {
+                        expandedPlanDetails.insert(plan.id)
+                    }
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Label(detailsExpanded ? "Hide path details" : "Show path details", systemImage: detailsExpanded ? "chevron.up.circle.fill" : "chevron.down.circle.fill")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(tint)
+                    Spacer(minLength: 0)
+                    Text("\(plan.estimatedLength) • Next: \(plan.recommendedNextActivity)")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
+                }
+                .padding(9)
+                .background(MatherTheme.card.opacity(0.72), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(detailsExpanded ? "Hide guided path details" : "Show guided path details")
+
+            if detailsExpanded {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 132), spacing: 8)], spacing: 8) {
+                    ForEach(plan.stages) { stage in
+                        stagePlanCard(stage, progress: progress, tint: tint)
+                    }
                 }
             }
         }
         .padding(12)
         .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(plan.title). \(plan.pathLabel).")
+        .accessibilityLabel("\(plan.title). Primary action: \(startLabel(for: plan)). Path: \(plan.pathLabel).")
     }
 
-    private func stagePlanCard(_ stage: LabSessionStagePlan, progress: LabConceptSessionProgress?, tint: Color) -> some View {
-        let stageState = progressState(for: stage.stage, progress: progress)
-        return VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
-                ZStack {
-                    Circle()
-                        .fill(tint.opacity(0.12))
+    private func stageSummaryStrip(_ plan: LabConceptSessionPlan, progress: LabConceptSessionProgress?, tint: Color) -> some View {
+        LabDetailFlowLayout(spacing: 6) {
+            ForEach(plan.stages) { stage in
+                let state = progressState(for: stage.stage, progress: progress)
+                HStack(spacing: 4) {
                     Image(systemName: stage.stage.symbolName)
-                        .font(.caption.weight(.black))
-                        .foregroundStyle(tint)
-                }
-                .frame(width: 26, height: 26)
-                .accessibilityLabel(stage.stage.artworkAccessibilityLabel)
-                Text(stage.stage.rawValue)
-                    .font(.caption.weight(.black))
-                    .foregroundStyle(MatherTheme.ink)
-                Spacer(minLength: 0)
-                if let stageState {
-                    Text(stageState)
                         .font(.caption2.weight(.black))
-                        .foregroundStyle(tint)
+                    Text(stage.stage.rawValue)
+                        .font(.caption2.weight(.black))
+                    if let state {
+                        Text(state)
+                            .font(.caption2.weight(.heavy))
+                    }
                 }
+                .foregroundStyle(state == nil ? MatherTheme.cardSubtitle : tint)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 5)
+                .background((state == nil ? MatherTheme.panel.opacity(0.58) : tint.opacity(0.12)), in: Capsule())
             }
-            Text(stage.title)
-                .font(.caption.weight(.black))
-                .foregroundStyle(MatherTheme.ink)
-            Text(stage.childCopy)
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(MatherTheme.cardSubtitle)
-                .lineLimit(3)
-                .minimumScaleFactor(0.75)
-            Text(stage.timerPolicy.childCopy)
-                .font(.caption2.weight(.bold))
-                .foregroundStyle(tint)
-                .lineLimit(2)
-                .minimumScaleFactor(0.72)
         }
-        .padding(10)
-        .frame(maxWidth: .infinity, minHeight: 138, alignment: .topLeading)
-        .background(MatherTheme.card.opacity(0.78), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(stage.accessibilityLabel)
+        .accessibilityLabel("Guided stages: \(plan.pathLabel)")
     }
 
     private func gamesSection(_ lane: CapabilityLane, tint: Color) -> some View {
@@ -835,7 +849,7 @@ struct LabLaneDetailView: View {
     }
 }
 
-private struct LabDetailFlowLayout: Layout {
+struct LabDetailFlowLayout: Layout {
     var spacing: CGFloat = 8
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -324,7 +324,7 @@ struct LabLaneDetailView: View {
 
     private func stagePlanCard(_ stage: LabSessionStagePlan, progress: LabConceptSessionProgress?, tint: Color) -> some View {
         let state = progressState(for: stage.stage, progress: progress)
-        VStack(alignment: .leading, spacing: 7) {
+        return VStack(alignment: .leading, spacing: 7) {
             HStack(spacing: 7) {
                 Image(systemName: stage.stage.symbolName)
                     .font(.caption.weight(.black))

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -322,6 +322,57 @@ struct LabLaneDetailView: View {
         .accessibilityLabel("Guided stages: \(plan.pathLabel)")
     }
 
+    private func stagePlanCard(_ stage: LabSessionStagePlan, progress: LabConceptSessionProgress?, tint: Color) -> some View {
+        let state = progressState(for: stage.stage, progress: progress)
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 7) {
+                Image(systemName: stage.stage.symbolName)
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(tint)
+                Text(stage.stage.rawValue)
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Spacer(minLength: 0)
+                if let state {
+                    Text(state)
+                        .font(.caption2.weight(.heavy))
+                        .foregroundStyle(tint)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 4)
+                        .background(tint.opacity(0.12), in: Capsule())
+                }
+            }
+
+            Text(stage.title)
+                .font(.subheadline.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+                .lineLimit(2)
+
+            Text(stage.childCopy)
+                .font(.caption)
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .lineLimit(3)
+
+            Text(stage.timerPolicy.childCopy)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .lineLimit(2)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MatherTheme.card.opacity(0.76), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+        .overlay(alignment: .topTrailing) {
+            if stage.route != nil {
+                Image(systemName: "arrow.up.forward.circle.fill")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(tint.opacity(0.82))
+                    .padding(8)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(stage.accessibilityLabel)
+    }
+
     private func gamesSection(_ lane: CapabilityLane, tint: Color) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Games")

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -1034,10 +1034,7 @@ struct LabLaneDetailPresentation: Equatable {
         sections = [
             .visualSummary,
             lane.isReady ? .activities : .comingSoon,
-            .modes,
-            .playStyles,
-            .ageEntries,
-            .recall,
+            .progressStatus,
         ]
     }
 }
@@ -1231,11 +1228,30 @@ struct CapabilityLane: Identifiable, Equatable {
         case .physics:
             return "Physics"
         case .mapWorld:
-            return "Geography"
+            return "Geography/Maps"
         case .chemistry:
             return "Chemistry"
         case .discoveryCards:
-            return "Discovery Cards"
+            return "Discovery"
+        case .electronics:
+            return "Electronics"
+        }
+    }
+
+    var subjectStreamShortLabel: String {
+        switch id {
+        case .numbers:
+            return "Numbers"
+        case .geometry:
+            return "Geometry"
+        case .physics:
+            return "Physics"
+        case .mapWorld:
+            return "Geography/Maps"
+        case .chemistry:
+            return "Chemistry"
+        case .discoveryCards:
+            return "Discovery"
         case .electronics:
             return "Electronics"
         }
@@ -1246,8 +1262,14 @@ struct CapabilityLane: Identifiable, Equatable {
         .geometry,
         .physics,
         .mapWorld,
+        .discoveryCards,
         .chemistry,
+        .electronics,
     ]
+
+    static var subjectStreamSummary: String {
+        labSubjectStreams.map(\.subjectStreamShortLabel).joined(separator: " · ")
+    }
 
     static var labSubjectStreams: [CapabilityLane] {
         labSubjectStreamIDs.compactMap { streamID in

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -5,8 +5,13 @@ struct LabView: View {
     @Environment(\.colorScheme) private var colorScheme
     @Bindable var appModel: AppModel
     @State private var playfulPulse = false
-    @State private var selectedPath: ExplorerPathID = .labs
+    @State private var selectedPath: ExplorerPathID
     @State private var sensorCapabilities = DeviceSensorCapabilities.unavailable
+
+    init(appModel: AppModel, initialPath: ExplorerPathID = .labs) {
+        self.appModel = appModel
+        _selectedPath = State(initialValue: initialPath)
+    }
 
     private let lanes = CapabilityLane.labSubjectStreams
     private let guidedPaths = GuidedLabPath.phaseOne
@@ -26,13 +31,15 @@ struct LabView: View {
                         pathSelector(compact: compactGrid)
 
                         if selectedPath == .labs {
-                            guidedLabsIntro(compact: compactGrid)
+                            labsStreamHeader(compact: compactGrid)
 
                             LazyVGrid(columns: labColumns(for: proxy.size.width), spacing: compactGrid ? 14 : 16) {
                                 ForEach(lanes) { lane in
                                     laneCard(lane, compact: compactGrid)
                                 }
                             }
+
+                            guidedLabsIntro(compact: compactGrid)
                         } else {
                             directGamesSection(compact: compactGrid, width: proxy.size.width)
                         }
@@ -72,13 +79,13 @@ struct LabView: View {
     private var header: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 6) {
-                Text("Explorer Lab")
+                Text(selectedPath == .labs ? "Labs" : "Games")
                     .font(.system(size: 36, weight: .black, design: .rounded))
                     .foregroundStyle(MatherTheme.ink)
-                Text("Labs and Games")
+                Text("Explorer Lab")
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(MatherTheme.cardSubtitle)
-                Text("Choose a subject stream, or jump straight into a game")
+                Text(selectedPath == .labs ? "Choose a subject stream first" : "Jump straight into a game")
                     .font(.caption.weight(.bold))
                     .foregroundStyle(MatherTheme.accent)
             }
@@ -157,55 +164,83 @@ struct LabView: View {
         )
     }
 
-    private func guidedLabsIntro(compact: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 14) {
+    private func labsStreamHeader(compact: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Subject streams")
                         .font(.title3.weight(.black))
                         .foregroundStyle(MatherTheme.ink)
-                    Text("Numbers & Arithmetic · Geometry · Physics · Geography · Chemistry")
+                    Text(CapabilityLane.subjectStreamSummary)
                         .font(.caption.weight(.black))
                         .foregroundStyle(MatherTheme.accent)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 0)
             }
 
-            stageStrip(compact: compact)
+            LabDetailFlowLayout(spacing: 6) {
+                ForEach(lanes) { lane in
+                    Text(lane.subjectStreamShortLabel)
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(laneColor(lane.id))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(laneColor(lane.id).opacity(0.10), in: Capsule())
+                }
+            }
+        }
+        .padding(14)
+        .background(MatherTheme.card.opacity(0.86), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(MatherTheme.accent.opacity(0.18), lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Subject streams: \(CapabilityLane.subjectStreamSummary)")
+    }
+
+    private func guidedLabsIntro(compact: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Guided path")
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text("Optional staged learning appears after the subject picker so other streams stay visible.")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                }
+                Spacer(minLength: 0)
+            }
+
+            compactStageStrip(compact: compact)
 
             ForEach(guidedPaths) { path in
                 guidedPathCard(path)
             }
         }
-        .padding(16)
-        .background(MatherTheme.card.opacity(0.86), in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .padding(14)
+        .background(MatherTheme.card.opacity(0.72), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .stroke(MatherTheme.accent.opacity(0.18), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(MatherTheme.accent.opacity(0.14), lineWidth: 1)
         )
         .accessibilityElement(children: .contain)
     }
 
-    private func stageStrip(compact: Bool) -> some View {
-        let columns = Array(repeating: GridItem(.flexible(), spacing: compact ? 6 : 8), count: compact ? 3 : 5)
-        return LazyVGrid(columns: columns, spacing: compact ? 6 : 8) {
+    private func compactStageStrip(compact: Bool) -> some View {
+        LabDetailFlowLayout(spacing: compact ? 5 : 6) {
             ForEach(GuidedLabStage.allCases) { stage in
-                VStack(spacing: 4) {
-                    stageArtwork(stage, tint: MatherTheme.accent, compact: compact)
-                    Text(stage.rawValue)
-                        .font(.caption2.weight(.black))
-                        .foregroundStyle(MatherTheme.ink)
-                    Text(stage.microcopy)
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.7)
-                }
-                .padding(8)
-                .frame(maxWidth: .infinity, minHeight: 82)
-                .background(MatherTheme.panel.opacity(0.62), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                Label(stage.rawValue, systemImage: stage.symbolName)
+                    .font(.caption2.weight(.black))
+                    .foregroundStyle(MatherTheme.accent)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(MatherTheme.panel.opacity(0.62), in: Capsule())
             }
         }
+        .accessibilityLabel(GuidedLabStage.allCases.map(\.rawValue).joined(separator: " to "))
     }
 
     private func explorerArtwork(_ path: ExplorerPathPresentation, tint: Color, compact: Bool) -> some View {

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -18,11 +18,15 @@ struct HomeView: View {
                     if ResponsiveLayout.isWide(horizontalSizeClass) {
                         HStack(alignment: .top, spacing: 20) {
                             makeAndBreakCard
-                            labCard
+                            labsCard
+                            gamesCard
                         }
                     } else {
                         makeAndBreakCard
-                        labCard
+                        HStack(alignment: .top, spacing: 14) {
+                            labsCard
+                            gamesCard
+                        }
                     }
 
                     HStack(spacing: 14) {
@@ -151,84 +155,164 @@ struct HomeView: View {
         }
     }
 
-    // MARK: - Explorer Lab card
+    // MARK: - Labs and Games cards
 
-    private var labCard: some View {
-        Button {
+    private var labsCard: some View {
+        explorerEntryCard(
+            title: "Labs",
+            subtitle: "Subject streams",
+            detail: "Numbers · Geometry · Physics",
+            emoji: "🔬",
+            symbolName: "sparkles.rectangle.stack.fill",
+            gradient: [MatherTheme.softBlue, MatherTheme.coral.opacity(0.8)],
+            accent: MatherTheme.softBlue,
+            accessibilityIdentifier: "ExplorerLab"
+        ) {
             appModel.engine.showLab()
-        } label: {
+        }
+    }
+
+    private var gamesCard: some View {
+        explorerEntryCard(
+            title: "Games",
+            subtitle: "One-tap play",
+            detail: "Launch ready games directly",
+            emoji: "🎮",
+            symbolName: "gamecontroller.fill",
+            gradient: [MatherTheme.warm, MatherTheme.accent.opacity(0.85)],
+            accent: MatherTheme.warm,
+            accessibilityIdentifier: "GamesEntry"
+        ) {
+            appModel.engine.showLabGames()
+        }
+    }
+
+    private func explorerEntryCard(
+        title: String,
+        subtitle: String,
+        detail: String,
+        emoji: String,
+        symbolName: String,
+        gradient: [Color],
+        accent: Color,
+        accessibilityIdentifier: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        HomeExplorerEntryCard(
+            title: title,
+            subtitle: subtitle,
+            detail: detail,
+            emoji: emoji,
+            symbolName: symbolName,
+            gradient: gradient,
+            accent: accent,
+            accessibilityIdentifier: accessibilityIdentifier,
+            isDark: colorScheme == .dark,
+            action: action
+        )
+    }
+
+}
+
+private struct HomeExplorerEntryCard: View {
+    let title: String
+    let subtitle: String
+    let detail: String
+    let emoji: String
+    let symbolName: String
+    let gradient: [Color]
+    let accent: Color
+    let accessibilityIdentifier: String
+    let isDark: Bool
+    let action: () -> Void
+
+    private var destinationLabel: String {
+        title == "Labs" ? "Open subject picker" : "Open game launcher"
+    }
+
+    private var accessibilityCopy: String {
+        title == "Labs" ? "Open Labs subject streams" : "Open Games direct launcher"
+    }
+
+    var body: some View {
+        Button(action: action) {
             VStack(spacing: 0) {
-                ZStack {
-                    LinearGradient(
-                        colors: [MatherTheme.softBlue, MatherTheme.coral.opacity(0.8)],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-
-                    HStack(spacing: 16) {
-                        Text("🔬")
-                            .font(.system(size: 48))
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Labs + Games")
-                                .font(.title3.weight(.black))
-                                .foregroundStyle(.white)
-                            Text("Subjects + one-tap play")
-                                .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(.white.opacity(0.85))
-                        }
-                        .layoutPriority(1)
-
-                        Spacer()
-                    }
-                    .padding(20)
-                }
-                .frame(height: 110)
-                .clipShape(
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: 20, bottomLeadingRadius: 0,
-                        bottomTrailingRadius: 0, topTrailingRadius: 20,
-                        style: .continuous
-                    )
-                )
-
-                HStack {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Numbers · Geometry · Physics · Geography")
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                        Text("Choose Labs or Games")
-                            .font(.headline.weight(.bold))
-                            .foregroundStyle(MatherTheme.ink)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    Spacer()
-                    Image(systemName: "chevron.right.circle.fill")
-                        .font(.system(size: 44))
-                        .foregroundStyle(MatherTheme.softBlue)
-                }
-                .padding(.horizontal, 20)
-                .padding(.vertical, 16)
-                .background(MatherTheme.card)
-                .clipShape(
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: 0, bottomLeadingRadius: 20,
-                        bottomTrailingRadius: 20, topTrailingRadius: 0,
-                        style: .continuous
-                    )
-                )
+                header
+                footer
             }
             .overlay(
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1)
+                    .strokeBorder(.white.opacity(isDark ? 0.08 : 0), lineWidth: 1)
             )
             .shadow(
-                color: colorScheme == .dark ? MatherTheme.softBlue.opacity(0.12) : .black.opacity(0.08),
-                radius: colorScheme == .dark ? 18 : 12,
-                y: colorScheme == .dark ? 8 : 5
+                color: isDark ? accent.opacity(0.12) : .black.opacity(0.08),
+                radius: isDark ? 18 : 12,
+                y: isDark ? 8 : 5
             )
         }
         .buttonStyle(.plain)
-        .accessibilityIdentifier("ExplorerLab")
+        .accessibilityIdentifier(accessibilityIdentifier)
+        .accessibilityLabel(accessibilityCopy)
+    }
+
+    private var header: some View {
+        ZStack {
+            LinearGradient(colors: gradient, startPoint: .topLeading, endPoint: .bottomTrailing)
+
+            HStack(spacing: 12) {
+                Text(emoji)
+                    .font(.system(size: 42))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .font(.title3.weight(.black))
+                        .foregroundStyle(.white)
+                    Text(subtitle)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.white.opacity(0.85))
+                }
+                .layoutPriority(1)
+
+                Spacer(minLength: 0)
+            }
+            .padding(18)
+        }
+        .frame(height: 104)
+        .clipShape(
+            UnevenRoundedRectangle(
+                topLeadingRadius: 20, bottomLeadingRadius: 0,
+                bottomTrailingRadius: 0, topTrailingRadius: 20,
+                style: .continuous
+            )
+        )
+    }
+
+    private var footer: some View {
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(detail)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                Text(destinationLabel)
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(MatherTheme.ink)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+            Image(systemName: symbolName)
+                .font(.system(size: 32, weight: .black))
+                .foregroundStyle(accent)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(MatherTheme.card)
+        .clipShape(
+            UnevenRoundedRectangle(
+                topLeadingRadius: 0, bottomLeadingRadius: 20,
+                bottomTrailingRadius: 20, topTrailingRadius: 0,
+                style: .continuous
+            )
+        )
     }
 }

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -20,10 +20,11 @@ final class LabModelsTests: XCTestCase {
     func testLabSubjectStreamsExposeFocusedSubjectPickerSeparateFromGames() throws {
         let streams = CapabilityLane.labSubjectStreams
 
-        XCTAssertEqual(streams.map(\.id), [.numbers, .geometry, .physics, .mapWorld, .chemistry])
-        XCTAssertEqual(streams.map(\.subjectStreamLabel), ["Numbers & Arithmetic", "Geometry", "Physics", "Geography", "Chemistry"])
+        XCTAssertEqual(streams.map(\.id), [.numbers, .geometry, .physics, .mapWorld, .discoveryCards, .chemistry, .electronics])
+        XCTAssertEqual(streams.map(\.subjectStreamShortLabel), ["Numbers", "Geometry", "Physics", "Geography/Maps", "Discovery", "Chemistry", "Electronics"])
+        XCTAssertEqual(CapabilityLane.subjectStreamSummary, "Numbers · Geometry · Physics · Geography/Maps · Discovery · Chemistry · Electronics")
         XCTAssertTrue(streams.allSatisfy(\.isLabSubjectStream))
-        XCTAssertFalse(CapabilityLane.defaultExplorerLanes.first { $0.id == .discoveryCards }?.isLabSubjectStream ?? true)
+        XCTAssertTrue(CapabilityLane.defaultExplorerLanes.first { $0.id == .discoveryCards }?.isLabSubjectStream ?? false)
         XCTAssertTrue(ExplorerGameRegistry.directLaunchEntries.contains { $0.activity.id == .memoryMatch })
     }
 
@@ -102,10 +103,11 @@ final class LabModelsTests: XCTestCase {
         let presentation = LabLaneDetailPresentation(lane: numbers)
 
         XCTAssertEqual(presentation.activityCountLabel, "3 games ready")
-        XCTAssertTrue(presentation.sections.contains(.modes))
-        XCTAssertTrue(presentation.sections.contains(.playStyles))
-        XCTAssertTrue(presentation.sections.contains(.ageEntries))
-        XCTAssertTrue(presentation.sections.contains(.recall))
+        XCTAssertEqual(presentation.sections, [.visualSummary, .activities, .progressStatus])
+        XCTAssertFalse(presentation.sections.contains(.modes))
+        XCTAssertFalse(presentation.sections.contains(.playStyles))
+        XCTAssertFalse(presentation.sections.contains(.ageEntries))
+        XCTAssertFalse(presentation.sections.contains(.recall))
         XCTAssertTrue(presentation.sections.contains(.activities))
         XCTAssertEqual(numbers.activities.map(\.id), [.sumSprint, .rectangleFactory, .factoryCards])
     }
@@ -120,6 +122,8 @@ final class LabModelsTests: XCTestCase {
     }
 
     func testLabLaneRouteCarriesSelectedLaneWithoutChangingGameRoutes() throws {
+        XCTAssertEqual(AppRoute.lab, AppRoute.lab)
+        XCTAssertEqual(AppRoute.labGames, AppRoute.labGames)
         XCTAssertEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.geometry))
         XCTAssertNotEqual(AppRoute.labLane(.geometry), AppRoute.labLane(.numbers))
         XCTAssertEqual(LabActivityID.sumSprint.appRoute, .sumSprint)

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -152,18 +152,12 @@ struct LabRouteRegressionTests {
         #expect(LabLaneDetailPresentation(lane: readyLane).sections == [
             .visualSummary,
             .activities,
-            .modes,
-            .playStyles,
-            .ageEntries,
-            .recall,
+            .progressStatus,
         ])
         #expect(LabLaneDetailPresentation(lane: futureLane).sections == [
             .visualSummary,
             .comingSoon,
-            .modes,
-            .playStyles,
-            .ageEntries,
-            .recall,
+            .progressStatus,
         ])
     }
 


### PR DESCRIPTION
## Summary
- Splits the home entry into separate Labs and Games cards so the main menu has two clear streams.
- Adds a dedicated `.labGames` route that opens Explorer Lab directly on the Games tab while keeping Labs focused on subject streams.
- Expands Labs subject streams to include Numbers, Geometry, Physics, Geography/Maps, Discovery, Chemistry, and Electronics.
- Reduces Lab detail/menu density with progressive disclosure: one primary next action, compact guided-stage summaries, and secondary plan/timing details behind expansion.

Fixes #946
Fixes #953
Fixes #954
Fixes #955

## Validation
- `git diff --check` ✅
- Focused `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MatherTests/LabModelsTests -only-testing:MatherTests/LabRouteRegressionTests` on `ganesh-mba` after rsyncing to `/tmp` was attempted, but the checked-in `Mather.xcodeproj` does not include several current source files/types (`CapabilityLaneID`, `KidProfileStore`, `MemoryAnimal`, `SliceTheme`, etc.), so the build fails before focused tests can execute. `xcodegen` is not installed on `ganesh-mba` to regenerate from `project.yml` there.
