### PR TITLE
Draw electronics card artwork

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -133,8 +133,46 @@ struct GameplayDisplayItem: Identifiable, Equatable, Hashable {
 
     var isFruitCard: Bool { entityID.hasPrefix("fruit-") }
 
+    var electronicsArtworkKey: ElectronicsArtworkKey? {
+        ElectronicsArtworkKey(entityID: entityID)
+    }
+
     var discoveryPrompt: String {
         isFruitCard ? "Spot the color, say the flavor, then tap I spotted it!" : "Tap the card, say one clue, then try the next one."
+    }
+}
+
+enum ElectronicsArtworkKey: String, CaseIterable, Equatable, Hashable {
+    case battery
+    case bulb
+    case wire
+    case switchControl
+    case closedCircuit
+    case openCircuit
+    case safeCircuit
+    case outletSafety
+
+    init?(entityID: String) {
+        switch entityID {
+        case "electronics-battery":
+            self = .battery
+        case "electronics-bulb":
+            self = .bulb
+        case "electronics-wire":
+            self = .wire
+        case "electronics-switch":
+            self = .switchControl
+        case "electronics-closed-circuit":
+            self = .closedCircuit
+        case "electronics-open-circuit":
+            self = .openCircuit
+        case "electronics-safe-circuit":
+            self = .safeCircuit
+        case "electronics-outlet-safety":
+            self = .outletSafety
+        default:
+            return nil
+        }
     }
 }
 

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -243,6 +243,9 @@ private struct GameplayDisplayVisual: View {
                 CountryMapShapeArtwork(shapeKey: shapeKey)
                     .accessibilityHidden(true)
                     .padding(visualAssetPadding)
+            } else if let artworkKey = item.electronicsArtworkKey {
+                ElectronicsCircuitArtwork(key: artworkKey, tint: tint)
+                    .padding(electronicsArtworkPadding)
             } else {
                 ZStack {
                     if item.isFruitCard && !concealed {
@@ -280,6 +283,10 @@ private struct GameplayDisplayVisual: View {
 
     private var visualAssetPadding: CGFloat {
         max(4, min(14, visualFrameHeight * 0.08))
+    }
+
+    private var electronicsArtworkPadding: CGFloat {
+        max(8, min(24, visualFrameHeight * 0.12))
     }
 }
 

--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -401,6 +401,17 @@ extension LabActivityID {
             return .gameplayThread(.electronics)
         }
     }
+
+    var electronicsArtworkKey: ElectronicsArtworkKey? {
+        switch self {
+        case .circuitSpark:
+            return .closedCircuit
+        case .sumSprint, .roomQuest, .symmetryFold, .rectangleFactory, .factoryCards, .angleCannon,
+             .twoFingerProtractor, .gravityArtist, .compassAngles, .shapeGeometry, .waterCycle, .soundVolume,
+             .memoryMatch, .countryCards, .worldAnimalCards, .worldBirdCards, .fruitCards:
+            return nil
+        }
+    }
 }
 
 

--- a/Shared/ElectronicsCircuitArtwork.swift
+++ b/Shared/ElectronicsCircuitArtwork.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+
+struct ElectronicsCircuitArtwork: View {
+    let key: ElectronicsArtworkKey
+    var tint: Color = MatherTheme.accent
+
+    var body: some View {
+        GeometryReader { proxy in
+            let size = min(proxy.size.width, proxy.size.height)
+            let lineWidth = max(3, size * 0.055)
+            ZStack {
+                switch key {
+                case .battery:
+                    battery(lineWidth: lineWidth)
+                case .bulb:
+                    bulb(lineWidth: lineWidth)
+                case .wire:
+                    wire(lineWidth: lineWidth)
+                case .switchControl:
+                    switchControl(lineWidth: lineWidth)
+                case .closedCircuit:
+                    circuit(closed: true, lineWidth: lineWidth)
+                case .openCircuit:
+                    circuit(closed: false, lineWidth: lineWidth)
+                case .safeCircuit:
+                    safeCircuit(lineWidth: lineWidth)
+                case .outletSafety:
+                    outletSafety(lineWidth: lineWidth)
+                }
+            }
+            .frame(width: proxy.size.width, height: proxy.size.height)
+        }
+        .aspectRatio(1, contentMode: .fit)
+        .accessibilityHidden(true)
+    }
+
+    private var wireColor: Color { MatherTheme.panelDeep.opacity(0.82) }
+    private var glowColor: Color { MatherTheme.warm }
+    private var dangerColor: Color { MatherTheme.coral }
+
+    @ViewBuilder
+    private func battery(lineWidth: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .fill(tint.opacity(0.22))
+            .frame(width: 72, height: 46)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(wireColor, lineWidth: lineWidth)
+            )
+        RoundedRectangle(cornerRadius: 3, style: .continuous)
+            .fill(wireColor)
+            .frame(width: 8, height: 24)
+            .offset(x: 44)
+        Rectangle()
+            .fill(wireColor)
+            .frame(width: 18, height: lineWidth)
+            .offset(x: -20)
+        Rectangle()
+            .fill(wireColor)
+            .frame(width: lineWidth, height: 18)
+            .offset(x: -20)
+        Rectangle()
+            .fill(wireColor)
+            .frame(width: 18, height: lineWidth)
+            .offset(x: 18)
+    }
+
+    @ViewBuilder
+    private func bulb(lineWidth: CGFloat) -> some View {
+        Circle()
+            .fill(glowColor.opacity(0.28))
+            .frame(width: 72, height: 72)
+        Circle()
+            .stroke(glowColor, lineWidth: lineWidth)
+            .frame(width: 54, height: 54)
+            .offset(y: -10)
+        Capsule()
+            .fill(wireColor)
+            .frame(width: 30, height: 16)
+            .offset(y: 30)
+        ForEach([-24, 0, 24], id: \.self) { x in
+            Capsule()
+                .fill(glowColor)
+                .frame(width: lineWidth, height: 14)
+                .offset(x: CGFloat(x), y: -48)
+        }
+        Path { path in
+            path.move(to: CGPoint(x: 38, y: 55))
+            path.addLine(to: CGPoint(x: 50, y: 43))
+            path.move(to: CGPoint(x: 58, y: 80))
+            path.addLine(to: CGPoint(x: 74, y: 80))
+        }
+        .stroke(wireColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+        .frame(width: 112, height: 112)
+    }
+
+    @ViewBuilder
+    private func wire(lineWidth: CGFloat) -> some View {
+        Path { path in
+            path.move(to: CGPoint(x: 14, y: 62))
+            path.addCurve(to: CGPoint(x: 42, y: 32), control1: CGPoint(x: 18, y: 32), control2: CGPoint(x: 34, y: 24))
+            path.addCurve(to: CGPoint(x: 74, y: 70), control1: CGPoint(x: 54, y: 44), control2: CGPoint(x: 42, y: 78))
+            path.addCurve(to: CGPoint(x: 102, y: 48), control1: CGPoint(x: 88, y: 62), control2: CGPoint(x: 90, y: 42))
+        }
+        .stroke(wireColor, style: StrokeStyle(lineWidth: lineWidth * 1.25, lineCap: .round, lineJoin: .round))
+        .frame(width: 116, height: 104)
+        Circle().fill(tint).frame(width: 13, height: 13).offset(x: -46, y: 10)
+        Circle().fill(tint).frame(width: 13, height: 13).offset(x: 46, y: -4)
+    }
+
+    @ViewBuilder
+    private func switchControl(lineWidth: CGFloat) -> some View {
+        Capsule().fill(wireColor).frame(width: 28, height: lineWidth).offset(x: -34, y: 20)
+        Capsule().fill(wireColor).frame(width: 28, height: lineWidth).offset(x: 34, y: 20)
+        Circle().fill(wireColor).frame(width: 14, height: 14).offset(x: -18, y: 20)
+        Circle().fill(wireColor).frame(width: 14, height: 14).offset(x: 48, y: 20)
+        Capsule()
+            .fill(tint)
+            .frame(width: 60, height: lineWidth * 1.45)
+            .rotationEffect(.degrees(-24))
+            .offset(x: 12, y: 4)
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .stroke(tint.opacity(0.42), lineWidth: lineWidth)
+            .frame(width: 96, height: 62)
+    }
+
+    @ViewBuilder
+    private func circuit(closed: Bool, lineWidth: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: 30, style: .continuous)
+            .trim(from: closed ? 0 : 0.10, to: closed ? 1 : 0.84)
+            .stroke(wireColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
+            .frame(width: 104, height: 78)
+        battery(lineWidth: lineWidth * 0.70)
+            .scaleEffect(0.45)
+            .offset(x: -34, y: 16)
+        bulb(lineWidth: lineWidth * 0.68)
+            .scaleEffect(0.46)
+            .offset(x: 30, y: -18)
+        if closed {
+            Circle()
+                .fill(glowColor.opacity(0.42))
+                .frame(width: 32, height: 32)
+                .offset(x: 30, y: -22)
+        } else {
+            Path { path in
+                path.move(to: CGPoint(x: 28, y: 28))
+                path.addLine(to: CGPoint(x: 84, y: 84))
+                path.move(to: CGPoint(x: 84, y: 28))
+                path.addLine(to: CGPoint(x: 28, y: 84))
+            }
+            .stroke(dangerColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+            .frame(width: 112, height: 112)
+        }
+    }
+
+    @ViewBuilder
+    private func safeCircuit(lineWidth: CGFloat) -> some View {
+        circuit(closed: true, lineWidth: lineWidth)
+        Circle()
+            .fill(MatherTheme.card.opacity(0.94))
+            .frame(width: 38, height: 38)
+            .offset(x: 30, y: 30)
+        Image(systemName: "checkmark")
+            .font(.system(size: 24, weight: .black, design: .rounded))
+            .foregroundStyle(tint)
+            .offset(x: 30, y: 30)
+    }
+
+    @ViewBuilder
+    private func outletSafety(lineWidth: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(MatherTheme.card.opacity(0.86))
+            .frame(width: 62, height: 78)
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(wireColor, lineWidth: lineWidth)
+            )
+        Capsule().fill(wireColor).frame(width: 9, height: 22).offset(x: -12, y: -8)
+        Capsule().fill(wireColor).frame(width: 9, height: 22).offset(x: 12, y: -8)
+        Path { path in
+            path.move(to: CGPoint(x: 28, y: 28))
+            path.addLine(to: CGPoint(x: 84, y: 84))
+            path.move(to: CGPoint(x: 84, y: 28))
+            path.addLine(to: CGPoint(x: 28, y: 84))
+        }
+        .stroke(dangerColor, style: StrokeStyle(lineWidth: lineWidth * 1.15, lineCap: .round))
+        .frame(width: 112, height: 112)
+        Circle()
+            .stroke(dangerColor, lineWidth: lineWidth)
+            .frame(width: 96, height: 96)
+    }
+}

--- a/Shared/GameActivityCard.swift
+++ b/Shared/GameActivityCard.swift
@@ -67,12 +67,17 @@ struct GameActivityCard: View {
                         endPoint: .bottomTrailing
                     )
                 )
