### PR TITLE
Fix duplicate quiz choice labels

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -387,7 +387,7 @@ enum GameplayStageContentBuilder {
             let fallbackDistractors = pairs
                 .filter { $0.id != pair.id }
                 .map(\.right)
-            let distractors = uniqued(sameTypeDistractors + fallbackDistractors, excluding: pair.right.id)
+            let distractors = uniqued(sameTypeDistractors + fallbackDistractors, excluding: pair.right)
             let choices = deterministicOrder([pair.right] + Array(distractors.prefix(max(0, choicesPerQuestion - 1))), seed: stableSeed(pair.id))
             return GameplayMultipleChoiceQuestion(
                 id: "quiz-\(pair.id)",
@@ -431,14 +431,22 @@ enum GameplayStageContentBuilder {
         thread.propertyTypesByID[id]?.displayName ?? id
     }
 
-    private static func uniqued(_ items: [GameplayDisplayItem], excluding id: String) -> [GameplayDisplayItem] {
-        var seen = Set([id])
+    private static func uniqued(_ items: [GameplayDisplayItem], excluding answer: GameplayDisplayItem) -> [GameplayDisplayItem] {
+        var seenIDs = Set([answer.id])
+        var seenVisibleLabels = Set([visibleChoiceKey(answer)])
         var result: [GameplayDisplayItem] = []
-        for item in items where !seen.contains(item.id) {
-            seen.insert(item.id)
+        for item in items {
+            let visibleKey = visibleChoiceKey(item)
+            guard !seenIDs.contains(item.id), !seenVisibleLabels.contains(visibleKey) else { continue }
+            seenIDs.insert(item.id)
+            seenVisibleLabels.insert(visibleKey)
             result.append(item)
         }
         return result
+    }
+
+    private static func visibleChoiceKey(_ item: GameplayDisplayItem) -> String {
+        item.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
     private static func deterministicOrder<T: Identifiable>(_ items: [T], seed: UInt64) -> [T] where T.ID == String {

--- a/Tests/MatherTests/CountryGameplayThreadTests.swift
+++ b/Tests/MatherTests/CountryGameplayThreadTests.swift
@@ -98,6 +98,39 @@ struct CountryGameplayThreadTests {
 
 
     @Test
+    func countryContinentQuizDoesNotRepeatVisibleAnswerLabels() throws {
+        let thread = CountryGameplayThread.thread
+        let selectedIDs = ["country-kenya", "country-egypt", "country-canada", "country-india"]
+        let items = try selectedIDs.map { entityID in
+            let entity = try #require(thread.entities.first { $0.id == entityID })
+            let continent = try #require(entity.properties.first { $0.typeID == "continent" })
+            return GameplayRoundItem(
+                id: "quiz-\(entityID)-continent",
+                entityID: entityID,
+                propertyID: continent.id,
+                propertyTypeID: continent.typeID
+            )
+        }
+        let round = GameplayRoundDefinition(
+            id: "country-continent-duplicates",
+            stageID: "multiple-choice",
+            kind: .multipleChoice,
+            items: items,
+            seed: 95
+        )
+
+        let questions = GameplayStageContentBuilder.multipleChoiceQuestions(thread: thread, round: round, choicesPerQuestion: 4)
+        let kenyaQuestion = try #require(questions.first { $0.answer.entityID == "country-kenya" })
+
+        #expect(kenyaQuestion.prompt == "Which one matches Kenya?")
+        #expect(kenyaQuestion.answer.title == "Africa")
+        #expect(kenyaQuestion.choices.map(\.title).filter { $0 == "Africa" }.count == 1)
+        #expect(questions.allSatisfy { question in
+            Set(question.choices.map { $0.title.lowercased() }).count == question.choices.count
+        })
+    }
+
+    @Test
     func mapShapeQuizItemsCarryDrawableShapeKeys() throws {
         let thread = CountryGameplayThread.thread
         let stage = try #require(thread.stages.first { $0.kind == .multipleChoice })


### PR DESCRIPTION
## Summary
- Dedupes multiple-choice distractors by visible choice title, not only display item ID.
- Keeps quiz choice ordering deterministic while preventing duplicate visible answers like `Africa` / `Africa`.
- Adds a Country Cards regression for the Kenya continent quiz case.

## Validation
- `git diff --check`
- Attempted targeted `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPad (A16)' -only-testing:MatherTests/CountryGameplayThreadTests/countryContinentQuizDoesNotRepeatVisibleAnswerLabels` on `ganesh-mba`; build failed before tests because the checked-in Xcode project was stale/missing generated source membership. CI post-clone regenerates with XcodeGen, so this should validate in CI.

Addresses #1023
