### PR TITLE
Simplify Lab detail guided cards

### DIFF
--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -32,10 +32,11 @@ struct LabLaneDetailView: View {
                     guidedSessionSection(tint: tint)
                     gamesSection(selectedLane, tint: tint)
                     supportPanel(selectedLane, progress: progress, tint: tint)
-                    researchQuestSection(selectedLane, tint: tint)
                     recallSection(selectedLane, tint: tint)
                 }
                 .padding(24)
+                .safeAreaPadding(.top, 12)
+                .safeAreaPadding(.bottom, 24)
             }
         }
         .onAppear {
@@ -143,60 +144,13 @@ struct LabLaneDetailView: View {
         .accessibilityElement(children: .contain)
     }
 
-    private func researchQuestSection(_ lane: CapabilityLane, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Label("Research quest", systemImage: "sparkles")
-                .font(.headline.weight(.black))
-                .foregroundStyle(tint)
-            Text("Try one tiny experiment, notice what changed, then earn a discovery spark.")
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(MatherTheme.cardSubtitle)
-            HStack(spacing: 10) {
-                researchQuestChip(icon: "lightbulb.fill", title: "Wonder", detail: lane.promise, tint: tint)
-                researchQuestChip(icon: "hand.tap.fill", title: "Try", detail: lane.isReady ? "Play a game" : "Preview ideas", tint: tint)
-                researchQuestChip(icon: "star.fill", title: "Notice", detail: "Collect a spark", tint: tint)
-            }
-        }
-        .padding(14)
-        .background(MatherTheme.card.opacity(0.82), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Research quest. Try one tiny experiment, notice what changed, then earn a discovery spark.")
-    }
-
-    private func researchQuestChip(icon: String, title: String, detail: String, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Image(systemName: icon)
-                .font(.headline.weight(.black))
-                .foregroundStyle(tint)
-            Text(title)
-                .font(.caption.weight(.black))
-                .foregroundStyle(MatherTheme.ink)
-            Text(detail)
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(MatherTheme.cardSubtitle)
-                .lineLimit(2)
-                .minimumScaleFactor(0.75)
-        }
-        .frame(maxWidth: .infinity, minHeight: 88, alignment: .topLeading)
-        .padding(10)
-        .background(tint.opacity(0.10), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-    }
-
     @ViewBuilder
     private func guidedSessionSection(tint: Color) -> some View {
         if !sessionPlans.isEmpty {
             VStack(alignment: .leading, spacing: 12) {
-                HStack(alignment: .top, spacing: 10) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Guided path")
-                            .font(.title3.weight(.black))
-                            .foregroundStyle(MatherTheme.ink)
-                        Text("Learn → Remember → Play → Blast → Score")
-                            .font(.caption.weight(.black))
-                            .foregroundStyle(tint)
-                    }
-                    Spacer(minLength: 0)
-                }
+                Text("Guided path")
+                    .font(.title3.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
 
                 ForEach(sessionPlans) { plan in
                     conceptSessionPlanCard(plan, tint: tint)
@@ -216,22 +170,22 @@ struct LabLaneDetailView: View {
     private func conceptSessionPlanCard(_ plan: LabConceptSessionPlan, tint: Color) -> some View {
         let progress = appModel.labConceptSessionProgressStore.progress(for: plan)
         let detailsExpanded = expandedPlanDetails.contains(plan.id)
+        let presentation = plan.cardPresentation
 
         return VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(plan.title)
+            HStack(alignment: .center, spacing: 12) {
+                Image(systemName: presentation.symbolName)
+                    .font(.title2.weight(.black))
+                    .foregroundStyle(tint)
+                    .frame(width: 56, height: 56)
+                    .background(MatherTheme.card.opacity(0.82), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .accessibilityHidden(true)
+
+                Text(presentation.title)
                         .font(.headline.weight(.black))
                         .foregroundStyle(MatherTheme.ink)
-                    Text(plan.subtitle)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
                         .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
-                    Text(plan.masteryStateLabel)
-                        .font(.caption2.weight(.black))
-                        .foregroundStyle(tint)
-                }
+                        .minimumScaleFactor(0.82)
 
                 Spacer(minLength: 0)
 
@@ -257,8 +211,6 @@ struct LabLaneDetailView: View {
                     .accessibilityLabel("Resume \(plan.title). \(progress.resumeCopy).")
             }
 
-            stageSummaryStrip(plan, progress: progress, tint: tint)
-
             Button {
                 withAnimation(.spring(response: 0.28, dampingFraction: 0.9)) {
                     if detailsExpanded {
@@ -273,11 +225,6 @@ struct LabLaneDetailView: View {
                         .font(.caption.weight(.black))
                         .foregroundStyle(tint)
                     Spacer(minLength: 0)
-                    Text("\(plan.estimatedLength) • Next: \(plan.recommendedNextActivity)")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.72)
                 }
                 .padding(9)
                 .background(MatherTheme.card.opacity(0.72), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
@@ -286,6 +233,21 @@ struct LabLaneDetailView: View {
             .accessibilityLabel(detailsExpanded ? "Hide guided path details" : "Show guided path details")
 
             if detailsExpanded {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(plan.subtitle)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("\(plan.masteryStateLabel) • \(plan.estimatedLength) • Next: \(plan.recommendedNextActivity)")
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(tint)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(presentation.hiddenDetailAccessibilityLabel)
+
+                stageSummaryStrip(plan, progress: progress, tint: tint)
+
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 132), spacing: 8)], spacing: 8) {
                     ForEach(plan.stages) { stage in
                         stagePlanCard(stage, progress: progress, tint: tint)
@@ -296,7 +258,7 @@ struct LabLaneDetailView: View {
         .padding(12)
         .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("\(plan.title). Primary action: \(startLabel(for: plan)). Path: \(plan.pathLabel).")
+        .accessibilityLabel("\(presentation.hiddenDetailAccessibilityLabel) Primary action: \(startLabel(for: plan)).")
     }
 
     private func stageSummaryStrip(_ plan: LabConceptSessionPlan, progress: LabConceptSessionProgress?, tint: Color) -> some View {

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -612,6 +612,9 @@ struct LabConceptSessionPlan: Identifiable, Equatable {
     var startAffordanceLabel: String { "Start" }
     var continueAffordanceLabel: String { "Continue" }
     var pathLabel: String { stageOrder.map(\.rawValue).joined(separator: " → ") }
+    var cardPresentation: LabConceptSessionPlanCardPresentation {
+        LabConceptSessionPlanCardPresentation(plan: self)
+    }
 
     static func plan(for id: String) -> LabConceptSessionPlan? {
         switch id {
@@ -731,6 +734,54 @@ struct LabConceptSessionPlan: Identifiable, Equatable {
         ]
     )
 
+}
+
+struct LabConceptSessionPlanCardPresentation: Equatable {
+    let title: String
+    let symbolName: String
+    let hiddenDetailAccessibilityLabel: String
+    let defaultVisibleText: [String]
+    let disclosureDetailText: [String]
+
+    init(plan: LabConceptSessionPlan) {
+        title = plan.title
+        symbolName = Self.symbolName(for: plan)
+        hiddenDetailAccessibilityLabel = [
+            plan.title,
+            plan.subtitle,
+            plan.masteryStateLabel,
+            plan.estimatedLength,
+            "Next: \(plan.recommendedNextActivity).",
+            "Path: \(plan.pathLabel).",
+        ].joined(separator: " ")
+        defaultVisibleText = [plan.title]
+        disclosureDetailText = [
+            plan.subtitle,
+            plan.masteryStateLabel,
+            plan.estimatedLength,
+            plan.recommendedNextActivity,
+            plan.pathLabel,
+        ]
+    }
+
+    var keepsDefaultFaceSparse: Bool {
+        defaultVisibleText == [title]
+    }
+
+    private static func symbolName(for plan: LabConceptSessionPlan) -> String {
+        switch plan.id {
+        case LabConceptSessionPlan.numbersNumberBondsTo10.id:
+            return "10.circle.fill"
+        case LabConceptSessionPlan.geometryShapeNames.id:
+            return "square.on.circle.fill"
+        case LabConceptSessionPlan.geometryAnglesBasic.id:
+            return "angle"
+        case LabConceptSessionPlan.geometrySymmetryFolds.id:
+            return "square.split.2x1.fill"
+        default:
+            return plan.stages.first?.stage.symbolName ?? "sparkles"
+        }
+    }
 }
 
 struct GuidedLabPath: Identifiable, Equatable {
@@ -1047,6 +1098,7 @@ struct LabLaneDetailPresentation: Equatable {
     let title: String
     let activityCountLabel: String
     let sections: [LabLaneCardSection]
+    let showsResearchQuest: Bool
 
     init(lane: CapabilityLane) {
         laneID = lane.id
@@ -1059,6 +1111,7 @@ struct LabLaneDetailPresentation: Equatable {
             lane.isReady ? .activities : .comingSoon,
             .progressStatus,
         ]
+        showsResearchQuest = false
     }
 }
 

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -114,7 +114,27 @@ final class LabModelsTests: XCTestCase {
         XCTAssertFalse(presentation.sections.contains(.ageEntries))
         XCTAssertFalse(presentation.sections.contains(.recall))
         XCTAssertTrue(presentation.sections.contains(.activities))
+        XCTAssertFalse(presentation.showsResearchQuest)
         XCTAssertEqual(numbers.activities.map(\.id), [.sumSprint, .rectangleFactory, .factoryCards])
+    }
+
+    func testGuidedPlanCardsKeepChildFacingFaceSparseWhilePreservingDetails() throws {
+        let geometryPath = try XCTUnwrap(GuidedLabPath.phaseOne.first { $0.laneID == .geometry })
+
+        for plan in geometryPath.sessionPlans {
+            let presentation = plan.cardPresentation
+
+            XCTAssertTrue(presentation.keepsDefaultFaceSparse)
+            XCTAssertEqual(presentation.defaultVisibleText, [plan.title])
+            XCTAssertFalse(presentation.defaultVisibleText.contains(plan.subtitle))
+            XCTAssertFalse(presentation.defaultVisibleText.contains(plan.masteryStateLabel))
+            XCTAssertFalse(presentation.defaultVisibleText.contains(plan.estimatedLength))
+            XCTAssertFalse(presentation.defaultVisibleText.contains(plan.recommendedNextActivity))
+            XCTAssertFalse(presentation.symbolName.isEmpty)
+            XCTAssertTrue(presentation.hiddenDetailAccessibilityLabel.contains(plan.subtitle))
+            XCTAssertTrue(presentation.hiddenDetailAccessibilityLabel.contains(plan.pathLabel))
+            XCTAssertTrue(presentation.disclosureDetailText.contains(plan.recommendedNextActivity))
+        }
     }
 
     func testPhysicsLaneAddsSoundLabAsThirdReadyActivity() throws {


### PR DESCRIPTION
## Summary\n- Removes the learner-facing Research Quest section from Lab detail.\n- Simplifies guided path cards to icon + title + primary action by default.\n- Moves guided plan subtitles, timing, next activity, and stage details behind disclosure/accessibility labels.\n- Adds top/bottom safe-area padding to reduce Lab detail header/control crowding.\n\nCloses #1060\nCloses #1059\nCloses #1058\nCloses #1052\n\n## Validation\n- git fetch origin main\n- git diff --check\n- Added/updated Lab model regression coverage for hidden Research Quest and sparse guided card presentation.\n\n## Blockers\n- Local environment does not have xcodebuild or xcodegen on PATH, so iOS tests/build were not run locally. Relying on GitHub CI after push.