-            Image(systemName: canLaunch ? "play.circle.fill" : "exclamationmark.triangle.fill")
-                .font(.title2.weight(.black))
-                .foregroundStyle(tint.opacity(canLaunch ? 1 : 0.45))
-            Text(activity.emoji)
-                .font(.system(size: 26))
-                .offset(x: 12, y: 12)
+            if let artworkKey = activity.id.electronicsArtworkKey {
+                ElectronicsCircuitArtwork(key: artworkKey, tint: tint)
+                    .padding(10)
+            } else {
+                Image(systemName: canLaunch ? "play.circle.fill" : "exclamationmark.triangle.fill")
+                    .font(.title2.weight(.black))
+                    .foregroundStyle(tint.opacity(canLaunch ? 1 : 0.45))
+                Text(activity.emoji)
+                    .font(.system(size: 26))
+                    .offset(x: 12, y: 12)
+            }
         }
         .frame(width: 68, height: 68)
         .accessibilityLabel(activity.artworkAccessibilityLabel)
@@ -118,10 +123,15 @@ struct GameActivityCard: View {
         ZStack {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .fill(tint.opacity(0.12))
-            visualMotif
-            Text(activity.emoji)
-                .font(.system(size: 38))
-                .offset(x: -18, y: -14)
+            if let artworkKey = activity.id.electronicsArtworkKey {
+                ElectronicsCircuitArtwork(key: artworkKey, tint: tint)
+                    .padding(12)
+            } else {
+                visualMotif
+                Text(activity.emoji)
+                    .font(.system(size: 38))
+                    .offset(x: -18, y: -14)
+            }
         }
         .frame(width: 104, height: 96)
         .accessibilityLabel(activity.artworkAccessibilityLabel)

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -157,6 +157,19 @@ struct GameplayThreadContentTests {
     }
 
     @Test
+    func electronicsCardsResolveToDeterministicVectorArtworkKeys() {
+        let thread = GameplayThreadCatalog.electronics
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: thread.stages[0], seed: 1071)
+        let cards = GameplayStageContentBuilder.flashcards(thread: thread, round: round)
+        let mappedKeys = Set(cards.compactMap(\.electronicsArtworkKey))
+
+        #expect(mappedKeys == Set(ElectronicsArtworkKey.allCases))
+        #expect(GameplayThreadCatalog.fruits.entities.allSatisfy { ElectronicsArtworkKey(entityID: $0.id) == nil })
+        #expect(LabActivityID.circuitSpark.electronicsArtworkKey == .closedCircuit)
+        #expect(LabActivityID.fruitCards.electronicsArtworkKey == nil)
+    }
+
+    @Test
     func fruitEasyMemoryIncludesGrowTasteAndClimateFacts() throws {
         let thread = GameplayThreadCatalog.fruits
         let stage = try #require(thread.stages.first { $0.id == "fruit-easy-memory" })


### PR DESCRIPTION
Summary\n- Added deterministic SwiftUI vector drawings for Circuit Spark concepts: battery, bulb, wire, switch, closed/open circuits, safe circuit, and outlet safety.\n- Routed electronics gameplay cards and the Circuit Spark activity card to custom artwork while leaving existing accessibility labels and non-electronics decks unchanged.\n- Added regression coverage for electronics artwork-key mapping.\n\nValidation\n- Passed: git diff --check\n- Blocked: native Swift/Xcode validation unavailable because command -v xcodegen, command -v xcodebuild, and command -v swift each exited 1 in this worker.\n\nCloses #1071