### PR TITLE
Harden Sound Lab local meter startup

### DIFF
--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 /// Reusable deterministic content for learn → quiz → match loops.
@@ -323,6 +324,108 @@ enum SoundMeterMicrophoneAuthorization: Equatable {
     case unknown
 }
 
+
+enum SoundMeterStartupPhase: String, Equatable {
+    case idle
+    case preflight
+    case requestingPermission
+    case permissionDenied
+    case activatingSession
+    case sessionActivationFailed
+    case routeUnavailable
+    case checkingInputFormat
+    case inputFormatUnavailable
+    case installingAudioTap
+    case startingAudioEngine
+    case engineStartFailed
+    case preparingRecorder
+    case recorderStartFailed
+    case listening
+}
+
+enum SoundMeterStartupFailure: String, Equatable {
+    case permissionDenied
+    case sessionActivation
+    case routeUnavailable
+    case inputFormatUnavailable
+    case engineStart
+    case recorderStart
+}
+
+struct SoundMeterAudioFormatSnapshot: Equatable {
+    let sampleRate: Double
+    let channelCount: UInt32
+    let commonFormat: AVAudioCommonFormat
+    let isInterleaved: Bool
+
+    init(sampleRate: Double, channelCount: UInt32, commonFormat: AVAudioCommonFormat = .pcmFormatFloat32, isInterleaved: Bool = false) {
+        self.sampleRate = sampleRate
+        self.channelCount = channelCount
+        self.commonFormat = commonFormat
+        self.isInterleaved = isInterleaved
+    }
+
+    init(format: AVAudioFormat) {
+        self.sampleRate = format.sampleRate
+        self.channelCount = format.channelCount
+        self.commonFormat = format.commonFormat
+        self.isInterleaved = format.isInterleaved
+    }
+
+    var isUsableForAudioTap: Bool {
+        sampleRate.isFinite
+            && sampleRate > 0
+            && channelCount > 0
+            && commonFormat == .pcmFormatFloat32
+            && !isInterleaved
+    }
+}
+
+struct SoundMeterStartupDiagnostics: Equatable {
+    let phase: SoundMeterStartupPhase
+    let authorization: SoundMeterMicrophoneAuthorization?
+    let isInputAvailable: Bool?
+    let routeInputCount: Int?
+    let inputSampleRate: Double?
+    let inputChannelCount: UInt32?
+    let failure: SoundMeterStartupFailure?
+
+    init(
+        phase: SoundMeterStartupPhase = .idle,
+        authorization: SoundMeterMicrophoneAuthorization? = nil,
+        isInputAvailable: Bool? = nil,
+        routeInputCount: Int? = nil,
+        inputSampleRate: Double? = nil,
+        inputChannelCount: UInt32? = nil,
+        failure: SoundMeterStartupFailure? = nil
+    ) {
+        self.phase = phase
+        self.authorization = authorization
+        self.isInputAvailable = isInputAvailable
+        self.routeInputCount = routeInputCount
+        self.inputSampleRate = inputSampleRate
+        self.inputChannelCount = inputChannelCount
+        self.failure = failure
+    }
+
+    func updating(
+        phase: SoundMeterStartupPhase? = nil,
+        routeInputCount: Int? = nil,
+        format: SoundMeterAudioFormatSnapshot? = nil,
+        failure: SoundMeterStartupFailure? = nil
+    ) -> SoundMeterStartupDiagnostics {
+        SoundMeterStartupDiagnostics(
+            phase: phase ?? self.phase,
+            authorization: authorization,
+            isInputAvailable: isInputAvailable,
+            routeInputCount: routeInputCount ?? self.routeInputCount,
+            inputSampleRate: format?.sampleRate ?? inputSampleRate,
+            inputChannelCount: format?.channelCount ?? inputChannelCount,
+            failure: failure ?? self.failure
+        )
+    }
+}
+
 enum SoundMeterStartupDecision: Equatable {
     case requestPermission
     case startMeter
@@ -418,6 +521,11 @@ struct SoundMeterReading: Equatable {
         case ..<85: return .busy
         default: return .protect
         }
+    }
+
+    static func rms(fromDecibelFS decibelFS: Float) -> Float {
+        guard decibelFS.isFinite else { return 0 }
+        return normalizedRMS(pow(10, decibelFS / 20))
     }
 
     private static func normalizedRMS(_ rms: Float) -> Float {

--- a/Services/SoundDetectionService.swift
+++ b/Services/SoundDetectionService.swift
@@ -25,16 +25,20 @@ final class SoundDetectionService {
     /// Local-only RMS loudness estimate for Sound Lab meter UI. Audio is never stored or transmitted.
     var meterReading = SoundMeterReading(rms: 0)
     var meterPermissionState: SoundMeterPermissionState = .notStarted
+    var meterStartupDiagnostics = SoundMeterStartupDiagnostics()
 
     // MARK: - Private
 
     // nonisolated(unsafe): AVAudioEngine is not Sendable, but we only ever
     // access it from @MainActor methods (start/stop are both @MainActor).
     nonisolated(unsafe) private var audioEngine: AVAudioEngine?
+    private var meterRecorder: AVAudioRecorder?
     private var isListening = false
     private var previousRMS: Float = 0
     private var clapResetTask: Task<Void, Never>?
+    private var meterPollingTask: Task<Void, Never>?
     private var pendingMeterPermissionRequestID: UUID?
+    private var pendingMeterStartAction: (@MainActor () -> Void)?
 
     // MARK: - Lifecycle
 
@@ -44,36 +48,61 @@ final class SoundDetectionService {
         guard !isListening else { return }
         let audioSession = AVAudioSession.sharedInstance()
 
-        switch soundMeterPreflight(for: audioSession).startupDecision() {
+        let preflight = soundMeterPreflight(for: audioSession)
+        meterStartupDiagnostics = SoundMeterStartupDiagnostics(
+            phase: .preflight,
+            authorization: preflight.authorization,
+            isInputAvailable: preflight.isInputAvailable
+        )
+
+        switch preflight.startupDecision() {
         case .requestPermission:
-            requestMicrophonePermission()
+            requestMicrophonePermission { [weak self] in
+                self?.startListening()
+            }
             return
         case .startMeter:
             break
         case .fail(let state):
-            resetSoundMeter(to: state)
+            resetSoundMeter(to: state, phase: startupPhase(for: state), failure: startupFailure(for: state))
             return
         }
 
+        meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .activatingSession)
         do {
             try audioSession.setCategory(.playAndRecord, mode: .measurement, options: [.duckOthers, .defaultToSpeaker])
             try audioSession.setActive(true, options: [])
         } catch {
-            resetSoundMeter(to: .unavailable)
+            resetSoundMeter(to: .unavailable, phase: .sessionActivationFailed, failure: .sessionActivation)
+            return
+        }
+
+        guard audioSession.isInputAvailable, !audioSession.currentRoute.inputs.isEmpty else {
+            resetSoundMeter(to: .unavailable, phase: .routeUnavailable, failure: .routeUnavailable)
             return
         }
 
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
-        let format = inputNode.inputFormat(forBus: 0)
-        // When input hardware is unavailable, inputFormat can return a
-        // zero-sample-rate format — installTap would crash.
-        guard format.sampleRate > 0, format.channelCount > 0 else {
-            resetSoundMeter(to: .unavailable)
+        let format = inputNode.outputFormat(forBus: 0)
+        let formatSnapshot = SoundMeterAudioFormatSnapshot(format: format)
+        meterStartupDiagnostics = meterStartupDiagnostics.updating(
+            phase: .checkingInputFormat,
+            routeInputCount: audioSession.currentRoute.inputs.count,
+            format: formatSnapshot
+        )
+        // When input hardware is unavailable or the route changes, the input
+        // node can expose a zero/unknown format. Installing a tap with that
+        // format can raise an Objective-C/AudioUnit assertion instead of a
+        // catchable Swift error, so fail closed before the tap boundary.
+        guard formatSnapshot.isUsableForAudioTap else {
+            resetSoundMeter(to: .unavailable, phase: .inputFormatUnavailable, failure: .inputFormatUnavailable, format: formatSnapshot)
             return
         }
 
         inputNode.removeTap(onBus: 0)
+        engine.prepare()
+        meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .installingAudioTap, format: formatSnapshot)
         inputNode.installTap(onBus: 0, bufferSize: 2048, format: format) { [weak self] buffer, _ in
             guard let channelData = buffer.floatChannelData?[0] else { return }
             let frameCount = Int(buffer.frameLength)
@@ -94,26 +123,34 @@ final class SoundDetectionService {
             }
         }
 
+        meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .startingAudioEngine)
         do {
             try engine.start()
             audioEngine = engine
             isListening = true
             meterPermissionState = .listening
+            meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .listening)
         } catch {
             // Silently fail: microphone permission may be denied, or the
             // audio session may be unavailable. Bond Blast still works without clap.
             inputNode.removeTap(onBus: 0)
-            resetSoundMeter(to: .unavailable)
+            resetSoundMeter(to: .unavailable, phase: .engineStartFailed, failure: .engineStart)
         }
     }
 
     /// Stop listening and tear down the audio tap.
     func stopListening() {
         pendingMeterPermissionRequestID = nil
+        pendingMeterStartAction = nil
+        meterPollingTask?.cancel()
+        meterPollingTask = nil
+        meterRecorder?.stop()
+        meterRecorder = nil
         guard isListening else {
             previousRMS = 0
             meterReading = SoundMeterReading(rms: 0)
             meterPermissionState = .notStarted
+            meterStartupDiagnostics = SoundMeterStartupDiagnostics(phase: .idle)
             clapResetTask?.cancel()
             clapDetected = false
             return
@@ -125,6 +162,7 @@ final class SoundDetectionService {
         previousRMS = 0
         meterReading = SoundMeterReading(rms: 0)
         meterPermissionState = .notStarted
+        meterStartupDiagnostics = SoundMeterStartupDiagnostics(phase: .idle)
         clapResetTask?.cancel()
         clapDetected = false
     }
@@ -138,7 +176,8 @@ final class SoundDetectionService {
     // MARK: - Private helpers
 
     func startSoundLabMeter() {
-        startListening()
+        guard !isListening else { return }
+        startRecorderBackedSoundLabMeter()
     }
 
     func stopSoundLabMeter() {
@@ -159,34 +198,156 @@ final class SoundDetectionService {
         previousRMS = rms
     }
 
-    private func requestMicrophonePermission() {
+    private func startRecorderBackedSoundLabMeter() {
+        let audioSession = AVAudioSession.sharedInstance()
+        let preflight = soundMeterPreflight(for: audioSession)
+        meterStartupDiagnostics = SoundMeterStartupDiagnostics(
+            phase: .preflight,
+            authorization: preflight.authorization,
+            isInputAvailable: preflight.isInputAvailable
+        )
+
+        switch preflight.startupDecision() {
+        case .requestPermission:
+            requestMicrophonePermission { [weak self] in
+                self?.startRecorderBackedSoundLabMeter()
+            }
+            return
+        case .startMeter:
+            break
+        case .fail(let state):
+            resetSoundMeter(to: state, phase: startupPhase(for: state), failure: startupFailure(for: state))
+            return
+        }
+
+        meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .activatingSession)
+        do {
+            try audioSession.setCategory(.playAndRecord, mode: .measurement, options: [.duckOthers, .defaultToSpeaker])
+            try audioSession.setActive(true, options: [])
+        } catch {
+            resetSoundMeter(to: .unavailable, phase: .sessionActivationFailed, failure: .sessionActivation)
+            return
+        }
+
+        guard audioSession.isInputAvailable, !audioSession.currentRoute.inputs.isEmpty else {
+            resetSoundMeter(to: .unavailable, phase: .routeUnavailable, failure: .routeUnavailable)
+            return
+        }
+
+        meterStartupDiagnostics = meterStartupDiagnostics.updating(
+            phase: .preparingRecorder,
+            routeInputCount: audioSession.currentRoute.inputs.count
+        )
+
+        do {
+            let recorder = try makeMeterRecorder()
+            recorder.isMeteringEnabled = true
+            guard recorder.prepareToRecord(), recorder.record() else {
+                resetSoundMeter(to: .unavailable, phase: .recorderStartFailed, failure: .recorderStart)
+                return
+            }
+
+            meterRecorder = recorder
+            isListening = true
+            meterPermissionState = .listening
+            meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .listening)
+            startMeterPolling()
+        } catch {
+            resetSoundMeter(to: .unavailable, phase: .recorderStartFailed, failure: .recorderStart)
+        }
+    }
+
+    private func makeMeterRecorder() throws -> AVAudioRecorder {
+        let url = URL(fileURLWithPath: "/dev/null")
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 44_100.0,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.min.rawValue,
+        ]
+        return try AVAudioRecorder(url: url, settings: settings)
+    }
+
+    private func startMeterPolling() {
+        meterPollingTask?.cancel()
+        meterPollingTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self, let recorder = self.meterRecorder else { return }
+                recorder.updateMeters()
+                let rms = SoundMeterReading.rms(fromDecibelFS: recorder.averagePower(forChannel: 0))
+                self.evaluateRMS(rms)
+                try? await Task.sleep(for: .milliseconds(160))
+            }
+        }
+    }
+
+    private func requestMicrophonePermission(then startAction: @escaping @MainActor () -> Void) {
         let requestID = UUID()
         pendingMeterPermissionRequestID = requestID
+        pendingMeterStartAction = startAction
         meterPermissionState = .requestingPermission
+        meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .requestingPermission)
 
         AVAudioSession.sharedInstance().requestRecordPermission { [weak self] granted in
             Task { @MainActor [weak self] in
                 guard let self, self.pendingMeterPermissionRequestID == requestID else { return }
+                let startAction = self.pendingMeterStartAction
                 self.pendingMeterPermissionRequestID = nil
+                self.pendingMeterStartAction = nil
                 if granted {
-                    self.startListening()
+                    startAction?()
                 } else {
-                    self.resetSoundMeter(to: .denied)
+                    self.resetSoundMeter(to: .denied, phase: .permissionDenied, failure: .permissionDenied)
                 }
             }
         }
     }
 
