### PR TITLE
Add lab learning-loop concept cards

### DIFF
--- a/Features/FactoryCards/FactoryCardsView.swift
+++ b/Features/FactoryCards/FactoryCardsView.swift
@@ -12,6 +12,7 @@ struct FactoryCardsView: View {
     @State private var faceUp = true
     @State private var sessionStart: Date = .now
     @State private var savedSession = false
+    @State private var didCompleteFirstLook = false
 
     private var currentStep: ArrayPreludeRound.Step? {
         guard round.steps.indices.contains(currentIndex) else { return nil }
@@ -32,7 +33,11 @@ struct FactoryCardsView: View {
 
                 if let step = currentStep {
                     cardSurface(for: step)
-                    totalChoices(for: step)
+                    if didCompleteFirstLook {
+                        totalChoices(for: step)
+                    } else {
+                        firstLookStep(for: step)
+                    }
                 } else {
                     completionView
                 }
@@ -162,6 +167,41 @@ struct FactoryCardsView: View {
         }
     }
 
+    private func firstLookStep(for step: ArrayPreludeRound.Step) -> some View {
+        let concept = LabActivityID.factoryCards.introConceptCard
+
+        return VStack(alignment: .leading, spacing: 10) {
+            Label("First look", systemImage: "eye.fill")
+                .font(.headline.weight(.black))
+                .foregroundStyle(MatherTheme.accent)
+            Text(concept?.principle ?? "Equal rows make one packed total.")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MatherTheme.ink)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("This card shows \(step.fact.rowColumnPhrase). Count each row before choosing the total.")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Button {
+                didCompleteFirstLook = true
+                speakCurrentPrompt()
+            } label: {
+                Label("I found the rows", systemImage: "checkmark.circle.fill")
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity, minHeight: 58)
+                    .background(MatherTheme.accent, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Complete first look for \(step.fact.rowColumnPhrase)")
+        }
+        .padding(14)
+        .background(MatherTheme.card.opacity(0.88), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(concept?.accessibilityLabel ?? "First look. \(step.fact.rowColumnPhrase)")
+    }
+
     private func totalChoices(for step: ArrayPreludeRound.Step) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("Choose the packed total")
@@ -195,7 +235,7 @@ struct FactoryCardsView: View {
             Text("Cards packed")
                 .font(.system(size: 34, weight: .black, design: .rounded))
                 .foregroundStyle(MatherTheme.ink)
-            Text("Now resize rectangles for the same factory idea.")
+            Text(LabActivityID.factoryCards.learningLoopSummaryPrompt ?? "Now resize rectangles for the same factory idea.")
                 .font(.headline.weight(.semibold))
                 .foregroundStyle(MatherTheme.cardSubtitle)
                 .multilineTextAlignment(.center)
@@ -232,8 +272,12 @@ struct FactoryCardsView: View {
         selectedTotal = nil
         faceUp = !difficulty.startsFaceDown
         savedSession = false
+        didCompleteFirstLook = false
         if speak {
-            speakCurrentPrompt()
+            appModel.speechService.speak(
+                LabActivityID.factoryCards.introConceptCard?.childPrompt ?? "First, find the rows and columns.",
+                enabled: appModel.featureFlags.audioEnabled
+            )
         }
     }
 

--- a/Features/GravityArtist/GravityArtistView.swift
+++ b/Features/GravityArtist/GravityArtistView.swift
@@ -416,29 +416,40 @@ struct GravityArtistView: View {
     }
 
     private var conceptCard: some View {
-        HStack(spacing: 10) {
+        let contract = LabActivityID.gravityArtist.introConceptCard
+
+        return HStack(alignment: .top, spacing: 10) {
             Image(systemName: phase == .fired ? (hitTarget ? "star.fill" : "lightbulb.fill") : "questionmark.bubble.fill")
                 .font(.headline.weight(.black))
                 .foregroundStyle(MatherTheme.warm)
-            Text(conceptCardText)
-                .font(.caption.weight(.bold))
-                .foregroundStyle(MatherTheme.cardSubtitle)
-                .frame(maxWidth: .infinity, alignment: .leading)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(contract?.title ?? "Gravity idea")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text(conceptCardText)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
         .background(MatherTheme.card.opacity(0.86), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
         .padding(.horizontal, 24)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(contract?.accessibilityLabel ?? conceptCardText)
     }
 
     private var conceptCardText: String {
+        let contract = LabActivityID.gravityArtist.introConceptCard
         switch phase {
         case .aim:
-            return "Flashcard: gravity pulls objects screen-down. Predict the path first."
+            return contract?.childPrompt ?? "Predict the path first."
         case .predicted:
             return "Now simulate: compare your dotted guess with the real roll."
         case .fired:
-            return hitTarget ? "Reward: your prediction matched the simulation." : "Learning: change angle or power, then test again."
+            return hitTarget ? (contract?.summaryPrompt ?? "Your prediction matched the simulation.") : "Learning: change angle or power, then test again."
         }
     }
 

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -394,6 +394,18 @@ extension LabActivityID {
     }
 }
 
+
+struct LabLearningLoopConceptCard: Equatable {
+    let title: String
+    let principle: String
+    let childPrompt: String
+    let summaryPrompt: String
+
+    var accessibilityLabel: String {
+        "Concept card. \(title). \(principle). \(childPrompt)"
+    }
+}
+
 struct LabActivity: Identifiable, Equatable {
     let id: LabActivityID
     let emoji: String
@@ -1061,6 +1073,31 @@ extension LabActivityID {
 
     func capabilitySummary(with capabilities: DeviceSensorCapabilities) -> String {
         sensorAffordances(with: capabilities).map(\.displayLabel).joined(separator: " • ")
+    }
+
+    var introConceptCard: LabLearningLoopConceptCard? {
+        switch self {
+        case .gravityArtist:
+            return LabLearningLoopConceptCard(
+                title: "Gravity pulls screen-down",
+                principle: "Tilt changes the downhill direction, so pebbles roll toward the gravity arrow.",
+                childPrompt: "Predict the roll, observe the path, then say what changed.",
+                summaryPrompt: "I can explain how tilt changes the direction objects roll."
+            )
+        case .factoryCards:
+            return LabLearningLoopConceptCard(
+                title: "Rows make a total",
+                principle: "Equal rows can be counted as rows of columns before writing a multiplication fact.",
+                childPrompt: "First look: find the rows, find the columns, then choose the packed total.",
+                summaryPrompt: "I can describe an array as rows of columns and count the total."
+            )
+        default:
+            return nil
+        }
+    }
+
+    var learningLoopSummaryPrompt: String? {
+        introConceptCard?.summaryPrompt
     }
 }
 

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -283,6 +283,22 @@ final class LabModelsTests: XCTestCase {
         XCTAssertTrue(score.parentDetailLines.contains("Coming back soon: 6 + 4, 7 + 3"))
     }
 
+    func testWeakLabLearningLoopConceptCardsExposeIntroAndSummaryContracts() throws {
+        let gravity = try XCTUnwrap(LabActivityID.gravityArtist.introConceptCard)
+        XCTAssertEqual(gravity.title, "Gravity pulls screen-down")
+        XCTAssertTrue(gravity.principle.contains("Tilt changes"))
+        XCTAssertTrue(gravity.childPrompt.contains("Predict"))
+        XCTAssertTrue(gravity.summaryPrompt.contains("tilt changes"))
+        XCTAssertTrue(gravity.accessibilityLabel.contains("Concept card"))
+
+        let packing = try XCTUnwrap(LabActivityID.factoryCards.introConceptCard)
+        XCTAssertEqual(packing.title, "Rows make a total")
+        XCTAssertTrue(packing.childPrompt.contains("First look"))
+        XCTAssertEqual(LabActivityID.factoryCards.learningLoopSummaryPrompt, packing.summaryPrompt)
+
+        XCTAssertNil(LabActivityID.sumSprint.introConceptCard)
+    }
+
     func testExplorerGamesRegistryDirectlyLaunchesEveryCurrentExplorerActivity() {
         let expectedEntries = CapabilityLane.defaultExplorerLanes.flatMap { lane in
             lane.activities.map { (laneID: lane.id, activityID: $0.id, route: $0.id.appRoute) }


### PR DESCRIPTION
## Summary

- Add a reusable lab learning-loop concept card contract for weak labs.
- Give Gravity Artist explicit prediction/observation/summary concept copy.
- Add a formal first-look step to Factory Cards before total selection.
- Cover the concept-card metadata with model tests.

Closes part of #987.
Refs #984.

## Validation

- `git diff --check`
- GitHub CI: project generation and build-for-testing reached green steps; unit tests were still in progress when the worker handed off.
- Remote Mac local `xcodebuild` attempt was not accepted as a gate because the remote temp clone could not regenerate `Mather.xcodeproj` without XcodeGen, and the checked-in project is stale/missing current generated source membership.
