### PR TITLE
Add World Animal Safari learn loops

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -105,9 +105,12 @@ struct GameplayDisplayItem: Identifiable, Equatable, Hashable {
     }
 
     var isFruitCard: Bool { entityID.hasPrefix("fruit-") }
+    var isSafariCard: Bool { entityID.hasPrefix("world-animal-") || entityID.hasPrefix("world-bird-") }
 
     var discoveryPrompt: String {
-        isFruitCard ? "Spot the color, say the flavor, then tap I spotted it!" : "Tap the card, say one clue, then try the next one."
+        if isFruitCard { return "Spot the color, say the flavor, then tap I spotted it!" }
+        if isSafariCard { return "Spot the creature, say its home, then tap I spotted it!" }
+        return "Tap the card, say one clue, then try the next one."
     }
 }
 
@@ -174,7 +177,9 @@ struct GameplayFlashcardStageViewModel: Equatable {
 
     var spottedFeedbackText: String {
         guard let activeCard else { return "Clue spotted!" }
-        return activeCard.isFruitCard ? "Flavor badge unlocked for \(activeCard.title)!" : "Clue spotted for \(activeCard.title)!"
+        if activeCard.isFruitCard { return "Flavor badge unlocked for \(activeCard.title)!" }
+        if activeCard.isSafariCard { return "Safari stamp unlocked for \(activeCard.title)!" }
+        return "Clue spotted for \(activeCard.title)!"
     }
 
     mutating func markActiveCardSpotted() {

--- a/Domain/GameplayThreadCatalog.swift
+++ b/Domain/GameplayThreadCatalog.swift
@@ -6,6 +6,8 @@ enum GameplayThreadID: String, Codable, CaseIterable, Hashable {
     case waterCycle = "water-cycle"
     case shapes
     case electronics
+    case worldAnimals = "world-animals"
+    case worldBirds = "world-birds"
 }
 
 extension GameplayThreadCatalog {
@@ -21,6 +23,10 @@ extension GameplayThreadCatalog {
             return shapes
         case .electronics:
             return electronics
+        case .worldAnimals:
+            return WorldSafariGameplayThreads.animals
+        case .worldBirds:
+            return WorldSafariGameplayThreads.birds
         }
     }
 
@@ -211,4 +217,244 @@ extension GameplayThreadCatalog {
         progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.70, retryMissedItemsFirst: true)
     )
 
+}
+
+enum WorldSafariGameplayThreads {
+    static let animals = GameplayThreadDefinition(
+        id: GameplayThreadID.worldAnimals.rawValue,
+        title: "Animal Homes Safari",
+        category: safariCategory,
+        propertyTypes: animalPropertyTypes,
+        entities: WorldSafariContentAdapter.entities(
+            from: MemoryDeck.domesticAnimals,
+            sourceIDs: [
+                "cow", "dog", "cat", "duck", "frog", "camel",
+                "llama", "goat", "rabbit", "goldfish", "horse", "mouse",
+            ],
+            threadPrefix: "world-animal",
+            nameTypeID: "name",
+            habitatTypeID: "habitat",
+            regionTypeID: "world-place"
+        ),
+        stages: [
+            GameplayStageDefinition(id: "animal-safari-learn", kind: .flashcards, title: "Meet the Animals", prompt: "Tap a creature, hear its home clue, then spot one thing.", maximumItemCount: 8),
+            GameplayStageDefinition(id: "animal-safari-habitat-hop", kind: .easyMemory, title: "Habitat Hop", prompt: "Help each animal hop, swim, or trot to its home.", propertyTypeIDs: ["habitat", "world-place"], maximumItemCount: 6),
+            GameplayStageDefinition(id: "animal-safari-explore", kind: .flipMemory, title: "Explore Tracks", prompt: "Remember animal homes, sounds, colors, and moves.", propertyTypeIDs: ["habitat", "sound", "movement", "colors"], maximumItemCount: 6),
+            GameplayStageDefinition(id: "animal-safari-stamp-blast", kind: .bondBlast, title: "Safari Stamps", prompt: "Collect matches for homes, sounds, moves, and world places.", propertyTypeIDs: ["habitat", "world-place", "sound", "movement", "colors", "kind"], maximumItemCount: 9),
+            GameplayStageDefinition(id: "animal-safari-quiz", kind: .multipleChoice, title: "Animal Quiz", prompt: "Pick the picture clue that helps the animal home.", propertyTypeIDs: ["habitat", "world-place", "sound", "movement"], maximumItemCount: 6),
+        ],
+        progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.70, retryMissedItemsFirst: true)
+    )
+
+    static let birds = GameplayThreadDefinition(
+        id: GameplayThreadID.worldBirds.rawValue,
+        title: "Bird World Tour",
+        category: safariCategory,
+        propertyTypes: birdPropertyTypes,
+        entities: WorldSafariContentAdapter.entities(
+            from: MemoryDeck.birds,
+            sourceIDs: [
+                "bird-a01", "bird-a02", "bird-a03", "bird-a05", "bird-a06", "bird-a12",
+                "bird-a18", "bird-b02", "bird-b03", "bird-b11", "bird-b16", "bird-b18",
+            ],
+            threadPrefix: "world-bird",
+            nameTypeID: "name",
+            habitatTypeID: "home",
+            regionTypeID: "world-region"
+        ),
+        stages: [
+            GameplayStageDefinition(id: "bird-safari-learn", kind: .flashcards, title: "Meet the Birds", prompt: "Tap a bird, hear its world clue, then spot its colors.", maximumItemCount: 8),
+            GameplayStageDefinition(id: "bird-safari-habitat-hop", kind: .easyMemory, title: "Habitat Hop", prompt: "Fly each bird to its habitat or world region.", propertyTypeIDs: ["home", "world-region"], maximumItemCount: 6),
+            GameplayStageDefinition(id: "bird-safari-explore", kind: .flipMemory, title: "World Explore", prompt: "Remember homes, regions, colors, and sizes.", propertyTypeIDs: ["home", "world-region", "colors", "size"], maximumItemCount: 6),
+            GameplayStageDefinition(id: "bird-safari-stamp-blast", kind: .bondBlast, title: "Safari Stamps", prompt: "Collect bird matches for home, region, colors, size, and lifespan.", propertyTypeIDs: ["home", "world-region", "colors", "size", "lifespan", "weight"], maximumItemCount: 9),
+            GameplayStageDefinition(id: "bird-safari-quiz", kind: .multipleChoice, title: "Bird Quiz", prompt: "Pick the clue that belongs with this bird.", propertyTypeIDs: ["home", "world-region", "colors", "size"], maximumItemCount: 6),
+        ],
+        progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.70, retryMissedItemsFirst: true)
+    )
+
+    private static let safariCategory = GameplayCategory(
+        id: "geography",
+        title: "World Safari",
+        subtitle: "Animal homes, habitats, bird regions, and picture-first world clues"
+    )
+
+    private static let animalPropertyTypes: [GameplayPropertyType] = [
+        GameplayPropertyType(id: "name", displayName: "Name", prompt: "Find the animal name."),
+        GameplayPropertyType(id: "habitat", displayName: "Home", prompt: "Find where this animal lives."),
+        GameplayPropertyType(id: "world-place", displayName: "World Place", prompt: "Find the broad world place."),
+        GameplayPropertyType(id: "sound", displayName: "Sound", prompt: "Find the animal sound."),
+        GameplayPropertyType(id: "movement", displayName: "Moves", prompt: "Find how this animal moves."),
+        GameplayPropertyType(id: "colors", displayName: "Colors", prompt: "Find its colors."),
+        GameplayPropertyType(id: "kind", displayName: "Kind", prompt: "Find the animal kind."),
+    ]
+
+    private static let birdPropertyTypes: [GameplayPropertyType] = [
+        GameplayPropertyType(id: "name", displayName: "Name", prompt: "Find the bird name."),
+        GameplayPropertyType(id: "home", displayName: "Home", prompt: "Find the bird home."),
+        GameplayPropertyType(id: "world-region", displayName: "World Region", prompt: "Find the broad world region."),
+        GameplayPropertyType(id: "colors", displayName: "Colors", prompt: "Find the bird colors."),
+        GameplayPropertyType(id: "size", displayName: "Size", prompt: "Find the size clue."),
+        GameplayPropertyType(id: "lifespan", displayName: "Lifespan", prompt: "Find how long some can live."),
+        GameplayPropertyType(id: "weight", displayName: "Weight", prompt: "Find the weight clue."),
+    ]
+}
+
+enum WorldSafariContentAdapter {
+    static func entities(
+        from sourceDeck: [MemoryAnimal],
+        sourceIDs: [String],
+        threadPrefix: String,
+        nameTypeID: String,
+        habitatTypeID: String,
+        regionTypeID: String
+    ) -> [GameplayEntity] {
+        let byID = Dictionary(uniqueKeysWithValues: sourceDeck.map { ($0.id, $0) })
+        return sourceIDs.compactMap { sourceID in
+            guard let animal = byID[sourceID] else { return nil }
+            return entity(from: animal, threadPrefix: threadPrefix, nameTypeID: nameTypeID, habitatTypeID: habitatTypeID, regionTypeID: regionTypeID)
+        }
+    }
+
+    static func fallbackClue(for animal: MemoryAnimal) -> String {
+        let metadata = animal.metadata
+        if let habitat = metadata.habitat {
+            if metadata.deck == .birds {
+                return "\(animal.canonicalName) lives around \(habitat.lowercased())."
+            }
+            return "\(animal.canonicalName) feels at home in \(habitat.lowercased())."
+        }
+        if let movement = metadata.movement {
+            return "\(animal.canonicalName) \(movement.lowercased())."
+        }
+        return "\(animal.canonicalName) is ready for a safari clue."
+    }
+
+    static func sanitizedGeneratedClue(_ text: String, for animal: MemoryAnimal) -> String? {
+        let collapsed = text
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsed.isEmpty, collapsed.count <= 120, !collapsed.contains("?") else { return nil }
+        let lowercased = collapsed.lowercased()
+        let blocked = [
+            "as an ai", "language model", "pretend", "roleplay", "click here", "http://", "https://",
+            "scary", "violent", "kill", "dead", "death", "blood", "disease", "danger", "weapon",
+            "mate", "mating", "predator", "prey", "hunt", "attack",
+        ]
+        guard !blocked.contains(where: { lowercased.contains($0) }) else { return nil }
+
+        let allowedTerms = metadataTerms(for: animal)
+        guard allowedTerms.contains(where: { lowercased.contains($0) }) else { return nil }
+        return collapsed.hasSuffix(".") || collapsed.hasSuffix("!") ? collapsed : collapsed + "."
+    }
+
+    private static func entity(
+        from animal: MemoryAnimal,
+        threadPrefix: String,
+        nameTypeID: String,
+        habitatTypeID: String,
+        regionTypeID: String
+    ) -> GameplayEntity {
+        let metadata = animal.metadata
+        let entityID = "\(threadPrefix)-\(animal.id)"
+        let habitat = metadata.habitat ?? "safe home place"
+        let region = safariRegion(for: animal)
+        let habitatKey = safariHabitatKey(for: animal)
+        var properties: [GameplayProperty] = [
+            property(entityID: entityID, typeID: nameTypeID, value: animal.canonicalName, explanation: "\(animal.canonicalName) is this creature's name.", visualKey: pictureEmoji(for: animal), visualAssetName: animal.imageAssetName),
+            property(entityID: entityID, typeID: habitatTypeID, value: habitat, explanation: "\(animal.canonicalName) lives in \(habitat.lowercased()).", visualKey: habitatSymbolName(for: habitatKey), visualShapeKey: habitatKey),
+            property(entityID: entityID, typeID: regionTypeID, value: region, explanation: "A broad world clue for \(animal.canonicalName) is \(region).", visualKey: "map", visualShapeKey: "safari-world-\(regionKey(for: region))"),
+            property(entityID: entityID, typeID: "kind", value: metadata.kind, explanation: "\(animal.canonicalName) is a \(metadata.kind).", visualKey: "pawprint.fill"),
+        ]
+        appendProperty(&properties, entityID: entityID, typeID: "sound", value: metadata.sound, explanationPrefix: "\(animal.canonicalName) can make")
+        appendProperty(&properties, entityID: entityID, typeID: "movement", value: metadata.movement, explanationPrefix: "\(animal.canonicalName)")
+        appendProperty(&properties, entityID: entityID, typeID: "colors", value: metadata.colors, explanationPrefix: "\(animal.canonicalName) can show")
+        appendProperty(&properties, entityID: entityID, typeID: "size", value: metadata.size, explanationPrefix: "\(animal.canonicalName) can be about")
+        appendProperty(&properties, entityID: entityID, typeID: "lifespan", value: metadata.lifespan, explanationPrefix: "Some \(animal.canonicalName) birds can live")
+        appendProperty(&properties, entityID: entityID, typeID: "weight", value: metadata.weight, explanationPrefix: "\(animal.canonicalName) can weigh about")
+
+        return GameplayEntity(
+            id: entityID,
+            name: animal.canonicalName,
+            summary: fallbackClue(for: animal),
+            visualKey: pictureEmoji(for: animal),
+            visualAssetName: animal.imageAssetName,
+            visualShapeKey: animal.imageAssetName == nil ? habitatKey : nil,
+            properties: properties
+        )
+    }
+
+    private static func appendProperty(_ properties: inout [GameplayProperty], entityID: String, typeID: String, value: String?, explanationPrefix: String) {
+        guard let value, !value.isEmpty else { return }
+        properties.append(property(entityID: entityID, typeID: typeID, value: value, explanation: "\(explanationPrefix) \(value.lowercased())."))
+    }
+
+    private static func property(
+        entityID: String,
+        typeID: String,
+        value: String,
+        explanation: String,
+        visualKey: String? = nil,
+        visualAssetName: String? = nil,
+        visualShapeKey: String? = nil
+    ) -> GameplayProperty {
+        GameplayProperty(id: "\(entityID)-\(typeID)", typeID: typeID, value: value, explanation: explanation, visualKey: visualKey, visualAssetName: visualAssetName, visualShapeKey: visualShapeKey)
+    }
+
+    private static func pictureEmoji(for animal: MemoryAnimal) -> String? {
+        animal.emoji ?? (animal.metadata.deck == .birds ? "bird.fill" : "pawprint.fill")
+    }
+
+    private static func safariHabitatKey(for animal: MemoryAnimal) -> String {
+        let habitat = (animal.metadata.habitat ?? "").lowercased()
+        if habitat.contains("pond") || habitat.contains("lake") || habitat.contains("stream") || habitat.contains("waterway") || habitat.contains("aquarium") { return "safari-habitat-pond" }
+        if habitat.contains("wetland") || habitat.contains("marsh") || habitat.contains("lagoon") { return "safari-habitat-wetland" }
+        if habitat.contains("rainforest") || habitat.contains("tropical") || habitat.contains("forest") || habitat.contains("woodland") || habitat.contains("canop") { return "safari-habitat-rainforest" }
+        if habitat.contains("desert") || habitat.contains("dry") { return "safari-habitat-desert" }
+        if habitat.contains("mountain") || habitat.contains("rocky") { return "safari-habitat-mountain" }
+        if habitat.contains("coast") || habitat.contains("island") || habitat.contains("atlantic") { return "safari-habitat-coast" }
+        if habitat.contains("garden") || habitat.contains("home") { return "safari-habitat-garden" }
+        if habitat.contains("farm") || habitat.contains("pasture") || habitat.contains("stable") || habitat.contains("barn") || habitat.contains("ranch") { return "safari-habitat-farm" }
+        return "safari-habitat-grassland"
+    }
+
+    private static func habitatSymbolName(for key: String) -> String {
+        switch key {
+        case "safari-habitat-pond": return "drop.fill"
+        case "safari-habitat-wetland": return "water.waves"
+        case "safari-habitat-rainforest": return "leaf.fill"
+        case "safari-habitat-desert": return "sun.max.fill"
+        case "safari-habitat-mountain": return "mountain.2.fill"
+        case "safari-habitat-coast": return "sailboat.fill"
+        case "safari-habitat-garden": return "house.fill"
+        case "safari-habitat-farm": return "house.fill"
+        default: return "globe.americas.fill"
+        }
+    }
+
+    private static func safariRegion(for animal: MemoryAnimal) -> String {
+        let habitat = (animal.metadata.habitat ?? "").lowercased()
+        if habitat.contains("south american") || habitat.contains("americas") || habitat.contains("atlantic") || habitat.contains("american") { return "Americas" }
+        if habitat.contains("australia") || habitat.contains("oceania") || habitat.contains("new guinea") || habitat.contains("island") { return "Australia and islands" }
+        if habitat.contains("india") || habitat.contains("sri lanka") || habitat.contains("asian") || habitat.contains("asia") { return "Asia" }
+        if habitat.contains("africa") { return "Africa" }
+        if habitat.contains("europe") { return "Europe and Asia" }
+        if habitat.contains("desert") { return "Dry world places" }
+        if habitat.contains("farm") || habitat.contains("home") || habitat.contains("garden") || habitat.contains("stable") || habitat.contains("barn") || habitat.contains("ranch") { return "Near people" }
+        return "World habitats"
+    }
+
+    private static func regionKey(for region: String) -> String {
+        region.lowercased().replacingOccurrences(of: " and ", with: "-").replacingOccurrences(of: " ", with: "-")
+    }
+
+    private static func metadataTerms(for animal: MemoryAnimal) -> Set<String> {
+        var terms = Set([animal.canonicalName.lowercased(), animal.name.lowercased()])
+        for card in animal.detailCards {
+            for chunk in card.value.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber }) where chunk.count >= 4 {
+                terms.insert(String(chunk))
+            }
+        }
+        return terms
+    }
 }