-    private func resetSoundMeter(to state: SoundMeterPermissionState) {
+    private func resetSoundMeter(
+        to state: SoundMeterPermissionState,
+        phase: SoundMeterStartupPhase? = nil,
+        failure: SoundMeterStartupFailure? = nil,
+        format: SoundMeterAudioFormatSnapshot? = nil
+    ) {
         isListening = false
+        meterPollingTask?.cancel()
+        meterPollingTask = nil
+        meterRecorder?.stop()
+        meterRecorder = nil
         audioEngine?.inputNode.removeTap(onBus: 0)
         audioEngine?.stop()
         audioEngine = nil
         previousRMS = 0
         meterReading = SoundMeterReading(rms: 0)
         meterPermissionState = state
+        meterStartupDiagnostics = meterStartupDiagnostics.updating(
+            phase: phase ?? startupPhase(for: state),
+            format: format,
+            failure: failure ?? startupFailure(for: state)
+        )
         clapResetTask?.cancel()
         clapDetected = false
+    }
+
+    private func startupPhase(for state: SoundMeterPermissionState) -> SoundMeterStartupPhase {
+        switch state {
+        case .notStarted: return .idle
+        case .requestingPermission: return .requestingPermission
+        case .listening: return .listening
+        case .unavailable: return .routeUnavailable
+        case .denied: return .permissionDenied
+        }
+    }
+
+    private func startupFailure(for state: SoundMeterPermissionState) -> SoundMeterStartupFailure? {
+        switch state {
+        case .notStarted, .requestingPermission, .listening:
+            return nil
+        case .unavailable:
+            return .routeUnavailable
+        case .denied:
+            return .permissionDenied
+        }
     }
 
     private func soundMeterPreflight(for audioSession: AVAudioSession) -> SoundMeterStartupPreflight {

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -207,6 +207,18 @@ extension LearningLoopTests {
         XCTAssertEqual(SoundMeterReading(rms: .infinity).bucket, .protect)
     }
 
+    func testSoundMeterRecorderDecibelConversionStaysFiniteAndClamped() {
+        XCTAssertEqual(SoundMeterReading.rms(fromDecibelFS: .nan), 0)
+        XCTAssertEqual(SoundMeterReading.rms(fromDecibelFS: -.infinity), 0)
+        XCTAssertEqual(SoundMeterReading.rms(fromDecibelFS: .infinity), 0)
+        XCTAssertLessThanOrEqual(SoundMeterReading.rms(fromDecibelFS: 12), 1)
+        XCTAssertGreaterThan(SoundMeterReading.rms(fromDecibelFS: -20), 0)
+
+        let reading = SoundMeterReading(rms: SoundMeterReading.rms(fromDecibelFS: -20))
+        XCTAssertTrue(reading.estimatedDecibels.isFinite)
+        XCTAssertTrue((20...100).contains(reading.roundedEstimatedDecibels))
+    }
+
     func testSoundMeterCopyIsLocalOnlyAndDoesNotRewardLoudness() {
         XCTAssertTrue(SoundMeterReading.privacyCopy.contains("Local microphone meter only"))
         XCTAssertTrue(SoundMeterReading.privacyCopy.contains("stores no audio"))

--- a/Tests/MatherTests/SoundDetectionServiceTests.swift
+++ b/Tests/MatherTests/SoundDetectionServiceTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Testing
 @testable import Mather
 
@@ -38,6 +39,44 @@ struct SoundDetectionServiceTests {
         #expect(service.meterPermissionState.guidance.contains("does not record audio"))
         #expect(SoundMeterReading.privacyCopy.contains("stores no audio"))
         #expect(SoundMeterReading.privacyCopy.contains("sends no audio"))
+    }
+
+    @Test
+    func initialStartupDiagnosticsArePrivacySafeAndIdle() {
+        let service = SoundDetectionService()
+        #expect(service.meterStartupDiagnostics.phase == .idle)
+        #expect(service.meterStartupDiagnostics.authorization == nil)
+        #expect(service.meterStartupDiagnostics.routeInputCount == nil)
+        #expect(service.meterStartupDiagnostics.inputSampleRate == nil)
+        #expect(service.meterStartupDiagnostics.failure == nil)
+    }
+
+    @Test
+    func audioTapFormatSnapshotFailsClosedForUnsafeFormats() {
+        #expect(SoundMeterAudioFormatSnapshot(sampleRate: 44_100, channelCount: 1).isUsableForAudioTap)
+        #expect(!SoundMeterAudioFormatSnapshot(sampleRate: 0, channelCount: 1).isUsableForAudioTap)
+        #expect(!SoundMeterAudioFormatSnapshot(sampleRate: .nan, channelCount: 1).isUsableForAudioTap)
+        #expect(!SoundMeterAudioFormatSnapshot(sampleRate: 44_100, channelCount: 0).isUsableForAudioTap)
+        #expect(!SoundMeterAudioFormatSnapshot(sampleRate: 44_100, channelCount: 1, commonFormat: .pcmFormatInt16).isUsableForAudioTap)
+        #expect(!SoundMeterAudioFormatSnapshot(sampleRate: 44_100, channelCount: 1, isInterleaved: true).isUsableForAudioTap)
+    }
+
+    @Test
+    func startupDiagnosticsCaptureOnlyCoarseAudioState() {
+        let diagnostics = SoundMeterStartupDiagnostics(
+            phase: .checkingInputFormat,
+            authorization: .granted,
+            isInputAvailable: true,
+            routeInputCount: 1
+        ).updating(format: SoundMeterAudioFormatSnapshot(sampleRate: 48_000, channelCount: 1))
+
+        #expect(diagnostics.phase == .checkingInputFormat)
+        #expect(diagnostics.authorization == .granted)
+        #expect(diagnostics.isInputAvailable == true)
+        #expect(diagnostics.routeInputCount == 1)
+        #expect(diagnostics.inputSampleRate == 48_000)
+        #expect(diagnostics.inputChannelCount == 1)
+        #expect(diagnostics.failure == nil)
     }
 
     // MARK: - startListening / stopListening idempotency


### PR DESCRIPTION
## Summary
- routes Sound Lab's Start local meter flow through an AVAudioRecorder-backed meter instead of an AVAudioEngine tap, so the local meter can fail closed without crossing the crash-prone tap-install boundary
- adds startup preflight/diagnostic state for permission, route availability, input-format, tap install, engine start, and recorder start failures using only coarse privacy-safe audio state
- preserves the existing non-finite RMS/dB protections and adds recorder dB-to-RMS clamping coverage

Fixes #1039
Fixes #1040

## Testing
- `git diff --check`
- `xcrun swiftc -typecheck -sdk $(xcrun --sdk iphonesimulator --show-sdk-path) -target arm64-apple-ios18.0-simulator Domain/LearningLoopModels.swift Services/SoundDetectionService.swift`
- Xcode simulator build/test attempted on ganesh-mba with Xcode 26.4.1 / iPhone 17 iOS 26.4.1, but blocked by a Swift frontend crash while type-checking existing `Features/ParentSummary/SettingsView.swift` (`SettingsView.profilesCard`), before tests could run. This blocker is unrelated to the Sound Lab files touched here.

## Privacy-safe validation notes
- No raw Apple diagnostics, device identity, raw audio, or user-identifying feedback content was copied into this PR.
- New diagnostics expose only coarse local meter startup state: authorization bucket, input availability, route input count, sample rate/channel count, phase, and failure category.
