### PR TITLE
fix: refine build 92 feedback flows

### DIFF
--- a/Domain/GameplayThreadContent+Shapes.swift
+++ b/Domain/GameplayThreadContent+Shapes.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension GameplayThreadCatalog {
-    /// Basic shape names thread (circle, triangle, square, rectangle, oval, diamond, star, heart).
+    /// Shape names thread with child-friendly core and enriched geometry shapes.
     /// Replaces the System-A ShapeGeometryContent / LearningCardIntroView pipeline so all
     /// subject-card threads share the single GameplayThreadView infrastructure.
     static let shapes: GameplayThreadDefinition = GameplayThreadDefinition(
@@ -19,44 +19,64 @@ extension GameplayThreadCatalog {
         ],
         entities: [
             GameplayEntity(id: "shape-circle", name: "Circle", summary: "Round with no corners or sides.", visualKey: "●", properties: [
-                GameplayProperty(id: "shape-circle-name",  typeID: "name",  value: "Circle",          explanation: "Circle is this shape's name.",                  visualKey: "●"),
+                GameplayProperty(id: "shape-circle-name",  typeID: "name",  value: "Circle",          explanation: "Circle is this shape's name.",                  visualKey: "Aa"),
                 GameplayProperty(id: "shape-circle-clue",  typeID: "clue",  value: "Round, no corners", explanation: "A circle is round with no corners."),
                 GameplayProperty(id: "shape-circle-sides", typeID: "sides", value: "0 sides",          explanation: "A circle has no straight sides."),
             ]),
             GameplayEntity(id: "shape-triangle", name: "Triangle", summary: "Three sides and three corners.", visualKey: "▲", properties: [
-                GameplayProperty(id: "shape-triangle-name",  typeID: "name",  value: "Triangle",       explanation: "Triangle is this shape's name.",                 visualKey: "▲"),
+                GameplayProperty(id: "shape-triangle-name",  typeID: "name",  value: "Triangle",       explanation: "Triangle is this shape's name.",                 visualKey: "Aa"),
                 GameplayProperty(id: "shape-triangle-clue",  typeID: "clue",  value: "3 corners",      explanation: "A triangle has three corners."),
                 GameplayProperty(id: "shape-triangle-sides", typeID: "sides", value: "3 sides",        explanation: "A triangle has three straight sides."),
             ]),
             GameplayEntity(id: "shape-square", name: "Square", summary: "Four equal sides and four square corners.", visualKey: "■", properties: [
-                GameplayProperty(id: "shape-square-name",  typeID: "name",  value: "Square",           explanation: "Square is this shape's name.",                   visualKey: "■"),
+                GameplayProperty(id: "shape-square-name",  typeID: "name",  value: "Square",           explanation: "Square is this shape's name.",                   visualKey: "Aa"),
                 GameplayProperty(id: "shape-square-clue",  typeID: "clue",  value: "4 equal sides",    explanation: "All four sides of a square are the same length."),
                 GameplayProperty(id: "shape-square-sides", typeID: "sides", value: "4 sides",          explanation: "A square has four straight sides."),
             ]),
             GameplayEntity(id: "shape-rectangle", name: "Rectangle", summary: "Four square corners, opposite sides matching.", visualKey: "▭", properties: [
-                GameplayProperty(id: "shape-rectangle-name",  typeID: "name",  value: "Rectangle",      explanation: "Rectangle is this shape's name.",                visualKey: "▭"),
+                GameplayProperty(id: "shape-rectangle-name",  typeID: "name",  value: "Rectangle",      explanation: "Rectangle is this shape's name.",                visualKey: "Aa"),
                 GameplayProperty(id: "shape-rectangle-clue",  typeID: "clue",  value: "Long box",       explanation: "A rectangle is like a stretched square."),
                 GameplayProperty(id: "shape-rectangle-sides", typeID: "sides", value: "4 sides",        explanation: "A rectangle has four straight sides."),
             ]),
             GameplayEntity(id: "shape-oval", name: "Oval", summary: "Stretched like an egg, no corners.", visualKey: "⬭", properties: [
-                GameplayProperty(id: "shape-oval-name",  typeID: "name",  value: "Oval",               explanation: "Oval is this shape's name.",                     visualKey: "⬭"),
+                GameplayProperty(id: "shape-oval-name",  typeID: "name",  value: "Oval",               explanation: "Oval is this shape's name.",                     visualKey: "Aa"),
                 GameplayProperty(id: "shape-oval-clue",  typeID: "clue",  value: "Egg shape",          explanation: "An oval is round and stretched like an egg."),
                 GameplayProperty(id: "shape-oval-sides", typeID: "sides", value: "0 sides",            explanation: "An oval has no straight sides."),
             ]),
             GameplayEntity(id: "shape-diamond", name: "Diamond", summary: "A square turned onto a point.", visualKey: "◆", properties: [
-                GameplayProperty(id: "shape-diamond-name",  typeID: "name",  value: "Diamond",          explanation: "Diamond is this shape's name.",                  visualKey: "◆"),
+                GameplayProperty(id: "shape-diamond-name",  typeID: "name",  value: "Diamond",          explanation: "Diamond is this shape's name.",                  visualKey: "Aa"),
                 GameplayProperty(id: "shape-diamond-clue",  typeID: "clue",  value: "Point on top",     explanation: "A diamond sits with a point at top and bottom."),
                 GameplayProperty(id: "shape-diamond-sides", typeID: "sides", value: "4 sides",          explanation: "A diamond has four straight sides."),
             ]),
             GameplayEntity(id: "shape-star", name: "Star", summary: "Points reaching out from the middle.", visualKey: "★", properties: [
-                GameplayProperty(id: "shape-star-name",  typeID: "name",  value: "Star",               explanation: "Star is this shape's name.",                     visualKey: "★"),
+                GameplayProperty(id: "shape-star-name",  typeID: "name",  value: "Star",               explanation: "Star is this shape's name.",                     visualKey: "Aa"),
                 GameplayProperty(id: "shape-star-clue",  typeID: "clue",  value: "Points out",         explanation: "A star has sharp points reaching outward."),
                 GameplayProperty(id: "shape-star-sides", typeID: "sides", value: "5+ points",          explanation: "A star has five or more pointed tips."),
             ]),
             GameplayEntity(id: "shape-heart", name: "Heart", summary: "Two bumps on top and one point below.", visualKey: "♥", properties: [
-                GameplayProperty(id: "shape-heart-name",  typeID: "name",  value: "Heart",             explanation: "Heart is this shape's name.",                    visualKey: "♥"),
+                GameplayProperty(id: "shape-heart-name",  typeID: "name",  value: "Heart",             explanation: "Heart is this shape's name.",                    visualKey: "Aa"),
                 GameplayProperty(id: "shape-heart-clue",  typeID: "clue",  value: "2 bumps, 1 point",  explanation: "A heart has two bumps at the top and a point at the bottom."),
                 GameplayProperty(id: "shape-heart-sides", typeID: "sides", value: "Curved",            explanation: "A heart is made of curved lines, not straight sides."),
+            ]),
+            GameplayEntity(id: "shape-pentagon", name: "Pentagon", summary: "Five straight sides like a little house outline.", visualKey: "⬟", properties: [
+                GameplayProperty(id: "shape-pentagon-name",  typeID: "name",  value: "Pentagon",          explanation: "Pentagon is this shape's name.",                 visualKey: "Aa"),
+                GameplayProperty(id: "shape-pentagon-clue",  typeID: "clue",  value: "House outline",     explanation: "A pentagon can look like a house with a roof."),
+                GameplayProperty(id: "shape-pentagon-sides", typeID: "sides", value: "5 sides",           explanation: "A pentagon has five straight sides."),
+            ]),
+            GameplayEntity(id: "shape-hexagon", name: "Hexagon", summary: "Six straight sides like a honeycomb cell.", visualKey: "⬢", properties: [
+                GameplayProperty(id: "shape-hexagon-name",  typeID: "name",  value: "Hexagon",           explanation: "Hexagon is this shape's name.",                  visualKey: "Aa"),
+                GameplayProperty(id: "shape-hexagon-clue",  typeID: "clue",  value: "Honeycomb",         explanation: "Honeycomb cells are often hexagons."),
+                GameplayProperty(id: "shape-hexagon-sides", typeID: "sides", value: "6 sides",           explanation: "A hexagon has six straight sides."),
+            ]),
+            GameplayEntity(id: "shape-crescent", name: "Crescent", summary: "A curved moon shape with two pointy tips.", visualKey: "☾", properties: [
+                GameplayProperty(id: "shape-crescent-name",  typeID: "name",  value: "Crescent",          explanation: "Crescent is this shape's name.",                 visualKey: "Aa"),
+                GameplayProperty(id: "shape-crescent-clue",  typeID: "clue",  value: "Moon curve",        explanation: "A crescent looks like a thin moon."),
+                GameplayProperty(id: "shape-crescent-sides", typeID: "sides", value: "Curved",            explanation: "A crescent is made from curved lines."),
+            ]),
+            GameplayEntity(id: "shape-trapezoid", name: "Trapezoid", summary: "Four sides with one pair of opposite sides parallel.", visualKey: "▰", properties: [
+                GameplayProperty(id: "shape-trapezoid-name",  typeID: "name",  value: "Trapezoid",        explanation: "Trapezoid is this shape's name.",               visualKey: "Aa"),
+                GameplayProperty(id: "shape-trapezoid-clue",  typeID: "clue",  value: "Table top",        explanation: "A trapezoid can look like a table top or ramp."),
+                GameplayProperty(id: "shape-trapezoid-sides", typeID: "sides", value: "4 sides",          explanation: "A trapezoid has four straight sides."),
             ]),
         ],
         stages: [
@@ -65,7 +85,7 @@ extension GameplayThreadCatalog {
                 kind: .flashcards,
                 title: "Shape Names",
                 prompt: "Meet each shape and its name.",
-                maximumItemCount: 8
+                maximumItemCount: 12
             ),
             GameplayStageDefinition(
                 id: "shapes-easy-memory",
@@ -73,7 +93,7 @@ extension GameplayThreadCatalog {
                 title: "Name Match",
                 prompt: "Match each shape to its clue.",
                 propertyTypeIDs: ["name", "clue"],
-                maximumItemCount: 6
+                maximumItemCount: 8
             ),
             GameplayStageDefinition(
                 id: "shapes-bond-blast",
@@ -81,7 +101,7 @@ extension GameplayThreadCatalog {
                 title: "Shape Blast",
                 prompt: "Connect shapes, names, and clues.",
                 propertyTypeIDs: ["name", "clue", "sides"],
-                maximumItemCount: 6
+                maximumItemCount: 9
             ),
         ]
     )

--- a/Features/GameplayStages/BondBlastStageView.swift
+++ b/Features/GameplayStages/BondBlastStageView.swift
@@ -42,6 +42,8 @@ struct ReusableBondBlastBoard: View {
     let onComplete: (Int, Int, Int) -> Void
 
     @State private var mismatchedRightID: String?
+    @State private var autoProgressTask: Task<Void, Never>?
+    @State private var autoProgressSignature: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 12 : 18) {
@@ -78,6 +80,10 @@ struct ReusableBondBlastBoard: View {
 
             progressDots
 
+            if autoProgressSignature != nil {
+                GameplayMatchRewardBanner(text: viewModel.canAdvanceTurn ? "Great matches! Next turn is coming…" : "Great matches! Your reward is coming…")
+            }
+
             if let item = viewModel.inspectedItem, shouldShowDetail(for: item) {
                 GameplayBondBlastDetailCallout(item: item, compact: compact)
             }
@@ -87,18 +93,60 @@ struct ReusableBondBlastBoard: View {
                     .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
                 Spacer()
                 if viewModel.canAdvanceTurn {
-                    Button("Next turn") { viewModel.advanceTurn() }
-                        .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
+                    Button("Next turn") {
+                        cancelAutoProgress()
+                        viewModel.advanceTurn()
+                    }
+                    .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
                 } else {
-                    Button("Finish stage") { onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount) }
-                        .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
-                        .disabled(!viewModel.isComplete)
+                    Button("Finish stage") {
+                        cancelAutoProgress()
+                        onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount)
+                    }
+                    .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
+                    .disabled(!viewModel.isComplete)
                 }
             }
         }
         .padding(compact ? 14 : 20)
         .background(GameplayStagePanel())
         .accessibilityLabel("\(title). \(viewModel.correctCount) of \(viewModel.pairs.count) bonds matched.")
+        .onDisappear { cancelAutoProgress() }
+    }
+
+
+    private func scheduleAutoProgressIfReady() {
+        let signature: String?
+        if viewModel.canAdvanceTurn {
+            signature = "turn-\(viewModel.activeTurnIndex)-\(viewModel.correctCount)"
+        } else if viewModel.isComplete {
+            signature = "complete-\(viewModel.correctCount)"
+        } else {
+            signature = nil
+        }
+        guard let signature else { return }
+        guard autoProgressSignature != signature else { return }
+        cancelAutoProgress()
+        autoProgressSignature = signature
+        autoProgressTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(1_200))
+            guard autoProgressSignature == signature else { return }
+            if viewModel.canAdvanceTurn {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
+                    viewModel.advanceTurn()
+                }
+            } else if viewModel.isComplete {
+                onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount)
+            }
+            autoProgressSignature = nil
+            autoProgressTask = nil
+        }
+    }
+
+    private func cancelAutoProgress() {
+        autoProgressTask?.cancel()
+        autoProgressTask = nil
+        autoProgressSignature = nil
     }
 
     private var instructionText: String {
@@ -155,9 +203,7 @@ struct ReusableBondBlastBoard: View {
                 actions.failure()
                 triggerMismatch(for: item.id)
             }
-            if viewModel.isComplete {
-                onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount)
-            }
+            scheduleAutoProgressIfReady()
         } label: {
             GameplayDisplayCard(
                 item: item,

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -233,6 +233,26 @@ private struct CountryMapSilhouette: Shape {
     }
 }
 
+struct GameplayMatchRewardBanner: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text("★")
+                .font(.title3.bold())
+                .foregroundStyle(MatherTheme.warm)
+            Text(text)
+                .font(.subheadline.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(Capsule().fill(MatherTheme.warm.opacity(0.24)))
+        .accessibilityElement(children: .combine)
+    }
+}
+
 struct GameplayPairingStageShell: View {
     let title: String
     let prompt: String
@@ -240,6 +260,9 @@ struct GameplayPairingStageShell: View {
     @Binding var viewModel: GameplayMatchStageViewModel
     let actions: GameplayStageFeedbackActions
     let onComplete: (Int, Int, Int) -> Void
+
+    @State private var autoProgressTask: Task<Void, Never>?
+    @State private var autoProgressSignature: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 12 : 18) {
@@ -268,7 +291,7 @@ struct GameplayPairingStageShell: View {
                         let correct = viewModel.chooseRight(item)
                         if correct { actions.success() }
                         else if wasMatching { actions.failure() }
-                        if viewModel.isComplete { onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount) }
+                        scheduleAutoProgressIfReady()
                     } label: {
                         GameplayDisplayCard(
                             item: item,
@@ -284,6 +307,9 @@ struct GameplayPairingStageShell: View {
                     .accessibilityLabel(viewModel.accessibilityLabel(for: item, side: .right))
                 }
             }
+            if autoProgressSignature != nil {
+                GameplayMatchRewardBanner(text: viewModel.canAdvanceTurn ? "Great matches! Next turn is coming…" : "Great matches! Your reward is coming…")
+            }
             if let item = viewModel.inspectedItem, !viewModel.shouldConcealRight(item) {
                 GameplayCardDetailCallout(item: item, compact: compact)
             }
@@ -292,17 +318,58 @@ struct GameplayPairingStageShell: View {
                     .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
                 Spacer()
                 if viewModel.canAdvanceTurn {
-                    Button("Next turn") { viewModel.advanceTurn() }
-                        .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
+                    Button("Next turn") {
+                        cancelAutoProgress()
+                        viewModel.advanceTurn()
+                    }
+                    .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
                 } else {
-                    Button("Finish stage") { onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount) }
-                        .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
-                        .disabled(!viewModel.isComplete)
+                    Button("Finish stage") {
+                        cancelAutoProgress()
+                        onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount)
+                    }
+                    .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: compact))
+                    .disabled(!viewModel.isComplete)
                 }
             }
         }
         .padding(compact ? 14 : 20)
         .background(GameplayStagePanel())
