### PR TITLE
Fix VS1 session quality UX

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -1027,7 +1027,7 @@ final class VerticalSliceEngine {
 
 }
 
-enum EquationSide {
+enum EquationSide: String {
     case left
     case right
 }

--- a/Features/VerticalSlice1/ConcreteBuildView.swift
+++ b/Features/VerticalSlice1/ConcreteBuildView.swift
@@ -41,38 +41,45 @@ struct ConcreteBuildView: View {
                 // Numerals and symbols only — no words, consistent with the no-reading principle.
                 // Connects the concrete ten-frame action to the abstract equation (CPA bridge).
                 HStack(spacing: 8) {
-                    Text("\(warmCount)")
+                    Text(equationPartText(warmCount))
                         .font(.system(size: 36, weight: .black, design: .rounded))
-                        .foregroundStyle(MatherTheme.warm)
+                        .foregroundStyle(warmCount == 0 ? .secondary : MatherTheme.warm)
                         .accessibilityIdentifier("warm-count-label")
                         .contentTransition(.numericText())
                         .animation(.spring(response: 0.3), value: warmCount)
                     Text("+")
                         .font(.system(size: 24, weight: .bold, design: .rounded))
                         .foregroundStyle(.secondary)
-                    Text("\(accentCount)")
+                    Text(equationPartText(accentCount))
                         .font(.system(size: 36, weight: .black, design: .rounded))
-                        .foregroundStyle(MatherTheme.accent)
+                        .foregroundStyle(accentCount == 0 ? .secondary : MatherTheme.accent)
                         .accessibilityIdentifier("accent-count-label")
                         .contentTransition(.numericText())
                         .animation(.spring(response: 0.3), value: accentCount)
-                    Text("= \(warmCount + accentCount)")
+                    Text("= \(target)")
                         .font(.system(size: 24, weight: .bold, design: .rounded))
                         .foregroundStyle(.secondary)
                 }
                 .frame(maxWidth: .infinity, alignment: .center)
 
-                Button("That is \(target)") {
+                Button(currentCount == target ? "That is \(target)" : "Make \(target)") {
                     onSubmit()
                 }
                 .buttonStyle(PrimaryActionButtonStyle())
+                .disabled(currentCount != target)
+                .opacity(currentCount == target ? 1 : 0.58)
             }
         }
     }
 
