### PR TITLE
Address build 101 pitch and matching feedback

### DIFF
--- a/Domain/CountryGameplayThread.swift
+++ b/Domain/CountryGameplayThread.swift
@@ -222,7 +222,7 @@ enum CountryGameplayThread {
         ],
         stages: [
             GameplayStageDefinition(id: "flashcards", kind: .flashcards, title: "Look + Learn", prompt: "Meet each country, flag, capital, map clue, language, and money.", maximumItemCount: 8),
-            GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Start by matching countries to flags, capitals, and continents.", propertyTypeIDs: ["flag", "capital", "continent"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Start with one focused round matching each country name to its flag.", propertyTypeIDs: ["flag"], maximumItemCount: 8),
             GameplayStageDefinition(id: "flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Flip and remember flags, capitals, and currencies.", propertyTypeIDs: ["flag", "capital", "currency"], maximumItemCount: 8),
             GameplayStageDefinition(id: "bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect each country to mixed facts.", propertyTypeIDs: ["capital", "currency", "continent", "language", "map-shape"], maximumItemCount: 10),
             GameplayStageDefinition(id: "multiple-choice", kind: .multipleChoice, title: "Quiz", prompt: "Pick the best country fact.", propertyTypeIDs: ["capital", "currency", "flag", "map-shape", "continent", "language"], maximumItemCount: 12)

