### PR TITLE
Add issue 987 compact UX regression coverage

### DIFF
--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -62,9 +62,19 @@ private extension MatherApp {
             appModel.engine.showWaterCycle()
         case "watercyclelab", "water-cycle-lab", "legacy-watercycle", "legacy-water-cycle":
             appModel.engine.showLegacyWaterCycleLab()
+        case "bondblast", "bond-blast", "bondblastfinale", "bond-blast-finale":
+            appModel.engine.startBondBlastFinale(target: uiTestBondBlastTarget(from: arguments))
         default:
             break
         }
+    }
+
+
+    static func uiTestBondBlastTarget(from arguments: [String]) -> Int {
+        guard let flagIndex = arguments.firstIndex(of: "-uiTest.bondBlastTarget"),
+              arguments.indices.contains(flagIndex + 1),
+              let target = Int(arguments[flagIndex + 1]) else { return 10 }
+        return target
     }
 
     static func seedSessionHistoryIfRequested(using appModel: AppModel) {

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -54,6 +54,17 @@ struct FeatureFlagTests {
         #expect(!flags2.makeBreakLoopV2Enabled)
     }
 
+
+    @Test func freshDefaultsKeepClapReactionOffUntilParentOptIn() {
+        let suiteName = "FeatureFlagTests.freshDefaultsKeepClapReactionOffUntilParentOptIn"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let flags = FeatureFlagService(defaults: defaults)
+
+        #expect(!flags.soundReactionEnabled)
+    }
+
     @Test func soundReactionPreferencePersistsAcrossInstances() {
         let defaults = UserDefaults(suiteName: #function)!
         let flags1 = FeatureFlagService(defaults: defaults)

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -1,7 +1,81 @@
+import UIKit
 import XCTest
 
 @MainActor
 final class CompactLayoutTests: XCTestCase {
+
+    func testIPadHomeRegularLayoutShowsFullMakeAndBreakTitle() throws {
+        guard UIDevice.current.userInterfaceIdiom == .pad else {
+            throw XCTSkip("iPad regular-layout regression only runs on iPad simulators")
+        }
+
+        let app = launchWithVS1()
+        XCTAssertTrue(app.staticTexts["Mather"].waitForExistence(timeout: 10))
+
+        let playCard = app.buttons["Play"]
+        XCTAssertTrue(playCard.waitForExistence(timeout: 5))
+        XCTAssertTrue(playCard.staticTexts["Make & Break"].waitForExistence(timeout: 5), "Expected the iPad home hero to expose the full Make & Break title")
+        XCTAssertTrue(playCard.staticTexts["Targets"].waitForExistence(timeout: 5), "Expected the iPad home hero subtitle to remain visible next to the title")
+    }
+
+    func testBondBlastTargetTwelveKeepsLowAndMiddlePairsReachableOnIPhone() throws {
+        guard UIDevice.current.userInterfaceIdiom == .phone else {
+            throw XCTSkip("Compact Bond Blast reachability regression only runs on iPhone simulators")
+        }
+
+        let app = launchBondBlastFinale(target: 12)
+        XCTAssertTrue(app.staticTexts["Bond Blast!"].waitForExistence(timeout: 10))
+
+        let firstLeft = app.buttons["bond-left-1"]
+        let firstRight = app.buttons["bond-right-11"]
+        XCTAssertTrue(firstLeft.waitForExistence(timeout: 5))
+        XCTAssertTrue(firstLeft.isHittable, "Expected the first target-12 Bond Blast source card to be reachable")
+        firstLeft.tap()
+        XCTAssertTrue(firstRight.waitForExistence(timeout: 5))
+        XCTAssertTrue(firstRight.isHittable, "Expected 1 + 11 target-12 match to be reachable")
+
+        let finalLeft = app.buttons["bond-left-6"]
+        let finalRight = app.buttons["bond-right-6"]
+        if !finalLeft.isHittable || !finalRight.isHittable {
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        XCTAssertTrue(finalLeft.waitForExistence(timeout: 5))
+        XCTAssertTrue(finalLeft.isHittable, "Expected the bottom target-12 Bond Blast source card to be reachable after the in-card scroll")
+        finalLeft.tap()
+        XCTAssertTrue(finalRight.waitForExistence(timeout: 5))
+        XCTAssertTrue(finalRight.isHittable, "Expected 6 + 6 target-12 match to be reachable after the in-card scroll")
+    }
+
+    func testGravitySplitSuccessCTAIsVisibleAndAdvancesOnIPhone() throws {
+        guard UIDevice.current.userInterfaceIdiom == .phone else {
+            throw XCTSkip("Compact Gravity Split CTA regression only runs on iPhone simulators")
+        }
+
+        let app = launchWithVS1()
+        XCTAssertTrue(app.staticTexts["Mather"].waitForExistence(timeout: 10))
+
+        app.buttons["Play"].tap()
+        XCTAssertTrue(app.staticTexts["Session setup"].waitForExistence(timeout: 10))
+        app.buttons["Start Session"].tap()
+        advanceStoryAnchorIfPresent(app)
+
+        XCTAssertTrue(app.buttons["That is 6"].waitForExistence(timeout: 10))
+        app.otherElements["counter-cell-4"].tap()
+        app.otherElements["counter-cell-5"].tap()
+        app.buttons["That is 6"].tap()
+
+        XCTAssertTrue(app.staticTexts["Gravity Split"].waitForExistence(timeout: 10))
+        app.buttons["gravity-complete-split-button"].tap()
+
+        let successCTA = app.otherElements["gravity-split-success-progression"]
+        let nextButton = app.buttons["gravity-split-next-button"]
+        XCTAssertTrue(successCTA.waitForExistence(timeout: 5), "Expected the Gravity Split success CTA to stay visible on compact layouts")
+        XCTAssertTrue(nextButton.waitForExistence(timeout: 5))
+        XCTAssertTrue(nextButton.isHittable, "Expected the Gravity Split success CTA button to be reachable")
+        nextButton.tap()
+        XCTAssertTrue(app.staticTexts["Sum Sprint"].waitForExistence(timeout: 10))
+    }
+
     func testVS1CompactFlowShowsUpdatedCopyAndKeepsCoreActionsReachableWithoutSwipe() {
         let app = launchWithVS1()
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 10)
@@ -189,6 +263,30 @@ final class CompactLayoutTests: XCTestCase {
         XCTAssertTrue(app.buttons["water-cycle-primary-action"].isHittable)
         XCTAssertTrue(app.buttons["water-cycle-replay-prompt"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.buttons["water-cycle-reset"].waitForExistence(timeout: 5))
+    }
+
+
+    private func advanceStoryAnchorIfPresent(_ app: XCUIApplication) {
+        let startBuilding = app.buttons["story-anchor-start-button"]
+        if startBuilding.waitForExistence(timeout: 3) {
+            startBuilding.tap()
+        }
+    }
+
+    private func launchBondBlastFinale(target: Int) -> XCUIApplication {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.motionControlsEnabled", "NO",
+            "-feature.soundReactionEnabled", "NO",
+            "-feature.testModeEnabled", "YES",
+            "-uiTest.startRoute", "bondBlast",
+            "-uiTest.bondBlastTarget", "\(target)"
+        ]
+        app.launch()
+        return app
     }
 
     private func configureRoomQuestSetupViaManualFallback(_ app: XCUIApplication) {


### PR DESCRIPTION
## Summary
- adds focused compact/iPad UX regression tests for issue #987 coverage gaps from review #984
- adds a UI-test start route for deterministic Bond Blast target-12 reachability coverage
- adds fresh-default coverage that clap/sound reaction stays off until parent opt-in

## Validation
- ✅ git diff --check
- ⚠️ xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'id=3A1BD382-28BD-4285-83B4-B6913DF496C4' -only-testing:MatherTests/FeatureFlagTests/freshDefaultsKeepClapReactionOffUntilParentOptIn CODE_SIGNING_ALLOWED=NO
  - blocked before executing tests by existing app-target build errors on origin/main: Cannot find type 'CardReviewResult' in scope; Cannot find 'CardReviewScheduler' in scope; Cannot find 'CardProgress' in scope; Cannot find 'KidProfileStore' in scope

Links #987
Refs #984