+    private var visibleCounterSlotCount: Int {
+        if target <= 10 { return 10 }
+        return min(max(target, 1), 20)
+    }
+
     private var tapCounterGrid: some View {
         LazyVGrid(columns: columns, spacing: 10) {
-            ForEach(0..<min(max(target, 1), 20), id: \.self) { index in
+            ForEach(0..<visibleCounterSlotCount, id: \.self) { index in
                 counterCell(index: index)
                     .frame(maxWidth: 72, maxHeight: 72)
                     .accessibilityIdentifier("counter-cell-\(index)")
@@ -114,6 +121,10 @@ struct ConcreteBuildView: View {
             }
             .frame(maxWidth: .infinity)
         }
+    }
+
+    private func equationPartText(_ value: Int) -> String {
+        value == 0 ? "?" : "\(value)"
     }
 
     private func groupedStepButton(step: Int) -> some View {
@@ -165,6 +176,11 @@ struct ConcreteBuildView: View {
         let isFirstRow = index < 10
         let rowIndex = index % 10
         let filled = isFirstRow ? rowIndex < warmCount : rowIndex < accentCount
-        CounterView(index: index, filled: filled, theme: theme)
+        CounterView(
+            index: index,
+            filled: filled,
+            theme: theme,
+            overrideColor: target <= 10 ? MatherTheme.warm : nil
+        )
     }
 }

--- a/Features/VerticalSlice1/EquationResolveView.swift
+++ b/Features/VerticalSlice1/EquationResolveView.swift
@@ -11,7 +11,12 @@ struct EquationResolveView: View {
     var showsInlineSubmit = true
     var theme: any SliceTheme = ClassicTheme()
 
-    @State private var selectedSide: EquationSide = .left
+    @SceneStorage("equationResolveSelectedSide") private var selectedSideRaw = EquationSide.left.rawValue
+
+    private var selectedSide: EquationSide {
+        get { EquationSide(rawValue: selectedSideRaw) ?? .left }
+        nonmutating set { selectedSideRaw = newValue.rawValue }
+    }
 
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 4)
 
@@ -93,20 +98,37 @@ struct EquationResolveView: View {
                 Text(title)
                     .font(.subheadline.weight(.bold))
                 ZStack(alignment: .topTrailing) {
-                    Text(value.isEmpty ? "?" : value)
-                        .font(.system(size: 30, weight: .black, design: .rounded))
-                        .frame(maxWidth: .infinity, minHeight: 60)
-                        .background(selectedSide == side ? MatherTheme.accent.opacity(colorScheme == .dark ? 0.28 : 0.18) : MatherTheme.softBlue.opacity(colorScheme == .dark ? 0.32 : 0.25))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                                .strokeBorder(
-                                    selectedSide == side
-                                        ? .white.opacity(colorScheme == .dark ? 0.12 : 0)
-                                        : MatherTheme.panelDeep.opacity(colorScheme == .dark ? 0.65 : 0),
-                                    lineWidth: 1
-                                )
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    VStack(spacing: 4) {
+                        Text(value.isEmpty ? "?" : value)
+                            .font(.system(size: 30, weight: .black, design: .rounded))
+                            .frame(maxWidth: .infinity, minHeight: 60)
+                            .background(selectedSide == side ? MatherTheme.accent.opacity(colorScheme == .dark ? 0.30 : 0.20) : MatherTheme.softBlue.opacity(colorScheme == .dark ? 0.32 : 0.25))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                    .strokeBorder(
+                                        selectedSide == side
+                                            ? MatherTheme.accent.opacity(colorScheme == .dark ? 0.95 : 0.78)
+                                            : MatherTheme.panelDeep.opacity(colorScheme == .dark ? 0.65 : 0),
+                                        lineWidth: selectedSide == side ? 3 : 1
+                                    )
+                            )
+                            .overlay(alignment: .bottom) {
+                                if selectedSide == side {
+                                    Capsule()
+                                        .fill(MatherTheme.accent)
+                                        .frame(width: 34, height: 4)
+                                        .offset(y: -6)
+                                }
+                            }
+                            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+                        if selectedSide == side {
+                            Label("typing here", systemImage: "arrow.up")
+                                .font(.caption2.weight(.black))
+                                .foregroundStyle(MatherTheme.accent)
+                                .accessibilityIdentifier("equation-active-side-indicator")
+                        }
+                    }
                     if !value.isEmpty {
                         Button {
                             onClear(side)

--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -141,9 +141,9 @@ struct GravitySplitView: View {
 
     private var liveCountRow: some View {
         HStack(spacing: 7) {
-            counterPill(value: state.leftCount, fill: MatherTheme.warm)
+            counterPill(value: state.leftCount, fill: MatherTheme.warm, isEmpty: state.leftCount == 0 && sourceCount == state.target)
             Text("+").font(.headline.weight(.black)).foregroundStyle(.secondary)
-            counterPill(value: state.rightCount, fill: MatherTheme.accent)
+            counterPill(value: state.rightCount, fill: MatherTheme.accent, isEmpty: state.rightCount == 0 && sourceCount == state.target)
             Text("=").font(.headline.weight(.black)).foregroundStyle(.secondary)
             Text("\(state.target)")
                 .font(.system(size: 24, weight: .black, design: .rounded))
@@ -151,10 +151,10 @@ struct GravitySplitView: View {
         }
     }
 
-    private func counterPill(value: Int, fill: Color) -> some View {
-        Text("\(value)")
+    private func counterPill(value: Int, fill: Color, isEmpty: Bool = false) -> some View {
+        Text(isEmpty ? "?" : "\(value)")
             .font(.system(size: 18, weight: .black, design: .rounded))
-            .foregroundStyle(fill)
+            .foregroundStyle(isEmpty ? .secondary : fill)
             .frame(minWidth: 58, minHeight: 36)
             .background(fill.opacity(0.13))
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
@@ -170,6 +170,7 @@ struct GravitySplitView: View {
         VStack(spacing: 10) {
             sourceTray
             seesawBalancePreview
+            reachableAddActionBar
 
             ViewThatFits(in: .horizontal) {
                 HStack(alignment: .top, spacing: 10) {
@@ -212,20 +213,22 @@ struct GravitySplitView: View {
 
 
     private var seesawBalancePreview: some View {
-        let totalPlaced = max(1, state.leftCount + state.rightCount)
+        let placedCount = state.leftCount + state.rightCount
+        let totalPlaced = max(1, placedCount)
         let tilt = CGFloat(state.rightCount - state.leftCount) / CGFloat(totalPlaced)
         let rotation = Double(max(-0.16, min(0.16, tilt)) * 18)
+        let barStyle = placedCount == 0
+            ? AnyShapeStyle(MatherTheme.cardSubtitle.opacity(0.24))
+            : AnyShapeStyle(LinearGradient(
+                colors: [MatherTheme.warm.opacity(0.86), MatherTheme.accent.opacity(0.86)],
+                startPoint: .leading,
+                endPoint: .trailing
+            ))
 
         return VStack(spacing: 4) {
             ZStack(alignment: .center) {
                 Capsule()
-                    .fill(
-                        LinearGradient(
-                            colors: [MatherTheme.warm.opacity(0.86), MatherTheme.accent.opacity(0.86)],
-                            startPoint: .leading,
-                            endPoint: .trailing
-                        )
-                    )
+                    .fill(barStyle)
                     .frame(height: 12)
                     .overlay(
                         Capsule()
@@ -249,7 +252,7 @@ struct GravitySplitView: View {
             }
             .frame(height: 58)
 
-            Text(state.isLocked ? "See-saw balanced" : "Balance the see-saw")
+            Text(state.isLocked ? "See-saw balanced" : placedCount == 0 ? "Start with either side" : "Balance the see-saw")
                 .font(.caption2.weight(.black))
                 .foregroundStyle(state.isLocked ? MatherTheme.accent : MatherTheme.cardSubtitle)
         }
@@ -259,6 +262,41 @@ struct GravitySplitView: View {
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Lever see-saw balance. Left side has \(state.leftCount), right side has \(state.rightCount).")
         .accessibilityIdentifier("gravity-seesaw-balance-preview")
+    }
+
+    private var reachableAddActionBar: some View {
+        HStack(spacing: 10) {
+            quickAddButton(label: vocabulary.leftLabel, count: state.leftCount, target: state.decompositionA, fill: MatherTheme.warm, side: .left)
+            quickAddButton(label: vocabulary.rightLabel, count: state.rightCount, target: state.decompositionB, fill: MatherTheme.accent, side: .right)
+        }
+        .accessibilityIdentifier("gravity-reachable-add-action-bar")
+    }
+
+    private func quickAddButton(label: String, count: Int, target: Int, fill: Color, side: TransferSide) -> some View {
+        let canAdd = !state.isLocked && sourceCount > 0 && count < target
+        let sideName = side == .left ? "left" : "right"
+        return Button {
+            onTap(1, side)
+        } label: {
+            Label("Add \(label)", systemImage: "plus.circle.fill")
+                .font(.subheadline.weight(.black))
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+                .frame(maxWidth: .infinity, minHeight: 46)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(canAdd ? fill : MatherTheme.cardSubtitle.opacity(0.55))
+        .background(canAdd ? fill.opacity(0.12) : Color.secondary.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(canAdd ? fill.opacity(0.34) : Color.secondary.opacity(0.16), lineWidth: 1.25)
+        )
+        .disabled(!canAdd)
+        .opacity(canAdd ? 1 : 0.72)
+        .accessibilityIdentifier("gravity-\(sideName)-quick-add-button")
+        .accessibilityLabel("Add \(label)")
+        .accessibilityHint(canAdd ? "Adds one token to the \(label) side." : "This side cannot accept more tokens right now.")
     }
 
     private func balancePan(label: String, count: Int, fill: Color) -> some View {

--- a/Features/VerticalSlice1/SessionConfigView.swift
+++ b/Features/VerticalSlice1/SessionConfigView.swift
@@ -21,90 +21,153 @@ struct SessionConfigView: View {
         ZStack {
             MatherTheme.background.ignoresSafeArea()
 
-            ScrollView {
-                VStack(spacing: 20) {
-                    CardSurface {
-                        VStack(alignment: .leading, spacing: 16) {
-                            Text("Session setup")
-                                .font(.title.weight(.black))
-                            Text("Keep sessions short and consistent.")
-                                .font(.headline)
-                                .foregroundStyle(MatherTheme.ink.opacity(0.6))
-                                .fixedSize(horizontal: false, vertical: true)
+            VStack(spacing: 0) {
+                topExitBar
 
-                            Divider()
+                GeometryReader { proxy in
+                    ScrollView {
+                        VStack(spacing: horizontalSizeClass == .regular ? 24 : 18) {
+                            setupCard
 
-                            Text("Theme")
-                                .font(.title3.weight(.semibold))
-                                .accessibilityIdentifier("session-setup-theme-section")
-
-                            // Theme picker — selected card gets accent border.
-                            // Tapping sets selectedThemeId; engine reads it at startSession().
-                            HStack(spacing: 12) {
-                                ForEach(themeOptions) { option in
-                                    themeCard(option)
-                                }
+                            if horizontalSizeClass == .regular {
+                                whatHappensNextPanel
                             }
+                        }
+                        .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .frame(minHeight: horizontalSizeClass == .regular ? max(proxy.size.height - 24, 0) : nil, alignment: .center)
+                        .padding(.horizontal, 24)
+                        .padding(.top, horizontalSizeClass == .regular ? 20 : 14)
+                        .padding(.bottom, 32)
+                    }
+                    .scrollIndicators(.visible)
+                }
+            }
+        }
+    }
 
-                            Divider()
+    private var topExitBar: some View {
+        HStack {
+            Button {
+                appModel.engine.showHome()
+            } label: {
+                Label("Back to Home", systemImage: "chevron.left")
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(MatherTheme.softBlue)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(MatherTheme.softBlue.opacity(0.14), in: Capsule())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("back-to-home-button")
 
-                            Stepper(value: Binding(
-                                get: { appModel.engine.config.maxProblems },
-                                set: { appModel.engine.updateConfig(problemCount: $0) }
-                            ), in: 4...8) {
-                                Text("Problems: \(appModel.engine.config.maxProblems)")
-                                    .font(.title3.weight(.semibold))
-                            }
-                            .accessibilityIdentifier("problems-stepper")
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 12)
+        .padding(.bottom, 8)
+        .background(MatherTheme.background.opacity(0.94))
+    }
 
-                            Divider()
+    private var setupCard: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Session setup")
+                    .font(.title.weight(.black))
+                Text("Keep sessions short and consistent.")
+                    .font(.headline)
+                    .foregroundStyle(MatherTheme.ink.opacity(0.6))
+                    .fixedSize(horizontal: false, vertical: true)
 
-                            VStack(alignment: .leading, spacing: 10) {
-                                Text("Target numbers")
-                                    .font(.title3.weight(.semibold))
-                                Text("Choose the largest number this session can ask for.")
-                                    .font(.subheadline)
-                                    .foregroundStyle(MatherTheme.ink.opacity(0.6))
+                Divider()
 
-                                LazyVGrid(columns: [GridItem(.adaptive(minimum: 96), spacing: 12)], spacing: 12) {
-                                    ForEach(ParentTargetCap.quickPicks, id: \.self) { maxTarget in
-                                        targetCapButton(maxTarget: maxTarget)
-                                    }
-                                }
-                            }
-                            .accessibilityIdentifier("target-cap-section")
+                Text("Theme")
+                    .font(.title3.weight(.semibold))
+                    .accessibilityIdentifier("session-setup-theme-section")
 
-                            Toggle("Speak prompts", isOn: Binding(
-                                get: { appModel.featureFlags.audioEnabled },
-                                set: {
-                                    appModel.featureFlags.audioEnabled = $0
-                                    appModel.engine.updateConfig(audioEnabled: $0)
-                                }
-                            ))
-                            .font(.title3.weight(.semibold))
-                            .accessibilityIdentifier("speak-prompts-toggle")
+                HStack(spacing: 12) {
+                    ForEach(themeOptions) { option in
+                        themeCard(option)
+                    }
+                }
 
-                            Button("Start Session") {
-                                appModel.engine.startSession()
-                            }
-                            .buttonStyle(PrimaryActionButtonStyle())
-                            .accessibilityIdentifier("start-session-button")
+                Divider()
+
+                Stepper(value: Binding(
+                    get: { appModel.engine.config.maxProblems },
+                    set: { appModel.engine.updateConfig(problemCount: $0) }
+                ), in: 4...8) {
+                    Text("Problems: \(appModel.engine.config.maxProblems)")
+                        .font(.title3.weight(.semibold))
+                }
+                .accessibilityIdentifier("problems-stepper")
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("Target numbers")
+                        .font(.title3.weight(.semibold))
+                    Text("Choose the largest number this session can ask for.")
+                        .font(.subheadline)
+                        .foregroundStyle(MatherTheme.ink.opacity(0.6))
+
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 96), spacing: 12)], spacing: 12) {
+                        ForEach(ParentTargetCap.quickPicks, id: \.self) { maxTarget in
+                            targetCapButton(maxTarget: maxTarget)
                         }
                     }
-
-                    Button("Back to Home") {
-                        appModel.engine.showHome()
-                    }
-                    .font(.headline.weight(.semibold))
-                    .accessibilityIdentifier("back-to-home-button")
                 }
-                .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
-                .frame(maxWidth: .infinity, alignment: .center)
-                .padding(.horizontal, 24)
-                .padding(.top, 24)
-                .padding(.bottom, 32)
+                .accessibilityIdentifier("target-cap-section")
+
+                Toggle("Speak prompts", isOn: Binding(
+                    get: { appModel.featureFlags.audioEnabled },
+                    set: {
+                        appModel.featureFlags.audioEnabled = $0
+                        appModel.engine.updateConfig(audioEnabled: $0)
+                    }
+                ))
+                .font(.title3.weight(.semibold))
+                .accessibilityIdentifier("speak-prompts-toggle")
+
+                Button("Start Session") {
+                    appModel.engine.startSession()
+                }
+                .buttonStyle(PrimaryActionButtonStyle())
+                .accessibilityIdentifier("start-session-button")
             }
-            .scrollIndicators(.visible)
+        }
+    }
+
+    private var whatHappensNextPanel: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("What happens next")
+                    .font(.title3.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                setupStep(icon: "hand.tap.fill", title: "Make it", detail: "Build the number with counters.")
+                setupStep(icon: "scalemass.fill", title: "Gravity Split", detail: "Split it into two balanced parts.")
+                setupStep(icon: "square.grid.2x2.fill", title: "Sum Sprint", detail: "Match sums to totals.")
+                setupStep(icon: "bolt.fill", title: "Bond Blast", detail: "Finish by finding all number bonds.")
+            }
+        }
+        .accessibilityIdentifier("session-setup-next-steps-panel")
+    }
+
+    private func setupStep(icon: String, title: String, detail: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.headline.weight(.black))
+                .foregroundStyle(MatherTheme.accent)
+                .frame(width: 30, height: 30)
+                .background(MatherTheme.accent.opacity(0.12), in: Circle())
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.subheadline.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text(detail)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+            }
         }
     }
 

--- a/Features/VerticalSlice1/SessionSummaryView.swift
+++ b/Features/VerticalSlice1/SessionSummaryView.swift
@@ -4,10 +4,25 @@ struct SessionSummaryView: View {
     @Bindable var appModel: AppModel
     @State private var scale: CGFloat = 0.7
     @State private var opacity: Double = 0
+    @State private var confettiBurst = false
+
+    private var summary: SessionSummaryDraft? { appModel.engine.completedSummary }
+    private var problemsSolvedText: String {
+        let completed = summary?.problemsCompleted ?? appModel.engine.problems.count
+        let maxTarget = appModel.engine.problems.map(\.target).max() ?? appModel.engine.config.parentTargetCap
+        return "\(completed) problems solved · Target up to \(maxTarget)"
+    }
+    private var firstTryText: String {
+        guard let summary else { return "Great effort all session" }
+        return "\(Int((summary.firstAttemptAccuracy * 100).rounded()))% first try"
+    }
+    private var transferText: String {
+        guard let summary else { return "Number bonds practised" }
+        return "\(summary.transferCorrectCount) review checks correct"
+    }
 
     var body: some View {
         ZStack {
-            // Warm gradient backdrop — feels festive without being alarming
             LinearGradient(
                 colors: [MatherTheme.warm.opacity(0.4), MatherTheme.accent.opacity(0.25)],
                 startPoint: .topLeading,
@@ -15,11 +30,12 @@ struct SessionSummaryView: View {
             )
             .ignoresSafeArea()
 
-            VStack(spacing: 28) {
-                Spacer()
+            celebrationSprinkles
 
-                // Central celebration — animates in on appear
-                VStack(spacing: 16) {
+            VStack(spacing: 24) {
+                Spacer(minLength: 18)
+
+                VStack(spacing: 14) {
                     Text("⭐️")
                         .font(.system(size: 96))
                         .scaleEffect(scale)
@@ -32,37 +48,113 @@ struct SessionSummaryView: View {
                     Text("You did it!")
                         .font(.title2.weight(.semibold))
                         .foregroundStyle(.secondary)
+
+                    Text(problemsSolvedText)
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(.white.opacity(0.52), in: Capsule())
+                        .accessibilityIdentifier("session-summary-progress-subtitle")
                 }
                 .multilineTextAlignment(.center)
-                .onAppear {
-                    withAnimation(.spring(response: 0.5, dampingFraction: 0.55)) {
-                        scale = 1.0
-                        opacity = 1.0
-                    }
-                }
 
-                Spacer()
+                progressCard
 
-                VStack(spacing: 14) {
+                Spacer(minLength: 12)
+
+                VStack(spacing: 12) {
                     Button("Play again") {
                         appModel.engine.showSessionConfig()
                     }
                     .buttonStyle(PrimaryActionButtonStyle())
+                    .accessibilityIdentifier("session-summary-play-again-button")
 
-                    HStack(spacing: 14) {
-                        Button("Parent summary") {
-                            appModel.engine.showParentSummary()
-                        }
-                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.6)))
-
-                        Button("Done") {
-                            appModel.engine.showHome()
-                        }
-                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.55)))
+                    Button("Done") {
+                        appModel.engine.showHome()
                     }
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(MatherTheme.softBlue)
+                    .frame(maxWidth: .infinity, minHeight: 50)
+                    .background(MatherTheme.softBlue.opacity(0.14), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("session-summary-done-button")
+
+                    Button("Parent summary") {
+                        appModel.engine.showParentSummary()
+                    }
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(.secondary)
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("session-summary-parent-summary-button")
                 }
             }
             .padding(24)
         }
+        .onAppear {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.55)) {
+                scale = 1.0
+                opacity = 1.0
+            }
+            withAnimation(.easeOut(duration: 0.9)) {
+                confettiBurst = true
+            }
+        }
+    }
+
+    private var progressCard: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                progressMetric(value: firstTryText, label: "accuracy", fill: MatherTheme.accent)
+                progressMetric(value: transferText, label: "review", fill: MatherTheme.warm)
+            }
+            if let next = summary?.nextTargetHint, !next.isEmpty {
+                Text(next)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .padding(16)
+        .background(.white.opacity(0.62), in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .strokeBorder(.white.opacity(0.55), lineWidth: 1)
+        )
+        .accessibilityIdentifier("session-summary-progress-card")
+    }
+
+    private func progressMetric(value: String, label: String, fill: Color) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(.headline.weight(.black))
+                .foregroundStyle(fill)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .minimumScaleFactor(0.78)
+            Text(label.uppercased())
+                .font(.caption2.weight(.black))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, minHeight: 76)
+        .padding(.horizontal, 8)
+        .background(fill.opacity(0.10), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+
+    private var celebrationSprinkles: some View {
+        ZStack {
+            ForEach(0..<10, id: \.self) { index in
+                Circle()
+                    .fill(index.isMultiple(of: 2) ? MatherTheme.accent.opacity(0.45) : MatherTheme.warm.opacity(0.45))
+                    .frame(width: 10 + CGFloat(index % 3) * 4, height: 10 + CGFloat(index % 3) * 4)
+                    .offset(
+                        x: confettiBurst ? CGFloat((index % 5) - 2) * 58 : 0,
+                        y: confettiBurst ? CGFloat((index / 5) == 0 ? -150 : 150) : 0
+                    )
+                    .opacity(confettiBurst ? 0.15 : 0.8)
+            }
+        }
+        .allowsHitTesting(false)
     }
 }

--- a/Features/VerticalSlice1/SplitView.swift
+++ b/Features/VerticalSlice1/SplitView.swift
@@ -10,18 +10,23 @@ struct SplitView: View {
     /// Hides the drag affordance and shows a "collected" badge.
     var isLocked: Bool = false
 
+    @State private var showDragHint = false
+
     private var rightCount: Int { target - leftCount }
+    private var splitHeading: String { "Split \(target) \(theme.counterNoun)" }
 
     var body: some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 20) {
-                HStack(alignment: .firstTextBaseline, spacing: 10) {
-                    Text("Break")
-                        .font(.title.weight(.bold))
-                        .foregroundStyle(.secondary)
-                    Text("\(target)")
-                        .font(.system(size: 56, weight: .black, design: .rounded))
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(splitHeading)
+                        .font(.title.weight(.black))
                         .foregroundStyle(MatherTheme.softBlue)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.78)
+                    Text("Drag or tap to choose two parts")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
                 }
 
                 ViewThatFits {
@@ -51,14 +56,19 @@ struct SplitView: View {
                 } else {
                     // Swipe affordance — left/right chevrons hint at the drag gesture.
                     // Tap on each bucket also adjusts the split (no reading required).
-                    HStack {
+                    HStack(spacing: 10) {
                         Image(systemName: "chevron.left")
-                        Spacer()
+                        Text("Drag to split")
+                            .font(.caption.weight(.black))
                         Image(systemName: "chevron.right")
                     }
-                    .font(.footnote.weight(.medium))
-                    .foregroundStyle(.secondary.opacity(0.45))
-                    .padding(.horizontal, 20)
+                    .font(.footnote.weight(.bold))
+                    .foregroundStyle(MatherTheme.softBlue.opacity(0.72))
+                    .frame(maxWidth: .infinity)
+                    .offset(x: showDragHint ? 14 : -14)
+                    .animation(.easeInOut(duration: 0.55).repeatCount(3, autoreverses: true), value: showDragHint)
+                    .onAppear { showDragHint = true }
+                    .accessibilityIdentifier("split-view-drag-hint")
                 }
 
                 // Live equation — shows A + B = target as the child adjusts the split.

--- a/Tests/MatherTests/ConcreteBuildViewTests.swift
+++ b/Tests/MatherTests/ConcreteBuildViewTests.swift
@@ -30,3 +30,11 @@ struct ConcreteBuildViewTests {
         #expect(action?.group == .accent)
     }
 }
+
+
+extension ConcreteBuildViewTests {
+    @Test func smallTargetsKeepAFullTenFrameAvailableWithoutAccentGroup() {
+        #expect(ConcreteBuildView.tapAction(for: 5, target: 6, warmCount: 5, accentCount: 0)?.group == .warm)
+        #expect(ConcreteBuildView.tapAction(for: 9, target: 6, warmCount: 5, accentCount: 0) == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Fix VS1 concrete build for targets <= 10 to always use a single standard 10-slot ten-frame and touched equation empty states as `?`.
- Add reachable Gravity Split quick-add controls for iPhone and improve SplitView first-use drag guidance/theme heading.
- Rework session setup and summary for visible back/exit, better iPad composition, dark-safe contrast, richer progress details, and clearer CTA hierarchy.
- Add active-side preservation/indicator in Equation Resolve.

Links #987
References #984

## Tests
- `git diff --check` ✅
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,id=3A1BD382-28BD-4285-83B4-B6913DF496C4" -only-testing:MatherTests/ConcreteBuildViewTests -only-testing:MatherTests/VerticalSliceEngineTests` ⚠️ blocked by Xcode 26.4 Swift compiler crash in `Features/ParentSummary/SettingsView.swift:162` (`TypeCheckFunctionBodyRequest(SettingsView.profilesCard)`). Same command on `origin/main` reproduces the same crash, so this appears baseline/toolchain rather than Slice A.
- Retried with `SWIFT_COMPILATION_MODE=singlefile` and simulator `arch=x86_64`; both hit the same baseline compiler crash.
