### PR TITLE
Address build 102 TestFlight simplification feedback

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -419,11 +419,12 @@ enum GameplayStageContentBuilder {
             guard let entity = thread.entities.first(where: { $0.id == item.entityID }) else { return nil }
             let property = entity.properties.first { $0.id == item.propertyID } ?? entity.properties.first
             let recallPrompt = nameRecallPrompt(thread: thread, property: property)
+            let isCountryFlagMatch = thread.id == "countries" && property?.typeID == "flag"
             let left = GameplayDisplayItem(
                 id: "\(item.id)-left",
                 entityID: entity.id,
-                title: recallPrompt ?? entity.name,
-                subtitle: entity.summary,
+                title: isCountryFlagMatch ? "Find this flag" : (recallPrompt ?? entity.name),
+                subtitle: isCountryFlagMatch ? "" : entity.summary,
                 visualKey: entity.visualKey,
                 visualAssetName: entity.visualAssetName,
                 visualShapeKey: entity.visualShapeKey
@@ -431,11 +432,11 @@ enum GameplayStageContentBuilder {
             let right = GameplayDisplayItem(
                 id: "\(item.id)-right",
                 entityID: entity.id,
-                title: property?.value ?? entity.name,
-                subtitle: property.map { recallPrompt == nil ? propertyTypeTitle($0.typeID, in: thread) : nameRecallSubtitle(thread: thread) } ?? "Name",
-                visualKey: visualKey(for: property, fallbackEntity: entity),
-                visualAssetName: property?.visualAssetName,
-                visualShapeKey: property?.visualShapeKey
+                title: isCountryFlagMatch ? entity.name : (property?.value ?? entity.name),
+                subtitle: isCountryFlagMatch ? "Country name" : (property.map { recallPrompt == nil ? propertyTypeTitle($0.typeID, in: thread) : nameRecallSubtitle(thread: thread) } ?? "Name"),
+                visualKey: isCountryFlagMatch ? "Aa" : visualKey(for: property, fallbackEntity: entity),
+                visualAssetName: isCountryFlagMatch ? nil : property?.visualAssetName,
+                visualShapeKey: isCountryFlagMatch ? nil : property?.visualShapeKey
             )
             return GameplayMatchPair(id: item.id, left: left, right: right)
         }
@@ -503,6 +504,8 @@ enum GameplayStageContentBuilder {
             return "Name this animal"
         case "world-birds":
             return "Name this bird"
+        case "electronics":
+            return "Name this part"
         default:
             return nil
         }
@@ -516,6 +519,8 @@ enum GameplayStageContentBuilder {
             return "Animal name"
         case "world-birds":
             return "Bird name"
+        case "electronics":
+            return "Part name"
         default:
             return "Name"
         }

--- a/Features/GameplayStages/FlashcardStageView.swift
+++ b/Features/GameplayStages/FlashcardStageView.swift
@@ -27,11 +27,12 @@ struct FlashcardStageView: View {
                     GameplayDisplayCard(
                         item: card,
                         compact: compact,
-                        prominence: card.isFruitCard || viewModel.cards.count == 1 ? .featured : .normal
+                        showsSubtitle: false,
+                        prominence: .featured
                     )
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Open flashcard: \(card.title), \(card.subtitle)")
+                .accessibilityLabel("Open flashcard: \(card.spokenText)")
 
                 VStack(spacing: 8) {
                     Text(viewModel.activeDiscoveryPrompt)

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -175,24 +175,24 @@ struct GameplayDisplayCard: View {
 
     private var isFeatured: Bool { prominence == .featured }
     private var visualSize: CGFloat {
-        if isFeatured { return item.isFruitCard ? (compact ? 126 : 168) : (compact ? 104 : 140) }
-        if item.isFruitCard { return compact ? 64 : 88 }
-        return compact ? 40 : 58
+        if isFeatured { return compact ? 150 : 206 }
+        if item.isFruitCard { return compact ? 76 : 104 }
+        return compact ? 54 : 76
     }
     private var visualFrameWidth: CGFloat {
-        if isFeatured { return item.isFruitCard ? (compact ? 250 : 360) : (compact ? 220 : 320) }
-        if item.isFruitCard { return compact ? 104 : 132 }
-        return compact ? 64 : 86
+        if isFeatured { return compact ? 280 : 420 }
+        if item.isFruitCard { return compact ? 124 : 154 }
+        return compact ? 88 : 116
     }
     private var visualFrameHeight: CGFloat {
-        if isFeatured { return item.isFruitCard ? (compact ? 190 : 260) : (compact ? 170 : 240) }
-        if item.isFruitCard { return compact ? 94 : 118 }
-        return compact ? 58 : 78
+        if isFeatured { return compact ? 220 : 320 }
+        if item.isFruitCard { return compact ? 108 : 136 }
+        return compact ? 76 : 102
     }
     private var minimumHeight: CGFloat {
-        if isFeatured { return item.isFruitCard ? (compact ? 330 : 430) : (compact ? 310 : 400) }
-        if item.isFruitCard { return compact ? 160 : 202 }
-        return compact ? 118 : 164
+        if isFeatured { return compact ? 330 : 440 }
+        if item.isFruitCard { return compact ? 172 : 218 }
+        return compact ? 134 : 184
     }
 }
 

--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -86,13 +86,15 @@ struct LabLaneDetailView: View {
                         .foregroundStyle(MatherTheme.ink)
                         .lineLimit(2)
                         .minimumScaleFactor(0.8)
-                    Text(lane.promise)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .fixedSize(horizontal: false, vertical: true)
-                    Label(presentation.activityCountLabel, systemImage: lane.isReady ? "gamecontroller.fill" : "sparkles")
-                        .font(.caption.weight(.black))
-                        .foregroundStyle(tint)
+                    if lane.id != .geometry {
+                        Text(lane.promise)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(MatherTheme.cardSubtitle)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Label(presentation.activityCountLabel, systemImage: lane.isReady ? "gamecontroller.fill" : "sparkles")
+                            .font(.caption.weight(.black))
+                            .foregroundStyle(tint)
+                    }
                 }
 
                 Spacer(minLength: 0)

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -194,14 +194,9 @@ struct LabView: View {
                     Text("Guided path")
                         .font(.headline.weight(.black))
                         .foregroundStyle(MatherTheme.ink)
-                    Text("Optional staged learning appears after the subject picker so other streams stay visible.")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
                 }
                 Spacer(minLength: 0)
             }
-
-            compactStageStrip(compact: compact)
 
             ForEach(guidedPaths) { path in
                 guidedPathCard(path)
@@ -287,16 +282,6 @@ struct LabView: View {
                     Text(path.title)
                         .font(.headline.weight(.black))
                         .foregroundStyle(MatherTheme.ink)
-                    Text(path.subtitle)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                    if let primaryPlan = path.primaryPlan {
-                        Text("First: \(primaryPlan.title) • \(primaryPlan.estimatedLength)")
-                            .font(.caption2.weight(.black))
-                            .foregroundStyle(tint)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.72)
-                    }
                 }
                 Spacer(minLength: 0)
                 Image(systemName: "chevron.right.circle.fill")
@@ -307,7 +292,7 @@ struct LabView: View {
             .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Open \(path.title). \(path.subtitle). Stages: \(path.stages.map(\.rawValue).joined(separator: ", "))")
+        .accessibilityLabel("Open \(path.title)")
     }
 
     private func directGamesSection(compact: Bool, width: CGFloat) -> some View {
@@ -416,11 +401,13 @@ struct LabView: View {
                     .minimumScaleFactor(0.76)
                     .multilineTextAlignment(.leading)
 
-                Text(presentation.statusLine)
-                    .font(.caption.weight(.black))
-                    .foregroundStyle(.white.opacity(0.88))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.78)
+                if lane.id != .geometry {
+                    Text(presentation.statusLine)
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(.white.opacity(0.88))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.78)
+                }
             }
         }
         .padding(compact ? 14 : 16)

--- a/Features/RectangleFactory/RectangleFactoryView.swift
+++ b/Features/RectangleFactory/RectangleFactoryView.swift
@@ -103,19 +103,14 @@ struct RectangleFactoryView: View {
                         .foregroundStyle(MatherTheme.cardSubtitle)
                         .fixedSize(horizontal: false, vertical: true)
 
-                    Text(Self.factorPairGuideText(for: targetN))
-                        .font(.caption2.weight(.black))
-                        .foregroundStyle(MatherTheme.accent)
-                        .fixedSize(horizontal: false, vertical: true)
-
-                    Label(Self.missionText(for: targetN), systemImage: "shippingbox.fill")
+                    Label(Self.missionText(for: targetN), systemImage: "square.grid.3x3.fill")
                         .font(.caption2.weight(.black))
                         .foregroundStyle(MatherTheme.coral)
                         .padding(.horizontal, 9)
                         .padding(.vertical, 5)
                         .background(MatherTheme.coral.opacity(0.12))
                         .clipShape(Capsule())
-                        .accessibilityLabel("Factory story: \(Self.missionText(for: targetN))")
+                        .accessibilityLabel("Rectangle goal: \(Self.missionText(for: targetN))")
                 }
             }
             Spacer(minLength: 12)