--- a/Features/GameplayStages/FlashcardStageView.swift
+++ b/Features/GameplayStages/FlashcardStageView.swift
@@ -27,7 +27,7 @@ struct FlashcardStageView: View {
                     GameplayDisplayCard(
                         item: card,
                         compact: compact,
-                        prominence: card.isFruitCard || viewModel.cards.count == 1 ? .featured : .normal
+                        prominence: card.isFruitCard || card.isSafariCard || viewModel.cards.count == 1 ? .featured : .normal
                     )
                 }
                 .buttonStyle(.plain)

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -175,23 +175,27 @@ struct GameplayDisplayCard: View {
 
     private var isFeatured: Bool { prominence == .featured }
     private var visualSize: CGFloat {
-        if isFeatured { return item.isFruitCard ? (compact ? 126 : 168) : (compact ? 104 : 140) }
+        if isFeatured { return item.isFruitCard || item.isSafariCard ? (compact ? 126 : 168) : (compact ? 104 : 140) }
         if item.isFruitCard { return compact ? 64 : 88 }
+        if item.isSafariCard { return compact ? 56 : 76 }
         return compact ? 40 : 58
     }
     private var visualFrameWidth: CGFloat {
-        if isFeatured { return item.isFruitCard ? (compact ? 250 : 360) : (compact ? 220 : 320) }
+        if isFeatured { return item.isFruitCard || item.isSafariCard ? (compact ? 250 : 360) : (compact ? 220 : 320) }
         if item.isFruitCard { return compact ? 104 : 132 }
+        if item.isSafariCard { return compact ? 96 : 126 }
         return compact ? 64 : 86
     }
     private var visualFrameHeight: CGFloat {
-        if isFeatured { return item.isFruitCard ? (compact ? 190 : 260) : (compact ? 170 : 240) }
+        if isFeatured { return item.isFruitCard || item.isSafariCard ? (compact ? 190 : 260) : (compact ? 170 : 240) }
         if item.isFruitCard { return compact ? 94 : 118 }
+        if item.isSafariCard { return compact ? 88 : 112 }
         return compact ? 58 : 78
     }
     private var minimumHeight: CGFloat {
-        if isFeatured { return item.isFruitCard ? (compact ? 330 : 430) : (compact ? 310 : 400) }
+        if isFeatured { return item.isFruitCard || item.isSafariCard ? (compact ? 330 : 430) : (compact ? 310 : 400) }
         if item.isFruitCard { return compact ? 160 : 202 }
+        if item.isSafariCard { return compact ? 150 : 194 }
         return compact ? 118 : 164
     }
 }
