### PR TITLE
Improve games and lab UX quality

### DIFF
--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -387,6 +387,7 @@ struct BondMatchState: Equatable {
 enum SumSprintBurstCardContent: Equatable {
     case prompt(String)
     case sum(Int)
+    case decoratedSum(value: Int, marker: String)
 
     var displayText: String {
         switch self {
@@ -394,6 +395,8 @@ enum SumSprintBurstCardContent: Equatable {
             return value
         case .sum(let value):
             return String(value)
+        case .decoratedSum(let value, let marker):
+            return "\(value) \(marker)"
         }
     }
 
@@ -407,8 +410,12 @@ enum SumSprintBurstCardContent: Equatable {
     }
 
     var sumValue: Int? {
-        guard case .sum(let value) = self else { return nil }
-        return value
+        switch self {
+        case .sum(let value), .decoratedSum(let value, _):
+            return value
+        case .prompt:
+            return nil
+        }
     }
 }
 
@@ -452,13 +459,24 @@ struct SumSprintBurstState: Equatable {
     }
 
     static func make(for problem: SliceProblem) -> SumSprintBurstState {
-        let cards = makeFacts(for: problem).flatMap { fact -> [SumSprintBurstCard] in
+        let facts = makeFacts(for: problem)
+        let duplicateTotals = Set(
+            Dictionary(grouping: facts.map { $0.0 + $0.1 }, by: { $0 })
+                .filter { $0.value.count > 1 }
+                .map(\.key)
+        )
+        let markers = ["●", "▲", "★", "◆", "■"]
+
+        let cards = facts.enumerated().flatMap { index, fact -> [SumSprintBurstCard] in
             let pairId = UUID()
             let prompt = "\(fact.0) + \(fact.1)"
             let sum = fact.0 + fact.1
+            let sumContent: SumSprintBurstCardContent = duplicateTotals.contains(sum)
+                ? .decoratedSum(value: sum, marker: markers[index % markers.count])
+                : .sum(sum)
             return [
                 SumSprintBurstCard(id: UUID(), pairId: pairId, content: .prompt(prompt)),
-                SumSprintBurstCard(id: UUID(), pairId: pairId, content: .sum(sum))
+                SumSprintBurstCard(id: UUID(), pairId: pairId, content: sumContent)
             ]
         }
         return SumSprintBurstState(target: problem.target, cards: cards.shuffled())

--- a/Features/AngleCannon/AngleCannonView.swift
+++ b/Features/AngleCannon/AngleCannonView.swift
@@ -22,6 +22,7 @@ struct AngleCannonView: View {
 
     @State private var neutralRoll: Double? = nil
     @State private var calibrating = false          // shows "Hold steady…" banner
+    @State private var calibrationProgress: Double = 0
     /// Current aim angle in degrees [10, 80]. Snaps to multiples of 15°.
     @State private var currentAngleDeg: Double = 45
     /// Non-nil once FIRE is tapped; freezes the arc on screen.
@@ -78,6 +79,11 @@ struct AngleCannonView: View {
                         Text("Setting your aim baseline")
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(MatherTheme.cardSubtitle)
+                        ProgressView(value: calibrationProgress)
+                            .tint(MatherTheme.accent)
+                            .frame(width: 160)
+                            .accessibilityLabel("Calibration progress")
+                            .accessibilityValue("\(Int(calibrationProgress * 100)) percent")
                     }
                     .padding(.horizontal, 24)
                     .padding(.vertical, 14)
@@ -119,9 +125,17 @@ struct AngleCannonView: View {
     private func autoCalibrateNeutral() {
         guard neutralRoll == nil else { return }
         calibrating = true
+        calibrationProgress = 0
         Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(600))
+            for progress in [0.25, 0.55, 0.82] {
+                try? await Task.sleep(for: .milliseconds(150))
+                withAnimation(.easeOut(duration: 0.12)) {
+                    calibrationProgress = progress
+                }
+            }
+            try? await Task.sleep(for: .milliseconds(150))
             neutralRoll = appModel.motionService.tiltRoll
+            calibrationProgress = 1
             withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
                 calibrating = false
             }

--- a/Features/GameplayStages/GameplayThreadView.swift
+++ b/Features/GameplayStages/GameplayThreadView.swift
@@ -214,9 +214,18 @@ struct GameplayThreadView: View {
                     .padding(.vertical, 8)
                     .background(Capsule().fill(MatherTheme.card))
             }
-            ProgressView(value: navigation.progressFraction(for: thread))
-                .tint(MatherTheme.accent)
-                .accessibilityLabel("Gameplay thread progress")
+            HStack(spacing: 10) {
+                ProgressView(value: navigation.progressFraction(for: thread))
+                    .tint(MatherTheme.accent)
+                    .frame(maxWidth: .infinity)
+                    .accessibilityLabel("Gameplay thread progress")
+                    .accessibilityValue("Stage \(min(navigation.activeStageIndex + 1, max(thread.stages.count, 1))) of \(thread.stages.count)")
+                Text("\(Int((navigation.progressFraction(for: thread) * 100).rounded()))%")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .monospacedDigit()
+                    .accessibilityHidden(true)
+            }
         }
     }
 

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// The Explorer Lab — a capability playground for maths, physics, geometry, and science inquiry.
 struct LabView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Bindable var appModel: AppModel
     @State private var playfulPulse = false
     @State private var selectedPath: ExplorerPathID
@@ -51,6 +52,10 @@ struct LabView: View {
         }
         .onAppear {
             sensorCapabilities = SensorCapabilityService().currentCapabilities()
+            guard !reduceMotion else {
+                playfulPulse = false
+                return
+            }
             withAnimation(.easeInOut(duration: 1.8).repeatForever(autoreverses: true)) {
                 playfulPulse = true
             }
@@ -370,6 +375,16 @@ struct LabView: View {
                     .lineLimit(2)
                     .minimumScaleFactor(0.78)
                     .multilineTextAlignment(.center)
+
+                if !canLaunch {
+                    Text(capabilitySummary.isEmpty ? "Needs a device sensor" : capabilitySummary)
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.76)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
             .padding(14)
             .frame(maxWidth: .infinity, minHeight: 132, alignment: .center)
@@ -426,7 +441,7 @@ struct LabView: View {
                 color: colorScheme == .dark ? .black.opacity(0.3) : .black.opacity(0.08),
                 radius: compact ? 7 : 8, y: compact ? 3 : 4
             )
-            .scaleEffect(playfulPulse ? 1.01 : 0.995, anchor: .center)
+            .scaleEffect(!reduceMotion && playfulPulse ? 1.01 : 1.0, anchor: .center)
         }
         .buttonStyle(.plain)
         .accessibilityLabel("\(presentation.accessibilityLabel). \(progress.progressSummaryLabel). \(progress.nextRecommendedModeLabel).")
@@ -510,8 +525,8 @@ struct LabView: View {
             laneMiniScene(lane.id, tint: tint)
             Text(lane.emoji)
                 .font(.system(size: size * 0.55))
-                .scaleEffect(playfulPulse ? 1.06 : 0.98)
-                .rotationEffect(.degrees(playfulPulse ? 2 : -2))
+                .scaleEffect(!reduceMotion && playfulPulse ? 1.06 : 1.0)
+                .rotationEffect(.degrees(!reduceMotion && playfulPulse ? 2 : 0))
         }
         .frame(width: size, height: size)
     }
@@ -525,7 +540,7 @@ struct LabView: View {
                     Circle()
                         .fill(tint.opacity(0.22))
                         .frame(width: 12, height: 12)
-                        .offset(y: playfulPulse ? CGFloat(-index * 3) : CGFloat(index * 2))
+                        .offset(y: !reduceMotion && playfulPulse ? CGFloat(-index * 3) : CGFloat(index * 2))
                 }
             }
             .offset(x: 16, y: 22)
@@ -533,7 +548,7 @@ struct LabView: View {
             Image(systemName: "triangle.fill")
                 .font(.system(size: 34, weight: .black))
                 .foregroundStyle(tint.opacity(0.24))
-                .rotationEffect(.degrees(playfulPulse ? 12 : -6))
+                .rotationEffect(.degrees(!reduceMotion && playfulPulse ? 12 : -6))
                 .offset(x: 20, y: 18)
         case .physics:
             Image(systemName: "moon.stars.fill")
@@ -543,7 +558,7 @@ struct LabView: View {
             Circle()
                 .fill(MatherTheme.warm.opacity(0.32))
                 .frame(width: 16, height: 16)
-                .offset(x: playfulPulse ? 24 : 10, y: playfulPulse ? 20 : 8)
+                .offset(x: !reduceMotion && playfulPulse ? 24 : 10, y: !reduceMotion && playfulPulse ? 20 : 8)
         case .mapWorld:
             Image(systemName: "map.fill")
                 .font(.system(size: 34, weight: .black))

--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -1037,33 +1037,17 @@ struct MemoryView: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .top, spacing: 12) {
-                Button {
-                    appModel.engine.showLab()
-                } label: {
-                    Image(systemName: "chevron.left")
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(MatherTheme.accent)
-                        .frame(width: 44, height: 44)
-                }
-                .accessibilityLabel("Back")
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Memory Match")
-                        .font(.title2.weight(.black))
-                        .foregroundStyle(MatherTheme.ink)
-                    Text("\(matchedPairs)/\(totalPairs) pairs matched")
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                    if Self.supportsLearningDetails(for: deckSelection) {
-                        Text(Self.learnMoreHintText(for: deckSelection))
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(MatherTheme.cardSubtitle)
-                            .accessibilityIdentifier("memory-learn-more-hint")
-                    }
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .top, spacing: 12) {
+                    backButton
+                    memoryHeaderCopy
+                    Spacer(minLength: 0)
                 }
 
-                Spacer(minLength: 0)
+                VStack(alignment: .leading, spacing: 8) {
+                    backButton
+                    memoryHeaderCopy
+                }
             }
 
             CardSurface {
@@ -1076,6 +1060,39 @@ struct MemoryView: View {
         }
     }
 
+
+    private var backButton: some View {
+        Button {
+            appModel.engine.showLab()
+        } label: {
+            Image(systemName: "chevron.left")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(MatherTheme.accent)
+                .frame(width: 44, height: 44)
+        }
+        .accessibilityLabel("Back")
+    }
+
+    private var memoryHeaderCopy: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text("Memory Match")
+                .font(.title2.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+            Text("\(matchedPairs)/\(totalPairs) pairs matched")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+            if Self.supportsLearningDetails(for: deckSelection) {
+                Text(Self.learnMoreHintText(for: deckSelection))
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityIdentifier("memory-learn-more-hint")
+            }
+        }
+    }
 
     private var deckAndDifficultyChooser: some View {
         VStack(alignment: .leading, spacing: 14) {

--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -91,7 +91,11 @@ struct BondMatchView: View {
                 reachablePairsGrid
                 progressDots
             }
+            .frame(maxWidth: 660, alignment: .center)
+            .frame(maxWidth: .infinity, alignment: .center)
         }
+        .frame(maxWidth: 760)
+        .frame(maxWidth: .infinity, alignment: .center)
         .onAppear {
             setupShuffledOrder()
         }

--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -212,16 +212,19 @@ struct GravitySplitView: View {
 
 
     private var seesawBalancePreview: some View {
-        let totalPlaced = max(1, state.leftCount + state.rightCount)
+        let placedCount = state.leftCount + state.rightCount
+        let totalPlaced = max(1, placedCount)
         let tilt = CGFloat(state.rightCount - state.leftCount) / CGFloat(totalPlaced)
-        let rotation = Double(max(-0.16, min(0.16, tilt)) * 18)
+        let rotation = placedCount == 0 ? 0 : Double(max(-0.16, min(0.16, tilt)) * 18)
 
         return VStack(spacing: 4) {
             ZStack(alignment: .center) {
                 Capsule()
                     .fill(
                         LinearGradient(
-                            colors: [MatherTheme.warm.opacity(0.86), MatherTheme.accent.opacity(0.86)],
+                            colors: placedCount == 0
+                                ? [MatherTheme.cardSubtitle.opacity(0.28), MatherTheme.cardSubtitle.opacity(0.28)]
+                                : [MatherTheme.warm.opacity(0.86), MatherTheme.accent.opacity(0.86)],
                             startPoint: .leading,
                             endPoint: .trailing
                         )
@@ -249,7 +252,7 @@ struct GravitySplitView: View {
             }
             .frame(height: 58)
 
-            Text(state.isLocked ? "See-saw balanced" : "Balance the see-saw")
+            Text(state.isLocked ? "See-saw balanced" : (placedCount == 0 ? "Place counters to start balancing" : "Balance the see-saw"))
                 .font(.caption2.weight(.black))
                 .foregroundStyle(state.isLocked ? MatherTheme.accent : MatherTheme.cardSubtitle)
         }

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -429,7 +429,7 @@ struct SliceSessionView: View {
         switch card.content {
         case .prompt(let prompt):
             return "sumsprint-prompt-\(normalizedSumSprintToken(prompt))"
-        case .sum(let value):
+        case .sum(let value), .decoratedSum(let value, _):
             let prompt = burst.cards.compactMap { sibling -> String? in
                 guard sibling.pairId == card.pairId,
                       case .prompt(let prompt) = sibling.content else { return nil }

--- a/Features/VerticalSlice1/SliceSessionView.swift
+++ b/Features/VerticalSlice1/SliceSessionView.swift
@@ -269,7 +269,11 @@ struct SliceSessionView: View {
                             }
                         }
                     }
+                    .frame(maxWidth: 680, alignment: .leading)
+                    .frame(maxWidth: .infinity, alignment: .center)
                 }
+                .frame(maxWidth: 760)
+                .frame(maxWidth: .infinity, alignment: .center)
             } else {
                 CardSurface { Text("Loading Sum Sprint...") }
             }

--- a/Features/WaterCycle/WaterCycleLabView.swift
+++ b/Features/WaterCycle/WaterCycleLabView.swift
@@ -871,13 +871,21 @@ struct WaterCycleLabView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             VStack(alignment: .leading, spacing: 6) {
+                Label("Key idea", systemImage: "drop.fill")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(MatherTheme.accent)
                 Text(card.answer)
                     .font(.system(size: 18, weight: .bold, design: .rounded))
                     .foregroundStyle(MatherTheme.ink)
+                    .fixedSize(horizontal: false, vertical: true)
                 Text(card.detail)
-                    .font(.subheadline.weight(.semibold))
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(MatherTheme.cardSubtitle)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
             }
+            .padding(12)
+            .background(MatherTheme.panel.opacity(0.58), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
         }
     }
 

--- a/Tests/MatherTests/NumberStoryStageVocabularyTests.swift
+++ b/Tests/MatherTests/NumberStoryStageVocabularyTests.swift
@@ -40,7 +40,7 @@ struct NumberStoryStageVocabularyTests {
             switch card.content {
             case .prompt:
                 return true
-            case .sum(let value):
+            case .sum(let value), .decoratedSum(let value, _):
                 return value == problem.target
             }
         })

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -667,10 +667,25 @@ struct VerticalSliceEngineTests {
         let contents = Set(firstPair.map { card -> String in
             switch card.content {
             case .prompt(let value): return "p:\(value)"
-            case .sum(let value): return "s:\(value)"
+            case .sum(let value), .decoratedSum(let value, _): return "s:\(value)"
             }
         })
         #expect(contents.count == 2)
+    }
+
+    @Test
+    func sumSprintDecoratesRepeatedTotalsForSmallTargets() {
+        for target in [4, 6] {
+            let problem = SliceProblem(target: target, decompositionA: target / 2, decompositionB: target - target / 2)
+            let state = SumSprintBurstState.make(for: problem)
+            let displayTexts = state.cards.map(\.content.displayText)
+
+            #expect(Set(displayTexts).count == displayTexts.count)
+
+            let resultCards = state.cards.filter { $0.content.sumValue == target }
+            #expect(resultCards.count >= 2)
+            #expect(resultCards.allSatisfy { $0.content.displayText.hasPrefix("\(target)") })
+        }
     }
 
     @Test
@@ -682,9 +697,7 @@ struct VerticalSliceEngineTests {
             return false
         }!
         let equivalentTotalFromOtherPair = state.cards.first { card in
-            guard card.pairId != prompt.pairId,
-                  case .sum(5) = card.content else { return false }
-            return true
+            card.pairId != prompt.pairId && card.content.sumValue == 5
         }!
 
         #expect(SumSprintBurstState.cardsFormValidMatch(prompt, equivalentTotalFromOtherPair))


### PR DESCRIPTION
## Summary

- Make repeated Sum Sprint totals visually unique while preserving equivalent-total matching.
- Add tests for duplicate display coverage on small targets.
- Center sparse Sum Sprint/Bond Blast content on wider iPad layouts.
- Add calibration progress feedback to Angle Cannon.
- Explain disabled lab/game capability requirements and respect Reduce Motion for lab pulses.
- Improve compact Memory header readability, GameplayThread progress visibility, Gravity Split empty seesaw state, and Water Cycle look-card reading load.

Closes part of #987.
Refs #984.

## Validation

- `git diff --check`
- GitHub CI is the authoritative build/test gate for this PR.
