### PR TITLE
Enrich fruit cards with playful review

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -103,6 +103,12 @@ struct GameplayDisplayItem: Identifiable, Equatable, Hashable {
     var spokenText: String {
         [title, subtitle].filter { !$0.isEmpty }.joined(separator: ". ")
     }
+
+    var isFruitCard: Bool { entityID.hasPrefix("fruit-") }
+
+    var discoveryPrompt: String {
+        isFruitCard ? "Spot the color, say the flavor, then tap I spotted it!" : "Tap the card, say one clue, then try the next one."
+    }
 }
 
 struct GameplayMatchPair: Identifiable, Equatable, Hashable {
@@ -126,6 +132,7 @@ struct GameplayFlashcardStageViewModel: Equatable {
     let cards: [GameplayDisplayItem]
     var activeIndex: Int = 0
     var exposureCount: Int = 0
+    var spottedCardIDs: Set<String> = []
 
     init(thread: GameplayThreadDefinition, round: GameplayRoundDefinition) {
         self.cards = GameplayStageContentBuilder.flashcards(thread: thread, round: round)
@@ -146,6 +153,26 @@ struct GameplayFlashcardStageViewModel: Equatable {
     var listenAgainAccessibilityLabel: String {
         guard let activeCard else { return "Listen again" }
         return "Listen again to \(activeCard.title)"
+    }
+
+    var activeDiscoveryPrompt: String {
+        activeCard?.discoveryPrompt ?? "Tap the card, say one clue, then try the next one."
+    }
+
+    var spottedActiveCard: Bool {
+        guard let activeCard else { return false }
+        return spottedCardIDs.contains(activeCard.id)
+    }
+
+    var spottedFeedbackText: String {
+        guard let activeCard else { return "Clue spotted!" }
+        return activeCard.isFruitCard ? "Flavor badge unlocked for \(activeCard.title)!" : "Clue spotted for \(activeCard.title)!"
+    }
+
+    mutating func markActiveCardSpotted() {
+        guard let activeCard else { return }
+        spottedCardIDs.insert(activeCard.id)
+        markExposure()
     }
 
     mutating func markExposure() {

--- a/Domain/GameplayThreadCatalog.swift
+++ b/Domain/GameplayThreadCatalog.swift
@@ -35,6 +35,9 @@ extension GameplayThreadCatalog {
             GameplayPropertyType(id: "taste", displayName: "Taste", prompt: "Find the taste clue."),
             GameplayPropertyType(id: "seed-skin", displayName: "Seed or Skin", prompt: "Find the seed or skin clue."),
             GameplayPropertyType(id: "grows-on", displayName: "Grows On", prompt: "Find where it grows."),
+            GameplayPropertyType(id: "grow-climate", displayName: "Grow Climate", prompt: "Find the warm, cool, or snowy-place clue."),
+            GameplayPropertyType(id: "origin", displayName: "Origin Clue", prompt: "Find a place people first grew this fruit."),
+            GameplayPropertyType(id: "flavor", displayName: "Flavor Friend", prompt: "Find the flavor it reminds you of."),
             GameplayPropertyType(id: "category", displayName: "Fruit Type", prompt: "Find the fruit family clue.")
         ],
         entities: [
@@ -44,6 +47,9 @@ extension GameplayThreadCatalog {
                 GameplayProperty(id: "fruit-apple-taste", typeID: "taste", value: "Sweet and crisp", explanation: "An apple often tastes sweet and makes a crisp crunch."),
                 GameplayProperty(id: "fruit-apple-seed-skin", typeID: "seed-skin", value: "Thin skin with small seeds inside", explanation: "Apple seeds hide in the core, and the skin is safe to eat after washing."),
                 GameplayProperty(id: "fruit-apple-grows-on", typeID: "grows-on", value: "Tree", explanation: "Apples grow on apple trees."),
+                GameplayProperty(id: "fruit-apple-grow-climate", typeID: "grow-climate", value: "Cool orchards", explanation: "Apples grow well in places with warm days and cool nights."),
+                GameplayProperty(id: "fruit-apple-origin", typeID: "origin", value: "Central Asia", explanation: "Many apple ancestors came from Central Asia long ago."),
+                GameplayProperty(id: "fruit-apple-flavor", typeID: "flavor", value: "Cinnamon pie", explanation: "Apple flavor often reminds people of cinnamon, pie, or fresh juice."),
                 GameplayProperty(id: "fruit-apple-category", typeID: "category", value: "Orchard fruit", explanation: "Orchards are places where many fruit trees grow.")
             ]),
             GameplayEntity(id: "fruit-banana", name: "Banana", summary: "A soft yellow fruit with a peel you remove.", visualKey: "🍌", properties: [
@@ -52,6 +58,9 @@ extension GameplayThreadCatalog {
                 GameplayProperty(id: "fruit-banana-taste", typeID: "taste", value: "Sweet and soft", explanation: "Bananas taste sweet and feel soft when ripe."),
                 GameplayProperty(id: "fruit-banana-seed-skin", typeID: "seed-skin", value: "Thick peel with tiny soft seeds", explanation: "The peel protects the banana. The tiny seeds are usually too small to notice."),
                 GameplayProperty(id: "fruit-banana-grows-on", typeID: "grows-on", value: "Large banana plant", explanation: "Bananas grow in bunches on tall banana plants."),
+                GameplayProperty(id: "fruit-banana-grow-climate", typeID: "grow-climate", value: "Warm tropical places", explanation: "Bananas like warm, rainy places with no snow."),
+                GameplayProperty(id: "fruit-banana-origin", typeID: "origin", value: "Southeast Asia", explanation: "People first grew bananas in warm parts of Southeast Asia."),
+                GameplayProperty(id: "fruit-banana-flavor", typeID: "flavor", value: "Creamy smoothie", explanation: "Banana flavor is sweet and creamy, like a smoothie."),
                 GameplayProperty(id: "fruit-banana-category", typeID: "category", value: "Tropical fruit", explanation: "Tropical fruits grow well in warm places.")
             ]),
             GameplayEntity(id: "fruit-mango", name: "Mango", summary: "A juicy tropical fruit with one big seed.", visualKey: "🥭", properties: [
@@ -60,6 +69,9 @@ extension GameplayThreadCatalog {
                 GameplayProperty(id: "fruit-mango-taste", typeID: "taste", value: "Very sweet and juicy", explanation: "A ripe mango is juicy and very sweet."),
                 GameplayProperty(id: "fruit-mango-seed-skin", typeID: "seed-skin", value: "Thin skin with one big flat seed", explanation: "A mango has one large seed in the middle."),
                 GameplayProperty(id: "fruit-mango-grows-on", typeID: "grows-on", value: "Tree", explanation: "Mangoes grow on mango trees."),
+                GameplayProperty(id: "fruit-mango-grow-climate", typeID: "grow-climate", value: "Hot tropical places", explanation: "Mango trees love heat and sunshine."),
+                GameplayProperty(id: "fruit-mango-origin", typeID: "origin", value: "South Asia", explanation: "Mangoes have been grown in South Asia for a very long time."),
+                GameplayProperty(id: "fruit-mango-flavor", typeID: "flavor", value: "Honey sunshine", explanation: "Mango flavor can feel sweet like honey and bright like sunshine."),
                 GameplayProperty(id: "fruit-mango-category", typeID: "category", value: "Tropical stone fruit", explanation: "A stone fruit has one big hard seed, or stone, inside.")
             ]),
             GameplayEntity(id: "fruit-orange", name: "Orange", summary: "A round citrus fruit with juicy sections.", visualKey: "🍊", properties: [
@@ -68,6 +80,9 @@ extension GameplayThreadCatalog {
                 GameplayProperty(id: "fruit-orange-taste", typeID: "taste", value: "Sweet and tangy", explanation: "Tangy means it has a bright little zing."),
                 GameplayProperty(id: "fruit-orange-seed-skin", typeID: "seed-skin", value: "Bumpy peel; some have seeds", explanation: "The peel comes off before eating the juicy parts."),
                 GameplayProperty(id: "fruit-orange-grows-on", typeID: "grows-on", value: "Tree", explanation: "Oranges grow on citrus trees."),
+                GameplayProperty(id: "fruit-orange-grow-climate", typeID: "grow-climate", value: "Warm citrus groves", explanation: "Oranges grow well in warm places with plenty of sun."),
+                GameplayProperty(id: "fruit-orange-origin", typeID: "origin", value: "East and Southeast Asia", explanation: "Sweet oranges came from citrus grown in Asia long ago."),
+                GameplayProperty(id: "fruit-orange-flavor", typeID: "flavor", value: "Sunny juice", explanation: "Orange flavor is juicy, bright, and a little zingy."),
                 GameplayProperty(id: "fruit-orange-category", typeID: "category", value: "Citrus fruit", explanation: "Citrus fruits often smell fresh and taste tangy.")
             ]),
             GameplayEntity(id: "fruit-grape", name: "Grape", summary: "A small juicy fruit that grows in bunches.", visualKey: "🍇", properties: [
@@ -76,6 +91,9 @@ extension GameplayThreadCatalog {
                 GameplayProperty(id: "fruit-grape-taste", typeID: "taste", value: "Sweet and juicy", explanation: "Grapes pop with sweet juice."),
                 GameplayProperty(id: "fruit-grape-seed-skin", typeID: "seed-skin", value: "Thin skin; seeded or seedless", explanation: "Some grapes have tiny seeds, and some are grown seedless."),
                 GameplayProperty(id: "fruit-grape-grows-on", typeID: "grows-on", value: "Vine", explanation: "Grapes grow in bunches on vines."),
+                GameplayProperty(id: "fruit-grape-grow-climate", typeID: "grow-climate", value: "Sunny vineyards", explanation: "Grapes like sunny places and can grow in warm or mild climates."),
+                GameplayProperty(id: "fruit-grape-origin", typeID: "origin", value: "Western Asia", explanation: "People have grown grapes around Western Asia and nearby regions since ancient times."),
+                GameplayProperty(id: "fruit-grape-flavor", typeID: "flavor", value: "Juice pop", explanation: "Grape flavor is sweet, juicy, and pops in your mouth."),
                 GameplayProperty(id: "fruit-grape-category", typeID: "category", value: "Vine fruit", explanation: "Vine fruits grow on long climbing stems.")
             ]),
             GameplayEntity(id: "fruit-watermelon", name: "Watermelon", summary: "A big melon with green rind and red juicy inside.", visualKey: "🍉", properties: [
@@ -84,6 +102,9 @@ extension GameplayThreadCatalog {
                 GameplayProperty(id: "fruit-watermelon-taste", typeID: "taste", value: "Sweet and watery", explanation: "Watermelon is full of sweet juice."),
                 GameplayProperty(id: "fruit-watermelon-seed-skin", typeID: "seed-skin", value: "Hard rind with black or white seeds", explanation: "The rind protects the juicy fruit inside."),
                 GameplayProperty(id: "fruit-watermelon-grows-on", typeID: "grows-on", value: "Vine on the ground", explanation: "Watermelons grow on vines that spread along the ground."),
+                GameplayProperty(id: "fruit-watermelon-grow-climate", typeID: "grow-climate", value: "Hot sunny fields", explanation: "Watermelons grow best in warm fields with lots of sun."),
+                GameplayProperty(id: "fruit-watermelon-origin", typeID: "origin", value: "Africa", explanation: "Watermelon ancestors grew in Africa."),
+                GameplayProperty(id: "fruit-watermelon-flavor", typeID: "flavor", value: "Cool summer sip", explanation: "Watermelon flavor feels cool, sweet, and watery."),
                 GameplayProperty(id: "fruit-watermelon-category", typeID: "category", value: "Melon", explanation: "Melons are large juicy fruits with rinds.")
             ]),
             GameplayEntity(id: "fruit-pineapple", name: "Pineapple", summary: "A tropical fruit with a spiky crown.", visualKey: "🍍", properties: [
@@ -92,6 +113,9 @@ extension GameplayThreadCatalog {
                 GameplayProperty(id: "fruit-pineapple-taste", typeID: "taste", value: "Sweet and tangy", explanation: "Pineapple tastes sweet with a bright tang."),
                 GameplayProperty(id: "fruit-pineapple-seed-skin", typeID: "seed-skin", value: "Tough spiky skin; tiny seeds", explanation: "The rough outside protects the sweet fruit."),
                 GameplayProperty(id: "fruit-pineapple-grows-on", typeID: "grows-on", value: "Low plant", explanation: "Pineapples grow from low plants near the ground."),
+                GameplayProperty(id: "fruit-pineapple-grow-climate", typeID: "grow-climate", value: "Warm tropical farms", explanation: "Pineapples like warm tropical places and do not like frost."),
+                GameplayProperty(id: "fruit-pineapple-origin", typeID: "origin", value: "South America", explanation: "Pineapple ancestors came from South America."),
+                GameplayProperty(id: "fruit-pineapple-flavor", typeID: "flavor", value: "Sweet tang sparkle", explanation: "Pineapple flavor is sweet with a tangy sparkle."),
                 GameplayProperty(id: "fruit-pineapple-category", typeID: "category", value: "Tropical fruit", explanation: "Pineapples like warm tropical places." )
             ]),
             GameplayEntity(id: "fruit-strawberry", name: "Strawberry", summary: "A red berry-like fruit with tiny seeds on the outside.", visualKey: "🍓", properties: [
@@ -100,15 +124,18 @@ extension GameplayThreadCatalog {
                 GameplayProperty(id: "fruit-strawberry-taste", typeID: "taste", value: "Sweet and a little tart", explanation: "Tart means a tiny sour sparkle with the sweet taste."),
                 GameplayProperty(id: "fruit-strawberry-seed-skin", typeID: "seed-skin", value: "Tiny seeds on the outside", explanation: "Strawberries carry many tiny seeds on their outside."),
                 GameplayProperty(id: "fruit-strawberry-grows-on", typeID: "grows-on", value: "Low plant", explanation: "Strawberries grow on low plants close to the ground."),
+                GameplayProperty(id: "fruit-strawberry-grow-climate", typeID: "grow-climate", value: "Cool-to-mild gardens", explanation: "Strawberries can grow in cooler gardens and mild farms."),
+                GameplayProperty(id: "fruit-strawberry-origin", typeID: "origin", value: "Europe and the Americas", explanation: "Garden strawberries came from strawberry plants from Europe and the Americas."),
+                GameplayProperty(id: "fruit-strawberry-flavor", typeID: "flavor", value: "Berry jam", explanation: "Strawberry flavor is sweet, a little tart, and jammy."),
                 GameplayProperty(id: "fruit-strawberry-category", typeID: "category", value: "Berry-like fruit", explanation: "Kids often call it a berry because it is small, soft, and juicy.")
             ])
         ],
         stages: [
             GameplayStageDefinition(id: "fruit-flashcards", kind: .flashcards, title: "Look + Learn", prompt: "Meet each fruit and its clues.", maximumItemCount: 8),
-            GameplayStageDefinition(id: "fruit-easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Match each fruit to a friendly clue.", propertyTypeIDs: ["name", "color"], maximumItemCount: 6),
-            GameplayStageDefinition(id: "fruit-flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Remember fruit colors and tastes.", propertyTypeIDs: ["color", "taste"], maximumItemCount: 6),
-            GameplayStageDefinition(id: "fruit-bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect fruit names, tastes, seeds, skins, and grow clues.", propertyTypeIDs: ["taste", "seed-skin", "grows-on", "category"], maximumItemCount: 8),
-            GameplayStageDefinition(id: "fruit-quiz", kind: .multipleChoice, title: "Fruit Quiz", prompt: "Pick the best fruit property.", propertyTypeIDs: ["color", "taste", "seed-skin", "grows-on"], maximumItemCount: 6)
+            GameplayStageDefinition(id: "fruit-easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Match fruits to taste and grow clues.", propertyTypeIDs: ["name", "taste", "grows-on", "grow-climate"], maximumItemCount: 6),
+            GameplayStageDefinition(id: "fruit-flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Remember fruit colors, origins, and flavors.", propertyTypeIDs: ["color", "taste", "flavor", "origin"], maximumItemCount: 6),
+            GameplayStageDefinition(id: "fruit-bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect fruit tastes, origins, climates, seeds, skins, and grow clues.", propertyTypeIDs: ["taste", "flavor", "seed-skin", "grows-on", "grow-climate", "origin", "category"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "fruit-quiz", kind: .multipleChoice, title: "Fruit Quiz", prompt: "Pick the best fruit property.", propertyTypeIDs: ["color", "taste", "flavor", "seed-skin", "grows-on", "grow-climate", "origin"], maximumItemCount: 6)
         ],
         progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.72, retryMissedItemsFirst: true)
     )

--- a/Features/GameplayStages/FlashcardStageView.swift
+++ b/Features/GameplayStages/FlashcardStageView.swift
@@ -27,11 +27,25 @@ struct FlashcardStageView: View {
                     GameplayDisplayCard(
                         item: card,
                         compact: compact,
-                        prominence: viewModel.cards.count == 1 ? .featured : .normal
+                        prominence: card.isFruitCard || viewModel.cards.count == 1 ? .featured : .normal
                     )
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Open flashcard: \(card.title), \(card.subtitle)")
+
+                VStack(spacing: 8) {
+                    Text(viewModel.activeDiscoveryPrompt)
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(MatherTheme.ink.opacity(0.72))
+                        .multilineTextAlignment(.center)
+
+                    Button(viewModel.spottedActiveCard ? viewModel.spottedFeedbackText : "I spotted it!") {
+                        viewModel.markActiveCardSpotted()
+                    }
+                    .buttonStyle(GameplayStageControlButtonStyle(kind: viewModel.spottedActiveCard ? .secondary : .primary, compact: compact))
+                    .accessibilityLabel(viewModel.spottedActiveCard ? viewModel.spottedFeedbackText : "Mark \(card.title) clue spotted")
+                }
+
                 HStack(spacing: 10) {
                     Button("Listen again") {
                         viewModel.markExposure()

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -154,19 +154,23 @@ struct GameplayDisplayCard: View {
 
     private var isFeatured: Bool { prominence == .featured }
     private var visualSize: CGFloat {
-        if isFeatured { return compact ? 104 : 140 }
+        if isFeatured { return item.isFruitCard ? (compact ? 126 : 168) : (compact ? 104 : 140) }
+        if item.isFruitCard { return compact ? 64 : 88 }
         return compact ? 40 : 58
     }
     private var visualFrameWidth: CGFloat {
-        if isFeatured { return compact ? 220 : 320 }
+        if isFeatured { return item.isFruitCard ? (compact ? 250 : 360) : (compact ? 220 : 320) }
+        if item.isFruitCard { return compact ? 104 : 132 }
         return compact ? 64 : 86
     }
     private var visualFrameHeight: CGFloat {
-        if isFeatured { return compact ? 170 : 240 }
+        if isFeatured { return item.isFruitCard ? (compact ? 190 : 260) : (compact ? 170 : 240) }
+        if item.isFruitCard { return compact ? 94 : 118 }
         return compact ? 58 : 78
     }
     private var minimumHeight: CGFloat {
-        if isFeatured { return compact ? 310 : 400 }
+        if isFeatured { return item.isFruitCard ? (compact ? 330 : 430) : (compact ? 310 : 400) }
+        if item.isFruitCard { return compact ? 160 : 202 }
         return compact ? 132 : 164
     }
 }
@@ -202,9 +206,21 @@ private struct GameplayDisplayVisual: View {
                     .accessibilityHidden(true)
                     .padding(visualAssetPadding)
             } else {
-                Text(item.visualKey ?? "✦")
-                    .font(.system(size: visualSize, weight: .regular, design: .rounded))
-                    .foregroundStyle(MatherTheme.ink)
+                ZStack {
+                    if item.isFruitCard && !concealed {
+                        Text("✨")
+                            .font(.system(size: max(18, visualSize * 0.26), weight: .bold, design: .rounded))
+                            .offset(x: -visualFrameWidth * 0.28, y: -visualFrameHeight * 0.28)
+                            .accessibilityHidden(true)
+                        Text("🌱")
+                            .font(.system(size: max(16, visualSize * 0.22), weight: .bold, design: .rounded))
+                            .offset(x: visualFrameWidth * 0.30, y: visualFrameHeight * 0.26)
+                            .accessibilityHidden(true)
+                    }
+                    Text(item.visualKey ?? "✦")
+                        .font(.system(size: visualSize, weight: .regular, design: .rounded))
+                        .foregroundStyle(MatherTheme.ink)
+                }
             }
         }
         .frame(width: visualFrameWidth, height: visualFrameHeight)

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -103,6 +103,24 @@ struct GameplayStageViewModelTests {
         #expect(GameplayStageRenderSupport.touchTargetSize(compact: true) >= 54)
         #expect(GameplayStageRenderSupport.maximumContentWidth(compact: false) == 920)
     }
+    @Test func fruitFlashcardsExposeSpottingAffordanceState() throws {
+        let thread = GameplayThreadCatalog.fruits
+        let stage = try #require(thread.stages.first { $0.kind == .flashcards })
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 1021)
+        var viewModel = GameplayFlashcardStageViewModel(thread: thread, round: round)
+
+        let card = try #require(viewModel.activeCard)
+        #expect(card.isFruitCard)
+        #expect(card.discoveryPrompt.contains("flavor"))
+        #expect(!viewModel.spottedActiveCard)
+
+        viewModel.markActiveCardSpotted()
+
+        #expect(viewModel.spottedActiveCard)
+        #expect(viewModel.spottedFeedbackText.contains(card.title))
+        #expect(viewModel.exposureCount == 1)
+    }
+
 }
 
 struct GameplayStageParityRegressionTests {

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -10,14 +10,14 @@ struct GameplayThreadContentTests {
         #expect(thread.id == "fruits")
         #expect(thread.category.id == "chemistry")
         #expect(thread.entities.count == 8)
-        #expect(Set(thread.propertyTypes.map(\.id)) == Set(["name", "color", "taste", "seed-skin", "grows-on", "category"]))
+        #expect(Set(thread.propertyTypes.map(\.id)) == Set(["name", "color", "taste", "seed-skin", "grows-on", "grow-climate", "origin", "flavor", "category"]))
         #expect(thread.entities.allSatisfy { $0.id.hasPrefix("fruit-") })
         #expect(thread.entities.allSatisfy { $0.visualKey?.isEmpty == false })
         #expect(thread.entities.allSatisfy { $0.visualAssetName == nil })
 
         for fruit in thread.entities {
             let propertyTypes = Set(fruit.properties.map(\.typeID))
-            #expect(propertyTypes == Set(["name", "color", "taste", "seed-skin", "grows-on", "category"]), "\(fruit.id) should expose every fruit property type")
+            #expect(propertyTypes == Set(["name", "color", "taste", "seed-skin", "grows-on", "grow-climate", "origin", "flavor", "category"]), "\(fruit.id) should expose every fruit property type")
             #expect(fruit.properties.allSatisfy { !$0.value.isEmpty && !$0.explanation.isEmpty }, "\(fruit.id) properties should be kid-readable")
         }
     }
@@ -29,10 +29,12 @@ struct GameplayThreadContentTests {
         #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
         #expect(thread.stages.allSatisfy { $0.maximumItemCount >= 6 })
         #expect(thread.stages[0].propertyTypeIDs.isEmpty)
-        #expect(thread.stages[1].propertyTypeIDs == ["name", "color"])
-        #expect(thread.stages[2].propertyTypeIDs == ["color", "taste"])
-        #expect(thread.stages[3].propertyTypeIDs.contains("seed-skin"))
+        #expect(thread.stages[1].propertyTypeIDs == ["name", "taste", "grows-on", "grow-climate"])
+        #expect(thread.stages[2].propertyTypeIDs == ["color", "taste", "flavor", "origin"])
+        #expect(thread.stages[3].propertyTypeIDs.contains("grow-climate"))
+        #expect(thread.stages[3].propertyTypeIDs.contains("origin"))
         #expect(thread.stages[4].propertyTypeIDs.contains("grows-on"))
+        #expect(thread.stages[4].propertyTypeIDs.contains("flavor"))
     }
 
     @Test
@@ -54,6 +56,16 @@ struct GameplayThreadContentTests {
                 }, "\(stage.id) should only select allowed fruit properties")
             }
         }
+    }
+
+    @Test
+    func fruitEasyMemoryIncludesGrowTasteAndClimateFacts() throws {
+        let thread = GameplayThreadCatalog.fruits
+        let stage = try #require(thread.stages.first { $0.id == "fruit-easy-memory" })
+        let candidatePropertyTypeIDs = Set(SpacedRepetitionScheduler.candidateItems(thread: thread, stage: stage).compactMap(\.propertyTypeID))
+
+        #expect(candidatePropertyTypeIDs == Set(["name", "taste", "grows-on", "grow-climate"]))
+        #expect(candidatePropertyTypeIDs.isSuperset(of: Set(["taste", "grows-on", "grow-climate"])))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds kid-safe fruit grow climate, origin, and flavor-friend metadata across the Fruit Cards deck.
- Updates fruit stages so Easy Memory includes taste/grow facts and later stages exercise flavor/origin/climate clues.
- Makes fruit visuals larger and more playful while preserving existing non-fruit card sizing; adds an active “I spotted it!” flashcard affordance.

## Validation
- `git diff --check`
- Targeted Xcode tests not run locally because Linux worker has no `xcodebuild`; remote Mac SSH timed out (`ssh ganesh-mba echo ok`).

Addresses #1020 #1021 #1022