### PR TITLE
Add playable Electronics Lab activity

### DIFF
--- a/Domain/GameplayThreadCatalog.swift
+++ b/Domain/GameplayThreadCatalog.swift
@@ -5,6 +5,7 @@ enum GameplayThreadID: String, Codable, CaseIterable, Hashable {
     case fruits
     case waterCycle = "water-cycle"
     case shapes
+    case electronics
 }
 
 extension GameplayThreadCatalog {
@@ -18,6 +19,8 @@ extension GameplayThreadCatalog {
             return waterCycle
         case .shapes:
             return shapes
+        case .electronics:
+            return electronics
         }
     }
 
@@ -139,4 +142,73 @@ extension GameplayThreadCatalog {
         ],
         progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.72, retryMissedItemsFirst: true)
     )
+
+
+    /// Kid-safe electronics cards for the Lab's first playable electricity and magnetism activity.
+    /// The facts avoid color-only cues and keep every choice readable as component, job, and rule text.
+    static let electronics: GameplayThreadDefinition = GameplayThreadDefinition(
+        id: "electronics",
+        title: "Circuit Spark",
+        category: GameplayCategory(
+            id: "electronics",
+            title: "Electronics",
+            subtitle: "Closed circuits, switches, materials, bulbs, batteries, and magnet poles"
+        ),
+        propertyTypes: [
+            GameplayPropertyType(id: "part", displayName: "Part", prompt: "Find the circuit or magnet part."),
+            GameplayPropertyType(id: "job", displayName: "Job", prompt: "Find what this part does."),
+            GameplayPropertyType(id: "rule", displayName: "Rule", prompt: "Find the rule that makes it work."),
+        ],
+        entities: [
+            GameplayEntity(id: "electronics-battery", name: "Battery", summary: "A battery gives a circuit a push of electric energy.", visualKey: "🔋", properties: [
+                GameplayProperty(id: "electronics-battery-part", typeID: "part", value: "Battery", explanation: "The battery is the power part.", visualKey: "🔋"),
+                GameplayProperty(id: "electronics-battery-job", typeID: "job", value: "Gives power", explanation: "A battery pushes electric energy around a closed path."),
+                GameplayProperty(id: "electronics-battery-rule", typeID: "rule", value: "Needs a loop", explanation: "Power can do work only when the circuit path comes back around."),
+            ]),
+            GameplayEntity(id: "electronics-bulb", name: "Bulb", summary: "A bulb lights when current can travel through it in a closed circuit.", visualKey: "💡", properties: [
+                GameplayProperty(id: "electronics-bulb-part", typeID: "part", value: "Bulb", explanation: "The bulb is the light-making part.", visualKey: "💡"),
+                GameplayProperty(id: "electronics-bulb-job", typeID: "job", value: "Makes light", explanation: "A working bulb turns electric energy into light."),
+                GameplayProperty(id: "electronics-bulb-rule", typeID: "rule", value: "Lights in a closed circuit", explanation: "The bulb stays off when the path is broken."),
+            ]),
+            GameplayEntity(id: "electronics-closed-circuit", name: "Closed Circuit", summary: "A closed circuit is an unbroken loop from battery to bulb and back.", visualKey: "↻", properties: [
+                GameplayProperty(id: "electronics-closed-circuit-part", typeID: "part", value: "Closed loop", explanation: "The wire path comes all the way back."),
+                GameplayProperty(id: "electronics-closed-circuit-job", typeID: "job", value: "Lets current move", explanation: "Electric current can travel around a closed loop."),
+                GameplayProperty(id: "electronics-closed-circuit-rule", typeID: "rule", value: "Bulb on", explanation: "A complete path can turn the bulb on."),
+            ]),
+            GameplayEntity(id: "electronics-open-circuit", name: "Open Circuit", summary: "An open circuit has a gap, so current cannot complete the trip.", visualKey: "⛔", properties: [
+                GameplayProperty(id: "electronics-open-circuit-part", typeID: "part", value: "Broken path", explanation: "A gap breaks the circuit path."),
+                GameplayProperty(id: "electronics-open-circuit-job", typeID: "job", value: "Stops current", explanation: "Current cannot jump across the open gap in this game."),
+                GameplayProperty(id: "electronics-open-circuit-rule", typeID: "rule", value: "Bulb off", explanation: "A broken path keeps the bulb off."),
+            ]),
+            GameplayEntity(id: "electronics-switch", name: "Switch", summary: "A switch opens or closes the circuit path.", visualKey: "⏻", properties: [
+                GameplayProperty(id: "electronics-switch-part", typeID: "part", value: "Switch", explanation: "The switch is the open-close part."),
+                GameplayProperty(id: "electronics-switch-job", typeID: "job", value: "Opens or closes", explanation: "A switch can connect the path or make a gap."),
+                GameplayProperty(id: "electronics-switch-rule", typeID: "rule", value: "Closed switch means on path", explanation: "When the switch closes, the path can be complete."),
+            ]),
+            GameplayEntity(id: "electronics-conductor", name: "Conductor", summary: "A conductor is a material that lets current move easily.", visualKey: "▰", properties: [
+                GameplayProperty(id: "electronics-conductor-part", typeID: "part", value: "Metal wire", explanation: "Metal wire is a common conductor."),
+                GameplayProperty(id: "electronics-conductor-job", typeID: "job", value: "Carries current", explanation: "Conductors make a path for electric current."),
+                GameplayProperty(id: "electronics-conductor-rule", typeID: "rule", value: "Copper helps the bulb", explanation: "Copper wire can help complete the circuit."),
+            ]),
+            GameplayEntity(id: "electronics-insulator", name: "Insulator", summary: "An insulator blocks current and helps keep touch parts safer.", visualKey: "□", properties: [
+                GameplayProperty(id: "electronics-insulator-part", typeID: "part", value: "Rubber cover", explanation: "Rubber is a common insulator."),
+                GameplayProperty(id: "electronics-insulator-job", typeID: "job", value: "Blocks current", explanation: "Insulators do not make an easy path for current."),
+                GameplayProperty(id: "electronics-insulator-rule", typeID: "rule", value: "Not for the light path", explanation: "A rubber gap will not complete the bulb circuit."),
+            ]),
+            GameplayEntity(id: "electronics-magnet-poles", name: "Magnet Poles", summary: "Magnets have north and south poles that push or pull each other.", visualKey: "🧲", properties: [
+                GameplayProperty(id: "electronics-magnet-poles-part", typeID: "part", value: "North and south poles", explanation: "A magnet has two named ends.", visualKey: "N/S"),
+                GameplayProperty(id: "electronics-magnet-poles-job", typeID: "job", value: "Push or pull", explanation: "Magnet poles can attract or repel."),
+                GameplayProperty(id: "electronics-magnet-poles-rule", typeID: "rule", value: "Opposites attract", explanation: "A north pole and a south pole pull together."),
+            ]),
+        ],
+        stages: [
+            GameplayStageDefinition(id: "electronics-flashcards", kind: .flashcards, title: "Spark Cards", prompt: "Meet each part, job, and rule.", maximumItemCount: 8),
+            GameplayStageDefinition(id: "electronics-easy-memory", kind: .easyMemory, title: "Part Match", prompt: "Match each part to what it does.", propertyTypeIDs: ["part", "job"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "electronics-flip-memory", kind: .flipMemory, title: "Rule Flip", prompt: "Remember the circuit and magnet rules.", propertyTypeIDs: ["job", "rule"], maximumItemCount: 6),
+            GameplayStageDefinition(id: "electronics-bond-blast", kind: .bondBlast, title: "Circuit Blast", prompt: "Connect parts, jobs, and rules.", propertyTypeIDs: ["part", "job", "rule"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "electronics-quiz", kind: .multipleChoice, title: "Spark Quiz", prompt: "Pick the best circuit or magnet clue.", propertyTypeIDs: ["job", "rule"], maximumItemCount: 6),
+        ],
+        progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.70, retryMissedItemsFirst: true)
+    )
+
 }

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -673,7 +673,7 @@ struct LabLaneDetailView: View {
             case .sumSprint:
                 appModel.sumSprintEngine.showDifficultyPick()
             case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
-                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .fruitCards:
+                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .fruitCards, .circuitSpark:
                 break
             }
         }
