### PR TITLE
Stabilize transfer rebuild tests after Build 95 merge

### DIFF
--- a/Tests/MatherTests/TransferExactRebuildTests.swift
+++ b/Tests/MatherTests/TransferExactRebuildTests.swift
@@ -73,6 +73,8 @@ struct TransferExactRebuildTests {
     private func makeEngine() -> VerticalSliceEngine {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true
+        flags.audioEnabled = false
+        flags.hapticsEnabled = false
         flags.makeBreakLoopV2Enabled = false
         flags.vs1GravitySplitEnabled = false
         return VerticalSliceEngine(


### PR DESCRIPTION
Addresses Build 95 post-merge CI timeout.

The latest main CI run timed out inside `TransferExactRebuildTests` after repeated CoreAudio/HALC overload logs. These tests exercise pure `VerticalSliceEngine` state transitions and do not need audio or haptics, so this disables both in the test helper to keep CI focused on deterministic logic.

Validation:
- `git diff --check` passed
- Main CI failure evidence: https://github.com/ganesh47/mather/actions/runs/25549969239