### PR TITLE
Fix Room Quest parent trust UX

### DIFF
--- a/Features/ParentSummary/ParentSummaryView.swift
+++ b/Features/ParentSummary/ParentSummaryView.swift
@@ -48,7 +48,9 @@ struct ParentSummaryView: View {
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 8)
                         }
-                        explorerLabProgressCard(summary: explorerLabSummary)
+                        if !explorerLabSummary.rows.isEmpty {
+                            explorerLabProgressCard(summary: explorerLabSummary)
+                        }
                     } else {
                         if overview.hasValidMakeBreakProgress {
                             makeBreakScorecard(digest: digest)
@@ -86,6 +88,8 @@ struct ParentSummaryView: View {
                             }
                         }
                     }
+
+                    parentSummaryBottomAffordance(hasAnyHistory: overview.hasAnyHistory)
                 }
                 .padding(ResponsiveLayout.contentPadding(for: horizontalSizeClass))
                 .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
@@ -152,6 +156,53 @@ struct ParentSummaryView: View {
         }
     }
 
+
+    private func parentSummaryBottomAffordance(hasAnyHistory: Bool) -> some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: hasAnyHistory ? "arrow.right.circle.fill" : "play.circle.fill")
+                        .font(.title3.weight(.bold))
+                        .foregroundStyle(MatherTheme.accent)
+                        .accessibilityHidden(true)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(hasAnyHistory ? "Ready for the next activity?" : "Start a session to fill this summary")
+                            .font(.headline.weight(.bold))
+                        Text(hasAnyHistory ? "Return home to keep playing, or adjust settings before the next session." : "After a game or Make & Break session, recent progress and scores appear here.")
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    Spacer(minLength: 0)
+                }
+
+                if ResponsiveLayout.isWide(horizontalSizeClass) {
+                    HStack(spacing: 12) {
+                        bottomButtons
+                    }
+                } else {
+                    VStack(spacing: 12) {
+                        bottomButtons
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier("parent-summary-bottom-affordance")
+    }
+
+    private var bottomButtons: some View {
+        Group {
+            Button("Home") {
+                appModel.engine.showHome()
+            }
+            .buttonStyle(PrimaryActionButtonStyle())
+
+            Button("Settings") {
+                appModel.engine.showSettings()
+            }
+            .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.7)))
+        }
+    }
 
     private var parentActionButtons: some View {
         LazyVGrid(
@@ -325,7 +376,7 @@ struct ParentSummaryView: View {
                 ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
                     HStack {
                         VStack(alignment: .leading, spacing: 4) {
-                            Text("Session \(index + 1)")
+                            Text(index == 0 ? "Latest" : "Recent \(index + 1)")
                                 .font(.caption.weight(.bold))
                                 .foregroundStyle(MatherTheme.accent)
                             Text(row.title)
@@ -343,13 +394,13 @@ struct ParentSummaryView: View {
                                 .foregroundStyle(MatherTheme.cardSubtitle)
                         }
                         Spacer()
-                        if index == 0 {
-                            Text("Latest")
+                        if row.source == .game {
+                            Text("Game")
                                 .font(.caption.weight(.bold))
-                                .foregroundStyle(MatherTheme.accent)
+                                .foregroundStyle(MatherTheme.warm)
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 4)
-                                .background(MatherTheme.accent.opacity(0.12))
+                                .background(MatherTheme.warm.opacity(0.14))
                                 .clipShape(Capsule())
                         }
                     }

--- a/Features/Profile/ProfilePickerView.swift
+++ b/Features/Profile/ProfilePickerView.swift
@@ -49,7 +49,10 @@ struct ProfilePickerView: View {
     }
 
     private func profileTile(_ profile: StoredKidProfile) -> some View {
-        Button {
+        let isActive = store.activeProfileId == profile.id
+        let showsTruncationFeedback = profile.name.count > 14
+
+        return Button {
             store.setActiveProfile(id: profile.id)
             onPicked()
         } label: {
@@ -64,12 +67,20 @@ struct ProfilePickerView: View {
                     .font(.headline.weight(.bold))
                     .foregroundStyle(MatherTheme.ink)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.7)
+                    .truncationMode(.tail)
+                    .minimumScaleFactor(0.82)
+
+                if showsTruncationFeedback {
+                    Text("Name shortened")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .lineLimit(1)
+                }
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 12)
             .background(
-                store.activeProfileId == profile.id
+                isActive
                     ? MatherTheme.accent.opacity(0.12)
                     : MatherTheme.card.opacity(0.5)
             )
@@ -77,13 +88,26 @@ struct ProfilePickerView: View {
             .overlay(
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
                     .strokeBorder(
-                        store.activeProfileId == profile.id ? MatherTheme.accent : Color.clear,
+                        isActive ? MatherTheme.accent : Color.clear,
                         lineWidth: 2
                     )
             )
+            .overlay(alignment: .topTrailing) {
+                if isActive {
+                    Label("Active", systemImage: "checkmark.circle.fill")
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(MatherTheme.accent)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(MatherTheme.card.opacity(0.94), in: Capsule())
+                        .padding(8)
+                        .accessibilityIdentifier("profile-active-badge")
+                }
+            }
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(profile.name), \(profile.emoji)")
+        .accessibilityLabel("\(profile.name), \(profile.emoji)\(isActive ? ", active profile" : "")")
+        .accessibilityHint(showsTruncationFeedback ? "Name is shortened visually; full name is \(profile.name)." : "")
     }
 
     private var addTile: some View {

--- a/Features/RoomQuest/RoomSessionView.swift
+++ b/Features/RoomQuest/RoomSessionView.swift
@@ -7,6 +7,8 @@ struct RoomSessionView: View {
     @Bindable var engine: RoomQuestEngine
     let vsEngine: VerticalSliceEngine
 
+    @State private var pendingAbandonReason: String?
+
     var body: some View {
         ZStack {
             MatherTheme.background.ignoresSafeArea()
@@ -15,7 +17,36 @@ struct RoomSessionView: View {
         .overlay(alignment: .topTrailing) {
             sessionChromeOverlay
         }
+        .alert("End Room Quest?", isPresented: abandonConfirmationBinding) {
+            Button("Keep playing", role: .cancel) {
+                pendingAbandonReason = nil
+            }
+            Button("End session", role: .destructive) {
+                confirmAbandonSession()
+            }
+        } message: {
+            Text("Progress in this Room Quest will be abandoned and you'll return home.")
+        }
         .onAppear { engine.startSession() }
+    }
+
+    private var abandonConfirmationBinding: Binding<Bool> {
+        Binding(
+            get: { pendingAbandonReason != nil },
+            set: { isPresented in
+                if !isPresented { pendingAbandonReason = nil }
+            }
+        )
+    }
+
+    private func requestAbandonSession(reason: String) {
+        pendingAbandonReason = reason
+    }
+
+    private func confirmAbandonSession() {
+        let reason = pendingAbandonReason ?? "parent_abort"
+        pendingAbandonReason = nil
+        engine.abandonSession(reason: reason)
     }
 
     /// Home / Pause chrome buttons overlaid on top of phases that don't manage their own chrome.
@@ -36,7 +67,7 @@ struct RoomSessionView: View {
                     engine.pauseSession()
                 }
                 roomLightChromeButton(title: "Home", systemImage: "house.circle.fill", accessibilityID: "room-home-session") {
-                    engine.abandonSession(reason: "parent_home")
+                    requestAbandonSession(reason: "parent_home")
                 }
             }
             .padding(24)
@@ -50,7 +81,7 @@ struct RoomSessionView: View {
                         engine.pauseSession()
                     }
                     roomLightChromeButton(title: "Home", systemImage: "house.circle.fill", accessibilityID: "room-home-route") {
-                        engine.abandonSession(reason: "parent_home")
+                        requestAbandonSession(reason: "parent_home")
                     }
                 }
                 .padding(24)
@@ -58,7 +89,7 @@ struct RoomSessionView: View {
 
         case .paused:
             roomLightChromeButton(title: "Home", systemImage: "house.circle.fill", accessibilityID: "room-home-paused") {
-                engine.abandonSession(reason: "parent_home")
+                requestAbandonSession(reason: "parent_home")
             }
             .padding(24)
 
@@ -84,7 +115,7 @@ struct RoomSessionView: View {
             SpotPromptView(engine: engine, spotIndex: idx)
 
         case .returning:
-            ReturningView(engine: engine)
+            ReturningView(engine: engine, onRequestAbandon: { requestAbandonSession(reason: $0) })
 
         case .onScreenPictorial:
             onScreenPictorialView
@@ -96,7 +127,7 @@ struct RoomSessionView: View {
             onScreenTransferView
 
         case .paused(let resumeTo):
-            RoomPausedView(engine: engine, resumingTo: resumeTo)
+            RoomPausedView(engine: engine, resumingTo: resumeTo, onRequestAbandon: { requestAbandonSession(reason: $0) })
 
         case .complete:
             RoomCompleteView(engine: engine, vsEngine: vsEngine)
@@ -388,6 +419,19 @@ private func appendDigit(to string: String, digit: Int) -> String {
 /// One-time parent safety acknowledgement — shown before the first Room Quest session.
 private struct SafetyAckView: View {
     @Bindable var engine: RoomQuestEngine
+    @State private var checkedItems: Set<Int> = []
+
+    private let checklistItems = [
+        "Both spot-cards in the same room as this iPad",
+        "Spots are away from stairs, windows, and balconies",
+        "Spots are away from the kitchen",
+        "A parent stays nearby during the room phase",
+        "Nothing in the activity rewards running or jumping"
+    ]
+
+    private var allItemsChecked: Bool {
+        checkedItems.count == checklistItems.count
+    }
 
     var body: some View {
         ScrollView {
@@ -405,11 +449,13 @@ private struct SafetyAckView: View {
                     VStack(alignment: .leading, spacing: 12) {
                         Label("Safety checklist", systemImage: "checklist")
                             .font(.headline.weight(.semibold))
-                        safetyItem("Both spot-cards in the same room as this iPad")
-                        safetyItem("Spots are away from stairs, windows, and balconies")
-                        safetyItem("Spots are away from the kitchen")
-                        safetyItem("A parent stays nearby during the room phase")
-                        safetyItem("Nothing in the activity rewards running or jumping")
+                        ForEach(Array(checklistItems.enumerated()), id: \.offset) { index, item in
+                            safetyItem(item, index: index)
+                        }
+                        Text(allItemsChecked ? "Checklist complete — you can continue." : "Tick every safety condition to continue.")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(allItemsChecked ? MatherTheme.accent : MatherTheme.coral)
+                            .accessibilityIdentifier("room-safety-checklist-status")
                     }
                 }
 
@@ -417,21 +463,36 @@ private struct SafetyAckView: View {
                     engine.acknowledgedSafety()
                 }
                 .buttonStyle(PrimaryActionButtonStyle())
+                .disabled(!allItemsChecked)
+                .opacity(allItemsChecked ? 1 : 0.55)
             }
             .padding(24)
         }
     }
 
-    private func safetyItem(_ text: String) -> some View {
-        Label(text, systemImage: "checkmark.circle.fill")
-            .font(.subheadline.weight(.medium))
-            .foregroundStyle(MatherTheme.ink)
+    private func safetyItem(_ text: String, index: Int) -> some View {
+        Button {
+            if checkedItems.contains(index) {
+                checkedItems.remove(index)
+            } else {
+                checkedItems.insert(index)
+            }
+        } label: {
+            Label(text, systemImage: checkedItems.contains(index) ? "checkmark.circle.fill" : "circle")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(checkedItems.contains(index) ? MatherTheme.accent : MatherTheme.ink)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("room-safety-check-\(index)")
+        .accessibilityValue(checkedItems.contains(index) ? "Checked" : "Not checked")
     }
 }
 
 /// Screen shown while child walks back to the iPad after collecting from both spots.
 private struct ReturningView: View {
     @Bindable var engine: RoomQuestEngine
+    let onRequestAbandon: (String) -> Void
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
@@ -483,7 +544,7 @@ private struct ReturningView: View {
                 }
 
                 roomReturningChromeButton(title: "Home", systemImage: "house.circle.fill", accessibilityID: "room-home-button-returning") {
-                    engine.onExitToHome?()
+                    onRequestAbandon("parent_home")
                 }
             }
             .padding(24)
@@ -525,6 +586,7 @@ private func roomReturningChromeButton(title: String, systemImage: String, acces
 private struct RoomPausedView: View {
     @Bindable var engine: RoomQuestEngine
     let resumingTo: RoomPhase
+    let onRequestAbandon: (String) -> Void
 
     var body: some View {
         VStack(spacing: 32) {
@@ -552,7 +614,7 @@ private struct RoomPausedView: View {
                 .buttonStyle(PrimaryActionButtonStyle())
 
                 Button("End session & go home") {
-                    engine.abandonSession(reason: "parent_abort")
+                    onRequestAbandon("parent_abort")
                 }
                 .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.danger.opacity(0.45)))
                 .foregroundStyle(MatherTheme.danger)

--- a/Tests/MatherUITests/RoomQuestUITests.swift
+++ b/Tests/MatherUITests/RoomQuestUITests.swift
@@ -20,6 +20,12 @@ final class RoomQuestUITests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["Before you start"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Safety checklist"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["Tick every safety condition to continue."].waitForExistence(timeout: 3))
+        XCTAssertFalse(app.buttons["I understand — let's go"].isEnabled)
+        for index in 0..<5 {
+            app.buttons["room-safety-check-\(index)"].tap()
+        }
+        XCTAssertTrue(app.staticTexts["Checklist complete — you can continue."].waitForExistence(timeout: 3))
         snapshot(app, "RoomQuest-SafetyAck")
 
         app.buttons["I understand — let's go"].tap()
@@ -144,16 +150,24 @@ final class RoomQuestUITests: XCTestCase {
 
     // MARK: - Abandon
 
-    func testRoomQuestAbandonSessionNavigatesToHome() {
+    func testRoomQuestAbandonSessionAsksForConfirmationBeforeHome() {
         let app = launchWithRoomQuestAndSafetyAck()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
         openRoomQuest(app)
         _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
-        completeSetupViaManualFallback(app)
 
-        _ = app.staticTexts["Red Rocket"].waitForExistence(timeout: 5)
-        XCTAssertTrue(app.buttons["room-pause-button"].waitForExistence(timeout: 5))
+        app.buttons["room-home-session"].tap()
+        XCTAssertTrue(app.alerts["End Room Quest?"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.alerts["End Room Quest?"].buttons["Keep playing"].exists)
+        XCTAssertTrue(app.alerts["End Room Quest?"].buttons["End session"].exists)
+
+        app.alerts["End Room Quest?"].buttons["Keep playing"].tap()
+        XCTAssertTrue(app.staticTexts["Set up the room"].waitForExistence(timeout: 5))
+
+        app.buttons["room-home-session"].tap()
+        app.alerts["End Room Quest?"].buttons["End session"].tap()
+        XCTAssertTrue(app.staticTexts["Mather"].waitForExistence(timeout: 5))
     }
 
     // MARK: - Global settings handoff


### PR DESCRIPTION
## Summary
- Require parents to tick every Room Quest safety checklist item before the first-session continue CTA enables.
- Add a confirmation alert before Room Quest Home/End actions abandon a session.
- Clean up Parent Summary empty/placeholder handling, remove generic session labels, and add a clear bottom Home/Settings affordance.
- Add Profile Picker active-profile badge plus visible/accessibility feedback when long names are truncated.

## Links
- Part of #987
- Remediates items from #984

## Tests
- `git diff --check` ✅
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.3.1' -only-testing:MatherTests/RoomQuestEngineTests -only-testing:MatherTests/ParentSummaryOverviewTests -quiet` ⚠️ blocked by existing Xcode 26.4 Swift frontend crash while type-checking `Features/ParentSummary/SettingsView.swift` (`/CI/blocker`, `F505EC45`, `B2C7E99A7828`).
- Initial simulator run with `OS=latest` also failed because no iPhone 16 latest-runtime destination exists on `ganesh-mba`; reran with OS 18.3.1 and hit the compiler crash above.

No release tags.