--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -243,8 +243,8 @@ struct GameplayMatchStageViewModel: Equatable {
     var currentRoundRequirementText: String {
         let remaining = activePairs.filter { !matchedPairIDs.contains($0.id) }.count
         if remaining == 0 { return isComplete ? "Ready to finish" : "Ready for next round" }
-        if remaining == 1 { return "1 left this round" }
-        return "\(remaining) left this round"
+        if remaining == 1 { return "1 pair left this round" }
+        return "\(remaining) pairs left this round"
     }
     var activePairs: [GameplayMatchPair] {
         let start = activeTurnIndex * turnItemCount

--- a/Domain/GameplayThreadContent+WorldBirds.swift
+++ b/Domain/GameplayThreadContent+WorldBirds.swift
@@ -22,7 +22,7 @@ extension GameplayThreadCatalog {
         },
         stages: [
             GameplayStageDefinition(id: "world-birds-flashcards", kind: .flashcards, title: "Bird Cards", prompt: "Meet colorful birds from different world habitats.", maximumItemCount: 12),
-            GameplayStageDefinition(id: "world-birds-easy-memory", kind: .easyMemory, title: "Bird Match", prompt: "Match birds to names, homes, colors, and size clues.", propertyTypeIDs: ["name", "home", "colors", "size"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "world-birds-easy-memory", kind: .easyMemory, title: "Bird Match", prompt: "Start with one focused round matching each bird picture to its name.", propertyTypeIDs: ["name"], maximumItemCount: 8),
             GameplayStageDefinition(id: "world-birds-bond-blast", kind: .bondBlast, title: "Bird Blast", prompt: "Connect each bird with its home, colors, size, lifespan, and weight.", propertyTypeIDs: ["home", "colors", "size", "lifespan", "weight"], maximumItemCount: 12),
         ],
         progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.70, retryMissedItemsFirst: true)

--- a/Domain/LearningLoopModels.swift
+++ b/Domain/LearningLoopModels.swift
@@ -728,6 +728,9 @@ enum SoundVolumeContent {
 
     static let pitchBands = SoundPitchBand.allCases
 
+    static let pitchFollowUpTitle = "Pitch follow-up"
+    static let pitchFollowUpRouteTitle = "Open pitch follow-up"
+
     static let pitchChallenge = SoundPitchChallenge(
         id: "bird-high-pitch",
         prompt: "A tiny bird chirp is usually which pitch?",

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -914,7 +914,7 @@ struct SoundVolumeLabView: View {
     private var soundMeterPitchActivity: some View {
         VStack(alignment: .leading, spacing: 14) {
             soundMeterCard
-            pitchTeachingCard
+            pitchFollowUpRouteCard
         }
     }
 
@@ -1003,62 +1003,29 @@ struct SoundVolumeLabView: View {
         .accessibilityElement(children: .contain)
     }
 
-    private var pitchTeachingCard: some View {
+    private var pitchFollowUpRouteCard: some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 12) {
-                Text("Pitch follow-up")
+                Text(SoundVolumeContent.pitchFollowUpTitle)
                     .font(.title2.weight(.black))
                     .foregroundStyle(MatherTheme.ink)
-                Text("Pitch means how deep or bright a sound is. It is different from loudness, so you never need to be louder to learn pitch.")
+                Text("Open a focused pitch screen after the meter. Pitch is separate from loudness, so no microphone or louder sound is needed.")
                     .font(.headline.weight(.semibold))
                     .foregroundStyle(MatherTheme.cardSubtitle)
                     .fixedSize(horizontal: false, vertical: true)
 
-                LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 10)], spacing: 10) {
-                    ForEach(SoundVolumeContent.pitchBands) { band in
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(band.visualKey).font(.largeTitle)
-                            Text(band.title)
-                                .font(.headline.weight(.black))
-                                .foregroundStyle(MatherTheme.ink)
-                            Text(band.frequencyRangeLabel)
-                                .font(.caption.weight(.black))
-                                .foregroundStyle(MatherTheme.accent)
-                            Text(band.teachingCopy)
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(MatherTheme.cardSubtitle)
-                        }
-                        .padding(12)
-                        .frame(maxWidth: .infinity, minHeight: 150, alignment: .topLeading)
-                        .background(MatherTheme.softBlue.opacity(0.18))
-                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-                        .accessibilityElement(children: .combine)
-                    }
+                NavigationLink {
+                    SoundPitchFollowUpView(
+                        pitchChallengeState: $pitchChallengeState,
+                        onFeedback: { feedback = $0 }
+                    )
+                } label: {
+                    Label(SoundVolumeContent.pitchFollowUpRouteTitle, systemImage: "music.note.list")
+                        .font(.headline.weight(.black))
+                        .frame(maxWidth: .infinity)
                 }
-
-                Text(pitchChallengeState.challenge.prompt)
-                    .font(.headline.weight(.black))
-                    .foregroundStyle(MatherTheme.ink)
-
-                HStack(spacing: 8) {
-                    ForEach(pitchChallengeState.challenge.options) { band in
-                        Button {
-                            pitchChallengeState.select(band)
-                            feedback = pitchChallengeState.feedback
-                        } label: {
-                            Text("\(band.visualKey) \(band.title)")
-                                .font(.caption.weight(.black))
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .tint(pitchChallengeState.selectedBand == band ? MatherTheme.accent : MatherTheme.softBlue)
-                        .accessibilityIdentifier("SoundPitchChoice-\(band.rawValue)")
-                    }
-                }
-
-                Text(pitchChallengeState.feedback)
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(pitchChallengeState.isCorrect ? MatherTheme.accent : MatherTheme.cardSubtitle)
+                .buttonStyle(PrimaryActionButtonStyle())
+                .accessibilityIdentifier("SoundPitchFollowUpRoute")
             }
         }
         .accessibilityElement(children: .contain)
@@ -1120,4 +1087,87 @@ struct SoundVolumeLabView: View {
             return MatherTheme.coral.opacity(0.20)
         }
     }
+}
+
+private struct SoundPitchFollowUpView: View {
+    @Binding var pitchChallengeState: SoundPitchChallengeState
+    let onFeedback: (String) -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                CardSurface {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(SoundVolumeContent.pitchFollowUpTitle)
+                            .font(.largeTitle.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                            .minimumScaleFactor(0.75)
+                        Text("Pitch means how deep or bright a sound is. It is different from loudness, so you never need to be louder to learn pitch.")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 10)], spacing: 10) {
+                    ForEach(SoundVolumeContent.pitchBands) { band in
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(band.visualKey).font(.largeTitle)
+                            Text(band.title)
+                                .font(.headline.weight(.black))
+                                .foregroundStyle(MatherTheme.ink)
+                            Text(band.frequencyRangeLabel)
+                                .font(.caption.weight(.black))
+                                .foregroundStyle(MatherTheme.accent)
+                            Text(band.teachingCopy)
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(MatherTheme.cardSubtitle)
+                        }
+                        .padding(12)
+                        .frame(maxWidth: .infinity, minHeight: 150, alignment: .topLeading)
+                        .background(MatherTheme.softBlue.opacity(0.18))
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .accessibilityElement(children: .combine)
+                    }
+                }
+
+                CardSurface {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(pitchChallengeState.challenge.prompt)
+                            .font(.headline.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+
+                        HStack(spacing: 8) {
+                            ForEach(pitchChallengeState.challenge.options) { band in
+                                Button {
+                                    pitchChallengeState.select(band)
+                                    onFeedback(pitchChallengeState.feedback)
+                                } label: {
+                                    Text("\(band.visualKey) \(band.title)")
+                                        .font(.caption.weight(.black))
+                                        .frame(maxWidth: .infinity)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .tint(pitchChallengeState.selectedBand == band ? MatherTheme.accent : MatherTheme.softBlue)
+                                .accessibilityIdentifier("SoundPitchChoice-\(band.rawValue)")
+                            }
+                        }
+
+                        Text(pitchChallengeState.feedback)
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(pitchChallengeState.isCorrect ? MatherTheme.accent : MatherTheme.cardSubtitle)
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 18)
+            .padding(.bottom, 32)
+            .frame(maxWidth: 900)
+            .frame(maxWidth: .infinity)
+        }
+        .background(MatherTheme.background.ignoresSafeArea())
+        .navigationTitle(SoundVolumeContent.pitchFollowUpTitle)
+        .accessibilityIdentifier("SoundPitchFollowUpScreen")
+    }
+
 }

