### PR TITLE
Fix Sound Lab meter pitch crash from non-finite readings

### DIFF
--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -391,16 +391,23 @@ struct SoundMeterReading: Equatable {
     static let privacyCopy = "Local microphone meter only: Mather computes an RMS loudness number on this device, stores no audio, and sends no audio anywhere."
     static let safetyCopy = "Use normal room sounds. Do not shout, scream, or try to make the meter higher. Quieter is safer."
 
+    var roundedEstimatedDecibels: Int {
+        Int(estimatedDecibels.rounded())
+    }
+
     init(rms: Float) {
-        let clampedRMS = min(max(rms, 0), 1)
+        let clampedRMS = SoundMeterReading.normalizedRMS(rms)
         self.rms = clampedRMS
         self.estimatedDecibels = SoundMeterReading.estimatedDecibels(forRMS: clampedRMS)
         self.bucket = SoundMeterReading.bucket(forRMS: clampedRMS)
     }
 
     static func estimatedDecibels(forRMS rms: Float) -> Double {
-        let clamped = max(Double(min(max(rms, 0), 1)), 0.000_001)
-        return min(max(20 * log10(clamped) + 94, 20), 100)
+        let normalized = normalizedRMS(rms)
+        let clamped = max(Double(normalized), 0.000_001)
+        let decibels = 20 * log10(clamped) + 94
+        guard decibels.isFinite else { return 20 }
+        return min(max(decibels, 20), 100)
     }
 
     static func bucket(forRMS rms: Float) -> SoundMeterLevelBucket {
@@ -411,6 +418,11 @@ struct SoundMeterReading: Equatable {
         case ..<85: return .busy
         default: return .protect
         }
+    }
+
+    private static func normalizedRMS(_ rms: Float) -> Float {
+        guard rms.isFinite else { return rms == .infinity ? 1 : 0 }
+        return min(max(rms, 0), 1)
     }
 }
 

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -948,7 +948,7 @@ struct SoundVolumeLabView: View {
                             .font(.headline.weight(.black))
                             .foregroundStyle(MatherTheme.ink)
                         Spacer()
-                        Text("~\(Int(reading.estimatedDecibels.rounded())) dB")
+                        Text("~\(reading.roundedEstimatedDecibels) dB")
                             .font(.headline.monospacedDigit().weight(.black))
                             .foregroundStyle(MatherTheme.accent)
                     }

--- a/Services/SoundDetectionService.swift
+++ b/Services/SoundDetectionService.swift
@@ -79,14 +79,18 @@ final class SoundDetectionService {
             let frameCount = Int(buffer.frameLength)
             guard frameCount > 0 else { return }
             var sumOfSquares: Float = 0
+            var finiteSampleCount = 0
             for i in 0..<frameCount {
-                sumOfSquares += channelData[i] * channelData[i]
+                let sample = channelData[i]
+                guard sample.isFinite else { continue }
+                sumOfSquares += sample * sample
+                finiteSampleCount += 1
             }
-            let rms = (sumOfSquares / Float(frameCount)).squareRoot()
+            let rms = finiteSampleCount > 0 ? (sumOfSquares / Float(finiteSampleCount)).squareRoot() : 0
 
             // The audio tap runs on the audio I/O thread — marshal to @MainActor.
             Task { @MainActor [weak self] in
-                self?.evaluateRMS(rms)
+                self?.evaluateRMS(rms.isFinite ? rms : 0)
             }
         }
 

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -192,6 +192,21 @@ extension LearningLoopTests {
         XCTAssertLessThanOrEqual(overRange.estimatedDecibels, 100)
     }
 
+    func testSoundMeterReadingSanitizesNonFiniteRMSBeforeRenderingDecibels() {
+        let invalidReadings = [
+            SoundMeterReading(rms: .nan),
+            SoundMeterReading(rms: -.infinity),
+            SoundMeterReading(rms: .infinity),
+        ]
+
+        XCTAssertTrue(invalidReadings.allSatisfy { $0.rms.isFinite })
+        XCTAssertTrue(invalidReadings.allSatisfy { $0.estimatedDecibels.isFinite })
+        XCTAssertTrue(invalidReadings.allSatisfy { (20...100).contains($0.roundedEstimatedDecibels) })
+        XCTAssertEqual(SoundMeterReading(rms: .nan).bucket, .quiet)
+        XCTAssertEqual(SoundMeterReading(rms: -.infinity).bucket, .quiet)
+        XCTAssertEqual(SoundMeterReading(rms: .infinity).bucket, .protect)
+    }
+
     func testSoundMeterCopyIsLocalOnlyAndDoesNotRewardLoudness() {
         XCTAssertTrue(SoundMeterReading.privacyCopy.contains("Local microphone meter only"))
         XCTAssertTrue(SoundMeterReading.privacyCopy.contains("stores no audio"))


### PR DESCRIPTION
## Summary
- Sanitize non-finite Sound Lab meter RMS samples before dB conversion.
- Clamp non-finite meter reading values to silent defaults so UI Int conversions cannot trap.
- Add regression coverage for NaN/infinite RMS values and finite dB output.

Addresses #1036

## Validation
- `git diff --check` passed.
- Remote Xcode validation attempted on `ganesh-mba`; build failed before reaching this change because the checked-in Xcode project is stale/missing generated source membership for many existing types. This matches the repo validation caveat and is recorded in the triage artifact.

## Privacy
No raw TestFlight/ASC crash diagnostics copied into GitHub.