@@ -220,6 +224,10 @@ private struct GameplayDisplayVisual: View {
                 Image(assetName)
                     .resizable()
                     .scaledToFit()
+                    .accessibilityHidden(true)
+                    .padding(visualAssetPadding)
+            } else if let shapeKey = item.visualShapeKey, shapeKey.hasPrefix("safari-") {
+                SafariHabitatArtwork(shapeKey: shapeKey)
                     .accessibilityHidden(true)
                     .padding(visualAssetPadding)
             } else if let shapeKey = item.visualShapeKey {
@@ -342,6 +350,165 @@ private struct CountryMapSilhouette: Shape {
         default:
             return [CGPoint(x: 0.30, y: 0.12), CGPoint(x: 0.74, y: 0.28), CGPoint(x: 0.66, y: 0.76), CGPoint(x: 0.24, y: 0.86), CGPoint(x: 0.16, y: 0.42)]
         }
+    }
+}
+
+private struct SafariHabitatArtwork: View {
+    let shapeKey: String
+
+    var body: some View {
+        GeometryReader { proxy in
+            let size = min(proxy.size.width, proxy.size.height)
+            ZStack {
+                habitatBackground
+                if shapeKey.hasPrefix("safari-world-") {
+                    SafariWorldBoard()
+                } else {
+                    habitatMotif(size: size)
+                }
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height)
+        }
+    }
+
+    @ViewBuilder
+    private var habitatBackground: some View {
+        switch shapeKey {
+        case "safari-habitat-pond", "safari-habitat-wetland", "safari-habitat-coast":
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(LinearGradient(colors: [.cyan.opacity(0.55), .blue.opacity(0.28)], startPoint: .top, endPoint: .bottom))
+        case "safari-habitat-desert":
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(LinearGradient(colors: [.yellow.opacity(0.58), .orange.opacity(0.32)], startPoint: .top, endPoint: .bottom))
+        case "safari-habitat-mountain":
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(LinearGradient(colors: [.mint.opacity(0.48), .gray.opacity(0.30)], startPoint: .top, endPoint: .bottom))
+        case "safari-habitat-rainforest", "safari-habitat-forest", "safari-habitat-grassland", "safari-habitat-garden", "safari-habitat-farm":
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(LinearGradient(colors: [.green.opacity(0.52), .mint.opacity(0.26)], startPoint: .topLeading, endPoint: .bottomTrailing))
+        default:
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(LinearGradient(colors: [MatherTheme.softBlue.opacity(0.60), MatherTheme.card.opacity(0.45)], startPoint: .topLeading, endPoint: .bottomTrailing))
+        }
+    }
+
+    @ViewBuilder
+    private func habitatMotif(size: CGFloat) -> some View {
+        switch shapeKey {
+        case "safari-habitat-pond":
+            SafariRipples().stroke(.blue.opacity(0.70), lineWidth: max(3, size * 0.035))
+            Image(systemName: "drop.fill").font(.system(size: size * 0.34, weight: .black)).foregroundStyle(.blue)
+        case "safari-habitat-wetland":
+            SafariGrass().fill(.green.opacity(0.75))
+            Image(systemName: "water.waves").font(.system(size: size * 0.30, weight: .black)).foregroundStyle(.blue)
+        case "safari-habitat-desert":
+            SafariDunes().fill(.orange.opacity(0.62))
+            Image(systemName: "sun.max.fill").font(.system(size: size * 0.34, weight: .black)).foregroundStyle(.yellow)
+        case "safari-habitat-mountain":
+            SafariMountains().fill(.gray.opacity(0.76))
+            Image(systemName: "mountain.2.fill").font(.system(size: size * 0.30, weight: .black)).foregroundStyle(.white.opacity(0.9))
+        case "safari-habitat-coast":
+            SafariDunes().fill(.yellow.opacity(0.50)).offset(y: size * 0.22)
+            Image(systemName: "sailboat.fill").font(.system(size: size * 0.34, weight: .black)).foregroundStyle(.white)
+        case "safari-habitat-farm":
+            SafariGrass().fill(.green.opacity(0.70))
+            Image(systemName: "house.fill").font(.system(size: size * 0.34, weight: .black)).foregroundStyle(.red.opacity(0.85))
+        case "safari-habitat-garden":
+            SafariGrass().fill(.green.opacity(0.72))
+            Image(systemName: "leaf.fill").font(.system(size: size * 0.34, weight: .black)).foregroundStyle(.green)
+        default:
+            SafariTreeCanopy().fill(.green.opacity(0.72))
+            Image(systemName: "leaf.fill").font(.system(size: size * 0.34, weight: .black)).foregroundStyle(.green)
+        }
+    }
+}
+
+private struct SafariWorldBoard: View {
+    var body: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            let height = proxy.size.height
+            ZStack {
+                Capsule()
+                    .fill(.green.opacity(0.55))
+                    .frame(width: width * 0.34, height: height * 0.24)
+                    .rotationEffect(.degrees(-18))
+                    .offset(x: -width * 0.20, y: -height * 0.06)
+                Capsule()
+                    .fill(.green.opacity(0.62))
+                    .frame(width: width * 0.26, height: height * 0.35)
+                    .rotationEffect(.degrees(18))
+                    .offset(x: width * 0.12, y: -height * 0.02)
+                Capsule()
+                    .fill(.green.opacity(0.50))
+                    .frame(width: width * 0.24, height: height * 0.18)
+                    .rotationEffect(.degrees(-8))
+                    .offset(x: width * 0.26, y: height * 0.20)
+                Image(systemName: "mappin.circle.fill")
+                    .font(.system(size: min(width, height) * 0.24, weight: .black))
+                    .foregroundStyle(MatherTheme.coral)
+            }
+        }
+    }
+}
+
+private struct SafariRipples: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        for scale in [0.38, 0.58, 0.78] {
+            let width = rect.width * scale
+            let height = rect.height * scale * 0.42
+            path.addEllipse(in: CGRect(x: rect.midX - width / 2, y: rect.midY - height / 2, width: width, height: height))
+        }
+        return path
+    }
+}
+
+private struct SafariDunes: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX, y: rect.maxY * 0.62))
+        path.addCurve(to: CGPoint(x: rect.maxX, y: rect.maxY * 0.66), control1: CGPoint(x: rect.width * 0.25, y: rect.height * 0.38), control2: CGPoint(x: rect.width * 0.68, y: rect.height * 0.86))
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
+        path.closeSubpath()
+        return path
+    }
+}
+
+private struct SafariMountains: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: rect.minX + rect.width * 0.06, y: rect.maxY * 0.78))
+        path.addLine(to: CGPoint(x: rect.width * 0.32, y: rect.height * 0.30))
+        path.addLine(to: CGPoint(x: rect.width * 0.50, y: rect.maxY * 0.78))
+        path.addLine(to: CGPoint(x: rect.width * 0.64, y: rect.height * 0.42))
+        path.addLine(to: CGPoint(x: rect.width * 0.94, y: rect.maxY * 0.78))
+        path.closeSubpath()
+        return path
+    }
+}
+
+private struct SafariGrass: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        for index in 0..<7 {
+            let x = rect.width * (0.12 + CGFloat(index) * 0.13)
+            path.move(to: CGPoint(x: x, y: rect.maxY * 0.82))
+            path.addQuadCurve(to: CGPoint(x: x + rect.width * 0.04, y: rect.maxY * 0.45), control: CGPoint(x: x - rect.width * 0.05, y: rect.maxY * 0.62))
+            path.addQuadCurve(to: CGPoint(x: x + rect.width * 0.08, y: rect.maxY * 0.82), control: CGPoint(x: x + rect.width * 0.10, y: rect.maxY * 0.62))
+        }
+        return path
+    }
+}
+
+private struct SafariTreeCanopy: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.addEllipse(in: CGRect(x: rect.width * 0.12, y: rect.height * 0.18, width: rect.width * 0.42, height: rect.height * 0.42))
+        path.addEllipse(in: CGRect(x: rect.width * 0.38, y: rect.height * 0.16, width: rect.width * 0.46, height: rect.height * 0.46))
+        path.addRoundedRect(in: CGRect(x: rect.width * 0.43, y: rect.height * 0.48, width: rect.width * 0.14, height: rect.height * 0.36), cornerSize: CGSize(width: 8, height: 8))
+        return path
     }
 }
 

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -673,7 +673,7 @@ struct LabLaneDetailView: View {
             case .sumSprint:
                 appModel.sumSprintEngine.showDifficultyPick()
             case .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
-                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .fruitCards, .circuitSpark:
+                 .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .worldAnimalSafari, .worldBirdSafari, .fruitCards, .circuitSpark:
                 break
             }
         }

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -354,6 +354,8 @@ enum LabActivityID: String, CaseIterable, Hashable {
     case soundVolume
     case memoryMatch
     case countryCards
+    case worldAnimalSafari
+    case worldBirdSafari
     case fruitCards
     case circuitSpark
 }
