### PR TITLE
Improve Water Cycle Order Match clarity

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -117,6 +117,14 @@ struct GameplayMatchPair: Identifiable, Equatable, Hashable {
     let right: GameplayDisplayItem
 }
 
+enum GameplayMatchCardState: Equatable {
+    case idle
+    case selected
+    case inspected
+    case matched
+    case justMatched
+}
+
 struct GameplayMultipleChoiceQuestion: Identifiable, Equatable, Hashable {
     let id: String
     let prompt: String
@@ -214,18 +222,29 @@ struct GameplayMatchStageViewModel: Equatable {
     var correctCount: Int { matchedPairIDs.count }
     var isComplete: Bool { !pairs.isEmpty && matchedPairIDs.count == pairs.count }
     var turnCount: Int { max(1, Int(ceil(Double(max(pairs.count, 1)) / Double(turnItemCount)))) }
-    var turnProgressText: String { "Turn \(min(activeTurnIndex + 1, turnCount))/\(turnCount)" }
+    var turnProgressText: String { "Round \(min(activeTurnIndex + 1, turnCount)) of \(turnCount)" }
+    var matchedProgressText: String {
+        if pairs.isEmpty { return "No matches yet" }
+        return "\(correctCount) of \(pairs.count) matched"
+    }
     var turnGuidanceText: String {
-        if isComplete { return "All matches found. Finish the stage to save your score." }
-        if canAdvanceTurn { return "This turn is done. Move to the next mini-round when ready." }
-        if lastMatchedPairID != nil { return "Nice match! Pick another prompt card." }
-        if selectedLeftID == nil { return "Pick a prompt card first, then tap its matching answer." }
-        return "Now tap the matching answer card."
+        if isComplete { return "All matches found. Tap Finish stage." }
+        if canAdvanceTurn { return "This round is done. Tap Next round." }
+        if lastMatchedPairID != nil { return "Nice match. Pick another card." }
+        if selectedLeftID == nil { return "Pick a card. Then find its match." }
+        return "Now tap the card that goes with it."
     }
     var finishRequirementText: String {
         let remaining = max(pairs.count - correctCount, 0)
-        if remaining == 1 { return "1 match left to finish" }
-        return "\(remaining) matches left to finish"
+        if remaining == 0 { return "All matches found" }
+        if remaining == 1 { return "Find 1 more match" }
+        return "Find \(remaining) more matches"
+    }
+    var currentRoundRequirementText: String {
+        let remaining = activePairs.filter { !matchedPairIDs.contains($0.id) }.count
+        if remaining == 0 { return isComplete ? "Ready to finish" : "Ready for next round" }
+        if remaining == 1 { return "1 left this round" }
+        return "\(remaining) left this round"
     }
     var activePairs: [GameplayMatchPair] {
         let start = activeTurnIndex * turnItemCount
@@ -261,6 +280,22 @@ struct GameplayMatchStageViewModel: Equatable {
 
     func pairID(forRight item: GameplayDisplayItem) -> String {
         pairs.first(where: { $0.right.id == item.id })?.id ?? item.id
+    }
+
+    func cardState(forLeft pair: GameplayMatchPair) -> GameplayMatchCardState {
+        if lastMatchedPairID == pair.id { return .justMatched }
+        if matchedPairIDs.contains(pair.id) { return .matched }
+        if selectedLeftID == pair.id { return .selected }
+        if inspectedItemID == pair.left.id { return .inspected }
+        return .idle
+    }
+
+    func cardState(forRight item: GameplayDisplayItem) -> GameplayMatchCardState {
+        let pairID = pairID(forRight: item)
+        if lastMatchedPairID == pairID { return .justMatched }
+        if matchedPairIDs.contains(pairID) { return .matched }
+        if inspectedItemID == item.id { return .inspected }
+        return .idle
     }
 
     mutating func selectLeft(pairID: String) {

--- a/Domain/GameplayThreadContent+WaterCycle.swift
+++ b/Domain/GameplayThreadContent+WaterCycle.swift
@@ -98,7 +98,7 @@ enum GameplayThreadCatalog {
             id: "water-cycle-easy-memory",
             kind: .easyMemory,
             title: "Order Match",
-            prompt: "Match each process to its cycle order clue.",
+            prompt: "Can you put the water cycle in order? Match each step to its number clue.",
             propertyTypeIDs: ["order"],
             maximumItemCount: 4
         ),

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -59,6 +59,7 @@ struct GameplayDisplayCard: View {
     let compact: Bool
     var showsSubtitle = true
     var selected = false
+    var inspected = false
     var matched = false
     var correct = false
     var concealed = false
@@ -76,10 +77,10 @@ struct GameplayDisplayCard: View {
                     cornerRadius: isFeatured ? 28 : 22,
                     tint: stateTint
                 )
-                if correct || matched {
-                    Text(correct ? "✨" : "✓")
-                        .font(.system(size: compact ? 18 : 24, weight: .black, design: .rounded))
-                        .foregroundStyle(correct ? MatherTheme.coral : MatherTheme.accent)
+                if showsStateBadge {
+                    Image(systemName: stateBadgeSystemName)
+                        .font(.system(size: compact ? 16 : 21, weight: .black, design: .rounded))
+                        .foregroundStyle(stateBadgeColor)
                         .padding(6)
                         .background(Circle().fill(MatherTheme.card.opacity(0.92)))
                         .offset(x: compact ? 4 : 8, y: compact ? -4 : -8)
@@ -98,7 +99,7 @@ struct GameplayDisplayCard: View {
                     .font(.caption.weight(.semibold))
                     .multilineTextAlignment(.center)
                     .foregroundStyle(MatherTheme.ink.opacity(0.68))
-                    .lineLimit(2)
+                    .lineLimit(3)
                     .minimumScaleFactor(0.76)
             }
         }
@@ -122,20 +123,22 @@ struct GameplayDisplayCard: View {
     private var cardFill: Color {
         if correct { return MatherTheme.warm.opacity(0.34) }
         if matched { return MatherTheme.accent.opacity(0.20) }
-        if selected { return MatherTheme.softBlue.opacity(0.85) }
+        if selected { return MatherTheme.coral.opacity(0.18) }
+        if inspected { return MatherTheme.softBlue.opacity(0.50) }
         return MatherTheme.card
     }
 
     private var cardBorder: Color {
         if correct { return MatherTheme.coral }
         if matched { return MatherTheme.accent }
-        if selected { return MatherTheme.panelDeep }
+        if selected { return MatherTheme.coral }
+        if inspected { return MatherTheme.softBlue }
         return MatherTheme.panelDeep.opacity(0.12)
     }
 
     private var borderWidth: CGFloat {
         if correct { return 4 }
-        if selected || matched { return 3 }
+        if selected || inspected || matched { return 3 }
         return 1
     }
 
@@ -148,8 +151,25 @@ struct GameplayDisplayCard: View {
     private var stateTint: Color {
         if correct { return MatherTheme.warm }
         if matched { return MatherTheme.accent }
-        if selected { return MatherTheme.softBlue }
+        if selected { return MatherTheme.coral }
+        if inspected { return MatherTheme.softBlue }
         return MatherTheme.softBlue
+    }
+
+    private var showsStateBadge: Bool {
+        selected || matched || correct
+    }
+
+    private var stateBadgeSystemName: String {
+        if correct { return "sparkles" }
+        if matched { return "checkmark.circle.fill" }
+        return "hand.tap.fill"
+    }
+
+    private var stateBadgeColor: Color {
+        if correct { return MatherTheme.coral }
+        if matched { return MatherTheme.accent }
+        return MatherTheme.coral
     }
 
     private var isFeatured: Bool { prominence == .featured }
@@ -344,6 +364,38 @@ struct GameplayMatchRewardBanner: View {
     }
 }
 
+struct GameplayMatchStatusStrip: View {
+    let matchedText: String
+    let roundText: String
+    let compact: Bool
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                statusPill(text: matchedText, systemImage: "checkmark.circle.fill", tint: MatherTheme.accent)
+                statusPill(text: roundText, systemImage: "target", tint: MatherTheme.coral)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                statusPill(text: matchedText, systemImage: "checkmark.circle.fill", tint: MatherTheme.accent)
+                statusPill(text: roundText, systemImage: "target", tint: MatherTheme.coral)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func statusPill(text: String, systemImage: String, tint: Color) -> some View {
+        Label(text, systemImage: systemImage)
+            .font((compact ? Font.caption : Font.subheadline).weight(.black))
+            .foregroundStyle(MatherTheme.ink)
+            .lineLimit(1)
+            .minimumScaleFactor(0.78)
+            .padding(.horizontal, compact ? 9 : 12)
+            .padding(.vertical, compact ? 6 : 8)
+            .background(tint.opacity(0.16), in: Capsule())
+    }
+}
+
 struct GameplayPairingStageShell: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -359,19 +411,26 @@ struct GameplayPairingStageShell: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 12 : 18) {
-            GameplayStageTitle(title: title, prompt: prompt, detail: "\(viewModel.turnProgressText) • \(viewModel.correctCount)/\(viewModel.pairs.count)")
+            GameplayStageTitle(title: title, prompt: prompt, detail: viewModel.turnProgressText)
             GameplayTurnGuidance(text: viewModel.turnGuidanceText, compact: compact)
+            GameplayMatchStatusStrip(
+                matchedText: viewModel.matchedProgressText,
+                roundText: viewModel.currentRoundRequirementText,
+                compact: compact
+            )
             LazyVGrid(columns: columns, spacing: 12) {
                 ForEach(viewModel.activePairs) { pair in
+                    let state = viewModel.cardState(forLeft: pair)
                     Button {
                         viewModel.selectLeft(pairID: pair.id)
                     } label: {
                         GameplayDisplayCard(
                             item: pair.left,
                             compact: compact,
-                            selected: viewModel.selectedLeftID == pair.id,
-                            matched: viewModel.matchedPairIDs.contains(pair.id),
-                            correct: viewModel.lastMatchedPairID == pair.id,
+                            selected: state == .selected,
+                            inspected: state == .inspected,
+                            matched: state == .matched,
+                            correct: state == .justMatched,
                             prominence: viewModel.activePairs.count == 1 ? .featured : .normal
                         )
                     }
@@ -381,6 +440,7 @@ struct GameplayPairingStageShell: View {
             }
             LazyVGrid(columns: columns, spacing: 12) {
                 ForEach(viewModel.shuffledRights) { item in
+                    let state = viewModel.cardState(forRight: item)
                     Button {
                         let wasMatching = viewModel.selectedLeftID != nil
                         let correct = viewModel.chooseRight(item)
@@ -392,9 +452,10 @@ struct GameplayPairingStageShell: View {
                             item: item,
                             compact: compact,
                             showsSubtitle: true,
-                            selected: viewModel.inspectedItemID == item.id && !viewModel.matchedPairIDs.contains(pairID(for: item)),
-                            matched: viewModel.matchedPairIDs.contains(pairID(for: item)),
-                            correct: viewModel.lastMatchedPairID == pairID(for: item),
+                            selected: state == .selected,
+                            inspected: state == .inspected,
+                            matched: state == .matched,
+                            correct: state == .justMatched,
                             concealed: viewModel.shouldConcealRight(item),
                             prominence: viewModel.activePairs.count == 1 ? .featured : .normal
                         )
@@ -515,10 +576,12 @@ private struct GameplayCardDetailCallout: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text(item.title)
                     .font(.headline.bold())
+                    .fixedSize(horizontal: false, vertical: true)
                 if !item.subtitle.isEmpty {
                     Text(item.subtitle)
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(MatherTheme.ink.opacity(0.72))
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
             Spacer()

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -247,7 +247,8 @@ struct GameplayStageParityRegressionTests {
         #expect(viewModel.cardState(forLeft: firstPair) == .selected)
         #expect(viewModel.cardState(forRight: firstPair.right) == .idle)
 
-        #expect(viewModel.chooseRight(firstPair.right))
+        let didMatchFirstPair = viewModel.chooseRight(firstPair.right)
+        #expect(didMatchFirstPair)
         #expect(viewModel.cardState(forLeft: firstPair) == .justMatched)
         #expect(viewModel.cardState(forRight: firstPair.right) == .justMatched)
 

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -139,7 +139,7 @@ struct GameplayStageParityRegressionTests {
         #expect(viewModel.pairs.count == 4)
         #expect(viewModel.activePairs.count == 2)
         #expect(viewModel.turnCount == 2)
-        #expect(viewModel.turnProgressText == "Turn 1/2")
+        #expect(viewModel.turnProgressText == "Round 1 of 2")
 
         for pair in viewModel.activePairs {
             viewModel.selectLeft(pairID: pair.id)
@@ -151,7 +151,7 @@ struct GameplayStageParityRegressionTests {
         viewModel.advanceTurn()
         #expect(viewModel.activeTurnIndex == 1)
         #expect(viewModel.activePairs.count == 2)
-        #expect(viewModel.turnProgressText == "Turn 2/2")
+        #expect(viewModel.turnProgressText == "Round 2 of 2")
     }
 
     @Test
@@ -191,8 +191,8 @@ struct GameplayStageParityRegressionTests {
         #expect(viewModel.correctCount == 1)
         #expect(viewModel.lastMatchedPairID == pair.id)
         #expect(
-            viewModel.turnGuidanceText == "Nice match! Pick another prompt card."
-                || viewModel.turnGuidanceText == "This turn is done. Move to the next mini-round when ready."
+            viewModel.turnGuidanceText == "Nice match. Pick another card."
+                || viewModel.turnGuidanceText == "This round is done. Tap Next round."
         )
     }
 
@@ -204,16 +204,21 @@ struct GameplayStageParityRegressionTests {
         var viewModel = GameplayMatchStageViewModel(thread: thread, round: round, mode: .easyMemory, turnItemCount: 2)
         let firstPair = viewModel.activePairs[0]
 
-        #expect(viewModel.turnGuidanceText == "Pick a prompt card first, then tap its matching answer.")
-        #expect(viewModel.finishRequirementText == "4 matches left to finish")
+        #expect(viewModel.turnProgressText == "Round 1 of 2")
+        #expect(viewModel.matchedProgressText == "0 of 4 matched")
+        #expect(viewModel.turnGuidanceText == "Pick a card. Then find its match.")
+        #expect(viewModel.finishRequirementText == "Find 4 more matches")
+        #expect(viewModel.currentRoundRequirementText == "2 left this round")
 
         viewModel.selectLeft(pairID: firstPair.id)
-        #expect(viewModel.turnGuidanceText == "Now tap the matching answer card.")
+        #expect(viewModel.turnGuidanceText == "Now tap the card that goes with it.")
 
         let firstMatched = viewModel.chooseRight(firstPair.right)
         #expect(firstMatched)
         #expect(viewModel.lastMatchedPairID == firstPair.id)
-        #expect(viewModel.finishRequirementText == "3 matches left to finish")
+        #expect(viewModel.matchedProgressText == "1 of 4 matched")
+        #expect(viewModel.finishRequirementText == "Find 3 more matches")
+        #expect(viewModel.currentRoundRequirementText == "1 left this round")
 
         for pair in viewModel.activePairs where !viewModel.matchedPairIDs.contains(pair.id) {
             viewModel.selectLeft(pairID: pair.id)
@@ -222,9 +227,34 @@ struct GameplayStageParityRegressionTests {
         }
 
         #expect(viewModel.canAdvanceTurn)
-        #expect(viewModel.turnGuidanceText == "This turn is done. Move to the next mini-round when ready.")
+        #expect(viewModel.currentRoundRequirementText == "Ready for next round")
+        #expect(viewModel.turnGuidanceText == "This round is done. Tap Next round.")
         viewModel.advanceTurn()
         #expect(viewModel.lastMatchedPairID == nil)
+    }
+
+    @Test
+    func matchCardStatesKeepSelectionAndCompletedMatchesDistinct() {
+        let thread = GameplaySampleThreads.countries
+        let stage = thread.stages.first { $0.kind == .easyMemory }!
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 49)
+        var viewModel = GameplayMatchStageViewModel(thread: thread, round: round, mode: .easyMemory, turnItemCount: 2)
+        let firstPair = viewModel.activePairs[0]
+        let secondPair = viewModel.activePairs[1]
+
+        #expect(viewModel.cardState(forLeft: firstPair) == .idle)
+        viewModel.selectLeft(pairID: firstPair.id)
+        #expect(viewModel.cardState(forLeft: firstPair) == .selected)
+        #expect(viewModel.cardState(forRight: firstPair.right) == .idle)
+
+        #expect(viewModel.chooseRight(firstPair.right))
+        #expect(viewModel.cardState(forLeft: firstPair) == .justMatched)
+        #expect(viewModel.cardState(forRight: firstPair.right) == .justMatched)
+
+        viewModel.selectLeft(pairID: secondPair.id)
+        #expect(viewModel.cardState(forLeft: firstPair) == .matched)
+        #expect(viewModel.cardState(forLeft: secondPair) == .selected)
+        #expect(viewModel.cardState(forLeft: firstPair) != viewModel.cardState(forLeft: secondPair))
     }
 
 

--- a/Tests/MatherTests/WaterCycleGameplayThreadTests.swift
+++ b/Tests/MatherTests/WaterCycleGameplayThreadTests.swift
@@ -63,6 +63,8 @@ struct WaterCycleGameplayThreadTests {
         #expect(flashcardRound.items.allSatisfy { $0.propertyID == nil && $0.propertyTypeID == nil })
 
         let orderStage = thread.stages[1]
+        #expect(orderStage.title == "Order Match")
+        #expect(orderStage.prompt == "Can you put the water cycle in order? Match each step to its number clue.")
         let orderRound = SpacedRepetitionScheduler.makeRound(thread: thread, stage: orderStage, seed: 912)
         #expect(orderRound.items.count == 4)
         #expect(orderRound.items.allSatisfy { $0.propertyTypeID == "order" })


### PR DESCRIPTION
## Summary\n- simplify Order Match progress/status copy into round, matched, and remaining-round messages\n- distinguish selected, inspected, matched, and just-matched card states in the reusable match stage UI\n- update the Water Cycle Order Match prompt and expose fuller clue text in cards/details\n\n## Validation\n- git diff --check\n- Blocked: xcodebuild is not installed in this container (/bin/bash: xcodebuild: command not found), so targeted XCTest/Swift Testing could not run locally.\n\nCloses #1026