### PR TITLE
Improve Rectangle Factory solved feedback

### DIFF
--- a/Features/RectangleFactory/RectangleFactoryView.swift
+++ b/Features/RectangleFactory/RectangleFactoryView.swift
@@ -158,6 +158,11 @@ struct RectangleFactoryView: View {
                     .transition(.scale.combined(with: .opacity))
             }
 
+            if valid {
+                solvedStatusBanner
+                    .transition(.scale.combined(with: .opacity))
+            }
+
             VStack(spacing: 10) {
                 Text("\(frameWidth) × \(frameHeight) = \(frameWidth * frameHeight)")
                     .font(.headline.weight(.bold))
@@ -283,6 +288,8 @@ struct RectangleFactoryView: View {
                             checkValidity()
                         }
                 )
+                .accessibilityLabel(Self.resizeHandleAccessibilityLabel)
+                .accessibilityHint(Self.resizeHandleAccessibilityHint(for: targetN))
         }
     }
 
@@ -308,11 +315,56 @@ struct RectangleFactoryView: View {
                     .padding(.horizontal, 24)
             }
 
-            Text("Shake to reset frame")
-                .font(.caption)
-                .foregroundStyle(.tertiary)
+            Button(action: resetFrame) {
+                Label(Self.resetButtonTitle, systemImage: "arrow.counterclockwise")
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(MatherTheme.ink)
+                    .frame(maxWidth: .infinity, minHeight: 72)
+                    .background(MatherTheme.card.opacity(0.96))
+                    .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .strokeBorder(MatherTheme.softBlue.opacity(0.45), lineWidth: 1.5)
+                    )
+            }
+            .accessibilityIdentifier("rectangle-factory-reset")
+            .accessibilityLabel(Self.resetButtonAccessibilityLabel)
+            .padding(.horizontal, 24)
                 .padding(.bottom, 16)
         }
+    }
+
+    private var solvedStatusBanner: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 28, weight: .black))
+                .foregroundStyle(.white)
+                .frame(width: 48, height: 48)
+                .background(MatherTheme.accent)
+                .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(Self.solvedStatusTitle)
+                    .font(.headline.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text(Self.solvedStatusSubtitle(for: targetN, allFound: allFoundForN))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .frame(maxWidth: 440)
+        .background(MatherTheme.accent.opacity(0.14))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(MatherTheme.accent.opacity(0.35), lineWidth: 1.5)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(Self.solvedStatusTitle) \(Self.solvedStatusSubtitle(for: targetN, allFound: allFoundForN))")
     }
 
     private func liveCountBadge(valid: Bool) -> some View {
@@ -384,6 +436,7 @@ struct RectangleFactoryView: View {
                             .background(MatherTheme.coral)
                             .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                     }
+                    .accessibilityLabel(Self.advanceButtonAccessibilityLabel(hasNext: sequenceIndex + 1 < RectangleFactoryView.nSequence.count))
                 }
                 .padding(16)
                 .background(
@@ -413,6 +466,7 @@ struct RectangleFactoryView: View {
                         .background(MatherTheme.accent)
                         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
                 }
+                .accessibilityLabel(Self.advanceButtonAccessibilityLabel(hasNext: sequenceIndex + 1 < RectangleFactoryView.nSequence.count))
             }
         }
     }
