### PR TITLE
Fix Build 84 lab feedback wave

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -1004,13 +1004,11 @@ struct LabLaneCardPresentation: Equatable {
         title = lane.subjectStreamLabel
         promiseLine = lane.promise
         progressMicrocopy = "\(progress.progressSummaryLabel) • \(progress.nextRecommendedModeLabel)"
-        openAffordanceLabel = "Enter world"
+        openAffordanceLabel = "Open"
         accessibilityLabel = "\(lane.subjectStreamLabel) subject stream. \(lane.ageBandHint). \(lane.promise)"
-        accessibilityHint = "Opens \(lane.subjectStreamLabel) to choose missions, review cards, play styles, and sensor options."
+        accessibilityHint = "Opens \(lane.subjectStreamLabel) to choose staged labs and games."
         sections = [
             .visualSummary,
-            .promise,
-            .progressStatus,
         ]
     }
 

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -126,30 +126,22 @@ struct LabView: View {
     private func explorerPathCard(_ path: ExplorerPathPresentation, isSelected: Bool, compact: Bool) -> some View {
         let tint = path.id == .labs ? MatherTheme.accent : MatherTheme.warm
 
-        return VStack(alignment: .leading, spacing: compact ? 8 : 10) {
-            HStack(spacing: 10) {
-                explorerArtwork(path, tint: tint, compact: compact)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(path.title)
-                        .font(.system(size: compact ? 22 : 26, weight: .black, design: .rounded))
-                        .foregroundStyle(MatherTheme.ink)
-                    Text(path.callToAction)
-                        .font(.caption.weight(.black))
-                        .foregroundStyle(tint)
-                }
-                Spacer(minLength: 0)
-                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                    .font(.title3.weight(.black))
-                    .foregroundStyle(tint)
-            }
+        return VStack(spacing: compact ? 8 : 10) {
+            explorerArtwork(path, tint: tint, compact: compact)
+            Text(path.title)
+                .font(.system(size: compact ? 22 : 26, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+                .lineLimit(1)
+                .minimumScaleFactor(0.78)
+                .multilineTextAlignment(.center)
 
-            Text(path.subtitle)
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(MatherTheme.cardSubtitle)
-                .lineLimit(compact ? 3 : 2)
+            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                .font(.title3.weight(.black))
+                .foregroundStyle(tint)
+                .accessibilityHidden(true)
         }
         .padding(compact ? 12 : 16)
-        .frame(maxWidth: .infinity, minHeight: compact ? 146 : 136, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: compact ? 132 : 136, alignment: .center)
         .background(
             LinearGradient(
                 colors: [tint.opacity(isSelected ? 0.18 : 0.08), MatherTheme.card],
@@ -352,9 +344,9 @@ struct LabView: View {
         return Button {
             launchDirectGame(entry)
         } label: {
-            HStack(spacing: 12) {
+            VStack(spacing: 10) {
                 ZStack {
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
                         .fill(
                             LinearGradient(
                                 colors: [tint.opacity(0.18), MatherTheme.card.opacity(0.88)],
@@ -362,41 +354,25 @@ struct LabView: View {
                                 endPoint: .bottomTrailing
                             )
                         )
-                    Image(systemName: "play.circle.fill")
+                    Image(systemName: canLaunch ? "play.circle.fill" : "exclamationmark.triangle.fill")
                         .font(.title2.weight(.black))
                         .foregroundStyle(tint.opacity(canLaunch ? 1 : 0.45))
                     Text(activity.emoji)
-                        .font(.system(size: 24))
-                        .offset(x: 11, y: 11)
+                        .font(.system(size: 26))
+                        .offset(x: 12, y: 12)
                 }
-                .frame(width: 62, height: 62)
+                .frame(width: 68, height: 68)
                 .accessibilityLabel(activity.artworkAccessibilityLabel)
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(activity.title)
-                        .font(.headline.weight(.black))
-                        .foregroundStyle(canLaunch ? MatherTheme.ink : MatherTheme.ink.opacity(0.55))
-                        .lineLimit(2)
-                    Text(activity.tagline)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .lineLimit(2)
-                    Text(canLaunch ? "Tap to play" : "Needs a sensor")
-                        .font(.caption2.weight(.black))
-                        .foregroundStyle(canLaunch ? tint : MatherTheme.cardSubtitle)
-                    if !canLaunch || activity.id.sensorNeeds != [.noSpecialSensor] {
-                        Text(capabilitySummary)
-                            .font(.caption2.weight(.bold))
-                            .foregroundStyle(MatherTheme.cardSubtitle)
-                            .lineLimit(1)
-                    }
-                }
-                Spacer(minLength: 0)
-                Image(systemName: canLaunch ? "play.circle.fill" : "exclamationmark.triangle.fill")
-                    .font(.title2.weight(.black))
-                    .foregroundStyle(canLaunch ? tint : MatherTheme.cardSubtitle)
+
+                Text(activity.title)
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(canLaunch ? MatherTheme.ink : MatherTheme.ink.opacity(0.55))
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.78)
+                    .multilineTextAlignment(.center)
             }
             .padding(14)
-            .frame(maxWidth: .infinity, minHeight: 126, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 132, alignment: .center)
             .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
@@ -464,32 +440,18 @@ struct LabView: View {
         tint: Color
     ) -> some View {
         VStack(spacing: 10) {
-            laneVisual(lane, tint: tint, size: 72)
+            laneVisual(lane, tint: tint, size: 74)
 
-            VStack(spacing: 4) {
-                Text(presentation.title)
-                    .font(.system(size: 17, weight: .black, design: .rounded))
-                    .foregroundStyle(MatherTheme.ink)
-                    .lineLimit(2)
-                    .minimumScaleFactor(0.78)
-                    .multilineTextAlignment(.center)
-
-                Text(lane.ageBandHint)
-                    .font(.caption2.weight(.black))
-                    .foregroundStyle(tint)
-                    .lineLimit(1)
-            }
-
-            compactProgressBadge(progress, tint: tint)
-
-            Image(systemName: "chevron.right.circle.fill")
-                .font(.title3.weight(.black))
-                .foregroundStyle(tint)
-                .accessibilityHidden(true)
+            Text(presentation.title)
+                .font(.system(size: 18, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.ink)
+                .lineLimit(2)
+                .minimumScaleFactor(0.78)
+                .multilineTextAlignment(.center)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 14)
-        .frame(maxWidth: .infinity, minHeight: 190, alignment: .center)
+        .frame(maxWidth: .infinity, minHeight: 142, alignment: .center)
     }
 
     private func fullLaneCard(
@@ -498,47 +460,18 @@ struct LabView: View {
         progress: CapabilityLaneProgress,
         tint: Color
     ) -> some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top, spacing: 14) {
-                laneVisual(lane, tint: tint)
+        VStack(spacing: 12) {
+            laneVisual(lane, tint: tint, size: 86)
 
-                VStack(alignment: .leading, spacing: 7) {
-                    HStack(spacing: 8) {
-                        Text(presentation.title)
-                            .font(.headline.weight(.black))
-                            .foregroundStyle(MatherTheme.ink)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.75)
-                        Text(lane.ageBandHint)
-                            .font(.caption2.weight(.black))
-                            .foregroundStyle(tint)
-                            .padding(.horizontal, 7)
-                            .padding(.vertical, 4)
-                            .background(tint.opacity(0.12), in: Capsule())
-                    }
-                    Text(presentation.promiseLine)
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .lineLimit(3)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                Spacer(minLength: 0)
-            }
-
-            progressPreview(progress, tint: tint)
-
-            HStack(spacing: 10) {
-                Label(lane.isReady ? "\(lane.activities.count) mission\(lane.activities.count == 1 ? "" : "s")" : "Missions coming soon", systemImage: lane.isReady ? "gamecontroller.fill" : "sparkles")
-                    .font(.caption.weight(.black))
-                    .foregroundStyle(tint)
-                Spacer(minLength: 8)
-                Label(presentation.openAffordanceLabel, systemImage: "chevron.right.circle.fill")
-                    .font(.caption.weight(.black))
-                    .foregroundStyle(tint)
-            }
+            Text(presentation.title)
+                .font(.title3.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+                .lineLimit(2)
+                .minimumScaleFactor(0.78)
+                .multilineTextAlignment(.center)
         }
         .padding(16)
-        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: 160, alignment: .center)
     }
 
     private func compactProgressBadge(_ progress: CapabilityLaneProgress, tint: Color) -> some View {

--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -175,6 +175,7 @@ struct GravitySplitView: View {
     private var tokenBoard: some View {
         VStack(spacing: 10) {
             sourceTray
+            seesawBalancePreview
 
             ViewThatFits(in: .horizontal) {
                 HStack(alignment: .top, spacing: 10) {
@@ -213,6 +214,72 @@ struct GravitySplitView: View {
             }
         }
         .accessibilityIdentifier("gravity-direct-token-board")
+    }
+
+
+    private var seesawBalancePreview: some View {
+        let totalPlaced = max(1, state.leftCount + state.rightCount)
+        let tilt = CGFloat(state.rightCount - state.leftCount) / CGFloat(totalPlaced)
+        let rotation = Double(max(-0.16, min(0.16, tilt)) * 18)
+
+        return VStack(spacing: 4) {
+            ZStack(alignment: .center) {
+                Capsule()
+                    .fill(
+                        LinearGradient(
+                            colors: [MatherTheme.warm.opacity(0.86), MatherTheme.accent.opacity(0.86)],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(height: 12)
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(MatherTheme.ink.opacity(0.10), lineWidth: 1)
+                    )
+                    .rotationEffect(.degrees(rotation))
+                    .animation(.spring(response: 0.32, dampingFraction: 0.72), value: state.leftCount)
+                    .animation(.spring(response: 0.32, dampingFraction: 0.72), value: state.rightCount)
+
+                GravitySplitTrianglePivot()
+                    .fill(MatherTheme.ink.opacity(0.18))
+                    .frame(width: 34, height: 24)
+                    .offset(y: 17)
+
+                HStack {
+                    balancePan(label: vocabulary.leftLabel, count: state.leftCount, fill: MatherTheme.warm)
+                    Spacer(minLength: 34)
+                    balancePan(label: vocabulary.rightLabel, count: state.rightCount, fill: MatherTheme.accent)
+                }
+                .padding(.horizontal, 8)
+            }
+            .frame(height: 58)
+
+            Text(state.isLocked ? "See-saw balanced" : "Balance the see-saw")
+                .font(.caption2.weight(.black))
+                .foregroundStyle(state.isLocked ? MatherTheme.accent : MatherTheme.cardSubtitle)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(MatherTheme.panel.opacity(0.56), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Lever see-saw balance. Left side has \(state.leftCount), right side has \(state.rightCount).")
+        .accessibilityIdentifier("gravity-seesaw-balance-preview")
+    }
+
+    private func balancePan(label: String, count: Int, fill: Color) -> some View {
+        VStack(spacing: 2) {
+            Text("\(count)")
+                .font(.caption.weight(.black))
+                .foregroundStyle(fill)
+                .frame(width: 34, height: 26)
+                .background(fill.opacity(0.13), in: Circle())
+            Text(label)
+                .font(.system(size: 9, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+        }
     }
 
     private var sourceTray: some View {
@@ -484,5 +551,17 @@ struct GravitySplitView: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+
+
+private struct GravitySplitTrianglePivot: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.closeSubpath()
+        return path
     }
 }

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -85,10 +85,10 @@ final class LabModelsTests: XCTestCase {
         )
 
         XCTAssertEqual(presentation.title, "Numbers & Arithmetic")
-        XCTAssertEqual(presentation.openAffordanceLabel, "Enter world")
+        XCTAssertEqual(presentation.openAffordanceLabel, "Open")
         XCTAssertEqual(
             presentation.sections,
-            [.visualSummary, .promise, .progressStatus]
+            [.visualSummary]
         )
         XCTAssertFalse(presentation.showsDetails)
         XCTAssertFalse(presentation.sections.contains(.modes))
@@ -96,6 +96,8 @@ final class LabModelsTests: XCTestCase {
         XCTAssertFalse(presentation.sections.contains(.recall))
         XCTAssertFalse(presentation.sections.contains(.activities))
         XCTAssertTrue(presentation.accessibilityHint.contains("Opens Numbers & Arithmetic"))
+        XCTAssertFalse(presentation.sections.contains(.promise))
+        XCTAssertFalse(presentation.sections.contains(.progressStatus))
     }
 
     func testLaneDetailPresentationRestoresDetailsWithoutDroppingLaunches() throws {


### PR DESCRIPTION
## Summary
- simplifies the Labs/Games chooser surfaces so top-level picker, lab stream cards, and direct game cards present only icon + name while retaining accessibility/detail metadata
- keeps Geometry/Angle/Shape labs on the shared Learn → Remember → Play → Blast → Score guided stage path already used by Numbers
- restores a visible lever/see-saw balance affordance in Gravity Split so the old balance gameplay is recognizable while keeping the touch controls

## Linked Issues
Closes #977
Closes #978
Closes #979
Closes #980
Closes #981
Closes #982

## Type of Change
- [x] Bug fix
- [x] Refactor (no behavior change)

## Testing
- [x] `git diff --check`
- [x] CI Build & Test passed: https://github.com/ganesh47/mather/actions/runs/25356515141/job/74346815202
- [ ] Local Linux `swift test --filter LabModelsTests` unavailable (`swift: command not found`)
- [ ] Direct ganesh-mba Xcode test without XcodeGen hit a Swift frontend crash in pre-existing `SettingsView.swift`; PR CI generated the project and passed