### PR TITLE
fix: add Compass Walk step fallback

### DIFF
--- a/Features/CompassAngles/CompassAnglesView.swift
+++ b/Features/CompassAngles/CompassAnglesView.swift
@@ -154,6 +154,7 @@ struct CompassAnglesView: View {
     @State private var sessionStart: Date = .now
     @State private var showDegreeLabel: Bool = false
     @State private var showTurnFallback: Bool = false
+    @State private var turnFallbackTask: Task<Void, Never>?
 
     private var level: CompassWalkTurnLevel { compassWalkTurnLevels[levelIndex % compassWalkTurnLevels.count] }
     private var currentYaw: Double { appModel.motionService.relativeYaw }
@@ -186,6 +187,7 @@ struct CompassAnglesView: View {
             appModel.motionService.startUpdates()
         }
         .onDisappear {
+            turnFallbackTask?.cancel()
             appModel.stepCountService.stop()
             appModel.motionService.stopRelativeYawTracking()
             appModel.motionService.stopUpdates()
@@ -533,12 +535,23 @@ struct CompassAnglesView: View {
     private func beginWalkPhase() {
         phase = .walking
         showDegreeLabel = false
+        turnFallbackTask?.cancel()
         appModel.motionService.stopRelativeYawTracking()
         stepService.start(requiredSteps: level.steps)
         appModel.speechService.speak(
             "Clear space. Walk \(level.steps) small careful steps \(level.walkDirection.title). No running.",
             enabled: appModel.featureFlags.audioEnabled
         )
+    }
+
+    private func scheduleTurnFallbackIfNeeded() {
+        turnFallbackTask?.cancel()
+        turnFallbackTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(3))
+            if !Task.isCancelled, phase == .turning, !appModel.motionService.relativeYawResponsive {
+                showTurnFallback = true
+            }
+        }
     }
 
     private func checkWalkProgress() {
@@ -550,18 +563,14 @@ struct CompassAnglesView: View {
         appModel.motionService.startRelativeYawTracking()
         appModel.hapticsService.success(enabled: appModel.featureFlags.hapticsEnabled)
         appModel.speechService.speak(level.turnHint, enabled: appModel.featureFlags.audioEnabled)
-        Task { @MainActor in
-            try? await Task.sleep(for: .seconds(3))
-            if phase == .turning, !appModel.motionService.relativeYawResponsive {
-                showTurnFallback = true
-            }
-        }
+        scheduleTurnFallbackIfNeeded()
     }
 
     private func checkSnap(yaw: Double) {
         guard phase == .turning else { return }
         showDegreeLabel = true
         if CompassMath.isInSnapZone(yaw: yaw, target: level.targetDeg) {
+            turnFallbackTask?.cancel()
             phase = .success
             wonCount += 1
             appModel.hapticsService.success(enabled: appModel.featureFlags.hapticsEnabled)
@@ -581,6 +590,7 @@ struct CompassAnglesView: View {
         phase = .ready
         showDegreeLabel = false
         showTurnFallback = false
+        turnFallbackTask?.cancel()
         stepService.stop()
         appModel.motionService.stopRelativeYawTracking()
     }

--- a/Services/StepCountService.swift
+++ b/Services/StepCountService.swift
@@ -2,6 +2,9 @@ import CoreMotion
 import Foundation
 import Observation
 
+typealias PedometerUpdateHandler = (CMPedometerData?, Error?) -> Void
+typealias PedometerUpdatesStarter = (Date, @escaping PedometerUpdateHandler) -> Void
+
 /// Pure, testable progress helper for small-step walking challenges.
 struct StepWalkProgress: Equatable {
     let requiredSteps: Int
@@ -37,17 +40,31 @@ enum StepCountMode: Equatable {
 @Observable
 final class StepCountService {
     nonisolated(unsafe) private let pedometer: CMPedometer
+    private let stepCountingAvailable: () -> Bool
+    private let startPedometerUpdates: PedometerUpdatesStarter
+    private let noStepUpdateFallbackDelay: Duration
+    private var noStepUpdateFallbackTask: Task<Void, Never>?
     private var startDate: Date?
 
     private(set) var progress = StepWalkProgress(requiredSteps: 1)
     private(set) var mode: StepCountMode = .idle
 
-    init(pedometer: CMPedometer = CMPedometer()) {
+    init(
+        pedometer: CMPedometer = CMPedometer(),
+        stepCountingAvailable: @escaping () -> Bool = { CMPedometer.isStepCountingAvailable() },
+        startPedometerUpdates: PedometerUpdatesStarter? = nil,
+        noStepUpdateFallbackDelay: Duration = .seconds(3)
+    ) {
         self.pedometer = pedometer
+        self.stepCountingAvailable = stepCountingAvailable
+        self.startPedometerUpdates = startPedometerUpdates ?? { date, handler in
+            pedometer.startUpdates(from: date, withHandler: handler)
+        }
+        self.noStepUpdateFallbackDelay = noStepUpdateFallbackDelay
     }
 
     var isStepCountingAvailable: Bool {
-        CMPedometer.isStepCountingAvailable()
+        stepCountingAvailable()
     }
 
     var isComplete: Bool { progress.isComplete }
@@ -65,27 +82,35 @@ final class StepCountService {
         }
 
         mode = .pedometer
-        pedometer.startUpdates(from: startDate ?? Date()) { [weak self] data, error in
+        scheduleNoStepUpdateFallback()
+        startPedometerUpdates(startDate ?? Date()) { [weak self] data, error in
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 if error != nil {
-                    self.pedometer.stopUpdates()
-                    self.mode = .manualFallback(reason: "Motion permission was not available. Tap each small step instead.")
+                    self.useManualFallback(reason: "Motion permission was not available. Tap each small step instead.")
                     return
                 }
                 guard let data else { return }
                 self.progress.setCountedSteps(data.numberOfSteps.intValue)
+                if self.progress.countedSteps > 0 {
+                    self.noStepUpdateFallbackTask?.cancel()
+                    self.noStepUpdateFallbackTask = nil
+                }
             }
         }
     }
 
     func stop() {
+        noStepUpdateFallbackTask?.cancel()
+        noStepUpdateFallbackTask = nil
         pedometer.stopUpdates()
         startDate = nil
         mode = .idle
     }
 
     func useManualFallback(reason: String = "Tap after each small careful step.") {
+        noStepUpdateFallbackTask?.cancel()
+        noStepUpdateFallbackTask = nil
         pedometer.stopUpdates()
         mode = .manualFallback(reason: reason)
     }
@@ -102,5 +127,16 @@ final class StepCountService {
     // Exposed for tests and previews so no hardware/permission is required.
     func applyCountedSteps(_ steps: Int) {
         progress.setCountedSteps(steps)
+    }
+
+    private func scheduleNoStepUpdateFallback() {
+        noStepUpdateFallbackTask?.cancel()
+        let delay = noStepUpdateFallbackDelay
+        noStepUpdateFallbackTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled, let self else { return }
+            guard case .pedometer = self.mode, self.progress.countedSteps == 0 else { return }
+            self.useManualFallback(reason: "If step sensing does not start, tap after each small careful step.")
+        }
     }
 }

--- a/Tests/MatherTests/CompassAnglesTests.swift
+++ b/Tests/MatherTests/CompassAnglesTests.swift
@@ -193,4 +193,29 @@ struct CompassWalkTurnTests {
         service.stop()
         #expect(service.mode == .idle)
     }
+
+    @MainActor
+    @Test func stepCountServiceFallsBackWhenPedometerProducesNoUpdates() async {
+        let service = StepCountService(
+            stepCountingAvailable: { true },
+            startPedometerUpdates: { _, _ in },
+            noStepUpdateFallbackDelay: .milliseconds(10)
+        )
+
+        service.start(requiredSteps: 2)
+        #expect(service.mode == .pedometer)
+
+        try? await Task.sleep(for: .milliseconds(30))
+
+        if case .manualFallback(let reason) = service.mode {
+            #expect(reason.contains("step sensing does not start"))
+        } else {
+            Issue.record("Expected no-update pedometer start to fall back to manual mode")
+        }
+
+        service.addManualStep()
+        service.addManualStep()
+        #expect(service.isComplete)
+        service.stop()
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a service-level no-update timeout for Compass Walk step counting so a silent `CMPedometer` start falls back to tap-count mode instead of leaving the child stuck at `0 / N` steps.
- Makes the Compass Walk turn fallback task cancellable across phase transitions/disappear, tightening the #1000 async fallback path.
- Adds a deterministic async regression test for pedometer-start-with-no-updates fallback.

## Validation
- `git diff --check` passed.
- Focused worker typechecked `StepCountService.swift` directly on ganesh-mba with the iOS simulator SDK.
- Targeted `xcodebuild test -only-testing:MatherTests/CompassWalkTurnTests` is currently blocked by an unrelated Swift frontend crash while typechecking `Features/ParentSummary/SettingsView.swift`.

Fixes #1001