@@ -619,7 +673,31 @@ struct RectangleFactoryView: View {
     }
 
     nonisolated static func instructionText(for n: Int) -> String {
-        "Drag the blue corner to resize the box. Cover exactly \(n) dots."
+        "Drag the corner handle to resize the box. Cover exactly \(n) dots."
+    }
+
+    nonisolated static var resizeHandleAccessibilityLabel: String {
+        "Resize corner handle"
+    }
+
+    nonisolated static func resizeHandleAccessibilityHint(for n: Int) -> String {
+        "Drag until the rectangle covers exactly \(n) dots."
+    }
+
+    nonisolated static var resetButtonTitle: String {
+        "Reset frame"
+    }
+
+    nonisolated static var resetButtonAccessibilityLabel: String {
+        "Reset rectangle frame"
+    }
+
+    nonisolated static var solvedStatusTitle: String {
+        "Perfect fit!"
+    }
+
+    nonisolated static func solvedStatusSubtitle(for n: Int, allFound: Bool) -> String {
+        allFound ? "All \(n)-dot rectangles are packed. Use the next button below." : "Lift your finger to ship this \(n)-dot rectangle."
     }
 
     nonisolated static func missionText(for n: Int) -> String {
@@ -642,6 +720,10 @@ struct RectangleFactoryView: View {
 
     nonisolated static func advanceButtonTitle(hasNext: Bool) -> String {
         hasNext ? "Next Number →" : "All done! 🎉"
+    }
+
+    nonisolated static func advanceButtonAccessibilityLabel(hasNext: Bool) -> String {
+        hasNext ? "Next number" : "All done"
     }
 
     /// Starting frame dimensions: one cell wider than the square-root floor,

--- a/Tests/MatherTests/RectangleFactoryTests.swift
+++ b/Tests/MatherTests/RectangleFactoryTests.swift
@@ -150,12 +150,28 @@ struct RectangleFactoryTests {
 
     @Test func instructionTextExplainsDragAndExactDotGoal() {
         let text = RectangleFactoryView.instructionText(for: 4)
-        #expect(text.contains("Drag the blue corner"))
+        #expect(text.contains("Drag the corner handle"))
         #expect(text.contains("Cover exactly 4 dots"))
+        #expect(!text.contains("blue"))
+    }
+
+    @Test func solvedStatusCopyMakesSuccessAndNextActionClear() {
+        #expect(RectangleFactoryView.solvedStatusTitle == "Perfect fit!")
+        #expect(RectangleFactoryView.solvedStatusSubtitle(for: 4, allFound: false) == "Lift your finger to ship this 4-dot rectangle.")
+        #expect(RectangleFactoryView.solvedStatusSubtitle(for: 4, allFound: true) == "All 4-dot rectangles are packed. Use the next button below.")
+    }
+
+    @Test func resetAndHandleAccessibilityCopyIsDiscoverable() {
+        #expect(RectangleFactoryView.resetButtonTitle == "Reset frame")
+        #expect(RectangleFactoryView.resetButtonAccessibilityLabel == "Reset rectangle frame")
+        #expect(RectangleFactoryView.resizeHandleAccessibilityLabel == "Resize corner handle")
+        #expect(RectangleFactoryView.resizeHandleAccessibilityHint(for: 9) == "Drag until the rectangle covers exactly 9 dots.")
     }
 
     @Test func advanceButtonTitleReflectsSequenceEnd() {
         #expect(RectangleFactoryView.advanceButtonTitle(hasNext: true) == "Next Number →")
         #expect(RectangleFactoryView.advanceButtonTitle(hasNext: false) == "All done! 🎉")
+        #expect(RectangleFactoryView.advanceButtonAccessibilityLabel(hasNext: true) == "Next number")
+        #expect(RectangleFactoryView.advanceButtonAccessibilityLabel(hasNext: false) == "All done")
     }
 }


### PR DESCRIPTION
## Summary\n- add an obvious Perfect fit status banner when the current Rectangle Factory frame matches the target dots\n- replace the faint shake-reset hint with a visible accessible Reset frame button\n- update instruction/accessibility copy so it refers to the corner handle instead of the wrong blue-color cue\n- add RectangleFactory unit coverage for solved-state, reset, handle, and next-action copy\n\n## Validation\n- git diff --check\n- xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' -only-testing:MatherTests/RectangleFactoryTests CODE_SIGNING_ALLOWED=NO (blocked: xcodebuild command not found in this worker image)\n\nCloses #1025