### PR TITLE
Fix build 93 lab stream picker cards

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -462,8 +462,8 @@ struct ExplorerPathPresentation: Identifiable, Equatable {
             symbolName: "sparkles.rectangle.stack.fill",
             artMotif: "guided compass path",
             title: "Labs",
-            subtitle: "Pick a subject stream, then follow a calm staged path when one is ready.",
-            callToAction: "Choose a subject"
+            subtitle: "Pick a learning stream, then follow a calm staged path when one is ready.",
+            callToAction: "Pick a stream"
         ),
         ExplorerPathPresentation(
             id: .games,
@@ -1006,6 +1006,7 @@ struct LabLaneCardPresentation: Equatable {
     let title: String
     let promiseLine: String
     let progressMicrocopy: String
+    let statusLine: String
     let openAffordanceLabel: String
     let accessibilityLabel: String
     let accessibilityHint: String
@@ -1016,9 +1017,12 @@ struct LabLaneCardPresentation: Equatable {
         title = lane.subjectStreamLabel
         promiseLine = lane.promise
         progressMicrocopy = "\(progress.progressSummaryLabel) • \(progress.nextRecommendedModeLabel)"
+        statusLine = lane.activities.isEmpty
+            ? "Coming soon"
+            : "\(lane.activities.count) game\(lane.activities.count == 1 ? "" : "s") ready"
         openAffordanceLabel = "Open"
-        accessibilityLabel = "\(lane.subjectStreamLabel) subject stream. \(lane.ageBandHint). \(lane.promise)"
-        accessibilityHint = "Opens \(lane.subjectStreamLabel) to choose staged labs and games."
+        accessibilityLabel = "\(lane.subjectStreamLabel). \(statusLine). \(lane.ageBandHint)."
+        accessibilityHint = "Opens \(lane.subjectStreamLabel) with staged labs, games, and progress details."
         sections = [
             .visualSummary,
         ]

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -90,7 +90,7 @@ struct LabView: View {
                 Text("Explorer Lab")
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(MatherTheme.cardSubtitle)
-                Text(selectedPath == .labs ? "Choose a subject stream first" : "Jump straight into a game")
+                Text(selectedPath == .labs ? "Pick a stream to explore" : "Jump straight into a game")
                     .font(.caption.weight(.bold))
                     .foregroundStyle(MatherTheme.accent)
             }
@@ -165,27 +165,17 @@ struct LabView: View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("Subject streams")
+                    Text("Pick a stream")
                         .font(.title3.weight(.black))
                         .foregroundStyle(MatherTheme.ink)
-                    Text(CapabilityLane.subjectStreamSummary)
-                        .font(.caption.weight(.black))
-                        .foregroundStyle(MatherTheme.accent)
+                    Text("Pick one card. Details open next.")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 0)
             }
 
-            LabDetailFlowLayout(spacing: 6) {
-                ForEach(lanes) { lane in
-                    Text(lane.subjectStreamShortLabel)
-                        .font(.caption2.weight(.black))
-                        .foregroundStyle(lane.id.themeColor)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 5)
-                        .background(lane.id.themeColor.opacity(0.10), in: Capsule())
-                }
-            }
         }
         .padding(14)
         .background(MatherTheme.card.opacity(0.86), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
@@ -194,7 +184,7 @@ struct LabView: View {
                 .stroke(MatherTheme.accent.opacity(0.18), lineWidth: 1)
         )
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Subject streams: \(CapabilityLane.subjectStreamSummary)")
+        .accessibilityLabel("Pick a stream: \(CapabilityLane.subjectStreamSummary)")
     }
 
     private func guidedLabsIntro(compact: Bool) -> some View {
@@ -375,17 +365,18 @@ struct LabView: View {
         return Button {
             appModel.engine.showLabLane(lane.id)
         } label: {
-            Group {
-                if compact {
-                    compactLaneTile(lane, presentation: presentation, progress: progress, tint: tint)
-                } else {
-                    fullLaneCard(lane, presentation: presentation, progress: progress, tint: tint)
-                }
-            }
-            .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+            laneStreamTile(lane, presentation: presentation, tint: tint, compact: compact)
+            .background(
+                LinearGradient(
+                    colors: [tint.opacity(0.95), tint.opacity(0.70)],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                ),
+                in: RoundedRectangle(cornerRadius: 24, style: .continuous)
+            )
             .overlay(
-                RoundedRectangle(cornerRadius: 22, style: .continuous)
-                    .stroke(tint.opacity(compact ? 0.28 : 0.18), lineWidth: compact ? 1.5 : 1)
+                RoundedRectangle(cornerRadius: 24, style: .continuous)
+                    .strokeBorder(.white.opacity(colorScheme == .dark ? 0.10 : 0.0), lineWidth: 1)
             )
             .shadow(
                 color: colorScheme == .dark ? .black.opacity(0.3) : .black.opacity(0.08),
@@ -394,49 +385,46 @@ struct LabView: View {
             .scaleEffect(!reduceMotion && playfulPulse ? 1.01 : 1.0, anchor: .center)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(presentation.accessibilityLabel). \(progress.progressSummaryLabel). \(progress.nextRecommendedModeLabel).")
+        .accessibilityIdentifier("lab-stream-card-\(lane.id.rawValue)")
+        .accessibilityLabel(presentation.accessibilityLabel)
         .accessibilityHint(presentation.accessibilityHint)
     }
 
-    private func compactLaneTile(
+    private func laneStreamTile(
         _ lane: CapabilityLane,
         presentation: LabLaneCardPresentation,
-        progress: CapabilityLaneProgress,
-        tint: Color
+        tint: Color,
+        compact: Bool
     ) -> some View {
-        VStack(spacing: 10) {
-            laneVisual(lane, tint: tint, size: 74)
+        VStack(alignment: .leading, spacing: compact ? 10 : 12) {
+            HStack(alignment: .top, spacing: 8) {
+                laneVisual(lane, tint: .white, size: compact ? 56 : 68)
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right.circle.fill")
+                    .font(.system(size: compact ? 22 : 26, weight: .black))
+                    .foregroundStyle(.white.opacity(0.86))
+                    .accessibilityHidden(true)
+            }
 
-            Text(presentation.title)
-                .font(.system(size: 18, weight: .black, design: .rounded))
-                .foregroundStyle(MatherTheme.ink)
-                .lineLimit(2)
-                .minimumScaleFactor(0.78)
-                .multilineTextAlignment(.center)
+            Spacer(minLength: 0)
+
+            VStack(alignment: .leading, spacing: compact ? 4 : 6) {
+                Text(presentation.title)
+                    .font(.system(size: compact ? 18 : 22, weight: .black, design: .rounded))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.76)
+                    .multilineTextAlignment(.leading)
+
+                Text(presentation.statusLine)
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(.white.opacity(0.88))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+            }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 14)
-        .frame(maxWidth: .infinity, minHeight: 142, alignment: .center)
-    }
-
-    private func fullLaneCard(
-        _ lane: CapabilityLane,
-        presentation: LabLaneCardPresentation,
-        progress: CapabilityLaneProgress,
-        tint: Color
-    ) -> some View {
-        VStack(spacing: 12) {
-            laneVisual(lane, tint: tint, size: 86)
-
-            Text(presentation.title)
-                .font(.title3.weight(.black))
-                .foregroundStyle(MatherTheme.ink)
-                .lineLimit(2)
-                .minimumScaleFactor(0.78)
-                .multilineTextAlignment(.center)
-        }
-        .padding(16)
-        .frame(maxWidth: .infinity, minHeight: 160, alignment: .center)
+        .padding(compact ? 14 : 16)
+        .frame(maxWidth: .infinity, minHeight: compact ? 150 : 174, alignment: .leading)
     }
 
     private func compactProgressBadge(_ progress: CapabilityLaneProgress, tint: Color) -> some View {

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -86,6 +86,8 @@ final class LabModelsTests: XCTestCase {
 
         XCTAssertEqual(presentation.title, "Numbers & Arithmetic")
         XCTAssertEqual(presentation.openAffordanceLabel, "Open")
+        XCTAssertEqual(presentation.statusLine, "3 games ready")
+        XCTAssertFalse(presentation.accessibilityLabel.contains("Build number bonds"))
         XCTAssertEqual(
             presentation.sections,
             [.visualSummary]
@@ -96,6 +98,7 @@ final class LabModelsTests: XCTestCase {
         XCTAssertFalse(presentation.sections.contains(.recall))
         XCTAssertFalse(presentation.sections.contains(.activities))
         XCTAssertTrue(presentation.accessibilityHint.contains("Opens Numbers & Arithmetic"))
+        XCTAssertTrue(presentation.accessibilityHint.contains("progress details"))
         XCTAssertFalse(presentation.sections.contains(.promise))
         XCTAssertFalse(presentation.sections.contains(.progressStatus))
     }
@@ -143,8 +146,8 @@ final class LabModelsTests: XCTestCase {
         let games = ExplorerPathPresentation.all[1]
 
         XCTAssertEqual(labs.title, "Labs")
-        XCTAssertTrue(labs.subtitle.contains("Pick a subject stream"))
-        XCTAssertEqual(labs.callToAction, "Choose a subject")
+        XCTAssertTrue(labs.subtitle.contains("Pick a learning stream"))
+        XCTAssertEqual(labs.callToAction, "Pick a stream")
         XCTAssertEqual(labs.symbolName, "sparkles.rectangle.stack.fill")
         XCTAssertTrue(labs.artworkAccessibilityLabel.contains("Labs"))
 

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -21,6 +21,25 @@ final class CompactLayoutTests: XCTestCase {
         XCTAssertFalse(app.staticTexts["Make & Break"].exists, "Home launcher should avoid copy-heavy child tiles")
     }
 
+
+    func testExplorerLabStreamPickerUsesSimpleReadableCardsOnIPhone() throws {
+        guard UIDevice.current.userInterfaceIdiom == .phone else {
+            throw XCTSkip("Compact Explorer Lab picker regression only runs on iPhone simulators")
+        }
+
+        let app = launchExplorerLab()
+        XCTAssertTrue(app.staticTexts["Explorer Lab"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Pick a stream to explore"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.staticTexts["Choose a subject stream first"].exists)
+
+        let numbers = app.buttons["lab-stream-card-numbers"]
+        let geometry = app.buttons["lab-stream-card-geometry"]
+        XCTAssertTrue(numbers.waitForExistence(timeout: 5))
+        XCTAssertTrue(geometry.waitForExistence(timeout: 5))
+        XCTAssertTrue(numbers.isHittable, "Expected the first Lab stream card to be reachable on compact iPhone")
+        XCTAssertTrue(geometry.isHittable, "Expected the second Lab stream card to be reachable on compact iPhone")
+    }
+
     func testBondBlastTargetTwelveKeepsLowAndMiddlePairsReachableOnIPhone() throws {
         guard UIDevice.current.userInterfaceIdiom == .phone else {
             throw XCTSkip("Compact Bond Blast reachability regression only runs on iPhone simulators")
@@ -337,6 +356,20 @@ final class CompactLayoutTests: XCTestCase {
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
             "-feature.roomQuestSafetyAcknowledged", "YES"
+        ]
+        app.launch()
+        return app
+    }
+
+    private func launchExplorerLab() -> XCUIApplication {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.testModeEnabled", "YES",
+            "-feature.skipProfilePicker", "YES",
+            "-uiTest.startRoute", "lab"
         ]
         app.launch()
         return app


### PR DESCRIPTION
## Summary
- Reworked the Labs stream picker into Home-style gradient cards with icon, title, forward affordance, and a single status line.
- Removed the confusing “choose subject first” copy and shortened the picker header.
- Kept stream detail richness on the lane detail presentation/screen; root cards stay sparse.
- Added model assertions and compact iPhone UI coverage for the simplified stream picker.

Fixes #1014

## Validation
- `git diff origin/main --check`
- Attempted `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 16,OS=18.3.1" -only-testing:MatherTests/LabModelsTests -quiet` on `ganesh-mba`; blocked because the checked-in project is stale without `xcodegen generate` (missing `CardReviewScheduler`, `KidProfileStore`, `GameplayThreadContent+Shapes` symbols). CI workflows regenerate with xcodegen before building.
