### PR TITLE
Harden Sound Lab microphone startup

### DIFF
--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -285,6 +285,7 @@ enum SoundLoudnessZone: String, CaseIterable, Equatable {
 
 enum SoundMeterPermissionState: String, Equatable {
     case notStarted
+    case requestingPermission
     case listening
     case unavailable
     case denied
@@ -292,6 +293,7 @@ enum SoundMeterPermissionState: String, Equatable {
     var title: String {
         switch self {
         case .notStarted: return "Meter off"
+        case .requestingPermission: return "Microphone check"
         case .listening: return "Meter listening"
         case .unavailable: return "Microphone unavailable"
         case .denied: return "Microphone off"
@@ -302,12 +304,47 @@ enum SoundMeterPermissionState: String, Equatable {
         switch self {
         case .notStarted:
             return "Start only when a grown-up says it is okay. Mather reads a local loudness number and does not record audio."
+        case .requestingPermission:
+            return "Mather is checking microphone access. If it is off, Sound Lab still works in no-mic learning mode."
         case .listening:
             return "Use normal room sounds only. Do not shout — quieter is safer."
         case .unavailable:
             return "This device cannot read the microphone right now. You can still learn with the safe example cards."
         case .denied:
             return "Microphone access is off. Mather will keep the Sound Lab in no-mic learning mode."
+        }
+    }
+}
+
+enum SoundMeterMicrophoneAuthorization: Equatable {
+    case undetermined
+    case denied
+    case granted
+    case unknown
+}
+
+enum SoundMeterStartupDecision: Equatable {
+    case requestPermission
+    case startMeter
+    case fail(SoundMeterPermissionState)
+}
+
+struct SoundMeterStartupPreflight: Equatable {
+    let isInputAvailable: Bool
+    let authorization: SoundMeterMicrophoneAuthorization
+
+    func startupDecision() -> SoundMeterStartupDecision {
+        guard isInputAvailable else { return .fail(.unavailable) }
+
+        switch authorization {
+        case .undetermined:
+            return .requestPermission
+        case .granted:
+            return .startMeter
+        case .denied:
+            return .fail(.denied)
+        case .unknown:
+            return .fail(.unavailable)
         }
     }
 }

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -977,7 +977,7 @@ struct SoundVolumeLabView: View {
                 HStack(spacing: 10) {
                     Button {
                         appModel.soundDetectionService.startSoundLabMeter()
-                        feedback = "Meter started. Use normal room sounds only — no shouting and no points for loudness."
+                        feedback = soundMeterStartFeedback(for: appModel.soundDetectionService.meterPermissionState)
                     } label: {
                         Label("Start local meter", systemImage: "mic.circle.fill")
                             .font(.headline.weight(.black))
@@ -1070,6 +1070,21 @@ struct SoundVolumeLabView: View {
         case .comfortable: return MatherTheme.accent
         case .busy: return MatherTheme.warm
         case .protect: return MatherTheme.coral
+        }
+    }
+
+    private func soundMeterStartFeedback(for state: SoundMeterPermissionState) -> String {
+        switch state {
+        case .notStarted:
+            return "Meter is off. Sound Lab still works with hearing-safe examples and pitch cards."
+        case .requestingPermission:
+            return "Checking microphone access. If it is off, keep using no-mic learning mode."
+        case .listening:
+            return "Meter started. Use normal room sounds only — no shouting and no points for loudness."
+        case .unavailable:
+            return "Microphone is unavailable right now. Keep using no-mic learning mode with the safe example cards."
+        case .denied:
+            return "Microphone access is off. Keep using no-mic learning mode with the safe example cards."
         }
     }
 

--- a/Services/SoundDetectionService.swift
+++ b/Services/SoundDetectionService.swift
@@ -30,10 +30,11 @@ final class SoundDetectionService {
 
     // nonisolated(unsafe): AVAudioEngine is not Sendable, but we only ever
     // access it from @MainActor methods (start/stop are both @MainActor).
-    nonisolated(unsafe) private let audioEngine = AVAudioEngine()
+    nonisolated(unsafe) private var audioEngine: AVAudioEngine?
     private var isListening = false
     private var previousRMS: Float = 0
     private var clapResetTask: Task<Void, Never>?
+    private var pendingMeterPermissionRequestID: UUID?
 
     // MARK: - Lifecycle
 
@@ -42,30 +43,41 @@ final class SoundDetectionService {
     func startListening() {
         guard !isListening else { return }
         let audioSession = AVAudioSession.sharedInstance()
-        guard audioSession.isInputAvailable else {
-            meterPermissionState = .unavailable
+
+        switch soundMeterPreflight(for: audioSession).startupDecision() {
+        case .requestPermission:
+            requestMicrophonePermission()
+            return
+        case .startMeter:
+            break
+        case .fail(let state):
+            resetSoundMeter(to: state)
             return
         }
+
         do {
             try audioSession.setCategory(.playAndRecord, mode: .measurement, options: [.duckOthers, .defaultToSpeaker])
             try audioSession.setActive(true, options: [])
         } catch {
-            meterPermissionState = .denied
+            resetSoundMeter(to: .unavailable)
             return
         }
 
-        let inputNode = audioEngine.inputNode
+        let engine = AVAudioEngine()
+        let inputNode = engine.inputNode
         let format = inputNode.inputFormat(forBus: 0)
         // When input hardware is unavailable, inputFormat can return a
         // zero-sample-rate format — installTap would crash.
-        guard format.sampleRate > 0 else {
-            meterPermissionState = .unavailable
+        guard format.sampleRate > 0, format.channelCount > 0 else {
+            resetSoundMeter(to: .unavailable)
             return
         }
 
+        inputNode.removeTap(onBus: 0)
         inputNode.installTap(onBus: 0, bufferSize: 2048, format: format) { [weak self] buffer, _ in
             guard let channelData = buffer.floatChannelData?[0] else { return }
             let frameCount = Int(buffer.frameLength)
+            guard frameCount > 0 else { return }
             var sumOfSquares: Float = 0
             for i in 0..<frameCount {
                 sumOfSquares += channelData[i] * channelData[i]
@@ -79,19 +91,21 @@ final class SoundDetectionService {
         }
 
         do {
-            try audioEngine.start()
+            try engine.start()
+            audioEngine = engine
             isListening = true
             meterPermissionState = .listening
         } catch {
             // Silently fail: microphone permission may be denied, or the
             // audio session may be unavailable. Bond Blast still works without clap.
-            meterPermissionState = .denied
             inputNode.removeTap(onBus: 0)
+            resetSoundMeter(to: .unavailable)
         }
     }
 
     /// Stop listening and tear down the audio tap.
     func stopListening() {
+        pendingMeterPermissionRequestID = nil
         guard isListening else {
             previousRMS = 0
             meterReading = SoundMeterReading(rms: 0)
@@ -100,8 +114,9 @@ final class SoundDetectionService {
             clapDetected = false
             return
         }
-        audioEngine.inputNode.removeTap(onBus: 0)
-        audioEngine.stop()
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
         isListening = false
         previousRMS = 0
         meterReading = SoundMeterReading(rms: 0)
@@ -138,5 +153,55 @@ final class SoundDetectionService {
             }
         }
         previousRMS = rms
+    }
+
+    private func requestMicrophonePermission() {
+        let requestID = UUID()
+        pendingMeterPermissionRequestID = requestID
+        meterPermissionState = .requestingPermission
+
+        AVAudioSession.sharedInstance().requestRecordPermission { [weak self] granted in
+            Task { @MainActor [weak self] in
+                guard let self, self.pendingMeterPermissionRequestID == requestID else { return }
+                self.pendingMeterPermissionRequestID = nil
+                if granted {
+                    self.startListening()
+                } else {
+                    self.resetSoundMeter(to: .denied)
+                }
+            }
+        }
+    }
+
+    private func resetSoundMeter(to state: SoundMeterPermissionState) {
+        isListening = false
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        audioEngine?.stop()
+        audioEngine = nil
+        previousRMS = 0
+        meterReading = SoundMeterReading(rms: 0)
+        meterPermissionState = state
+        clapResetTask?.cancel()
+        clapDetected = false
+    }
+
+    private func soundMeterPreflight(for audioSession: AVAudioSession) -> SoundMeterStartupPreflight {
+        SoundMeterStartupPreflight(
+            isInputAvailable: audioSession.isInputAvailable,
+            authorization: microphoneAuthorization(for: audioSession)
+        )
+    }
+
+    private func microphoneAuthorization(for audioSession: AVAudioSession) -> SoundMeterMicrophoneAuthorization {
+        switch audioSession.recordPermission {
+        case .undetermined:
+            return .undetermined
+        case .denied:
+            return .denied
+        case .granted:
+            return .granted
+        @unknown default:
+            return .unknown
+        }
     }
 }

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -202,6 +202,33 @@ extension LearningLoopTests {
         XCTAssertFalse(SoundMeterLevelBucket.allCases.map(\.targetCopy).joined(separator: " ").localizedCaseInsensitiveContains("louder"))
     }
 
+    func testSoundMeterStartupPreflightDoesNotTouchAudioWhenUnavailableOrDenied() {
+        XCTAssertEqual(
+            SoundMeterStartupPreflight(isInputAvailable: false, authorization: .granted).startupDecision(),
+            .fail(.unavailable)
+        )
+        XCTAssertEqual(
+            SoundMeterStartupPreflight(isInputAvailable: true, authorization: .denied).startupDecision(),
+            .fail(.denied)
+        )
+        XCTAssertEqual(
+            SoundMeterStartupPreflight(isInputAvailable: true, authorization: .unknown).startupDecision(),
+            .fail(.unavailable)
+        )
+    }
+
+    func testSoundMeterStartupPreflightRequestsBeforeStartingEngine() {
+        XCTAssertEqual(
+            SoundMeterStartupPreflight(isInputAvailable: true, authorization: .undetermined).startupDecision(),
+            .requestPermission
+        )
+        XCTAssertEqual(
+            SoundMeterStartupPreflight(isInputAvailable: true, authorization: .granted).startupDecision(),
+            .startMeter
+        )
+        XCTAssertTrue(SoundMeterPermissionState.requestingPermission.guidance.contains("no-mic learning mode"))
+    }
+
     func testSoundPitchChallengeStateTeachesPitchWithoutMicrophone() {
         var state = SoundPitchChallengeState(challenge: SoundVolumeContent.pitchChallenge)
         XCTAssertFalse(state.isAnswered)


### PR DESCRIPTION
## Summary
- Lazy-create Sound Lab's AVAudioEngine only when the local meter is explicitly started.
- Preflight microphone input availability and authorization before touching the engine or installing taps.
- Keep denied/unavailable/unknown audio states in no-mic learning mode with clear fallback feedback.
- Add regression tests for Sound Meter startup decisions that do not require simulator microphone hardware.

## Root cause
No raw TestFlight crash log is available, so this targets likely launch/startup crash paths around AVAudioSession/AVAudioEngine input setup. The prior service eagerly owned an AVAudioEngine and could proceed toward input tap setup without an explicit permission preflight.

## Validation
- `git diff --check`
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO` could not run in this worker because `xcodebuild` is not installed.

Closes #1029