### PR TITLE
Fix critical residual UX issues

### DIFF
--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -138,7 +138,7 @@ struct SettingsView: View {
                     )
                     VS1ToggleRow(
                         title: "Clap reaction (mic)",
-                        subtitle: "On by default. Listens for a clap to trigger celebrations when microphone access is available.",
+                        subtitle: "Off by default. If a parent turns it on, Mather asks for microphone access and only listens for a clap to trigger celebrations.",
                         isOn: soundReactionBinding
                     )
                  }

--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -48,7 +48,9 @@ struct GravitySplitView: View {
             VStack(alignment: .leading, spacing: 12) {
                 headerRow
                 tokenBoard
-                if !state.isLocked {
+                if state.isLocked {
+                    successProgressionCTA
+                } else {
                     instructionText
                 }
             }
@@ -63,11 +65,7 @@ struct GravitySplitView: View {
         .onChange(of: state.isLocked) { _, locked in
             guard locked else { return }
             withAnimation(.spring(response: 0.38, dampingFraction: 0.48)) {
-                lockScale = 1.12
-            }
-            Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(600))
-                onSubmit()
+                lockScale = 1.06
             }
         }
         .accessibilityElement(children: .contain)
@@ -117,18 +115,14 @@ struct GravitySplitView: View {
     private var compactActionRail: some View {
         VStack(alignment: .trailing, spacing: 8) {
             if state.isLocked {
-                Text("⭐️")
-                    .font(.system(size: 34))
+                Label("Ready to review", systemImage: "checkmark.seal.fill")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.accent)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 7)
+                    .background(MatherTheme.accent.opacity(0.12), in: Capsule())
                     .scaleEffect(lockScale)
-                    .transition(.scale.combined(with: .opacity))
-
-                Button("Next") {
-                    onSubmit()
-                }
-                .font(.caption.weight(.black))
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-                .accessibilityIdentifier("gravity-split-next-button")
+                    .accessibilityIdentifier("gravity-split-success-status")
             } else {
                 Button {
                     onReset()
@@ -469,6 +463,39 @@ struct GravitySplitView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilityLabel)
     }
+    private var successProgressionCTA: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("Great split — now review your equation", systemImage: "checkmark.seal.fill")
+                .font(.headline.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("Keep this proof visible: \(state.leftCount) + \(state.rightCount) = \(state.target).")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button {
+                onSubmit()
+            } label: {
+                Label("Next: review equation", systemImage: "arrow.right.circle.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(PrimaryActionButtonStyle())
+            .accessibilityIdentifier("gravity-split-next-button")
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MatherTheme.accent.opacity(0.10), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .strokeBorder(MatherTheme.accent.opacity(0.26), lineWidth: 1.5)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("gravity-split-success-progression")
+    }
+
+
 
     private func tokenGrid(
         count: Int,

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -462,7 +462,8 @@ struct WaterCycleLabView: View {
                     lessonPlayScene(
                         availableWidth: contentWidth,
                         availableHeight: proxy.size.height,
-                        horizontalPadding: horizontalPadding
+                        horizontalPadding: horizontalPadding,
+                        bottomSafeArea: proxy.safeAreaInsets.bottom
                     )
                 } else {
                     ScrollView {
@@ -739,9 +740,11 @@ struct WaterCycleLabView: View {
     private func lessonPlayScene(
         availableWidth: CGFloat,
         availableHeight: CGFloat,
-        horizontalPadding: CGFloat
+        horizontalPadding: CGFloat,
+        bottomSafeArea: CGFloat
     ) -> some View {
-        let boardHeight = max(260, availableHeight - 244)
+        let bottomClearance = max(18, bottomSafeArea + 14)
+        let boardHeight = max(240, availableHeight - bottomClearance - 244)
 
         return VStack(alignment: .leading, spacing: 12) {
             header(availableWidth: availableWidth)
@@ -763,7 +766,8 @@ struct WaterCycleLabView: View {
         }
         .frame(maxWidth: availableWidth, maxHeight: .infinity, alignment: .topLeading)
         .padding(.horizontal, horizontalPadding)
-        .padding(.vertical, 14)
+        .padding(.top, 14)
+        .padding(.bottom, bottomClearance)
         .frame(maxWidth: .infinity, alignment: .center)
         .accessibilityIdentifier("water-cycle-playable-lesson")
     }

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -74,7 +74,7 @@ final class FeatureFlagService {
     }
 
     /// Enables AVAudioEngine clap detection in Bond Blast.
-    /// Defaults to true and persists as a parent preference.
+    /// Defaults to false; parent can opt in after reviewing microphone behavior.
     var soundReactionEnabled: Bool {
         didSet { defaults.set(soundReactionEnabled, forKey: Keys.soundReactionEnabled) }
     }
@@ -168,7 +168,7 @@ final class FeatureFlagService {
             Keys.vs1GravitySplitEnabled: true,
             Keys.makeBreakLoopV2Enabled: true,
             Keys.motionControlsEnabled: true,
-            Keys.soundReactionEnabled: true,
+            Keys.soundReactionEnabled: false,
             Keys.roomQuestSafetyAcknowledged: false,
             Keys.roomQuestMarkerSetupEnabled: true,
             Keys.roomQuestReferenceCaptureEnabled: true,

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -41,7 +41,7 @@ struct FeatureFlagTests {
         #expect(flags.vs1BondMatchEnabled)
         #expect(flags.vs1GravitySplitEnabled)
         #expect(flags.makeBreakLoopV2Enabled)
-        #expect(flags.soundReactionEnabled)
+        #expect(!flags.soundReactionEnabled)
         #expect(!flags.routeQuestEnabled)
     }
 


### PR DESCRIPTION
## Summary

- Fix Water Cycle lesson CTA bottom clearance by accounting for iPad/home-indicator safe area in the complete lesson scene.
- Replace Gravity Split's tiny corner success advance/auto-submit with an explicit full-width `Next: review equation` CTA below the success proof, keeping the split equation visible.
- Default Clap reaction (mic) off and update parent settings copy to make mic behavior opt-in and clear.

## Validation

- `git diff --check`
- Remote Mac attempted: `xcodebuild -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.3.1' -only-testing:MatherTests/FeatureFlagTests test CODE_SIGNING_ALLOWED=NO`
  - Blocked by existing Xcode 26.4 Swift compiler crash while type-checking `Features/ParentSummary/SettingsView.swift` (same baseline blocker noted in #985 wave).

Fixes critical residuals NC1, NC2, NC3 from #984.