@@ -389,6 +391,10 @@ extension LabActivityID {
             return .memory
         case .countryCards:
             return .gameplayThread(.countries)
+        case .worldAnimalSafari:
+            return .gameplayThread(.worldAnimals)
+        case .worldBirdSafari:
+            return .gameplayThread(.worldBirds)
         case .fruitCards:
             return .gameplayThread(.fruits)
         case .circuitSpark:
@@ -1059,7 +1065,7 @@ struct LabLaneDetailPresentation: Equatable {
 extension LabActivityID {
     var sensorNeeds: [LabSensorNeed] {
         switch self {
-        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .fruitCards, .circuitSpark:
+        case .sumSprint, .rectangleFactory, .factoryCards, .twoFingerProtractor, .shapeGeometry, .waterCycle, .soundVolume, .memoryMatch, .countryCards, .worldAnimalSafari, .worldBirdSafari, .fruitCards, .circuitSpark:
             return [.noSpecialSensor]
         case .symmetryFold, .angleCannon, .gravityArtist:
             return [.motion]
@@ -1468,6 +1474,20 @@ struct CapabilityLane: Identifiable, Equatable {
                     title: "Country Cards",
                     tagline: "Flashcards for capitals, flags, languages, currency, and continents",
                     modes: [.learn, .review, .challenge]
+                ),
+                LabActivity(
+                    id: .worldAnimalSafari,
+                    emoji: "🐾",
+                    title: "Animal Homes Safari",
+                    tagline: "Help animals find farms, ponds, deserts, mountains, and homes",
+                    modes: [.learn, .explore, .challenge]
+                ),
+                LabActivity(
+                    id: .worldBirdSafari,
+                    emoji: "🪽",
+                    title: "Bird World Tour",
+                    tagline: "Fly birds to habitats, colors, sizes, and world regions",
+                    modes: [.learn, .explore, .challenge]
                 ),
             ]
         ),

--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -494,6 +494,68 @@ final class MemoryCardDescribeService {
 }
 
 
+struct WorldCreatureGuidePrompt: Equatable {
+    let systemInstruction: String
+    let userPrompt: String
+
+    static func childSafePrompt(for animal: MemoryAnimal) -> WorldCreatureGuidePrompt {
+        let facts = animal.detailCards
+            .prefix(5)
+            .map { "\($0.title): \($0.value)" }
+            .joined(separator: "; ")
+        return WorldCreatureGuidePrompt(
+            systemInstruction: "Write one factual clue for a child age 5 to 8. Use 120 characters or fewer. Use only supplied facts. Do not ask questions, roleplay, mention AI, use markdown, emoji, danger, predators, mating, illness, or death.",
+            userPrompt: "Creature: \(animal.canonicalName). Deck: \(animal.metadata.deck.displayName). Known facts: \(facts)."
+        )
+    }
+}
+
+@MainActor
+protocol WorldCreatureGuideAIAdapter {
+    var isAvailable: Bool { get }
+    func clue(for animal: MemoryAnimal, prompt: WorldCreatureGuidePrompt) async throws -> String?
+}
+
+private struct NullWorldCreatureGuideAIAdapter: WorldCreatureGuideAIAdapter {
+    var isAvailable: Bool { false }
+    func clue(for animal: MemoryAnimal, prompt: WorldCreatureGuidePrompt) async throws -> String? { nil }
+}
+
+@MainActor
+final class WorldCreatureGuideService {
+    enum Source: Equatable {
+        case curatedFallback
+        case appleIntelligence
+    }
+
+    struct Clue: Equatable {
+        let text: String
+        let source: Source
+    }
+
+    private let appleIntelligenceEnabled: () -> Bool
+    private let aiAdapter: any WorldCreatureGuideAIAdapter
+
+    init(
+        appleIntelligenceEnabled: @escaping () -> Bool = { false },
+        aiAdapter: (any WorldCreatureGuideAIAdapter)? = nil
+    ) {
+        self.appleIntelligenceEnabled = appleIntelligenceEnabled
+        self.aiAdapter = aiAdapter ?? NullWorldCreatureGuideAIAdapter()
+    }
+
+    func clue(for animal: MemoryAnimal) async -> Clue {
+        let prompt = WorldCreatureGuidePrompt.childSafePrompt(for: animal)
+        if appleIntelligenceEnabled(), aiAdapter.isAvailable,
+           let generated = try? await aiAdapter.clue(for: animal, prompt: prompt),
+           let sanitized = WorldSafariContentAdapter.sanitizedGeneratedClue(generated, for: animal) {
+            return Clue(text: sanitized, source: .appleIntelligence)
+        }
+        return Clue(text: WorldSafariContentAdapter.fallbackClue(for: animal), source: .curatedFallback)
+    }
+}
+
+
 private extension Data {
     mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
         var littleEndianValue = value.littleEndian

--- a/Tests/MatherTests/GameplayStageViewModelsTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelsTests.swift
@@ -144,7 +144,7 @@ struct GameplayStageViewModelsTests {
 struct GameplayThreadCatalogRegressionTests {
     @Test
     func allDirectGameplayEntriesUseFiveStageReusableThread() {
-        let directEntries: [GameplayThreadID] = [.countries, .fruits, .waterCycle]
+        let directEntries: [GameplayThreadID] = [.countries, .fruits, .waterCycle, .worldAnimals, .worldBirds]
 
         for id in directEntries {
             let thread = GameplayThreadCatalog.thread(for: id)

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -167,3 +167,110 @@ struct GameplayThreadContentTests {
     }
 
 }
+
+struct WorldSafariGameplayThreadTests {
+    @Test
+    func worldSafariThreadsReuseMemoryDeckContentAndExposeFiveStageLoop() {
+        let animals = GameplayThreadCatalog.thread(for: .worldAnimals)
+        let birds = GameplayThreadCatalog.thread(for: .worldBirds)
+
+        #expect(animals.id == "world-animals")
+        #expect(birds.id == "world-birds")
+        #expect(animals.category.id == "geography")
+        #expect(birds.category.title == "World Safari")
+        #expect(animals.entities.count == 12)
+        #expect(birds.entities.count == 12)
+        #expect(animals.stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+        #expect(birds.stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
+
+        let memoryAnimalNames = Set(MemoryDeck.domesticAnimals.map(\.canonicalName))
+        let memoryBirdNames = Set(MemoryDeck.birds.map(\.canonicalName))
+        #expect(animals.entities.allSatisfy { memoryAnimalNames.contains($0.name) })
+        #expect(birds.entities.allSatisfy { memoryBirdNames.contains($0.name) })
+        #expect(birds.entities.allSatisfy { $0.visualAssetName?.hasPrefix("MemoryBird") == true })
+    }
+
+    @Test
+    func worldSafariContentHasHabitatRegionAndKidReadableFacts() {
+        for thread in [GameplayThreadCatalog.thread(for: .worldAnimals), GameplayThreadCatalog.thread(for: .worldBirds)] {
+            #expect(thread.entities.allSatisfy { !$0.summary.isEmpty })
+            #expect(thread.entities.allSatisfy { entity in
+                let typeIDs = Set(entity.properties.map(\.typeID))
+                return typeIDs.contains(thread.id == "world-animals" ? "habitat" : "home")
+                    && typeIDs.contains(thread.id == "world-animals" ? "world-place" : "world-region")
+                    && entity.properties.allSatisfy { !$0.value.isEmpty && !$0.explanation.isEmpty }
+            })
+            #expect(thread.entities.contains { entity in
+                entity.properties.contains { $0.visualShapeKey?.hasPrefix("safari-habitat-") == true }
+            })
+            #expect(thread.entities.contains { entity in
+                entity.properties.contains { $0.visualShapeKey?.hasPrefix("safari-world-") == true }
+            })
+        }
+    }
+
+    @Test
+    func worldSafariRoundsAndQuizChoicesArePlayableAndUnambiguous() throws {
+        for thread in [GameplayThreadCatalog.thread(for: .worldAnimals), GameplayThreadCatalog.thread(for: .worldBirds)] {
+            for stage in thread.stages {
+                let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 1044)
+                #expect(!round.items.isEmpty, "\(stage.id) should produce a round")
+                #expect(round.items.count <= stage.maximumItemCount)
+                if !stage.propertyTypeIDs.isEmpty {
+                    let allowed = Set(stage.propertyTypeIDs)
+                    #expect(round.items.allSatisfy { item in
+                        guard let propertyTypeID = item.propertyTypeID else { return false }
+                        return allowed.contains(propertyTypeID)
+                    })
+                }
+            }
+
+            let quizStage = try #require(thread.stages.first { $0.kind == .multipleChoice })
+            let quizRound = SpacedRepetitionScheduler.makeRound(thread: thread, stage: quizStage, seed: 1044)
+            let questions = GameplayStageContentBuilder.multipleChoiceQuestions(thread: thread, round: quizRound)
+            #expect(questions.count == quizRound.items.count)
+            for question in questions {
+                #expect(question.choices.contains(question.answer))
+                #expect(Set(question.choices.map { $0.title.lowercased() }).count == question.choices.count)
+                #expect(question.choices.count >= 2)
+            }
+        }
+    }
+
+    @MainActor @Test
+    func worldCreatureGuideFallsBackAndSanitizesGeneratedClues() async {
+        let animal = MemoryDeck.birds[0]
+        let fallbackService = WorldCreatureGuideService(
+            appleIntelligenceEnabled: { false },
+            aiAdapter: StubWorldGuideAdapter(isAvailable: true, response: "Macaw lives in South American rainforests.")
+        )
+        let fallback = await fallbackService.clue(for: animal)
+        #expect(fallback.source == .curatedFallback)
+        #expect(fallback.text.localizedCaseInsensitiveContains("rainforests"))
+
+        let generatedService = WorldCreatureGuideService(
+            appleIntelligenceEnabled: { true },
+            aiAdapter: StubWorldGuideAdapter(isAvailable: true, response: "Macaw lives in South American rainforests.")
+        )
+        let generated = await generatedService.clue(for: animal)
+        #expect(generated.source == .appleIntelligence)
+        #expect(generated.text == "Macaw lives in South American rainforests.")
+
+        let unsafeService = WorldCreatureGuideService(
+            appleIntelligenceEnabled: { true },
+            aiAdapter: StubWorldGuideAdapter(isAvailable: true, response: "Pretend this predator can attack.")
+        )
+        let unsafe = await unsafeService.clue(for: animal)
+        #expect(unsafe.source == .curatedFallback)
+    }
+}
+
+@MainActor
+private struct StubWorldGuideAdapter: WorldCreatureGuideAIAdapter {
+    let isAvailable: Bool
+    let response: String?
+
+    func clue(for animal: MemoryAnimal, prompt: WorldCreatureGuidePrompt) async throws -> String? {
+        response
+    }
+}

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -315,6 +315,8 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(Set(entries.map(\.id)).count, entries.count)
         XCTAssertTrue(entries.contains { $0.activity.id == .sumSprint && $0.directRoute == .sumSprint })
         XCTAssertTrue(entries.contains { $0.activity.id == .waterCycle && $0.directRoute == .gameplayThread(.waterCycle) })