@@ -724,8 +719,8 @@ struct RectangleFactoryView: View {
         let count = factorsOf(n).count
         let noun = count == 1 ? "rectangle" : "rectangles"
         return completionStyle(for: n) == .prime
-            ? "\(n) is prime. Only one factory box works!"
-            : "Factory complete! You found all \(count) \(noun) for \(n)!"
+            ? "\(n) is prime. Only one rectangle works."
+            : "You found all \(count) \(noun) for \(n)."
     }
 
     nonisolated static func instructionText(for n: Int) -> String {
@@ -793,25 +788,25 @@ struct RectangleFactoryView: View {
     }
 
     nonisolated static func solvedStatusSubtitle(for n: Int, allFound: Bool) -> String {
-        allFound ? "All \(n)-dot rectangles are packed. Use the next button below." : "Lift your finger to ship this \(n)-dot rectangle."
+        allFound ? "All \(n)-dot rectangles are found. Use the next button below." : "Lift your finger to save this \(n)-dot rectangle."
     }
 
     nonisolated static func missionText(for n: Int) -> String {
-        "Factory order: pack \(n) dots with no gaps"
+        "Make a rectangle with exactly \(n) dots"
     }
 
     nonisolated static func openingSpeech(for n: Int) -> String {
-        "Factory order! Can you pack \(n) dots into a perfect rectangle?"
+        "Can you make a rectangle with exactly \(n) dots?"
     }
 
     nonisolated static func discoverySpeech(width: Int, height: Int, target: Int) -> String {
-        let rows = height
-        let columns = width
-        return "Nice packing! \(rows) rows of \(columns) makes \(target)."
+        let rows = min(width, height)
+        let columns = max(width, height)
+        return "Yes. \(rows) rows of \(columns) makes \(target)."
     }
 
     nonisolated static func transitionSpeech(from previous: Int, to next: Int) -> String {
-        "Order \(previous) shipped! Next factory order: \(next) dots."
+        "Done with \(previous). Next, make \(next) dots."
     }
 
     nonisolated static func advanceButtonTitle(hasNext: Bool) -> String {

--- a/Tests/MatherTests/CountryGameplayThreadTests.swift
+++ b/Tests/MatherTests/CountryGameplayThreadTests.swift
@@ -109,8 +109,12 @@ struct CountryGameplayThreadTests {
 
         #expect(round.items.count == min(stage.maximumItemCount, thread.entities.count))
         #expect(round.items.allSatisfy { $0.propertyTypeID == "flag" })
-        #expect(pairs.allSatisfy { pair in thread.entities.contains { $0.id == pair.left.entityID && $0.name == pair.left.title } })
-        #expect(pairs.allSatisfy { $0.right.subtitle == "Flag" })
+        #expect(pairs.allSatisfy { pair in pair.left.title == "Find this flag" })
+        #expect(pairs.allSatisfy { pair in pair.left.subtitle.isEmpty })
+        #expect(pairs.allSatisfy { pair in thread.entities.contains { $0.id == pair.right.entityID && $0.name == pair.right.title } })
+        #expect(pairs.allSatisfy { $0.right.subtitle == "Country name" })
+        #expect(pairs.allSatisfy { $0.right.visualKey == "Aa" })
+        #expect(pairs.allSatisfy { $0.right.visualAssetName == nil })
         #expect(Set(pairs.map { $0.right.title.lowercased() }).count == pairs.count)
     }
 

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -64,9 +64,10 @@ struct GameplayThreadContentTests {
 
         #expect(thread.id == "electronics")
         #expect(thread.category.id == "electronics")
+        #expect(thread.category.title == "Electricity")
         #expect(thread.title == "Circuit Spark")
-        #expect(thread.entities.count == 8)
-        #expect(Set(thread.propertyTypes.map(\.id)) == Set(["part", "job", "rule"]))
+        #expect(thread.entities.count == 7)
+        #expect(Set(thread.propertyTypes.map(\.id)) == Set(["name", "symbol", "job", "safety"]))
         #expect(Set(thread.entities.map(\.name)).isSuperset(of: [
             "Battery",
             "Bulb",
@@ -113,6 +114,9 @@ struct GameplayThreadContentTests {
         #expect(!allCopy.localizedCaseInsensitiveContains("danger"))
 
         #expect(thread.entities.allSatisfy { entity in
+            Set(entity.properties.map(\.typeID)) == Set(["name", "symbol", "job", "safety"])
+        })
+        #expect(thread.entities.allSatisfy { entity in
             entity.properties.allSatisfy { property in
                 !property.value.isEmpty && !property.explanation.isEmpty
             }
@@ -124,10 +128,10 @@ struct GameplayThreadContentTests {
         let thread = GameplayThreadCatalog.electronics
 
         #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])
-        #expect(thread.stages[1].propertyTypeIDs == ["part", "job"])
-        #expect(thread.stages[2].propertyTypeIDs == ["job", "rule"])
-        #expect(thread.stages[3].propertyTypeIDs == ["part", "job", "rule"])
-        #expect(thread.stages[4].propertyTypeIDs == ["job", "rule"])
+        #expect(thread.stages[1].propertyTypeIDs == ["name"])
+        #expect(thread.stages[2].propertyTypeIDs == ["name", "symbol"])
+        #expect(thread.stages[3].propertyTypeIDs == ["name", "symbol", "job", "safety"])
+        #expect(thread.stages[4].propertyTypeIDs == ["name", "symbol", "job", "safety"])
 
         for stage in thread.stages {
             let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 1024)

--- a/Tests/MatherTests/RectangleFactoryTests.swift
+++ b/Tests/MatherTests/RectangleFactoryTests.swift
@@ -137,15 +137,15 @@ struct RectangleFactoryTests {
     }
 
     @Test func completionSpeechDifferentiatesPrimeAndComposite() {
-        #expect(RectangleFactoryView.completionSpeech(for: 13) == "13 is prime. Only one factory box works!")
-        #expect(RectangleFactoryView.completionSpeech(for: 12) == "Factory complete! You found all 3 rectangles for 12!")
+        #expect(RectangleFactoryView.completionSpeech(for: 13) == "13 is prime. Only one rectangle works.")
+        #expect(RectangleFactoryView.completionSpeech(for: 12) == "You found all 3 rectangles for 12.")
     }
 
     @Test func factoryStoryCopyStaysShortAndMathSpecific() {
-        #expect(RectangleFactoryView.missionText(for: 4) == "Factory order: pack 4 dots with no gaps")
-        #expect(RectangleFactoryView.openingSpeech(for: 4) == "Factory order! Can you pack 4 dots into a perfect rectangle?")
-        #expect(RectangleFactoryView.discoverySpeech(width: 2, height: 3, target: 6) == "Nice packing! 3 rows of 2 makes 6.")
-        #expect(RectangleFactoryView.transitionSpeech(from: 4, to: 6) == "Order 4 shipped! Next factory order: 6 dots.")
+        #expect(RectangleFactoryView.missionText(for: 4) == "Make a rectangle with exactly 4 dots")
+        #expect(RectangleFactoryView.openingSpeech(for: 4) == "Can you make a rectangle with exactly 4 dots?")
+        #expect(RectangleFactoryView.discoverySpeech(width: 2, height: 3, target: 6) == "Yes. 2 rows of 3 makes 6.")
+        #expect(RectangleFactoryView.transitionSpeech(from: 4, to: 6) == "Done with 4. Next, make 6 dots.")
     }
 
     @Test func instructionTextExplainsDragAndExactDotGoal() {
@@ -177,8 +177,8 @@ struct RectangleFactoryTests {
 
     @Test func solvedStatusCopyMakesSuccessAndNextActionClear() {
         #expect(RectangleFactoryView.solvedStatusTitle == "Perfect fit!")
-        #expect(RectangleFactoryView.solvedStatusSubtitle(for: 4, allFound: false) == "Lift your finger to ship this 4-dot rectangle.")
-        #expect(RectangleFactoryView.solvedStatusSubtitle(for: 4, allFound: true) == "All 4-dot rectangles are packed. Use the next button below.")
+        #expect(RectangleFactoryView.solvedStatusSubtitle(for: 4, allFound: false) == "Lift your finger to save this 4-dot rectangle.")
+        #expect(RectangleFactoryView.solvedStatusSubtitle(for: 4, allFound: true) == "All 4-dot rectangles are found. Use the next button below.")
     }
 
     @Test func resetAndHandleAccessibilityCopyIsDiscoverable() {


### PR DESCRIPTION
## Summary
- simplify gameplay flashcards so pictures are featured, subtitles are hidden visually, and spoken accessibility keeps the details
- reduce country flag matching duplication by showing the flag prompt on one side and the country name on the other
- remove guided-path/research-quest detail copy from lab cards and simplify geometry presentation
- rework Circuit Spark as elementary electricity content with name/symbol/safety concepts

## Issues
Closes #1054
Closes #1055
Closes #1056
Closes #1057
Closes #1058
Closes #1059
Closes #1060
Closes #1061
Closes #1062
Closes #1063

## Validation
- git diff --check
