### PR TITLE
Add world animals and birds learn loops

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -418,11 +418,11 @@ enum GameplayStageContentBuilder {
         round.items.compactMap { item in
             guard let entity = thread.entities.first(where: { $0.id == item.entityID }) else { return nil }
             let property = entity.properties.first { $0.id == item.propertyID } ?? entity.properties.first
-            let usesShapeNameRecallPrompt = isShapeNameRecallPrompt(thread: thread, property: property)
+            let recallPrompt = nameRecallPrompt(thread: thread, property: property)
             let left = GameplayDisplayItem(
                 id: "\(item.id)-left",
                 entityID: entity.id,
-                title: usesShapeNameRecallPrompt ? "Name this shape" : entity.name,
+                title: recallPrompt ?? entity.name,
                 subtitle: entity.summary,
                 visualKey: entity.visualKey,
                 visualAssetName: entity.visualAssetName,
@@ -432,7 +432,7 @@ enum GameplayStageContentBuilder {
                 id: "\(item.id)-right",
                 entityID: entity.id,
                 title: property?.value ?? entity.name,
-                subtitle: property.map { usesShapeNameRecallPrompt ? "Shape name" : propertyTypeTitle($0.typeID, in: thread) } ?? "Name",
+                subtitle: property.map { recallPrompt == nil ? propertyTypeTitle($0.typeID, in: thread) : nameRecallSubtitle(thread: thread) } ?? "Name",
                 visualKey: visualKey(for: property, fallbackEntity: entity),
                 visualAssetName: property?.visualAssetName,
                 visualShapeKey: property?.visualShapeKey
@@ -494,8 +494,31 @@ enum GameplayStageContentBuilder {
         thread.propertyTypesByID[id]?.displayName ?? id
     }
 
-    private static func isShapeNameRecallPrompt(thread: GameplayThreadDefinition, property: GameplayProperty?) -> Bool {
-        thread.id == "shapes" && property?.typeID == "name"
+    private static func nameRecallPrompt(thread: GameplayThreadDefinition, property: GameplayProperty?) -> String? {
+        guard property?.typeID == "name" else { return nil }
+        switch thread.id {
+        case "shapes":
+            return "Name this shape"
+        case "world-animals":
+            return "Name this animal"
+        case "world-birds":
+            return "Name this bird"
+        default:
+            return nil
+        }
+    }
+
+    private static func nameRecallSubtitle(thread: GameplayThreadDefinition) -> String {
+        switch thread.id {
+        case "shapes":
+            return "Shape name"
+        case "world-animals":
+            return "Animal name"
+        case "world-birds":
+            return "Bird name"
+        default:
+            return "Name"
+        }
     }
 
     private static func visualKey(for property: GameplayProperty?, fallbackEntity entity: GameplayEntity) -> String? {

--- a/Domain/GameplayThreadCatalog.swift
+++ b/Domain/GameplayThreadCatalog.swift
@@ -6,6 +6,8 @@ enum GameplayThreadID: String, Codable, CaseIterable, Hashable {
     case waterCycle = "water-cycle"
     case shapes
     case electronics
+    case worldAnimals = "world-animals"
+    case worldBirds = "world-birds"
 }
 
 extension GameplayThreadCatalog {
@@ -21,6 +23,10 @@ extension GameplayThreadCatalog {
             return shapes
         case .electronics:
             return electronics
+        case .worldAnimals:
+            return worldAnimals
+        case .worldBirds:
+            return worldBirds
         }
     }
 

--- a/Domain/GameplayThreadContent+WorldAnimals.swift
+++ b/Domain/GameplayThreadContent+WorldAnimals.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+extension GameplayThreadCatalog {
+    static let worldAnimals: GameplayThreadDefinition = GameplayThreadDefinition(
+        id: "world-animals",
+        title: "World Animals",
+        category: GameplayCategory(
+            id: "geography-world",
+            title: "Geography + World",
+            subtitle: "Animal homes, sounds, movements, colors, and kinds around the world"
+        ),
+        propertyTypes: [
+            GameplayPropertyType(id: "name", displayName: "Name", prompt: "Find the animal name."),
+            GameplayPropertyType(id: "habitat", displayName: "Home", prompt: "Find where this animal can live."),
+            GameplayPropertyType(id: "movement", displayName: "Moves", prompt: "Find how this animal moves."),
+            GameplayPropertyType(id: "sound", displayName: "Sound", prompt: "Find the animal sound."),
+            GameplayPropertyType(id: "colors", displayName: "Colors", prompt: "Find the animal colors."),
+            GameplayPropertyType(id: "kind", displayName: "Kind", prompt: "Find the animal kind.")
+        ],
+        entities: MemoryDeck.domesticAnimals.prefix(12).map { memoryAnimal in
+            worldAnimalEntity(from: memoryAnimal)
+        },
+        stages: [
+            GameplayStageDefinition(id: "world-animals-flashcards", kind: .flashcards, title: "Animal Cards", prompt: "Meet animals and notice where they live.", maximumItemCount: 12),
+            GameplayStageDefinition(id: "world-animals-easy-memory", kind: .easyMemory, title: "Animal Match", prompt: "Match animals to names, homes, sounds, and moves.", propertyTypeIDs: ["name", "habitat", "movement", "sound"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "world-animals-bond-blast", kind: .bondBlast, title: "Animal Blast", prompt: "Connect each animal with its home, movement, sound, colors, and kind.", propertyTypeIDs: ["habitat", "movement", "sound", "colors", "kind"], maximumItemCount: 12),
+        ],
+        progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.70, retryMissedItemsFirst: true)
+    )
+
+    static func worldAnimalEntity(from memoryAnimal: MemoryAnimal) -> GameplayEntity {
+        let metadata = memoryAnimal.metadata
+        let safeID = "world-animal-\(memoryAnimal.id)"
+        return GameplayEntity(
+            id: safeID,
+            name: memoryAnimal.name,
+            summary: "A \(metadata.kind) that lives in \(metadata.habitat ?? "animal places") and \(metadata.movement ?? "moves in its own way").",
+            visualKey: memoryAnimal.emoji,
+            visualAssetName: memoryAnimal.imageAssetName,
+            properties: [
+                GameplayProperty(id: "\(safeID)-name", typeID: "name", value: memoryAnimal.name, explanation: "\(memoryAnimal.name) is this animal's name.", visualKey: memoryAnimal.emoji, visualAssetName: memoryAnimal.imageAssetName),
+                memoryProperty(entityID: safeID, typeID: "habitat", value: metadata.habitat, fallback: "animal homes", explanationPrefix: "This animal can live in"),
+                memoryProperty(entityID: safeID, typeID: "movement", value: metadata.movement, fallback: "moves in its own way", explanationPrefix: "This animal"),
+                memoryProperty(entityID: safeID, typeID: "sound", value: metadata.sound, fallback: "quiet animal clue", explanationPrefix: "Listen for"),
+                memoryProperty(entityID: safeID, typeID: "colors", value: metadata.colors, fallback: "animal colors", explanationPrefix: "Look for"),
+                GameplayProperty(id: "\(safeID)-kind", typeID: "kind", value: metadata.kind.capitalized, explanation: "This card is a \(metadata.kind).")
+            ]
+        )
+    }
+
+    static func memoryProperty(entityID: String, typeID: String, value: String?, fallback: String, explanationPrefix: String) -> GameplayProperty {
+        let displayValue = value?.isEmpty == false ? value! : fallback
+        return GameplayProperty(
+            id: "\(entityID)-\(typeID)",
+            typeID: typeID,
+            value: displayValue,
+            explanation: "\(explanationPrefix) \(displayValue)."
+        )
+    }
+}

--- a/Domain/GameplayThreadContent+WorldBirds.swift
+++ b/Domain/GameplayThreadContent+WorldBirds.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+extension GameplayThreadCatalog {
+    static let worldBirds: GameplayThreadDefinition = GameplayThreadDefinition(
+        id: "world-birds",
+        title: "World Birds",
+        category: GameplayCategory(
+            id: "geography-world",
+            title: "Geography + World",
+            subtitle: "Bird homes, colors, size, weight, and lifespan around the world"
+        ),
+        propertyTypes: [
+            GameplayPropertyType(id: "name", displayName: "Name", prompt: "Find the bird name."),
+            GameplayPropertyType(id: "home", displayName: "Home", prompt: "Find where this bird lives."),
+            GameplayPropertyType(id: "colors", displayName: "Colors", prompt: "Find the bird colors."),
+            GameplayPropertyType(id: "size", displayName: "Size", prompt: "Find the bird size."),
+            GameplayPropertyType(id: "lifespan", displayName: "Lifespan", prompt: "Find how long this bird can live."),
+            GameplayPropertyType(id: "weight", displayName: "Weight", prompt: "Find the bird weight.")
+        ],
+        entities: MemoryDeck.birds.prefix(12).map { memoryBird in
+            worldBirdEntity(from: memoryBird)
+        },
+        stages: [
+            GameplayStageDefinition(id: "world-birds-flashcards", kind: .flashcards, title: "Bird Cards", prompt: "Meet colorful birds from different world habitats.", maximumItemCount: 12),
+            GameplayStageDefinition(id: "world-birds-easy-memory", kind: .easyMemory, title: "Bird Match", prompt: "Match birds to names, homes, colors, and size clues.", propertyTypeIDs: ["name", "home", "colors", "size"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "world-birds-bond-blast", kind: .bondBlast, title: "Bird Blast", prompt: "Connect each bird with its home, colors, size, lifespan, and weight.", propertyTypeIDs: ["home", "colors", "size", "lifespan", "weight"], maximumItemCount: 12),
+        ],
+        progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.70, retryMissedItemsFirst: true)
+    )
+
+    static func worldBirdEntity(from memoryBird: MemoryAnimal) -> GameplayEntity {
+        let metadata = memoryBird.metadata
+        let safeID = "world-bird-\(memoryBird.id)"
+        return GameplayEntity(
+            id: safeID,
+            name: memoryBird.name,
+            summary: "A bird from \(metadata.habitat ?? "a world habitat") with \(metadata.colors ?? "colorful feathers").",
+            visualKey: memoryBird.emoji,
+            visualAssetName: memoryBird.imageAssetName,
+            properties: [
+                GameplayProperty(id: "\(safeID)-name", typeID: "name", value: memoryBird.name, explanation: "\(memoryBird.name) is this bird's name.", visualKey: memoryBird.emoji, visualAssetName: memoryBird.imageAssetName),
+                memoryProperty(entityID: safeID, typeID: "home", value: metadata.habitat, fallback: "bird habitat", explanationPrefix: "This bird lives in"),
+                memoryProperty(entityID: safeID, typeID: "colors", value: metadata.colors, fallback: "bird colors", explanationPrefix: "Look for"),
+                memoryProperty(entityID: safeID, typeID: "size", value: metadata.size, fallback: "bird size", explanationPrefix: "Its size is"),
+                memoryProperty(entityID: safeID, typeID: "lifespan", value: metadata.lifespan, fallback: "bird lifespan", explanationPrefix: "It can live about"),
+                memoryProperty(entityID: safeID, typeID: "weight", value: metadata.weight, fallback: "bird weight", explanationPrefix: "It can weigh about")
+            ]
+        )
+    }
+}

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -673,7 +673,7 @@ struct LabLaneDetailView: View {
             case .sumSprint:
                 appModel.sumSprintEngine.showDifficultyPick()
             case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
-                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .fruitCards, .circuitSpark:
+                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .worldAnimalCards, .worldBirdCards, .fruitCards, .circuitSpark:
                 break
             }
         }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -354,6 +354,8 @@ enum LabActivityID: String, CaseIterable, Hashable {
     case soundVolume
     case memoryMatch
     case countryCards
+    case worldAnimalCards
+    case worldBirdCards
     case fruitCards
     case circuitSpark
 }
@@ -389,6 +391,10 @@ extension LabActivityID {
             return .memory
         case .countryCards:
             return .gameplayThread(.countries)
+        case .worldAnimalCards:
+            return .gameplayThread(.worldAnimals)
+        case .worldBirdCards:
+            return .gameplayThread(.worldBirds)
         case .fruitCards:
             return .gameplayThread(.fruits)
         case .circuitSpark:
@@ -1059,7 +1065,7 @@ struct LabLaneDetailPresentation: Equatable {
 extension LabActivityID {
     var sensorNeeds: [LabSensorNeed] {
         switch self {
-        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .fruitCards, .circuitSpark:
+        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .worldAnimalCards, .worldBirdCards, .fruitCards, .circuitSpark:
             return [.noSpecialSensor]
         case .symmetryFold, .angleCannon, .gravityArtist:
             return [.motion]
@@ -1467,6 +1473,20 @@ struct CapabilityLane: Identifiable, Equatable {
                     emoji: "🌍",
                     title: "Country Cards",
                     tagline: "Flashcards for capitals, flags, languages, currency, and continents",
+                    modes: [.learn, .review, .challenge]
+                ),
+                LabActivity(
+                    id: .worldAnimalCards,
+                    emoji: "🐾",
+                    title: "World Animals",
+                    tagline: "Learn animal homes, sounds, movement, colors, and kinds",
+                    modes: [.learn, .review, .challenge]
+                ),
+                LabActivity(
+                    id: .worldBirdCards,
+                    emoji: "🦜",
+                    title: "World Birds",
+                    tagline: "Learn bird homes, colors, size, weight, and lifespan",
                     modes: [.learn, .review, .challenge]
                 ),
             ]

--- a/Mather.xcodeproj/project.pbxproj
+++ b/Mather.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		A912D0000000000000000021 /* GameplayThreadContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912D0000000000000000020 /* GameplayThreadContentTests.swift */; };
 		A912C0000000000000000013 /* CountryGameplayThread.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000012 /* CountryGameplayThread.swift */; };
 		A912E0000000000000000011 /* GameplayThreadContent+WaterCycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912E0000000000000000010 /* GameplayThreadContent+WaterCycle.swift */; };
+		B10440000000000000000011 /* GameplayThreadContent+WorldAnimals.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10440000000000000000010 /* GameplayThreadContent+WorldAnimals.swift */; };
+		B10440000000000000000021 /* GameplayThreadContent+WorldBirds.swift in Sources */ = {isa = PBXBuildFile; fileRef = B10440000000000000000020 /* GameplayThreadContent+WorldBirds.swift */; };
 		A912E0000000000000000021 /* WaterCycleGameplayThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912E0000000000000000020 /* WaterCycleGameplayThreadTests.swift */; };
 		A912C0000000000000000021 /* GameplayStageViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000020 /* GameplayStageViewModels.swift */; };
 		A912C0000000000000000031 /* GameplayThreadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A912C0000000000000000030 /* GameplayThreadView.swift */; };
@@ -117,6 +119,8 @@
 		A912D0000000000000000020 /* GameplayThreadContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayThreadContentTests.swift; sourceTree = "<group>"; };
 		A912C0000000000000000012 /* CountryGameplayThread.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryGameplayThread.swift; sourceTree = "<group>"; };
 		A912E0000000000000000010 /* GameplayThreadContent+WaterCycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GameplayThreadContent+WaterCycle.swift"; sourceTree = "<group>"; };
+		B10440000000000000000010 /* GameplayThreadContent+WorldAnimals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GameplayThreadContent+WorldAnimals.swift"; sourceTree = "<group>"; };
+		B10440000000000000000020 /* GameplayThreadContent+WorldBirds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GameplayThreadContent+WorldBirds.swift"; sourceTree = "<group>"; };
 		A912E0000000000000000020 /* WaterCycleGameplayThreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaterCycleGameplayThreadTests.swift; sourceTree = "<group>"; };
 		A912C0000000000000000020 /* GameplayStageViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayStageViewModels.swift; sourceTree = "<group>"; };
 		A912C0000000000000000030 /* GameplayThreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayThreadView.swift; sourceTree = "<group>"; };
@@ -187,6 +191,8 @@
 				A912D0000000000000000010 /* GameplayThreadCatalog.swift */,
 				A912C0000000000000000012 /* CountryGameplayThread.swift */,
 				A912E0000000000000000010 /* GameplayThreadContent+WaterCycle.swift */,
+				B10440000000000000000010 /* GameplayThreadContent+WorldAnimals.swift */,
+				B10440000000000000000020 /* GameplayThreadContent+WorldBirds.swift */,
 				A912C0000000000000000020 /* GameplayStageViewModels.swift */,
 				111111111111111111111112 /* SpacedRepetitionModels.swift */,
 				4BE99DB8FC85397C3E504E0B /* ProblemGenerator.swift */,
@@ -401,6 +407,8 @@
 				A912D0000000000000000011 /* GameplayThreadCatalog.swift in Sources */,
 				A912C0000000000000000013 /* CountryGameplayThread.swift in Sources */,
 				A912E0000000000000000011 /* GameplayThreadContent+WaterCycle.swift in Sources */,
+				B10440000000000000000011 /* GameplayThreadContent+WorldAnimals.swift in Sources */,
+				B10440000000000000000021 /* GameplayThreadContent+WorldBirds.swift in Sources */,
 				A912C0000000000000000021 /* GameplayStageViewModels.swift in Sources */,
 				A912C0000000000000000031 /* GameplayThreadView.swift in Sources */,
 				A912C0000000000000000041 /* FlashcardStageView.swift in Sources */,

--- a/Shared/GameActivityCard.swift
+++ b/Shared/GameActivityCard.swift
@@ -190,7 +190,7 @@ struct GameActivityCard: View {
                 .font(.system(size: 48, weight: .bold))
                 .foregroundStyle(tint.opacity(0.35))
                 .offset(x: 20, y: 12)
-        case .memoryMatch, .countryCards, .fruitCards:
+        case .memoryMatch, .countryCards, .worldAnimalCards, .worldBirdCards, .fruitCards:
             Image(systemName: "rectangle.on.rectangle.angled")
                 .font(.system(size: 48, weight: .bold))
                 .foregroundStyle(tint.opacity(0.35))

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -167,3 +167,80 @@ struct GameplayThreadContentTests {
     }
 
 }
+
+struct WorldCreatureGameplayThreadTests {
+    @Test
+    func worldCreatureThreadsResolveFromCatalogAndUseMemoryDeckSource() {
+        let animalThread = GameplayThreadCatalog.thread(for: .worldAnimals)
+        let birdThread = GameplayThreadCatalog.thread(for: .worldBirds)
+
+        #expect(animalThread.id == "world-animals")
+        #expect(birdThread.id == "world-birds")
+        #expect(animalThread.category.id == "geography-world")
+        #expect(birdThread.category.id == "geography-world")
+        #expect(animalThread.entities.map(\.name) == MemoryDeck.domesticAnimals.prefix(12).map(\.name))
+        #expect(birdThread.entities.map(\.name) == MemoryDeck.birds.prefix(12).map(\.name))
+        #expect(birdThread.entities.allSatisfy { $0.visualAssetName?.isEmpty == false })
+        #expect(animalThread.entities.allSatisfy { $0.visualKey?.isEmpty == false })
+    }
+
+    @Test
+    func worldCreatureThreadsHaveNonEmptyEntitiesAndResolvableStageProperties() {
+        for threadID in [GameplayThreadID.worldAnimals, .worldBirds] {
+            let thread = GameplayThreadCatalog.thread(for: threadID)
+            let propertyTypeIDs = Set(thread.propertyTypes.map(\.id))
+
+            #expect(!thread.entities.isEmpty)
+            #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .bondBlast])
+            #expect(thread.entities.allSatisfy { !$0.properties.isEmpty })
+            #expect(thread.entities.allSatisfy { entity in
+                Set(entity.properties.map(\.typeID)).isSubset(of: propertyTypeIDs)
+            })
+            #expect(thread.stages.allSatisfy { stage in
+                Set(stage.propertyTypeIDs).isSubset(of: propertyTypeIDs)
+            })
+
+            for stage in thread.stages {
+                let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 1044)
+                #expect(!round.items.isEmpty, "\(stage.id) should generate playable items")
+                #expect(round.items.count <= stage.maximumItemCount)
+            }
+        }
+    }
+
+    @Test
+    func worldCreatureEasyMemoryAvoidsIdenticalNamePromptAndAnswerDuplicates() throws {
+        for threadID in [GameplayThreadID.worldAnimals, .worldBirds] {
+            let thread = GameplayThreadCatalog.thread(for: threadID)
+            let stage = try #require(thread.stages.first { $0.kind == .easyMemory })
+            let nameItems = thread.entities.prefix(4).compactMap { entity -> GameplayRoundItem? in
+                guard let property = entity.properties.first(where: { $0.typeID == "name" }) else { return nil }
+                return GameplayRoundItem(id: "\(entity.id)::\(property.id)", entityID: entity.id, propertyID: property.id, propertyTypeID: property.typeID)
+            }
+            let round = GameplayRoundDefinition(id: "\(thread.id)-names-test", stageID: stage.id, kind: stage.kind, items: nameItems, seed: 1044)
+            let pairs = GameplayStageContentBuilder.matchPairs(thread: thread, round: round)
+
+            #expect(pairs.count == nameItems.count)
+            #expect(pairs.allSatisfy { $0.left.title != $0.right.title })
+            #expect(pairs.allSatisfy { $0.right.subtitle == (threadID == .worldAnimals ? "Animal name" : "Bird name") })
+        }
+    }
+
+    @Test
+    func worldCreatureBondBlastHasEnoughFactProperties() throws {
+        let animalThread = GameplayThreadCatalog.worldAnimals
+        let birdThread = GameplayThreadCatalog.worldBirds
+
+        let animalStage = try #require(animalThread.stages.first { $0.kind == .bondBlast })
+        let birdStage = try #require(birdThread.stages.first { $0.kind == .bondBlast })
+
+        #expect(animalStage.propertyTypeIDs.count >= 5)
+        #expect(birdStage.propertyTypeIDs.count >= 5)
+        #expect(animalThread.entities.allSatisfy { entity in
+            Set(animalStage.propertyTypeIDs).isSubset(of: Set(entity.properties.map(\.typeID)))
+        })
+        #expect(birdThread.entities.allSatisfy { entity in
+            Set(birdStage.propertyTypeIDs).isSubset(of: Set(entity.properties.map(\.typeID)))
+        })
+    }
+}

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -37,6 +37,8 @@ struct LabRouteRegressionTests {
             .soundVolume: .soundVolume,
             .memoryMatch: .memory,
             .countryCards: .gameplayThread(.countries),
+            .worldAnimalCards: .gameplayThread(.worldAnimals),
+            .worldBirdCards: .gameplayThread(.worldBirds),
             .fruitCards: .gameplayThread(.fruits),
             .circuitSpark: .gameplayThread(.electronics),
         ]