--- a/Services/SpacedRepetitionScheduler.swift
+++ b/Services/SpacedRepetitionScheduler.swift
@@ -21,7 +21,8 @@ enum SpacedRepetitionScheduler {
         let selected = childSafeSelection(
             from: ranked,
             maximumItemCount: effectivePolicy.maximumItemCount,
-            stageKind: stage.kind
+            stageKind: stage.kind,
+            thread: thread
         )
         return GameplayRoundDefinition(
             id: "\(stage.id)-round-\(seed)",
@@ -80,7 +81,8 @@ enum SpacedRepetitionScheduler {
     private static func childSafeSelection(
         from ranked: [GameplayRoundItem],
         maximumItemCount: Int,
-        stageKind: GameplayStageKind
+        stageKind: GameplayStageKind,
+        thread: GameplayThreadDefinition
     ) -> [GameplayRoundItem] {
         let limit = max(1, maximumItemCount)
         guard stageKind == .easyMemory || stageKind == .flipMemory else {
@@ -89,10 +91,13 @@ enum SpacedRepetitionScheduler {
 
         var selected: [GameplayRoundItem] = []
         var selectedEntityIDs = Set<String>()
+        var selectedAnswerKeys = Set<String>()
         var deferred: [GameplayRoundItem] = []
         for item in ranked {
             guard selected.count < limit else { break }
-            if selectedEntityIDs.insert(item.entityID).inserted {
+            let answerKey = visibleAnswerKey(for: item, in: thread)
+            if selectedEntityIDs.insert(item.entityID).inserted,
+               selectedAnswerKeys.insert(answerKey).inserted {
                 selected.append(item)
             } else {
                 deferred.append(item)
@@ -102,6 +107,15 @@ enum SpacedRepetitionScheduler {
             selected.append(item)
         }
         return selected
+    }
+
+    private static func visibleAnswerKey(for item: GameplayRoundItem, in thread: GameplayThreadDefinition) -> String {
+        guard let entity = thread.entities.first(where: { $0.id == item.entityID }),
+              let property = entity.properties.first(where: { $0.id == item.propertyID }) ?? entity.properties.first
+        else {
+            return item.id.lowercased()
+        }
+        return "\(property.typeID)::\(property.value)".trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
     private static func rank(item: GameplayRoundItem, record: GameplayExposureRecord?, now: Date, seed: UInt64) -> GameplayItemRank {

--- a/Tests/MatherTests/CountryGameplayThreadTests.swift
+++ b/Tests/MatherTests/CountryGameplayThreadTests.swift
@@ -80,7 +80,7 @@ struct CountryGameplayThreadTests {
 
         let easy = try round(kind: .easyMemory, thread: thread)
         #expect(!easy.items.isEmpty)
-        #expect(easy.items.allSatisfy { ["flag", "capital", "continent"].contains($0.propertyTypeID ?? "") })
+        #expect(easy.items.allSatisfy { $0.propertyTypeID == "flag" })
         #expect(!GameplayStageContentBuilder.matchPairs(thread: thread, round: easy).isEmpty)
 
         let flip = try round(kind: .flipMemory, thread: thread)
@@ -94,6 +94,24 @@ struct CountryGameplayThreadTests {
         let questions = GameplayStageContentBuilder.multipleChoiceQuestions(thread: thread, round: quiz)
         #expect(!questions.isEmpty)
         #expect(questions.allSatisfy { $0.choices.contains($0.answer) })
+    }
+
+    @Test
+    func countryEasyMemoryStartsWithDeterministicFlagNameRoundWithoutDuplicateVisibleAnswers() throws {
+        let thread = CountryGameplayThread.thread
+        let stage = try #require(thread.stages.first { $0.kind == .easyMemory })
+        #expect(stage.propertyTypeIDs == ["flag"])
+        #expect(stage.prompt.localizedCaseInsensitiveContains("country name"))
+        #expect(stage.prompt.localizedCaseInsensitiveContains("flag"))
+
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 912)
+        let pairs = GameplayStageContentBuilder.matchPairs(thread: thread, round: round)
+
+        #expect(round.items.count == min(stage.maximumItemCount, thread.entities.count))
+        #expect(round.items.allSatisfy { $0.propertyTypeID == "flag" })
+        #expect(pairs.allSatisfy { pair in thread.entities.contains { $0.id == pair.left.entityID && $0.name == pair.left.title } })
+        #expect(pairs.allSatisfy { $0.right.subtitle == "Flag" })
+        #expect(Set(pairs.map { $0.right.title.lowercased() }).count == pairs.count)
     }
 
 

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -208,7 +208,7 @@ struct GameplayStageParityRegressionTests {
         #expect(viewModel.matchedProgressText == "0 of 4 matched")
         #expect(viewModel.turnGuidanceText == "Pick a card. Then find its match.")
         #expect(viewModel.finishRequirementText == "Find 4 more matches")
-        #expect(viewModel.currentRoundRequirementText == "2 left this round")
+        #expect(viewModel.currentRoundRequirementText == "2 pairs left this round")
 
         viewModel.selectLeft(pairID: firstPair.id)
         #expect(viewModel.turnGuidanceText == "Now tap the card that goes with it.")
@@ -218,7 +218,7 @@ struct GameplayStageParityRegressionTests {
         #expect(viewModel.lastMatchedPairID == firstPair.id)
         #expect(viewModel.matchedProgressText == "1 of 4 matched")
         #expect(viewModel.finishRequirementText == "Find 3 more matches")
-        #expect(viewModel.currentRoundRequirementText == "1 left this round")
+        #expect(viewModel.currentRoundRequirementText == "1 pair left this round")
 
         for pair in viewModel.activePairs where !viewModel.matchedPairIDs.contains(pair.id) {
             viewModel.selectLeft(pairID: pair.id)

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -225,6 +225,25 @@ struct WorldCreatureGameplayThreadTests {
             #expect(pairs.allSatisfy { $0.right.subtitle == (threadID == .worldAnimals ? "Animal name" : "Bird name") })
         }
     }
+    @Test
+    func worldBirdsEasyMemoryStartsWithDeterministicPictureNameRoundWithoutDuplicateVisibleAnswers() throws {
+        let thread = GameplayThreadCatalog.worldBirds
+        let stage = try #require(thread.stages.first { $0.kind == .easyMemory })
+        #expect(stage.propertyTypeIDs == ["name"])
+        #expect(stage.prompt.localizedCaseInsensitiveContains("picture"))
+        #expect(stage.prompt.localizedCaseInsensitiveContains("name"))
+
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 1049)
+        let pairs = GameplayStageContentBuilder.matchPairs(thread: thread, round: round)
+
+        #expect(round.items.count == min(stage.maximumItemCount, thread.entities.count))
+        #expect(round.items.allSatisfy { $0.propertyTypeID == "name" })
+        #expect(pairs.allSatisfy { $0.left.title == "Name this bird" })
+        #expect(pairs.allSatisfy { $0.left.visualAssetName?.isEmpty == false })
+        #expect(pairs.allSatisfy { $0.right.subtitle == "Bird name" })
+        #expect(Set(pairs.map { $0.right.title.lowercased() }).count == pairs.count)
+    }
+
 
     @Test
     func worldCreatureBondBlastHasEnoughFactProperties() throws {

--- a/Tests/MatherTests/LearningLoopTests.swift
+++ b/Tests/MatherTests/LearningLoopTests.swift
@@ -273,6 +273,13 @@ extension LearningLoopTests {
         XCTAssertTrue(state.isCorrect)
         XCTAssertEqual(state.feedback, SoundVolumeContent.pitchChallenge.feedback)
     }
+    func testSoundPitchFollowUpHasDedicatedRouteCopyAndQuizContent() {
+        XCTAssertEqual(SoundVolumeContent.pitchFollowUpTitle, "Pitch follow-up")
+        XCTAssertEqual(SoundVolumeContent.pitchFollowUpRouteTitle, "Open pitch follow-up")
+        XCTAssertEqual(SoundVolumeContent.pitchChallenge.prompt, "A tiny bird chirp is usually which pitch?")
+        XCTAssertEqual(SoundVolumeContent.pitchChallenge.options, [.low, .middle, .high])
+    }
+
 
     func testSoundVolumeQuizScoringUsesCorrectSafeAnswers() {
         let questions = SoundVolumeContent.quizQuestions


### PR DESCRIPTION
## Summary
- Adds a dedicated Sound Lab pitch follow-up route/screen instead of keeping pitch instruction inline on the meter card.
- Makes Country Cards Easy Memory a focused deterministic country-name ↔ flag round.
- Makes World Birds Easy Memory a focused deterministic bird-picture ↔ bird-name round.
- Clarifies match progress copy to `pair/pairs left this round`.
- Adds targeted coverage for the focused rounds, progress copy, and pitch route copy/content.

Fixes #1047
Fixes #1048
Fixes #1049

## Validation
- `git diff --check` ✅
- Remote Xcode validation attempted on `ganesh-mba`:
  - `xcodebuild -list -project Mather.xcodeproj` ✅
  - `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,OS=18.3.1,name=iPhone 16" -only-testing:MatherTests/CountryGameplayThreadTests -only-testing:MatherTests/WorldCreatureGameplayThreadTests -only-testing:MatherTests/GameplayStageViewModelTests -only-testing:MatherTests/LearningLoopTests` blocked because the checked-in `Mather.xcodeproj` is stale and missing generated source entries (examples: `MemoryDeck`, `KidProfileStore`, `CardReviewResult`).
  - `xcodegen generate` could not be run locally because `xcodegen` is not installed on `ganesh-mba`.
