### PR TITLE
feat: add hearing-safe Sound Lab meter and pitch path

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -21,7 +21,7 @@
 	<key>NSMotionUsageDescription</key>
 	<string>Mather counts a few small careful steps during motion games. If motion access is unavailable, your child can use tap-to-count instead.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Mather listens for claps to celebrate with you. You can turn Clap reaction off any time in Settings.</string>
+	<string>Mather listens locally for claps and optional Sound Lab loudness estimates. Audio is not recorded, saved, or sent anywhere.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Room Quest uses the camera to scan station markers and unlock playful AR moments for kids.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -282,6 +282,170 @@ enum SoundLoudnessZone: String, CaseIterable, Equatable {
     }
 }
 
+
+enum SoundMeterPermissionState: String, Equatable {
+    case notStarted
+    case listening
+    case unavailable
+    case denied
+
+    var title: String {
+        switch self {
+        case .notStarted: return "Meter off"
+        case .listening: return "Meter listening"
+        case .unavailable: return "Microphone unavailable"
+        case .denied: return "Microphone off"
+        }
+    }
+
+    var guidance: String {
+        switch self {
+        case .notStarted:
+            return "Start only when a grown-up says it is okay. Mather reads a local loudness number and does not record audio."
+        case .listening:
+            return "Use normal room sounds only. Do not shout — quieter is safer."
+        case .unavailable:
+            return "This device cannot read the microphone right now. You can still learn with the safe example cards."
+        case .denied:
+            return "Microphone access is off. Mather will keep the Sound Lab in no-mic learning mode."
+        }
+    }
+}
+
+enum SoundMeterLevelBucket: String, CaseIterable, Equatable {
+    case quiet
+    case comfortable
+    case busy
+    case protect
+
+    var label: String {
+        switch self {
+        case .quiet: return "Quiet"
+        case .comfortable: return "Comfortable"
+        case .busy: return "Busy"
+        case .protect: return "Protect ears"
+        }
+    }
+
+    var targetCopy: String {
+        switch self {
+        case .quiet: return "Soft room sounds. Great for reading."
+        case .comfortable: return "Normal talking zone. Keep it easy."
+        case .busy: return "Busy room. Take breaks if it feels tiring."
+        case .protect: return "Too much sound. Move away, lower volume, or cover ears."
+        }
+    }
+
+    var fillFraction: Double {
+        switch self {
+        case .quiet: return 0.22
+        case .comfortable: return 0.46
+        case .busy: return 0.70
+        case .protect: return 0.92
+        }
+    }
+}
+
+struct SoundMeterReading: Equatable {
+    let rms: Float
+    let estimatedDecibels: Double
+    let bucket: SoundMeterLevelBucket
+
+    static let privacyCopy = "Local microphone meter only: Mather computes an RMS loudness number on this device, stores no audio, and sends no audio anywhere."
+    static let safetyCopy = "Use normal room sounds. Do not shout, scream, or try to make the meter higher. Quieter is safer."
+
+    init(rms: Float) {
+        let clampedRMS = min(max(rms, 0), 1)
+        self.rms = clampedRMS
+        self.estimatedDecibels = SoundMeterReading.estimatedDecibels(forRMS: clampedRMS)
+        self.bucket = SoundMeterReading.bucket(forRMS: clampedRMS)
+    }
+
+    static func estimatedDecibels(forRMS rms: Float) -> Double {
+        let clamped = max(Double(min(max(rms, 0), 1)), 0.000_001)
+        return min(max(20 * log10(clamped) + 94, 20), 100)
+    }
+
+    static func bucket(forRMS rms: Float) -> SoundMeterLevelBucket {
+        let db = estimatedDecibels(forRMS: rms)
+        switch db {
+        case ..<50: return .quiet
+        case ..<70: return .comfortable
+        case ..<85: return .busy
+        default: return .protect
+        }
+    }
+}
+
+enum SoundPitchBand: String, CaseIterable, Equatable, Identifiable {
+    case low
+    case middle
+    case high
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .low: return "Low pitch"
+        case .middle: return "Middle pitch"
+        case .high: return "High pitch"
+        }
+    }
+
+    var visualKey: String {
+        switch self {
+        case .low: return "🐘"
+        case .middle: return "🎵"
+        case .high: return "🐦"
+        }
+    }
+
+    var teachingCopy: String {
+        switch self {
+        case .low: return "Low pitch sounds deep, like a drum or a big animal."
+        case .middle: return "Middle pitch sits near many singing and talking notes."
+        case .high: return "High pitch sounds bright, like a tiny bell or bird chirp."
+        }
+    }
+
+    var frequencyRangeLabel: String {
+        switch self {
+        case .low: return "about 80–250 Hz"
+        case .middle: return "about 250–900 Hz"
+        case .high: return "about 900 Hz or more"
+        }
+    }
+}
+
+struct SoundPitchChallenge: Identifiable, Equatable {
+    let id: String
+    let prompt: String
+    let correctBand: SoundPitchBand
+    let options: [SoundPitchBand]
+    let feedback: String
+
+    func isCorrect(_ band: SoundPitchBand) -> Bool {
+        band == correctBand
+    }
+}
+
+struct SoundPitchChallengeState: Equatable {
+    let challenge: SoundPitchChallenge
+    var selectedBand: SoundPitchBand?
+
+    var isAnswered: Bool { selectedBand != nil }
+    var isCorrect: Bool { selectedBand.map(challenge.isCorrect) ?? false }
+
+    var feedback: String {
+        guard let selectedBand else { return "Tap the pitch you think matches. No microphone is needed for this part." }
+        return challenge.isCorrect(selectedBand) ? challenge.feedback : "Not that one yet — listen for whether the sound is deep, middle, or bright."
+    }
+
+    mutating func select(_ band: SoundPitchBand) {
+        selectedBand = band
+    }
+}
+
 struct SoundVolumeIntroPage: Identifiable, Equatable {
     let id: String
     let eyebrow: String
@@ -293,7 +457,7 @@ struct SoundVolumeIntroPage: Identifiable, Equatable {
 }
 
 enum SoundVolumeContent {
-    static let safetyNote = "Use listening clues only — no screaming. Protect your ears. A live microphone meter comes later and is not used in this activity."
+    static let safetyNote = "Use hearing-safe clues only — no screaming, no shouting, and no points for loudness. Protect your ears."
 
     static func clampedIntroPageIndex(_ index: Int) -> Int {
         min(max(index, 0), introPages.count - 1)
@@ -317,7 +481,7 @@ enum SoundVolumeContent {
             id: "safety",
             eyebrow: "Step 2 of 5",
             title: "Use hearing-safe play",
-            subtitle: "Use listening clues only — no screaming, no loud-noise challenge, and no microphone permission in this activity.",
+            subtitle: "Use normal room sounds only — no screaming, no shouting, no loud-noise challenge, and no points for making the meter higher.",
             visualKey: "👂",
             primaryActionTitle: "Next: decibels",
             primaryActionIcon: "arrow.right.circle.fill"
@@ -335,7 +499,7 @@ enum SoundVolumeContent {
             id: "zones",
             eyebrow: "Step 4 of 5",
             title: "Sort sounds into zones",
-            subtitle: "The zone cards are examples, not a live sound meter. If a sound hurts, move away or protect your ears.",
+            subtitle: "The live meter is an estimate, not a calibrated safety tool. If a sound hurts, move away or protect your ears.",
             visualKey: "📊",
             primaryActionTitle: "Next: sound clues",
             primaryActionIcon: "arrow.right.circle.fill"
@@ -404,6 +568,16 @@ enum SoundVolumeContent {
     ]
 
     static let estimatedZones: [SoundLoudnessZone] = [.quiet, .normal, .loud, .tooLoud]
+
+    static let pitchBands = SoundPitchBand.allCases
+
+    static let pitchChallenge = SoundPitchChallenge(
+        id: "bird-high-pitch",
+        prompt: "A tiny bird chirp is usually which pitch?",
+        correctBand: .high,
+        options: [.low, .middle, .high],
+        feedback: "Yes — tiny chirps are bright, high-pitch sounds."
+    )
 
     static func zone(forEstimatedDecibels decibels: Double) -> SoundLoudnessZone {
         switch decibels {

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -439,6 +439,7 @@ struct ConceptMixMatchRoundView: View {
 
 private enum SoundVolumeActivityStage: CaseIterable {
     case flashcards
+    case meterPitch
     case quiz
     case match
     case summary
@@ -446,6 +447,7 @@ private enum SoundVolumeActivityStage: CaseIterable {
     var title: String {
         switch self {
         case .flashcards: return "Flashcards"
+        case .meterPitch: return "Meter + Pitch"
         case .quiz: return "Quiz"
         case .match: return "Mix + Match"
         case .summary: return "Stars"
@@ -454,7 +456,8 @@ private enum SoundVolumeActivityStage: CaseIterable {
 
     var primaryActionTitle: String {
         switch self {
-        case .flashcards: return "Go to Quiz"
+        case .flashcards: return "Try Meter + Pitch"
+        case .meterPitch: return "Go to Quiz"
         case .quiz: return "Go to Mix + Match"
         case .match: return "See Sound Score"
         case .summary: return "Review Flashcards"
@@ -463,7 +466,8 @@ private enum SoundVolumeActivityStage: CaseIterable {
 
     var primaryActionIcon: String {
         switch self {
-        case .flashcards: return "checkmark.circle.fill"
+        case .flashcards: return "waveform"
+        case .meterPitch: return "checkmark.circle.fill"
         case .quiz: return "rectangle.grid.2x2.fill"
         case .match: return "star.fill"
         case .summary: return "arrow.counterclockwise"
@@ -472,7 +476,8 @@ private enum SoundVolumeActivityStage: CaseIterable {
 
     var next: SoundVolumeActivityStage {
         switch self {
-        case .flashcards: return .quiz
+        case .flashcards: return .meterPitch
+        case .meterPitch: return .quiz
         case .quiz: return .match
         case .match: return .summary
         case .summary: return .flashcards
@@ -482,7 +487,8 @@ private enum SoundVolumeActivityStage: CaseIterable {
     var previous: SoundVolumeActivityStage {
         switch self {
         case .flashcards: return .summary
-        case .quiz: return .flashcards
+        case .meterPitch: return .flashcards
+        case .quiz: return .meterPitch
         case .match: return .quiz
         case .summary: return .match
         }
@@ -500,6 +506,7 @@ struct SoundVolumeLabView: View {
     @State private var matchedPairIds: Set<String> = []
     @State private var matchShuffleSeed = UInt64.random(in: UInt64.min...UInt64.max)
     @State private var feedback = SoundVolumeContent.safetyNote
+    @State private var pitchChallengeState = SoundPitchChallengeState(challenge: SoundVolumeContent.pitchChallenge)
 
     private var introPages: [SoundVolumeIntroPage] { SoundVolumeContent.introPages }
     private var safeIntroPageIndex: Int { SoundVolumeContent.clampedIntroPageIndex(introPageIndex) }
@@ -559,6 +566,7 @@ struct SoundVolumeLabView: View {
             }
         }
         .onDisappear {
+            appModel.soundDetectionService.stopSoundLabMeter()
             if summary.starCount > 0 || matchedPairIds.count == SoundVolumeContent.matchPairs.count {
                 appModel.markExplorerLabModeCompleted(laneID: .physics, mode: .review)
                 appModel.setExplorerLabConceptConfidence(.steady, for: ConceptId(rawValue: "sound-volume"), laneID: .physics)
@@ -707,6 +715,8 @@ struct SoundVolumeLabView: View {
                 selectedIndex: $selectedSoundCardIndex,
                 onPlaySound: playSoundExample
             )
+        case .meterPitch:
+            soundMeterPitchActivity
         case .quiz:
             ConceptQuizRoundView(
                 questions: SoundVolumeContent.quizQuestions,
@@ -730,8 +740,7 @@ struct SoundVolumeLabView: View {
         HStack(spacing: 10) {
             if activityStage != .flashcards {
                 Button {
-                    activityStage = activityStage.previous
-                    updateFeedbackForCurrentStage()
+                    setActivityStage(activityStage.previous)
                 } label: {
                     Label("Back", systemImage: "chevron.left")
                         .font(.headline.weight(.black))
@@ -742,8 +751,7 @@ struct SoundVolumeLabView: View {
             }
 
             Button {
-                activityStage = activityStage.next
-                updateFeedbackForCurrentStage()
+                setActivityStage(activityStage.next)
             } label: {
                 Label(activityStage.primaryActionTitle, systemImage: activityStage.primaryActionIcon)
                     .font(.headline.weight(.black))
@@ -753,10 +761,20 @@ struct SoundVolumeLabView: View {
         }
     }
 
+    private func setActivityStage(_ newStage: SoundVolumeActivityStage) {
+        if activityStage == .meterPitch && newStage != .meterPitch {
+            appModel.soundDetectionService.stopSoundLabMeter()
+        }
+        activityStage = newStage
+        updateFeedbackForCurrentStage()
+    }
+
     private func updateFeedbackForCurrentStage() {
         switch activityStage {
         case .flashcards:
             feedback = "Tap Play sound on each card for a short, hearing-safe example."
+        case .meterPitch:
+            feedback = "Try the local-only meter with normal room sounds, then answer the pitch card."
         case .quiz:
             feedback = "Now try the quiz. Use the flashcard clues you heard."
         case .match:
@@ -799,7 +817,7 @@ struct SoundVolumeLabView: View {
                             .font(.largeTitle.weight(.black))
                             .foregroundStyle(MatherTheme.ink)
                             .minimumScaleFactor(0.75)
-                        Text("Quiz and match safe listening clues. No microphone permission or live meter is used.")
+                        Text("Try a local-only meter, pitch cards, quiz, and safe listening matches. No recording, no loudness rewards.")
                             .font(.headline.weight(.semibold))
                             .foregroundStyle(MatherTheme.cardSubtitle)
                     }
@@ -825,7 +843,7 @@ struct SoundVolumeLabView: View {
                 Text("Hearing-safe play")
                     .font(.headline.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
-                Text("No microphone permission, no live meter, and no loud-noise challenge in this round. Match the clues and choose safe actions.")
+                Text("The meter asks for microphone access only after you tap Start. Audio stays on this device as a loudness number only: no recording, no storage, no sending. No shouting or loud-noise challenge.")
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(MatherTheme.cardSubtitle)
             }
@@ -864,7 +882,7 @@ struct SoundVolumeLabView: View {
             Text("Estimated loudness zones")
                 .font(.title2.weight(.black))
                 .foregroundStyle(MatherTheme.ink)
-            Text("These are learning examples, not a calibrated sound meter.")
+            Text("These are learning examples. The live meter is estimated, not calibrated safety equipment.")
                 .font(.caption.weight(.bold))
                 .foregroundStyle(MatherTheme.cardSubtitle)
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 10)], spacing: 10) {
@@ -889,6 +907,169 @@ struct SoundVolumeLabView: View {
                     .accessibilityLabel("\(zone.label), estimated \(zone.estimatedRangeLabel). \(zone.safetyCopy)")
                 }
             }
+        }
+    }
+
+
+    private var soundMeterPitchActivity: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            soundMeterCard
+            pitchTeachingCard
+        }
+    }
+
+    private var soundMeterCard: some View {
+        let reading = appModel.soundDetectionService.meterReading
+        let permissionState = appModel.soundDetectionService.meterPermissionState
+        return CardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: "waveform.badge.magnifyingglass")
+                        .font(.title.weight(.black))
+                        .foregroundStyle(MatherTheme.accent)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Hearing-safe sound meter")
+                            .font(.title2.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text(SoundMeterReading.privacyCopy)
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Text(SoundMeterReading.safetyCopy)
+                            .font(.caption.weight(.black))
+                            .foregroundStyle(MatherTheme.panelDeep)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text(permissionState.title)
+                            .font(.headline.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Spacer()
+                        Text("~\(Int(reading.estimatedDecibels.rounded())) dB")
+                            .font(.headline.monospacedDigit().weight(.black))
+                            .foregroundStyle(MatherTheme.accent)
+                    }
+                    GeometryReader { proxy in
+                        ZStack(alignment: .leading) {
+                            Capsule().fill(MatherTheme.softBlue.opacity(0.30))
+                            Capsule()
+                                .fill(meterFill(reading.bucket))
+                                .frame(width: max(CGFloat(12), proxy.size.width * CGFloat(reading.bucket.fillFraction)))
+                        }
+                    }
+                    .frame(height: 18)
+                    Text("\(reading.bucket.label): \(reading.bucket.targetCopy)")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                }
+                .padding(12)
+                .background(MatherTheme.card.opacity(0.70))
+                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+                Text(permissionState.guidance)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: 10) {
+                    Button {
+                        appModel.soundDetectionService.startSoundLabMeter()
+                        feedback = "Meter started. Use normal room sounds only — no shouting and no points for loudness."
+                    } label: {
+                        Label("Start local meter", systemImage: "mic.circle.fill")
+                            .font(.headline.weight(.black))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(PrimaryActionButtonStyle())
+                    .accessibilityIdentifier("SoundLabStartLocalMeter")
+
+                    Button {
+                        appModel.soundDetectionService.stopSoundLabMeter()
+                        feedback = "Meter stopped. Audio was not recorded or saved."
+                    } label: {
+                        Label("Stop", systemImage: "stop.circle.fill")
+                            .font(.headline.weight(.black))
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+                    .accessibilityIdentifier("SoundLabStopLocalMeter")
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var pitchTeachingCard: some View {
+        CardSurface {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Pitch follow-up")
+                    .font(.title2.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text("Pitch means how deep or bright a sound is. It is different from loudness, so you never need to be louder to learn pitch.")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 10)], spacing: 10) {
+                    ForEach(SoundVolumeContent.pitchBands) { band in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(band.visualKey).font(.largeTitle)
+                            Text(band.title)
+                                .font(.headline.weight(.black))
+                                .foregroundStyle(MatherTheme.ink)
+                            Text(band.frequencyRangeLabel)
+                                .font(.caption.weight(.black))
+                                .foregroundStyle(MatherTheme.accent)
+                            Text(band.teachingCopy)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                        }
+                        .padding(12)
+                        .frame(maxWidth: .infinity, minHeight: 150, alignment: .topLeading)
+                        .background(MatherTheme.softBlue.opacity(0.18))
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .accessibilityElement(children: .combine)
+                    }
+                }
+
+                Text(pitchChallengeState.challenge.prompt)
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+
+                HStack(spacing: 8) {
+                    ForEach(pitchChallengeState.challenge.options) { band in
+                        Button {
+                            pitchChallengeState.select(band)
+                            feedback = pitchChallengeState.feedback
+                        } label: {
+                            Text("\(band.visualKey) \(band.title)")
+                                .font(.caption.weight(.black))
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(pitchChallengeState.selectedBand == band ? MatherTheme.accent : MatherTheme.softBlue)
+                        .accessibilityIdentifier("SoundPitchChoice-\(band.rawValue)")
+                    }
+                }
+
+                Text(pitchChallengeState.feedback)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(pitchChallengeState.isCorrect ? MatherTheme.accent : MatherTheme.cardSubtitle)
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private func meterFill(_ bucket: SoundMeterLevelBucket) -> Color {
+        switch bucket {
+        case .quiet: return MatherTheme.softBlue
+        case .comfortable: return MatherTheme.accent
+        case .busy: return MatherTheme.warm
+        case .protect: return MatherTheme.coral
         }
     }
 

--- a/Services/SoundDetectionService.swift
+++ b/Services/SoundDetectionService.swift
@@ -22,6 +22,10 @@ final class SoundDetectionService {
     /// Momentarily true when a clap is detected; auto-resets after 500 ms.
     var clapDetected: Bool = false
 
+    /// Local-only RMS loudness estimate for Sound Lab meter UI. Audio is never stored or transmitted.
+    var meterReading = SoundMeterReading(rms: 0)
+    var meterPermissionState: SoundMeterPermissionState = .notStarted
+
     // MARK: - Private
 
     // nonisolated(unsafe): AVAudioEngine is not Sendable, but we only ever
@@ -37,11 +41,27 @@ final class SoundDetectionService {
     /// Does nothing if already listening.
     func startListening() {
         guard !isListening else { return }
+        let audioSession = AVAudioSession.sharedInstance()
+        guard audioSession.isInputAvailable else {
+            meterPermissionState = .unavailable
+            return
+        }
+        do {
+            try audioSession.setCategory(.playAndRecord, mode: .measurement, options: [.duckOthers, .defaultToSpeaker])
+            try audioSession.setActive(true, options: [])
+        } catch {
+            meterPermissionState = .denied
+            return
+        }
+
         let inputNode = audioEngine.inputNode
         let format = inputNode.inputFormat(forBus: 0)
-        // When the AVAudioSession category is .playback (set by SpeechService),
-        // inputFormat can return a zero-sample-rate format — installTap would crash.
-        guard format.sampleRate > 0 else { return }
+        // When input hardware is unavailable, inputFormat can return a
+        // zero-sample-rate format — installTap would crash.
+        guard format.sampleRate > 0 else {
+            meterPermissionState = .unavailable
+            return
+        }
 
         inputNode.installTap(onBus: 0, bufferSize: 2048, format: format) { [weak self] buffer, _ in
             guard let channelData = buffer.floatChannelData?[0] else { return }
@@ -61,20 +81,31 @@ final class SoundDetectionService {
         do {
             try audioEngine.start()
             isListening = true
+            meterPermissionState = .listening
         } catch {
             // Silently fail: microphone permission may be denied, or the
             // audio session may be unavailable. Bond Blast still works without clap.
+            meterPermissionState = .denied
             inputNode.removeTap(onBus: 0)
         }
     }
 
     /// Stop listening and tear down the audio tap.
     func stopListening() {
-        guard isListening else { return }
+        guard isListening else {
+            previousRMS = 0
+            meterReading = SoundMeterReading(rms: 0)
+            meterPermissionState = .notStarted
+            clapResetTask?.cancel()
+            clapDetected = false
+            return
+        }
         audioEngine.inputNode.removeTap(onBus: 0)
         audioEngine.stop()
         isListening = false
         previousRMS = 0
+        meterReading = SoundMeterReading(rms: 0)
+        meterPermissionState = .notStarted
         clapResetTask?.cancel()
         clapDetected = false
     }
@@ -87,7 +118,16 @@ final class SoundDetectionService {
 
     // MARK: - Private helpers
 
+    func startSoundLabMeter() {
+        startListening()
+    }
+
+    func stopSoundLabMeter() {
+        stopListening()
+    }
+
     private func evaluateRMS(_ rms: Float) {
+        meterReading = SoundMeterReading(rms: rms)
         // Clap signature: near-silence followed by a sharp spike.
         if rms > 0.3 && previousRMS < 0.05 && !clapDetected {
             clapDetected = true

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -122,10 +122,12 @@ extension LearningLoopTests {
 
         XCTAssertEqual(pages.map(\.id), ["welcome", "safety", "decibels", "zones", "clues"])
         XCTAssertEqual(pages.last?.primaryActionTitle, "Start Sound Lab")
-        XCTAssertTrue(pages[1].subtitle.contains("no microphone permission"))
+        XCTAssertTrue(pages[1].subtitle.contains("no shouting"))
+        XCTAssertTrue(pages[1].subtitle.contains("no points"))
         XCTAssertTrue(pages[1].subtitle.contains("no loud-noise challenge"))
         XCTAssertTrue(pages[2].subtitle.contains("decibel"))
-        XCTAssertTrue(pages[3].subtitle.contains("not a live sound meter"))
+        XCTAssertTrue(pages[3].subtitle.contains("estimate"))
+        XCTAssertTrue(pages[3].subtitle.contains("not a calibrated safety tool"))
     }
 
     func testSoundVolumeIntroPageLookupClampsOutOfRangeIndexes() {
@@ -155,7 +157,8 @@ extension LearningLoopTests {
             "Protect Ears",
         ]))
         XCTAssertTrue(SoundVolumeContent.safetyNote.contains("no screaming"))
-        XCTAssertTrue(SoundVolumeContent.safetyNote.contains("microphone meter comes later"))
+        XCTAssertTrue(SoundVolumeContent.safetyNote.contains("no shouting"))
+        XCTAssertTrue(SoundVolumeContent.safetyNote.contains("no points for loudness"))
     }
 
     func testSoundVolumeCardsExposeExplicitHearingSafePlaybackExamples() {
@@ -174,6 +177,47 @@ extension LearningLoopTests {
             XCTAssertGreaterThan(example.profile.durationSeconds, 0)
             XCTAssertGreaterThan(example.profile.peakAmplitude, 0)
         }
+    }
+
+
+    func testSoundMeterReadingBucketsArePureAndConservative() {
+        XCTAssertEqual(SoundMeterReading.bucket(forRMS: 0.001), .quiet)
+        XCTAssertEqual(SoundMeterReading.bucket(forRMS: 0.01), .comfortable)
+        XCTAssertEqual(SoundMeterReading.bucket(forRMS: 0.10), .busy)
+        XCTAssertEqual(SoundMeterReading.bucket(forRMS: 0.50), .protect)
+
+        let overRange = SoundMeterReading(rms: 2)
+        XCTAssertEqual(overRange.rms, 1)
+        XCTAssertEqual(overRange.bucket, .protect)
+        XCTAssertLessThanOrEqual(overRange.estimatedDecibels, 100)
+    }
+
+    func testSoundMeterCopyIsLocalOnlyAndDoesNotRewardLoudness() {
+        XCTAssertTrue(SoundMeterReading.privacyCopy.contains("Local microphone meter only"))
+        XCTAssertTrue(SoundMeterReading.privacyCopy.contains("stores no audio"))
+        XCTAssertTrue(SoundMeterReading.privacyCopy.contains("sends no audio"))
+        XCTAssertTrue(SoundMeterReading.safetyCopy.contains("Do not shout"))
+        XCTAssertTrue(SoundMeterReading.safetyCopy.contains("scream"))
+        XCTAssertTrue(SoundMeterReading.safetyCopy.contains("try to make the meter higher"))
+        XCTAssertFalse(SoundMeterLevelBucket.allCases.map(\.targetCopy).joined(separator: " ").localizedCaseInsensitiveContains("louder"))
+    }
+
+    func testSoundPitchChallengeStateTeachesPitchWithoutMicrophone() {
+        var state = SoundPitchChallengeState(challenge: SoundVolumeContent.pitchChallenge)
+        XCTAssertFalse(state.isAnswered)
+        XCTAssertTrue(state.feedback.contains("No microphone"))
+        XCTAssertEqual(SoundVolumeContent.pitchBands, [.low, .middle, .high])
+        XCTAssertTrue(SoundPitchBand.low.teachingCopy.contains("deep"))
+        XCTAssertTrue(SoundPitchBand.high.teachingCopy.contains("bright"))
+
+        state.select(.low)
+        XCTAssertTrue(state.isAnswered)
+        XCTAssertFalse(state.isCorrect)
+        XCTAssertTrue(state.feedback.contains("Not that one"))
+
+        state.select(.high)
+        XCTAssertTrue(state.isCorrect)
+        XCTAssertEqual(state.feedback, SoundVolumeContent.pitchChallenge.feedback)
     }
 
     func testSoundVolumeQuizScoringUsesCorrectSafeAnswers() {

--- a/Tests/MatherTests/SoundDetectionServiceTests.swift
+++ b/Tests/MatherTests/SoundDetectionServiceTests.swift
@@ -28,6 +28,16 @@ struct SoundDetectionServiceTests {
     func initialStateIsQuiescent() {
         let service = SoundDetectionService()
         #expect(!service.clapDetected)
+        #expect(service.meterPermissionState == .notStarted)
+        #expect(service.meterReading == SoundMeterReading(rms: 0))
+    }
+
+    @Test
+    func soundMeterStartsInPrivacySafeNoAudioState() {
+        let service = SoundDetectionService()
+        #expect(service.meterPermissionState.guidance.contains("does not record audio"))
+        #expect(SoundMeterReading.privacyCopy.contains("stores no audio"))
+        #expect(SoundMeterReading.privacyCopy.contains("sends no audio"))
     }
 
     // MARK: - startListening / stopListening idempotency
@@ -38,6 +48,7 @@ struct SoundDetectionServiceTests {
         // Calling stop before start should be a no-op (guarded by isListening).
         service.stopListening()
         #expect(!service.clapDetected)
+        #expect(service.meterPermissionState == .notStarted)
     }
 
     // startListening() calls AVAudioEngine.start() which requires real audio hardware.
@@ -88,5 +99,6 @@ struct SoundDetectionServiceTests {
         let service = SoundDetectionService()
         service.stopListening()
         #expect(!service.clapDetected)
+        #expect(service.meterPermissionState == .notStarted)
     }
 }


### PR DESCRIPTION
## Summary
- adds a hearing-safe Sound Lab “Meter + Pitch” activity between flashcards and quiz
- exposes local-only RMS loudness buckets with explicit microphone/privacy copy and no loudness rewards
- adds pitch teaching cards + a no-microphone pitch challenge
- updates microphone usage copy and SoundDetectionService state for local meter feedback

Addresses #1009.

## Validation
- `git diff --check`
- Added tests for Sound Lab safety copy, pure meter bucket behavior, local-only/no-loudness-reward copy, pitch challenge state, and meter default privacy state.
- Worker attempted Xcode validation on `ganesh-mba`, but that run failed from the known checked-project/source-membership issue (`Cannot find type ... in scope` across many existing app types), not from these focused changes; GitHub CI is authoritative.