@@ -52,6 +54,8 @@ struct LabRouteRegressionTests {
     func explorerLabContentRoutesUseReusableGameplayThreads() {
         let reusableThreadRoutes: [LabActivityID: GameplayThreadID] = [
             .countryCards: .countries,
+            .worldAnimalCards: .worldAnimals,
+            .worldBirdCards: .worldBirds,
             .fruitCards: .fruits,
             .waterCycle: .waterCycle,
             .circuitSpark: .electronics,
@@ -59,7 +63,13 @@ struct LabRouteRegressionTests {
 
         for (activityID, threadID) in reusableThreadRoutes {
             #expect(activityID.appRoute == .gameplayThread(threadID))
-            #expect(GameplayThreadCatalog.thread(for: threadID).stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+            let stageKinds = GameplayThreadCatalog.thread(for: threadID).stages.map(\.kind)
+            #expect(!stageKinds.isEmpty)
+            if threadID == .worldAnimals || threadID == .worldBirds {
+                #expect(stageKinds == [.flashcards, .easyMemory, .bondBlast])
+            } else {
+                #expect(stageKinds == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add World Animals and World Birds gameplay threads under the Geography + World category.
- Reuse the existing Memory animal/bird decks as the content source for entity facts and visuals.
- Route both new Lab tiles through the shared reusable GameplayThread stage loop.
- Generalize name-recall prompt handling so animal/bird name matches avoid identical visible prompt/answer pairs.

Closes #1044.

## Validation
- `git diff --check`
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" "-only-testing:MatherTests/WorldCreatureGameplayThreadTests" SWIFT_COMPILATION_MODE=wholemodule` on `ganesh-mba` passed before push.

## Note
A follow-up combined targeted re-run including `LabRouteRegressionTests` was attempted after the worker finished, but SSH to `ganesh-mba` timed out. The branch is pushed so hosted CI can be the merge gate.