+        XCTAssertTrue(entries.contains { $0.activity.id == .worldAnimalSafari && $0.laneID == .mapWorld && $0.directRoute == .gameplayThread(.worldAnimals) })
+        XCTAssertTrue(entries.contains { $0.activity.id == .worldBirdSafari && $0.laneID == .mapWorld && $0.directRoute == .gameplayThread(.worldBirds) })
         XCTAssertTrue(entries.contains { $0.activity.id == .memoryMatch && $0.directRoute == .memory })
         XCTAssertTrue(entries.contains { $0.activity.id == .circuitSpark && $0.laneID == .electronics && $0.directRoute == .gameplayThread(.electronics) })
     }

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -37,6 +37,8 @@ struct LabRouteRegressionTests {
             .soundVolume: .soundVolume,
             .memoryMatch: .memory,
             .countryCards: .gameplayThread(.countries),
+            .worldAnimalSafari: .gameplayThread(.worldAnimals),
+            .worldBirdSafari: .gameplayThread(.worldBirds),
             .fruitCards: .gameplayThread(.fruits),
             .circuitSpark: .gameplayThread(.electronics),
         ]
@@ -52,6 +54,8 @@ struct LabRouteRegressionTests {
     func explorerLabContentRoutesUseReusableGameplayThreads() {
         let reusableThreadRoutes: [LabActivityID: GameplayThreadID] = [
             .countryCards: .countries,
+            .worldAnimalSafari: .worldAnimals,
+            .worldBirdSafari: .worldBirds,
             .fruitCards: .fruits,
             .waterCycle: .waterCycle,
             .circuitSpark: .electronics,


### PR DESCRIPTION
## Summary\n- Adds Geography/Maps entries for Animal Homes Safari and Bird World Tour, backed by existing MemoryDeck domestic animal and bird content.\n- Reuses the shared GameplayThread loop with Learn, Habitat Hop/Explore, Safari Stamps, and Quiz stages.\n- Adds SwiftUI-drawn safari habitat/world visuals plus fallback-first WorldCreatureGuideService sanitization boundary.\n- Keeps Memory Match directly routed and adds regression coverage for routes, content, quiz choices, and fallback behavior.\n\n## Validation\n- git diff --check\n- Blocked locally: xcodegen, xcodebuild, xcrun, and swift are not installed in this container, so the iOS unit/build gate could not run here.\n\nCloses #1044