+        .onDisappear { cancelAutoProgress() }
+    }
+
+    private func scheduleAutoProgressIfReady() {
+        let signature: String?
+        if viewModel.canAdvanceTurn {
+            signature = "turn-\(viewModel.activeTurnIndex)-\(viewModel.correctCount)"
+        } else if viewModel.isComplete {
+            signature = "complete-\(viewModel.correctCount)"
+        } else {
+            signature = nil
+        }
+        guard let signature else { return }
+        guard autoProgressSignature != signature else { return }
+        cancelAutoProgress()
+        autoProgressSignature = signature
+        autoProgressTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(1_200))
+            guard autoProgressSignature == signature else { return }
+            if viewModel.canAdvanceTurn {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.75)) {
+                    viewModel.advanceTurn()
+                }
+            } else if viewModel.isComplete {
+                onComplete(viewModel.correctCount, viewModel.mismatchCount, viewModel.hintCount)
+            }
+            autoProgressSignature = nil
+            autoProgressTask = nil
+        }
+    }
+
+    private func cancelAutoProgress() {
+        autoProgressTask?.cancel()
+        autoProgressTask = nil
+        autoProgressSignature = nil
     }
 
     private var columns: [GridItem] {

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -15,12 +15,7 @@ struct HomeView: View {
                         .foregroundStyle(MatherTheme.ink)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
-                    makeAndBreakCard
-
-                    HStack(alignment: .top, spacing: ResponsiveLayout.isWide(horizontalSizeClass) ? 20 : 14) {
-                        labsCard
-                        gamesCard
-                    }
+                    childLauncherGrid
 
                     HStack(spacing: 14) {
                         Button("Parent Summary") {
@@ -43,271 +38,82 @@ struct HomeView: View {
         }
     }
 
-    // MARK: - Make & Break card
+    // MARK: - Child launcher
 
-    private var makeAndBreakCard: some View {
-        Button {
-            appModel.pickProfileThenRun { appModel.engine.showSessionConfig() }
-        } label: {
-            VStack(spacing: 0) {
-                ZStack {
-                    LinearGradient(
-                        colors: [MatherTheme.warm, MatherTheme.accent],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-
-                    HStack(spacing: 16) {
-                        // Mini ten-frame preview
-                        VStack(spacing: 5) {
-                            ForEach(0..<2, id: \.self) { row in
-                                HStack(spacing: 5) {
-                                    ForEach(0..<5, id: \.self) { col in
-                                        let idx = row * 5 + col
-                                        Circle()
-                                            .fill(idx < 7 ? Color.white : Color.white.opacity(0.3))
-                                            .frame(width: 18, height: 18)
-                                    }
-                                }
-                            }
-                        }
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Make & Break")
-                                .font(.title3.weight(.black))
-                                .foregroundStyle(.white)
-                            Text("Targets")
-                                .font(.system(size: 36, weight: .black, design: .rounded))
-                                .foregroundStyle(.white)
-                        }
-                        .layoutPriority(1)
-
-                        Spacer()
-                    }
-                    .padding(20)
-                }
-                .frame(height: 110)
-                .clipShape(
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: 20, bottomLeadingRadius: 0,
-                        bottomTrailingRadius: 0, topTrailingRadius: 20,
-                        style: .continuous
-                    )
-                )
-
-                HStack {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Ready to play?")
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                        Text("Tap to start a session")
-                            .font(.headline.weight(.bold))
-                            .foregroundStyle(MatherTheme.ink)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    Spacer()
-                    Image(systemName: "play.circle.fill")
-                        .font(.system(size: 44))
-                        .foregroundStyle(MatherTheme.accent)
-                }
-                .padding(.horizontal, 20)
-                .padding(.vertical, 16)
-                .background(MatherTheme.card)
-                .clipShape(
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: 0, bottomLeadingRadius: 20,
-                        bottomTrailingRadius: 20, topTrailingRadius: 0,
-                        style: .continuous
-                    )
-                )
+    private var childLauncherGrid: some View {
+        LazyVGrid(columns: childLauncherColumns, spacing: ResponsiveLayout.isWide(horizontalSizeClass) ? 20 : 14) {
+            childLauncherTile(
+                title: "Targets",
+                icon: "circle.grid.2x2.fill",
+                gradient: [MatherTheme.warm, MatherTheme.accent],
+                accessibilityIdentifier: "Play"
+            ) {
+                appModel.pickProfileThenRun { appModel.engine.showSessionConfig() }
             }
+            childLauncherTile(
+                title: "Labs",
+                icon: "sparkles.rectangle.stack.fill",
+                gradient: [MatherTheme.softBlue, MatherTheme.coral.opacity(0.8)],
+                accessibilityIdentifier: "ExplorerLab"
+            ) {
+                appModel.engine.showLab()
+            }
+            childLauncherTile(
+                title: "Games",
+                icon: "gamecontroller.fill",
+                gradient: [MatherTheme.warm, MatherTheme.accent.opacity(0.85)],
+                accessibilityIdentifier: "GamesEntry"
+            ) {
+                appModel.engine.showLabGames()
+            }
+        }
+    }
+
+    private var childLauncherColumns: [GridItem] {
+        let spacing: CGFloat = ResponsiveLayout.isWide(horizontalSizeClass) ? 20 : 12
+        return Array(repeating: GridItem(.flexible(minimum: 88), spacing: spacing), count: 3)
+    }
+
+    private func childLauncherTile(
+        title: String,
+        icon: String,
+        gradient: [Color],
+        accessibilityIdentifier: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            VStack(spacing: 14) {
+                Image(systemName: icon)
+                    .font(.system(size: 42, weight: .black, design: .rounded))
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(.white)
+                    .frame(width: 76, height: 76)
+                    .background(Circle().fill(.white.opacity(0.18)))
+                Text(title)
+                    .font(.system(size: 26, weight: .black, design: .rounded))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: ResponsiveLayout.isWide(horizontalSizeClass) ? 190 : 156)
+            .padding(.horizontal, 12)
+            .background(
+                LinearGradient(colors: gradient, startPoint: .topLeading, endPoint: .bottomTrailing)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
             .overlay(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
                     .strokeBorder(.white.opacity(colorScheme == .dark ? 0.08 : 0), lineWidth: 1)
             )
             .shadow(
-                color: colorScheme == .dark ? MatherTheme.coral.opacity(0.12) : .black.opacity(0.08),
+                color: colorScheme == .dark ? gradient.first?.opacity(0.12) ?? .clear : .black.opacity(0.08),
                 radius: colorScheme == .dark ? 18 : 12,
                 y: colorScheme == .dark ? 8 : 5
             )
         }
         .buttonStyle(.plain)
-        .frame(maxWidth: .infinity)
-        .accessibilityIdentifier("Play")
-    }
-
-    private var lockedActivityCard: some View {
-        CardSurface {
-            VStack(alignment: .leading, spacing: 14) {
-                Text("Make & Break")
-                    .font(.title2.weight(.bold))
-                Text("Enable the activity in Settings before handing the iPad to your child.")
-                    .font(.headline)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-    }
-
-    // MARK: - Labs and Games cards
-
-    private var labsCard: some View {
-        explorerEntryCard(
-            title: "Labs",
-            subtitle: "Subject streams",
-            detail: "Numbers · Geometry · Physics",
-            emoji: "🔬",
-            symbolName: "sparkles.rectangle.stack.fill",
-            gradient: [MatherTheme.softBlue, MatherTheme.coral.opacity(0.8)],
-            accent: MatherTheme.softBlue,
-            accessibilityIdentifier: "ExplorerLab"
-        ) {
-            appModel.engine.showLab()
-        }
-    }
-
-    private var gamesCard: some View {
-        explorerEntryCard(
-            title: "Games",
-            subtitle: "One-tap play",
-            detail: "Launch games directly",
-            emoji: "🎮",
-            symbolName: "gamecontroller.fill",
-            gradient: [MatherTheme.warm, MatherTheme.accent.opacity(0.85)],
-            accent: MatherTheme.warm,
-            accessibilityIdentifier: "GamesEntry"
-        ) {
-            appModel.engine.showLabGames()
-        }
-    }
-
-    private func explorerEntryCard(
-        title: String,
-        subtitle: String,
-        detail: String,
-        emoji: String,
-        symbolName: String,
-        gradient: [Color],
-        accent: Color,
-        accessibilityIdentifier: String,
-        action: @escaping () -> Void
-    ) -> some View {
-        HomeExplorerEntryCard(
-            title: title,
-            subtitle: subtitle,
-            detail: detail,
-            emoji: emoji,
-            symbolName: symbolName,
-            gradient: gradient,
-            accent: accent,
-            accessibilityIdentifier: accessibilityIdentifier,
-            isDark: colorScheme == .dark,
-            action: action
-        )
-    }
-
-}
-
-private struct HomeExplorerEntryCard: View {
-    let title: String
-    let subtitle: String
-    let detail: String
-    let emoji: String
-    let symbolName: String
-    let gradient: [Color]
-    let accent: Color
-    let accessibilityIdentifier: String
-    let isDark: Bool
-    let action: () -> Void
-
-    private var destinationLabel: String {
-        title == "Labs" ? "Open subject picker" : "Open game launcher"
-    }
-
-    private var accessibilityCopy: String {
-        title == "Labs" ? "Open Labs subject streams" : "Open Games direct launcher"
-    }
-
-    var body: some View {
-        Button(action: action) {
-            VStack(spacing: 0) {
-                header
-                footer
-            }
-            .overlay(
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .strokeBorder(.white.opacity(isDark ? 0.08 : 0), lineWidth: 1)
-            )
-            .shadow(
-                color: isDark ? accent.opacity(0.12) : .black.opacity(0.08),
-                radius: isDark ? 18 : 12,
-                y: isDark ? 8 : 5
-            )
-        }
-        .buttonStyle(.plain)
-        .frame(maxWidth: .infinity)
         .accessibilityIdentifier(accessibilityIdentifier)
-        .accessibilityLabel(accessibilityCopy)
-    }
-
-    private var header: some View {
-        ZStack {
-            LinearGradient(colors: gradient, startPoint: .topLeading, endPoint: .bottomTrailing)
-
-            HStack(spacing: 12) {
-                Text(emoji)
-                    .font(.system(size: 42))
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(.title3.weight(.black))
-                        .foregroundStyle(.white)
-                    Text(subtitle)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.white.opacity(0.85))
-                }
-                .layoutPriority(1)
-
-                Spacer(minLength: 0)
-            }
-            .padding(18)
-        }
-        .frame(height: 104)
-        .clipShape(
-            UnevenRoundedRectangle(
-                topLeadingRadius: 20, bottomLeadingRadius: 0,
-                bottomTrailingRadius: 0, topTrailingRadius: 20,
-                style: .continuous
-            )
-        )
-    }
-
-    private var footer: some View {
-        HStack(spacing: 10) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(detail)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                Text(destinationLabel)
-                    .font(.headline.weight(.bold))
-                    .foregroundStyle(MatherTheme.ink)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer(minLength: 0)
-            Image(systemName: symbolName)
-                .font(.system(size: 32, weight: .black))
-                .foregroundStyle(accent)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .background(MatherTheme.card)
-        .clipShape(
-            UnevenRoundedRectangle(
-                topLeadingRadius: 0, bottomLeadingRadius: 20,
-                bottomTrailingRadius: 20, topTrailingRadius: 0,
-                style: .continuous
-            )
-        )
+        .accessibilityLabel(title)
     }
 }

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -70,4 +70,26 @@ struct GameplayThreadContentTests {
             #expect(question.choices.allSatisfy { !$0.title.isEmpty })
         }
     }
+
+    @Test
+    func shapeThreadAddsRicherCardsAndNameCardsUseNeutralVisuals() throws {
+        let thread = GameplayThreadCatalog.shapes
+
+        #expect(thread.entities.count >= 12)
+        #expect(Set(thread.entities.map(\.name)).isSuperset(of: ["Pentagon", "Hexagon", "Crescent", "Trapezoid"]))
+
+        let nameStage = try #require(thread.stages.first { $0.id == "shapes-easy-memory" })
+        let nameItems = thread.entities.prefix(4).compactMap { entity -> GameplayRoundItem? in
+            guard let property = entity.properties.first(where: { $0.typeID == "name" }) else { return nil }
+            return GameplayRoundItem(id: "\(entity.id)::\(property.id)", entityID: entity.id, propertyID: property.id, propertyTypeID: property.typeID)
+        }
+        let round = GameplayRoundDefinition(id: "shape-names-test", stageID: nameStage.id, kind: nameStage.kind, items: nameItems, seed: 1006)
+        let namePairs = GameplayStageContentBuilder.matchPairs(thread: thread, round: round)
+
+        #expect(namePairs.count == 4)
+        #expect(namePairs.allSatisfy { $0.right.subtitle == "Name" })
+        #expect(namePairs.allSatisfy { $0.right.visualKey != $0.left.visualKey })
+        #expect(nameStage.maximumItemCount >= 8)
+    }
+
 }

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -239,7 +239,7 @@ extension LearningLoopTests {
         let thread = GameplayThreadCatalog.shapes
         let names = Set(thread.entities.map(\.name))
         XCTAssertTrue(names.isSuperset(of: ["Circle", "Triangle", "Square", "Rectangle", "Oval", "Diamond", "Star", "Heart"]))
-        XCTAssertEqual(thread.entities.count, 8)
+        XCTAssertEqual(thread.entities.count, 12)
     }
 
     func testShapeThreadEntitiesCarryVisualKeys() {

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @MainActor
 final class CompactLayoutTests: XCTestCase {
 
-    func testIPadHomeRegularLayoutShowsFullMakeAndBreakTitle() throws {
+    func testIPadHomeRegularLayoutUsesSimpleChildLauncherTiles() throws {
         guard UIDevice.current.userInterfaceIdiom == .pad else {
             throw XCTSkip("iPad regular-layout regression only runs on iPad simulators")
         }
@@ -12,10 +12,13 @@ final class CompactLayoutTests: XCTestCase {
         let app = launchWithVS1()
         XCTAssertTrue(app.staticTexts["Mather"].waitForExistence(timeout: 10))
 
-        let playCard = app.buttons["Play"]
-        XCTAssertTrue(playCard.waitForExistence(timeout: 5))
-        XCTAssertTrue(playCard.staticTexts["Make & Break"].waitForExistence(timeout: 5), "Expected the iPad home hero to expose the full Make & Break title")
-        XCTAssertTrue(playCard.staticTexts["Targets"].waitForExistence(timeout: 5), "Expected the iPad home hero subtitle to remain visible next to the title")
+        XCTAssertTrue(app.buttons["Play"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["ExplorerLab"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["GamesEntry"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Play"].staticTexts["Targets"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["ExplorerLab"].staticTexts["Labs"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["GamesEntry"].staticTexts["Games"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.staticTexts["Make & Break"].exists, "Home launcher should avoid copy-heavy child tiles")
     }
 
     func testBondBlastTargetTwelveKeepsLowAndMiddlePairsReachableOnIPhone() throws {


### PR DESCRIPTION
## Summary
- Simplifies the child home launcher into three icon/title tiles for Targets, Labs, and Games, with parent/settings actions remaining secondary.
- Adds reward banner + delayed auto-progress for completed match turns/stages while keeping the manual “Next turn” / finish controls available.
- Enriches Shape Names content/card treatment: expands shape entities to 12 and uses neutral visuals for name cards so they do not duplicate the answer shape.

## Validation
- `git diff --check` passed.
- Targeted iOS simulator test attempt on `ganesh-mba`:
  - `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:MatherTests/GameplayThreadContentTests -only-testing:MatherTests/LearningLoopTests CODE_SIGNING_ALLOWED=NO`
  - Blocked by the existing Swift frontend crash while typechecking `Features/ParentSummary/SettingsView.swift` (same unrelated compiler crash seen in prior #1001 validation), before tests could run.

Fixes #1003
Fixes #1004
Fixes #1005
Fixes #1006