@@ -714,4 +714,3 @@ struct LabLaneDetailView: View {
     }
 
 }
-

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -355,6 +355,7 @@ enum LabActivityID: String, CaseIterable, Hashable {
     case memoryMatch
     case countryCards
     case fruitCards
+    case circuitSpark
 }
 
 extension LabActivityID {
@@ -390,6 +391,8 @@ extension LabActivityID {
             return .gameplayThread(.countries)
         case .fruitCards:
             return .gameplayThread(.fruits)
+        case .circuitSpark:
+            return .gameplayThread(.electronics)
         }
     }
 }
@@ -1056,7 +1059,7 @@ struct LabLaneDetailPresentation: Equatable {
 extension LabActivityID {
     var sensorNeeds: [LabSensorNeed] {
         switch self {
-        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .fruitCards:
+        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .fruitCards, .circuitSpark:
             return [.noSpecialSensor]
         case .symmetryFold, .angleCannon, .gravityArtist:
             return [.motion]
@@ -1515,8 +1518,8 @@ struct CapabilityLane: Identifiable, Equatable {
         CapabilityLane(
             id: .electronics,
             emoji: "💡",
-            promise: "Future: switches, circuits, sensors, and input/output systems.",
-            ageBandHint: "Future lane",
+            promise: "Build closed circuits, compare materials, and match magnet poles.",
+            ageBandHint: "Ages 4–12",
             modes: [.explore, .challenge, .review],
             ageEntries: [
                 CapabilityAgeEntry(ageBand: .preschool, posture: "switch and output", entryPlay: "light on/off"),
@@ -1524,7 +1527,15 @@ struct CapabilityLane: Identifiable, Equatable {
                 CapabilityAgeEntry(ageBand: .upperElementary, posture: "debug and sensors", entryPlay: "input/output"),
                 CapabilityAgeEntry(ageBand: .preteen, posture: "logic and systems", entryPlay: "gate puzzles"),
             ],
-            activities: []
+            activities: [
+                LabActivity(
+                    id: .circuitSpark,
+                    emoji: "💡",
+                    title: "Circuit Spark",
+                    tagline: "Match batteries, bulbs, switches, materials, and magnet poles",
+                    modes: [.learn, .explore, .review]
+                ),
+            ]
         ),
     ]
 

--- a/Shared/GameActivityCard.swift
+++ b/Shared/GameActivityCard.swift
@@ -195,6 +195,11 @@ struct GameActivityCard: View {
                 .font(.system(size: 48, weight: .bold))
                 .foregroundStyle(tint.opacity(0.35))
                 .offset(x: 20, y: 12)
+        case .circuitSpark:
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 48, weight: .bold))
+                .foregroundStyle(tint.opacity(0.35))
+                .offset(x: 20, y: 12)
         }
     }
 

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -59,6 +59,66 @@ struct GameplayThreadContentTests {
     }
 
     @Test
+    func electronicsThreadCoversCircuitAndMagnetBasicsWithoutColorOnlyAnswers() {
+        let thread = GameplayThreadCatalog.electronics
+
+        #expect(thread.id == "electronics")
+        #expect(thread.category.id == "electronics")
+        #expect(thread.title == "Circuit Spark")
+        #expect(thread.entities.count == 8)
+        #expect(Set(thread.propertyTypes.map(\.id)) == Set(["part", "job", "rule"]))
+        #expect(Set(thread.entities.map(\.name)).isSuperset(of: [
+            "Battery",
+            "Bulb",
+            "Closed Circuit",
+            "Open Circuit",
+            "Switch",
+            "Conductor",
+            "Insulator",
+            "Magnet Poles",
+        ]))
+
+        let propertyValues = thread.entities.flatMap { $0.properties.map(\.value) }
+        for requiredValue in [
+            "Needs a loop",
+            "Lights in a closed circuit",
+            "Bulb on",
+            "Bulb off",
+            "Closed switch means on path",
+            "Copper helps the bulb",
+            "Not for the light path",
+            "Opposites attract",
+        ] {
+            #expect(propertyValues.contains(requiredValue), "Circuit Spark should teach \(requiredValue)")
+        }
+
+        #expect(thread.entities.allSatisfy { entity in
+            entity.properties.allSatisfy { property in
+                !property.value.isEmpty && !property.explanation.isEmpty
+            }
+        })
+    }
+
+    @Test
+    func electronicsStagesGeneratePlayableReusableRounds() {
+        let thread = GameplayThreadCatalog.electronics
+
+        #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+        #expect(thread.stages[1].propertyTypeIDs == ["part", "job"])
+        #expect(thread.stages[2].propertyTypeIDs == ["job", "rule"])
+        #expect(thread.stages[3].propertyTypeIDs == ["part", "job", "rule"])
+        #expect(thread.stages[4].propertyTypeIDs == ["job", "rule"])
+
+        for stage in thread.stages {
+            let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 1024)
+            #expect(round.stageID == stage.id)
+            #expect(round.kind == stage.kind)
+            #expect(!round.items.isEmpty, "\(stage.id) should generate playable items")
+            #expect(round.items.count <= stage.maximumItemCount)
+        }
+    }
+
+    @Test
     func fruitEasyMemoryIncludesGrowTasteAndClimateFacts() throws {
         let thread = GameplayThreadCatalog.fruits
         let stage = try #require(thread.stages.first { $0.id == "fruit-easy-memory" })

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -136,6 +136,7 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(LabActivityID.waterCycle.appRoute, .gameplayThread(.waterCycle))
         XCTAssertEqual(LabActivityID.soundVolume.appRoute, .soundVolume)
         XCTAssertEqual(LabActivityID.memoryMatch.appRoute, .memory)
+        XCTAssertEqual(LabActivityID.circuitSpark.appRoute, .gameplayThread(.electronics))
     }
 
     func testExplorerPathSplitKeepsLabsAndGamesAsTopLevelChoices() {
@@ -315,6 +316,7 @@ final class LabModelsTests: XCTestCase {
         XCTAssertTrue(entries.contains { $0.activity.id == .sumSprint && $0.directRoute == .sumSprint })
         XCTAssertTrue(entries.contains { $0.activity.id == .waterCycle && $0.directRoute == .gameplayThread(.waterCycle) })
         XCTAssertTrue(entries.contains { $0.activity.id == .memoryMatch && $0.directRoute == .memory })
+        XCTAssertTrue(entries.contains { $0.activity.id == .circuitSpark && $0.laneID == .electronics && $0.directRoute == .gameplayThread(.electronics) })
     }
 
 
@@ -677,6 +679,7 @@ extension LabModelsTests {
         XCTAssertEqual(LabActivityID.roomQuest.sensorNeeds, [.cameraMarkerMode, .haptics])
         XCTAssertEqual(LabActivityID.soundVolume.sensorNeeds, [.noSpecialSensor])
         XCTAssertEqual(LabActivityID.memoryMatch.sensorNeeds, [.noSpecialSensor])
+        XCTAssertEqual(LabActivityID.circuitSpark.sensorNeeds, [.noSpecialSensor])
     }
 
     func testUnavailableSensorAffordancesExposeVisibleFallbackCopy() {
@@ -798,6 +801,7 @@ extension LabModelsTests {
         XCTAssertEqual(LabActivityID.twoFingerProtractor.appRoute, .twoFingerProtractor)
         XCTAssertEqual(LabActivityID.symmetryFold.appRoute, .symmetryFold)
         XCTAssertEqual(LabActivityID.shapeGeometry.appRoute, .shapeGeometry)
+        XCTAssertEqual(LabActivityID.circuitSpark.appRoute, .gameplayThread(.electronics))
     }
 
     func testGeometryRememberDecksAreCalmReusableCards() throws {

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -38,6 +38,7 @@ struct LabRouteRegressionTests {
             .memoryMatch: .memory,
             .countryCards: .gameplayThread(.countries),
             .fruitCards: .gameplayThread(.fruits),
+            .circuitSpark: .gameplayThread(.electronics),
         ]
 
         #expect(Set(expectedRoutes.keys) == Set(LabActivityID.allCases))
@@ -53,6 +54,7 @@ struct LabRouteRegressionTests {
             .countryCards: .countries,
             .fruitCards: .fruits,
             .waterCycle: .waterCycle,
+            .circuitSpark: .electronics,
         ]
 
         for (activityID, threadID) in reusableThreadRoutes {
@@ -110,7 +112,7 @@ struct LabRouteRegressionTests {
     }
 
     @Test
-    func discoveryChemistryAndElectronicsShellsStayRegistered() throws {
+    func discoveryChemistryAndElectronicsLanesExposePlayableActivities() throws {
         let lanes = CapabilityLane.defaultExplorerLanes
         let discovery = try #require(lanes.first { $0.id == .discoveryCards })
         let chemistry = try #require(lanes.first { $0.id == .chemistry })
@@ -123,11 +125,15 @@ struct LabRouteRegressionTests {
         #expect(chemistry.activities.map(\.id) == [.fruitCards])
         #expect(chemistry.activities.first?.title == "Fruit Cards")
 
-        #expect(electronics.activities.isEmpty)
-        for futureShell in [chemistry, electronics] {
-            #expect(!futureShell.promise.isEmpty)
-            #expect(futureShell.starterMixMatchCards.count >= 8)
-            #expect(futureShell.modeChoiceCards.count == futureShell.modes.count)
+        #expect(electronics.activities.map(\.id) == [.circuitSpark])
+        #expect(electronics.activities.first?.title == "Circuit Spark")
+        #expect(electronics.activities.first?.accessibilityLabel.contains("batteries") == true)
+        #expect(electronics.accessibilityHint == "Choose an activity or review cards.")
+        #expect(!electronics.promise.contains("Future"))
+        for lane in [chemistry, electronics] {
+            #expect(!lane.promise.isEmpty)
+            #expect(lane.starterMixMatchCards.count >= 8)
+            #expect(lane.modeChoiceCards.count == lane.modes.count)
         }
     }
 
@@ -147,18 +153,19 @@ struct LabRouteRegressionTests {
     @Test
     func laneDetailPresentationPrioritizesActivitiesBeforeSupportMetadata() throws {
         let readyLane = try #require(CapabilityLane.defaultExplorerLanes.first { $0.id == .numbers })
-        let futureLane = try #require(CapabilityLane.defaultExplorerLanes.first { $0.id == .electronics })
+        let electronicsLane = try #require(CapabilityLane.defaultExplorerLanes.first { $0.id == .electronics })
 
         #expect(LabLaneDetailPresentation(lane: readyLane).sections == [
             .visualSummary,
             .activities,
             .progressStatus,
         ])
-        #expect(LabLaneDetailPresentation(lane: futureLane).sections == [
+        #expect(LabLaneDetailPresentation(lane: electronicsLane).sections == [
             .visualSummary,
-            .comingSoon,
+            .activities,
             .progressStatus,
         ])
+        #expect(LabLaneDetailPresentation(lane: electronicsLane).activityCountLabel == "1 game ready")
     }
 
     @Test


### PR DESCRIPTION
## Summary\n- Adds Circuit Spark as a playable Electronics Lab activity routed through the existing reusable GameplayThread infrastructure.\n- Updates Electronics lane catalog metadata so it is no longer a future/dead-end lane.\n- Adds route/catalog/content tests for the Electronics activity and kid-readable electricity/magnetism content.\n\n## Validation\n- git diff --check\n- Unable to run xcodegen/xcodebuild locally: this worker image does not have xcodegen, xcodebuild, or swift installed.\n\nCloses #1024