### PR TITLE
feat: add Sound Lab flashcard playback

### DIFF
--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -7,13 +7,92 @@ struct LearningConceptCard: Identifiable, Equatable {
     let explanation: String
     let visualKey: String
     let audioPrompt: String
+    let soundExample: SoundExampleKind?
 
-    init(id: String, title: String, explanation: String, visualKey: String, audioPrompt: String? = nil) {
+    init(
+        id: String,
+        title: String,
+        explanation: String,
+        visualKey: String,
+        audioPrompt: String? = nil,
+        soundExample: SoundExampleKind? = nil
+    ) {
         self.id = id
         self.title = title
         self.explanation = explanation
         self.visualKey = visualKey
         self.audioPrompt = audioPrompt ?? "Learn about \(title)."
+        self.soundExample = soundExample
+    }
+}
+
+struct SoundExamplePlaybackProfile: Equatable {
+    let durationSeconds: Double
+    let peakAmplitude: Double
+    let primaryFrequency: Double
+    let secondaryFrequency: Double?
+
+    init(durationSeconds: Double, peakAmplitude: Double, primaryFrequency: Double, secondaryFrequency: Double? = nil) {
+        self.durationSeconds = min(max(durationSeconds, 0.12), SoundExampleKind.hearingSafeMaximumDurationSeconds)
+        self.peakAmplitude = min(max(peakAmplitude, 0.01), SoundExampleKind.hearingSafeMaximumPeakAmplitude)
+        self.primaryFrequency = primaryFrequency
+        self.secondaryFrequency = secondaryFrequency
+    }
+}
+
+enum SoundExampleKind: String, CaseIterable, Equatable {
+    case decibelPulse
+    case quietChime
+    case conversationPulse
+    case trafficRumble
+    case sirenSweep
+    case headphonesLow
+    case pleasantBirds
+    case noisyBurst
+    case protectEarsMuffle
+
+    static let hearingSafeMaximumDurationSeconds = 0.65
+    static let hearingSafeMaximumPeakAmplitude = 0.18
+
+    var label: String {
+        switch self {
+        case .decibelPulse: return "dB pulse"
+        case .quietChime: return "quiet chime"
+        case .conversationPulse: return "talking pulse"
+        case .trafficRumble: return "traffic rumble"
+        case .sirenSweep: return "soft siren sweep"
+        case .headphonesLow: return "low headphone tone"
+        case .pleasantBirds: return "bird chirp"
+        case .noisyBurst: return "short noise burst"
+        case .protectEarsMuffle: return "muffled warning"
+        }
+    }
+
+    var accessibilityLabel: String {
+        "Play hearing-safe \(label) example"
+    }
+
+    var profile: SoundExamplePlaybackProfile {
+        switch self {
+        case .decibelPulse:
+            return SoundExamplePlaybackProfile(durationSeconds: 0.38, peakAmplitude: 0.12, primaryFrequency: 660, secondaryFrequency: 880)
+        case .quietChime:
+            return SoundExamplePlaybackProfile(durationSeconds: 0.46, peakAmplitude: 0.08, primaryFrequency: 523.25, secondaryFrequency: 659.25)
+        case .conversationPulse:
+            return SoundExamplePlaybackProfile(durationSeconds: 0.52, peakAmplitude: 0.11, primaryFrequency: 220, secondaryFrequency: 330)
+        case .trafficRumble:
+            return SoundExamplePlaybackProfile(durationSeconds: 0.48, peakAmplitude: 0.13, primaryFrequency: 110, secondaryFrequency: 165)
+        case .sirenSweep:
+            return SoundExamplePlaybackProfile(durationSeconds: 0.50, peakAmplitude: 0.12, primaryFrequency: 520, secondaryFrequency: 860)
+        case .headphonesLow:
+            return SoundExamplePlaybackProfile(durationSeconds: 0.42, peakAmplitude: 0.09, primaryFrequency: 440, secondaryFrequency: 554.37)
+        case .pleasantBirds:
+            return SoundExamplePlaybackProfile(durationSeconds: 0.50, peakAmplitude: 0.10, primaryFrequency: 980, secondaryFrequency: 1320)
+        case .noisyBurst:
+            return SoundExamplePlaybackProfile(durationSeconds: 0.32, peakAmplitude: 0.10, primaryFrequency: 260, secondaryFrequency: 520)
+        case .protectEarsMuffle:
+            return SoundExamplePlaybackProfile(durationSeconds: 0.44, peakAmplitude: 0.08, primaryFrequency: 320, secondaryFrequency: 180)
+        }
     }
 }
 
@@ -273,15 +352,15 @@ enum SoundVolumeContent {
     ]
 
     static let cards: [LearningConceptCard] = [
-        LearningConceptCard(id: "decibel", title: "Decibel (dB)", explanation: "A decibel is a number for loudness. Bigger dB usually means a louder sound.", visualKey: "dB", audioPrompt: "A decibel, or dB, is a number for loudness."),
-        LearningConceptCard(id: "quiet", title: "Quiet", explanation: "Quiet sounds are soft and gentle, like a whisper or leaves.", visualKey: "🍃", audioPrompt: "Quiet sounds are soft and gentle."),
-        LearningConceptCard(id: "conversation", title: "Conversation", explanation: "A talking voice sits in the middle loudness zone.", visualKey: "💬", audioPrompt: "Conversation is a middle loudness zone."),
-        LearningConceptCard(id: "traffic", title: "Traffic", explanation: "Busy traffic is loud and can turn into noise pollution.", visualKey: "🚗", audioPrompt: "Traffic can be loud and unwanted."),
-        LearningConceptCard(id: "siren", title: "Siren", explanation: "Sirens warn us, but they are very loud. Move away and protect ears.", visualKey: "🚨", audioPrompt: "Sirens are very loud warning sounds."),
-        LearningConceptCard(id: "headphones", title: "Headphones", explanation: "Keep headphones low, take breaks, and never play a volume that hurts.", visualKey: "🎧", audioPrompt: "Headphones should stay low and safe."),
-        LearningConceptCard(id: "pleasant", title: "Pleasant Sound", explanation: "Pleasant sounds feel nice and safe, like birds or soft music.", visualKey: "🐦", audioPrompt: "Pleasant sounds feel nice and safe."),
-        LearningConceptCard(id: "unpleasant", title: "Noisy Sound", explanation: "Noisy sounds feel harsh, distracting, or unwanted.", visualKey: "📣", audioPrompt: "Noisy sounds are unwanted or harsh."),
-        LearningConceptCard(id: "protect-ears", title: "Protect Ears", explanation: "Lower volume, move away, cover ears, or ask a grown-up for help.", visualKey: "👂", audioPrompt: "Protect ears when sound is too loud."),
+        LearningConceptCard(id: "decibel", title: "Decibel (dB)", explanation: "A decibel is a number for loudness. Bigger dB usually means a louder sound.", visualKey: "dB", audioPrompt: "A decibel, or dB, is a number for loudness.", soundExample: .decibelPulse),
+        LearningConceptCard(id: "quiet", title: "Quiet", explanation: "Quiet sounds are soft and gentle, like a whisper or leaves.", visualKey: "🍃", audioPrompt: "Quiet sounds are soft and gentle.", soundExample: .quietChime),
+        LearningConceptCard(id: "conversation", title: "Conversation", explanation: "A talking voice sits in the middle loudness zone.", visualKey: "💬", audioPrompt: "Conversation is a middle loudness zone.", soundExample: .conversationPulse),
+        LearningConceptCard(id: "traffic", title: "Traffic", explanation: "Busy traffic is loud and can turn into noise pollution.", visualKey: "🚗", audioPrompt: "Traffic can be loud and unwanted.", soundExample: .trafficRumble),
+        LearningConceptCard(id: "siren", title: "Siren", explanation: "Sirens warn us, but they are very loud. Move away and protect ears.", visualKey: "🚨", audioPrompt: "Sirens are very loud warning sounds.", soundExample: .sirenSweep),
+        LearningConceptCard(id: "headphones", title: "Headphones", explanation: "Keep headphones low, take breaks, and never play a volume that hurts.", visualKey: "🎧", audioPrompt: "Headphones should stay low and safe.", soundExample: .headphonesLow),
+        LearningConceptCard(id: "pleasant", title: "Pleasant Sound", explanation: "Pleasant sounds feel nice and safe, like birds or soft music.", visualKey: "🐦", audioPrompt: "Pleasant sounds feel nice and safe.", soundExample: .pleasantBirds),
+        LearningConceptCard(id: "unpleasant", title: "Noisy Sound", explanation: "Noisy sounds feel harsh, distracting, or unwanted.", visualKey: "📣", audioPrompt: "Noisy sounds are unwanted or harsh.", soundExample: .noisyBurst),
+        LearningConceptCard(id: "protect-ears", title: "Protect Ears", explanation: "Lower volume, move away, cover ears, or ask a grown-up for help.", visualKey: "👂", audioPrompt: "Protect ears when sound is too loud.", soundExample: .protectEarsMuffle),
     ]
 
     static let quizQuestions: [ConceptQuizQuestion] = [

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -39,6 +39,111 @@ struct LearningCardIntroView: View {
     }
 }
 
+struct SoundConceptFlashcardCarouselView: View {
+    let cards: [LearningConceptCard]
+    @Binding var selectedIndex: Int
+    let onPlaySound: (LearningConceptCard) -> Void
+
+    private var safeIndex: Int {
+        guard !cards.isEmpty else { return 0 }
+        return min(max(selectedIndex, 0), cards.count - 1)
+    }
+
+    private var activeCard: LearningConceptCard? {
+        guard cards.indices.contains(safeIndex) else { return nil }
+        return cards[safeIndex]
+    }
+
+    var body: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 10) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Flashcards")
+                            .font(.title2.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text(cards.isEmpty ? "No cards" : "Card \(safeIndex + 1) of \(cards.count)")
+                            .font(.caption.weight(.black).monospacedDigit())
+                            .foregroundStyle(MatherTheme.accent)
+                    }
+                    Spacer()
+                    Image(systemName: "speaker.wave.2.circle.fill")
+                        .font(.title2.weight(.black))
+                        .foregroundStyle(MatherTheme.accent)
+                        .accessibilityHidden(true)
+                }
+
+                if let card = activeCard {
+                    HStack(alignment: .center, spacing: 14) {
+                        Text(card.visualKey)
+                            .font(.system(size: 48, weight: .bold))
+                            .frame(width: 64, height: 64)
+                            .background(MatherTheme.softBlue.opacity(0.22))
+                            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(card.title)
+                                .font(.title3.weight(.black))
+                                .foregroundStyle(MatherTheme.ink)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.72)
+                            Text(card.explanation)
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                                .lineLimit(3)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+
+                    HStack(spacing: 10) {
+                        Button {
+                            selectedIndex = max(0, safeIndex - 1)
+                        } label: {
+                            Label("Back", systemImage: "chevron.left")
+                                .labelStyle(.titleAndIcon)
+                        }
+                        .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: true))
+                        .disabled(safeIndex == 0)
+
+                        Button {
+                            onPlaySound(card)
+                        } label: {
+                            Label("Play sound", systemImage: "speaker.wave.2.fill")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(GameplayStageControlButtonStyle(kind: .primary, compact: true))
+                        .accessibilityLabel(card.soundExample?.accessibilityLabel ?? "Play hearing-safe sound example")
+                        .accessibilityIdentifier("SoundLabPlaySound-\(card.id)")
+                        .disabled(card.soundExample == nil)
+
+                        Button {
+                            selectedIndex = min(cards.count - 1, safeIndex + 1)
+                        } label: {
+                            Label("Next", systemImage: "chevron.right")
+                                .labelStyle(.titleAndIcon)
+                        }
+                        .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: true))
+                        .disabled(safeIndex >= cards.count - 1)
+                    }
+
+                    Text("Short, low-volume examples only. No microphone or live loudness meter is used.")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(MatherTheme.panelDeep)
+                        .padding(10)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(MatherTheme.warm.opacity(0.18))
+                        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                }
+            }
+        }
+        .onChange(of: cards.count) { _, _ in
+            selectedIndex = safeIndex
+        }
+        .accessibilityElement(children: .contain)
+    }
+}
+
+
 struct ConceptQuizRoundView: View {
     let questions: [ConceptQuizQuestion]
     @Binding var answersByQuestionId: [String: String]
@@ -333,12 +438,14 @@ struct ConceptMixMatchRoundView: View {
 
 
 private enum SoundVolumeActivityStage: CaseIterable {
+    case flashcards
     case quiz
     case match
     case summary
 
     var title: String {
         switch self {
+        case .flashcards: return "Flashcards"
         case .quiz: return "Quiz"
         case .match: return "Mix + Match"
         case .summary: return "Stars"
@@ -347,14 +454,16 @@ private enum SoundVolumeActivityStage: CaseIterable {
 
     var primaryActionTitle: String {
         switch self {
+        case .flashcards: return "Go to Quiz"
         case .quiz: return "Go to Mix + Match"
         case .match: return "See Sound Score"
-        case .summary: return "Review Quiz"
+        case .summary: return "Review Flashcards"
         }
     }
 
     var primaryActionIcon: String {
         switch self {
+        case .flashcards: return "checkmark.circle.fill"
         case .quiz: return "rectangle.grid.2x2.fill"
         case .match: return "star.fill"
         case .summary: return "arrow.counterclockwise"
@@ -363,15 +472,17 @@ private enum SoundVolumeActivityStage: CaseIterable {
 
     var next: SoundVolumeActivityStage {
         switch self {
+        case .flashcards: return .quiz
         case .quiz: return .match
         case .match: return .summary
-        case .summary: return .quiz
+        case .summary: return .flashcards
         }
     }
 
     var previous: SoundVolumeActivityStage {
         switch self {
-        case .quiz: return .summary
+        case .flashcards: return .summary
+        case .quiz: return .flashcards
         case .match: return .quiz
         case .summary: return .match
         }
@@ -382,7 +493,8 @@ struct SoundVolumeLabView: View {
     @Bindable var appModel: AppModel
     @State private var introPageIndex = 0
     @State private var hasStartedActivities = false
-    @State private var activityStage: SoundVolumeActivityStage = .quiz
+    @State private var activityStage: SoundVolumeActivityStage = .flashcards
+    @State private var selectedSoundCardIndex = 0
     @State private var answersByQuestionId: [String: String] = [:]
     @State private var selectedMatchPairId: String?
     @State private var matchedPairIds: Set<String> = []
@@ -542,8 +654,8 @@ struct SoundVolumeLabView: View {
     private func advanceIntro() {
         if isLastIntroPage {
             hasStartedActivities = true
-            activityStage = .quiz
-            feedback = "Start with the quiz. Mix + Match comes on the next screen."
+            activityStage = .flashcards
+            feedback = "Start with flashcards. Tap Play sound for a short, hearing-safe example."
         } else {
             introPageIndex = SoundVolumeContent.clampedIntroPageIndex(safeIntroPageIndex + 1)
         }
@@ -589,6 +701,12 @@ struct SoundVolumeLabView: View {
     @ViewBuilder
     private var currentActivityStage: some View {
         switch activityStage {
+        case .flashcards:
+            SoundConceptFlashcardCarouselView(
+                cards: SoundVolumeContent.cards,
+                selectedIndex: $selectedSoundCardIndex,
+                onPlaySound: playSoundExample
+            )
         case .quiz:
             ConceptQuizRoundView(
                 questions: SoundVolumeContent.quizQuestions,
@@ -610,9 +728,10 @@ struct SoundVolumeLabView: View {
 
     private var activityStageControls: some View {
         HStack(spacing: 10) {
-            if activityStage != .quiz {
+            if activityStage != .flashcards {
                 Button {
                     activityStage = activityStage.previous
+                    updateFeedbackForCurrentStage()
                 } label: {
                     Label("Back", systemImage: "chevron.left")
                         .font(.headline.weight(.black))
@@ -624,11 +743,7 @@ struct SoundVolumeLabView: View {
 
             Button {
                 activityStage = activityStage.next
-                if activityStage == .match {
-                    feedback = "Now match each sound clue to its safe idea."
-                } else if activityStage == .summary {
-                    feedback = "Review your Sound Lab score."
-                }
+                updateFeedbackForCurrentStage()
             } label: {
                 Label(activityStage.primaryActionTitle, systemImage: activityStage.primaryActionIcon)
                     .font(.headline.weight(.black))
@@ -636,6 +751,26 @@ struct SoundVolumeLabView: View {
             }
             .buttonStyle(PrimaryActionButtonStyle())
         }
+    }
+
+    private func updateFeedbackForCurrentStage() {
+        switch activityStage {
+        case .flashcards:
+            feedback = "Tap Play sound on each card for a short, hearing-safe example."
+        case .quiz:
+            feedback = "Now try the quiz. Use the flashcard clues you heard."
+        case .match:
+            feedback = "Now match each sound clue to its safe idea."
+        case .summary:
+            feedback = "Review your Sound Lab score."
+        }
+    }
+
+    private func playSoundExample(for card: LearningConceptCard) {
+        guard let soundExample = card.soundExample else { return }
+        appModel.speechService.playSoundExample(soundExample, enabled: appModel.featureFlags.audioEnabled)
+        appModel.hapticsService.cardPickup(enabled: appModel.featureFlags.hapticsEnabled)
+        feedback = "Played a short, hearing-safe \(soundExample.label) example for \(card.title)."
     }
 
     private func playSoundMatchHaptic(_ cue: ConceptMixMatchHapticCue) {

--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -8,6 +8,7 @@ import FoundationModels
 @Observable
 final class SpeechService {
     private let synthesizer = AVSpeechSynthesizer()
+    private var soundExamplePlayer: AVAudioPlayer?
     private var lastUtteranceID = UUID()
     private(set) var lastSpokenText: String?
     private(set) var lastSpeechDiagnostic: String?
@@ -19,12 +20,7 @@ final class SpeechService {
         // during speech; .duckOthers lowers (rather than cuts) background audio.
         // The in-app audio toggle (speak(_:enabled:)) remains the parent's control.
         do {
-            try AVAudioSession.sharedInstance().setCategory(
-                .playback,
-                mode: .spokenAudio,
-                options: .duckOthers
-            )
-            try AVAudioSession.sharedInstance().setActive(true)
+            try configureAudioSession(mode: .spokenAudio)
             lastSpeechDiagnostic = nil
         } catch {
             lastSpeechDiagnostic = "Audio session setup failed: \(error.localizedDescription)"
@@ -60,6 +56,113 @@ final class SpeechService {
 
     func speakLearningDetails(_ text: String, enabled: Bool) {
         speak(text, enabled: enabled)
+    }
+
+    func playSoundExample(_ example: SoundExampleKind, enabled: Bool) {
+        guard enabled else {
+            lastSpeechDiagnostic = "Sound example skipped because audio prompts are disabled."
+            print("[Mather][SpeechService] \(lastSpeechDiagnostic!)")
+            return
+        }
+
+        do {
+            try configureAudioSession(mode: .default)
+            let player = try AVAudioPlayer(data: Self.hearingSafeWAVData(for: example))
+            player.volume = Float(min(SoundExampleKind.hearingSafeMaximumPeakAmplitude * 2.5, 0.45))
+            player.prepareToPlay()
+            soundExamplePlayer = player
+            lastSpeechDiagnostic = nil
+            lastSpokenText = nil
+            player.play()
+        } catch {
+            lastSpeechDiagnostic = "Sound example playback failed: \(error.localizedDescription)"
+            print("[Mather][SpeechService] \(lastSpeechDiagnostic!)")
+        }
+    }
+
+    private func configureAudioSession(mode: AVAudioSession.Mode) throws {
+        try AVAudioSession.sharedInstance().setCategory(
+            .playback,
+            mode: mode,
+            options: .duckOthers
+        )
+        try AVAudioSession.sharedInstance().setActive(true)
+    }
+
+    static func hearingSafeWAVData(for example: SoundExampleKind) -> Data {
+        let profile = example.profile
+        let sampleRate = 22_050
+        let channelCount = 1
+        let bitsPerSample = 16
+        let bytesPerSample = bitsPerSample / 8
+        let sampleCount = max(1, Int(profile.durationSeconds * Double(sampleRate)))
+        var pcm = Data(capacity: sampleCount * bytesPerSample)
+
+        for index in 0..<sampleCount {
+            let t = Double(index) / Double(sampleRate)
+            let progress = Double(index) / Double(max(sampleCount - 1, 1))
+            let envelope = sin(Double.pi * progress)
+            let raw = waveform(for: example, at: t, progress: progress, sampleIndex: index)
+            let safeSample = max(-1, min(1, raw * profile.peakAmplitude * envelope))
+            pcm.appendLittleEndian(Int16(safeSample * Double(Int16.max)))
+        }
+
+        var data = Data(capacity: 44 + pcm.count)
+        data.append(contentsOf: "RIFF".utf8)
+        data.appendLittleEndian(UInt32(36 + pcm.count))
+        data.append(contentsOf: "WAVE".utf8)
+        data.append(contentsOf: "fmt ".utf8)
+        data.appendLittleEndian(UInt32(16))
+        data.appendLittleEndian(UInt16(1))
+        data.appendLittleEndian(UInt16(channelCount))
+        data.appendLittleEndian(UInt32(sampleRate))
+        data.appendLittleEndian(UInt32(sampleRate * channelCount * bytesPerSample))
+        data.appendLittleEndian(UInt16(channelCount * bytesPerSample))
+        data.appendLittleEndian(UInt16(bitsPerSample))
+        data.append(contentsOf: "data".utf8)
+        data.appendLittleEndian(UInt32(pcm.count))
+        data.append(pcm)
+        return data
+    }
+
+    private static func waveform(for example: SoundExampleKind, at t: Double, progress: Double, sampleIndex: Int) -> Double {
+        let profile = example.profile
+        let primary = profile.primaryFrequency
+        let secondary = profile.secondaryFrequency ?? primary
+        let twoPi = 2 * Double.pi
+
+        switch example {
+        case .decibelPulse:
+            let tone = progress < 0.5 ? primary : secondary
+            return sin(twoPi * tone * t)
+        case .quietChime:
+            return 0.72 * sin(twoPi * primary * t) + 0.28 * sin(twoPi * secondary * t)
+        case .conversationPulse:
+            let syllableGate = 0.45 + 0.55 * max(0, sin(twoPi * 4.2 * t))
+            return syllableGate * (0.65 * sin(twoPi * primary * t) + 0.35 * sin(twoPi * secondary * t))
+        case .trafficRumble:
+            return 0.58 * sin(twoPi * primary * t) + 0.27 * sin(twoPi * secondary * t) + 0.15 * deterministicNoise(sampleIndex)
+        case .sirenSweep:
+            let sweep = primary + (secondary - primary) * progress
+            return sin(twoPi * sweep * t)
+        case .headphonesLow:
+            return 0.62 * sin(twoPi * primary * t) + 0.38 * sin(twoPi * secondary * t)
+        case .pleasantBirds:
+            let chirpGate = sin(twoPi * 5.5 * t) > -0.15 ? 1.0 : 0.20
+            let chirpFrequency = primary + (secondary - primary) * (progress < 0.5 ? progress * 2 : (1 - progress) * 2)
+            return chirpGate * sin(twoPi * chirpFrequency * t)
+        case .noisyBurst:
+            return 0.72 * deterministicNoise(sampleIndex) + 0.28 * sin(twoPi * secondary * t)
+        case .protectEarsMuffle:
+            let falling = primary + (secondary - primary) * progress
+            return 0.70 * sin(twoPi * falling * t) + 0.30 * sin(twoPi * (falling * 0.5) * t)
+        }
+    }
+
+    private static func deterministicNoise(_ sampleIndex: Int) -> Double {
+        var value = UInt64(sampleIndex) &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+        value ^= value >> 33
+        return (Double(value & 0xFFFF) / 32_767.5) - 1.0
     }
 
     func resetSession() {
@@ -364,5 +467,15 @@ final class MemoryCardDescribeService {
         #else
         NullMemoryCardAIAdapter()
         #endif
+    }
+}
+
+
+private extension Data {
+    mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
+        var littleEndianValue = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndianValue) { buffer in
+            append(contentsOf: buffer)
+        }
     }
 }

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -158,6 +158,24 @@ extension LearningLoopTests {
         XCTAssertTrue(SoundVolumeContent.safetyNote.contains("microphone meter comes later"))
     }
 
+    func testSoundVolumeCardsExposeExplicitHearingSafePlaybackExamples() {
+        let examples = SoundVolumeContent.cards.compactMap(\.soundExample)
+
+        XCTAssertEqual(examples.count, SoundVolumeContent.cards.count)
+        XCTAssertEqual(Set(examples).count, SoundVolumeContent.cards.count)
+        XCTAssertTrue(examples.allSatisfy { !$0.label.isEmpty })
+        XCTAssertTrue(examples.allSatisfy { $0.accessibilityLabel.contains("Play hearing-safe") })
+    }
+
+    func testSoundVolumePlaybackProfilesStayShortAndLowAmplitude() {
+        for example in SoundVolumeContent.cards.compactMap(\.soundExample) {
+            XCTAssertLessThanOrEqual(example.profile.durationSeconds, SoundExampleKind.hearingSafeMaximumDurationSeconds)
+            XCTAssertLessThanOrEqual(example.profile.peakAmplitude, SoundExampleKind.hearingSafeMaximumPeakAmplitude)
+            XCTAssertGreaterThan(example.profile.durationSeconds, 0)
+            XCTAssertGreaterThan(example.profile.peakAmplitude, 0)
+        }
+    }
+
     func testSoundVolumeQuizScoringUsesCorrectSafeAnswers() {
         let questions = SoundVolumeContent.quizQuestions
         let answers = Dictionary(uniqueKeysWithValues: questions.map { ($0.id, $0.correctChoice) })


### PR DESCRIPTION
## Summary
- adds a Sound Lab flashcard stage before the quiz so kids can review one sound concept at a time
- adds explicit "Play sound" controls for every Sound Lab card using short, generated, hearing-safe speaker examples instead of voice-over
- keeps microphone/live meter scope out of this PR and adds tests for playback metadata safety limits

Fixes #1010.
Fixes #1011.

## Validation
- `git diff --check`
- updated `LearningLoopTests` coverage for Sound Lab playback metadata and hearing-safe limits

Note: worker attempted to enumerate remote iOS simulators on `ganesh-mba`; full Xcode validation is left to hosted CI for this PR.