### PR TITLE
Fix critical UX layout regressions

### DIFF
--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -60,6 +60,9 @@ struct BondMatchView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     private var cardSize: CGFloat { ResponsiveLayout.isWide(horizontalSizeClass) ? 110 : 88 }
     private let cardSpacing: CGFloat = 12
+    private var compactPairsMaxHeight: CGFloat? {
+        ResponsiveLayout.isWide(horizontalSizeClass) ? nil : 408
+    }
 
     private var vocabulary: NumberStoryStageVocabulary {
         if let storyPrompt {
@@ -85,7 +88,7 @@ struct BondMatchView: View {
         CardSurface {
             VStack(spacing: 20) {
                 headerView
-                pairsGrid
+                reachablePairsGrid
                 progressDots
             }
         }
@@ -122,6 +125,16 @@ struct BondMatchView: View {
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.secondary)
         }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var reachablePairsGrid: some View {
+        ScrollView(.vertical) {
+            pairsGrid
+                .padding(.vertical, 2)
+        }
+        .scrollIndicators(.visible)
+        .frame(maxHeight: compactPairsMaxHeight)
         .frame(maxWidth: .infinity)
     }
 

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -15,18 +15,11 @@ struct HomeView: View {
                         .foregroundStyle(MatherTheme.ink)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
-                    if ResponsiveLayout.isWide(horizontalSizeClass) {
-                        HStack(alignment: .top, spacing: 20) {
-                            makeAndBreakCard
-                            labsCard
-                            gamesCard
-                        }
-                    } else {
-                        makeAndBreakCard
-                        HStack(alignment: .top, spacing: 14) {
-                            labsCard
-                            gamesCard
-                        }
+                    makeAndBreakCard
+
+                    HStack(alignment: .top, spacing: ResponsiveLayout.isWide(horizontalSizeClass) ? 20 : 14) {
+                        labsCard
+                        gamesCard
                     }
 
                     HStack(spacing: 14) {
@@ -139,6 +132,7 @@ struct HomeView: View {
             )
         }
         .buttonStyle(.plain)
+        .frame(maxWidth: .infinity)
         .accessibilityIdentifier("Play")
     }
 
@@ -176,7 +170,7 @@ struct HomeView: View {
         explorerEntryCard(
             title: "Games",
             subtitle: "One-tap play",
-            detail: "Launch ready games directly",
+            detail: "Launch games directly",
             emoji: "🎮",
             symbolName: "gamecontroller.fill",
             gradient: [MatherTheme.warm, MatherTheme.accent.opacity(0.85)],
@@ -251,6 +245,7 @@ private struct HomeExplorerEntryCard: View {
             )
         }
         .buttonStyle(.plain)
+        .frame(maxWidth: .infinity)
         .accessibilityIdentifier(accessibilityIdentifier)
         .accessibilityLabel(accessibilityCopy)
     }


### PR DESCRIPTION
## Summary
- makes the Make & Break home card a full-width row, with Labs + Games below it so the core entry point remains legible on iPad regular-width layouts
- wraps Bond Blast pairs in a bounded vertical scroll area on compact layouts so target-12 pairs are reachable on iPhone
- shortens the Games card detail copy to avoid the known footer truncation

## Validation
- `git diff --check`
- Attempted remote Mac build:
  - `xcodebuild -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.3.1' build CODE_SIGNING_ALLOWED=NO`
  - Result: blocked by an existing Xcode 26.4 Swift compiler crash while type-checking `Features/ParentSummary/SettingsView.swift`.
  - Verified the same command fails on a fresh `origin/main` clone with the same SettingsView compiler crash, so this is not introduced by this PR.

Fixes the C1/C2 critical items from #984. Includes low-risk M1 copy polish.
