### PR TITLE
Make quizzes one card at a time

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -399,6 +399,7 @@ struct GameplayMultipleChoiceStageViewModel: Equatable {
     let questions: [GameplayMultipleChoiceQuestion]
     var activeIndex = 0
     var selectedChoiceID: String?
+    var selectedChoiceWasCorrect: Bool?
     var correctCount = 0
     var mistakeCount = 0
 
@@ -418,13 +419,44 @@ struct GameplayMultipleChoiceStageViewModel: Equatable {
         return "\(min(activeIndex + 1, questions.count)) of \(questions.count)"
     }
 
+    var canAdvanceAfterCorrectChoice: Bool {
+        selectedChoiceWasCorrect == true
+    }
+
+    func isSelected(_ choice: GameplayDisplayItem) -> Bool {
+        selectedChoiceID == choice.id
+    }
+
+    func isSelectedCorrect(_ choice: GameplayDisplayItem) -> Bool {
+        isSelected(choice) && selectedChoiceWasCorrect == true
+    }
+
+    func isSelectedIncorrect(_ choice: GameplayDisplayItem) -> Bool {
+        isSelected(choice) && selectedChoiceWasCorrect == false
+    }
+
     mutating func choose(_ choice: GameplayDisplayItem) -> Bool {
         guard let question = activeQuestion else { return false }
+        if selectedChoiceWasCorrect == true {
+            return question.isCorrect(choice)
+        }
         selectedChoiceID = choice.id
         let correct = question.isCorrect(choice)
-        if correct { correctCount += 1 } else { mistakeCount += 1 }
-        activeIndex += 1
+        selectedChoiceWasCorrect = correct
+        if correct {
+            correctCount += 1
+        } else {
+            mistakeCount += 1
+        }
         return correct
+    }
+
+    mutating func advanceAfterCorrectChoice() -> Bool {
+        guard canAdvanceAfterCorrectChoice else { return false }
+        activeIndex += 1
+        selectedChoiceID = nil
+        selectedChoiceWasCorrect = nil
+        return isComplete
     }
 }
 

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -94,8 +94,9 @@ struct GameplayDisplayCard: View {
                     .font(titleFont)
                     .multilineTextAlignment(.center)
                     .foregroundStyle(MatherTheme.ink)
-                    .lineLimit(item.presentation == .titleOnly ? 3 : 2)
+                    .lineLimit(titleLineLimit)
                     .minimumScaleFactor(0.76)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             let subtitle = concealed ? "Tap to check" : item.subtitle
             if showsSubtitle && item.presentation == .visualWithTitle && !subtitle.isEmpty {
@@ -185,6 +186,10 @@ struct GameplayDisplayCard: View {
             return compact ? .title3.bold() : .title.bold()
         }
         return prominence == .featured ? (compact ? .title3.bold() : .title.bold()) : (compact ? .headline.bold() : .title3.bold())
+    }
+    private var titleLineLimit: Int {
+        if item.presentation == .titleOnly { return 4 }
+        return compact ? 3 : 2
     }
     private var visualSize: CGFloat {
         if item.presentation == .visualOnly { return compact ? 86 : 124 }

--- a/Features/GameplayStages/MultipleChoiceStageView.swift
+++ b/Features/GameplayStages/MultipleChoiceStageView.swift
@@ -6,6 +6,7 @@ struct MultipleChoiceStageView: View {
     let compact: Bool
     let onComplete: (Int, Int, Int) -> Void
     @State private var viewModel: GameplayMultipleChoiceStageViewModel
+    @State private var showCorrectCelebration = false
 
     init(thread: GameplayThreadDefinition, stage: GameplayStageDefinition, round: GameplayRoundDefinition, actions: GameplayStageFeedbackActions, compact: Bool, onComplete: @escaping (Int, Int, Int) -> Void) {
         self.stage = stage
@@ -19,21 +20,49 @@ struct MultipleChoiceStageView: View {
         VStack(alignment: .leading, spacing: compact ? 12 : 18) {
             GameplayStageTitle(stage: stage, detail: viewModel.progressText)
             if let question = viewModel.activeQuestion {
-                Text(question.prompt)
-                    .font(compact ? .title3.bold() : .title.bold())
-                    .foregroundStyle(MatherTheme.ink)
-                    .accessibilityAddTraits(.isHeader)
-                LazyVGrid(columns: [GridItem(.adaptive(minimum: compact ? 142 : 190), spacing: 12)], spacing: 12) {
-                    ForEach(question.choices) { choice in
-                        Button {
-                            let correct = viewModel.choose(choice)
-                            if correct { actions.success() } else { actions.failure() }
-                            if viewModel.isComplete { onComplete(viewModel.correctCount, viewModel.mistakeCount, 0) }
-                        } label: {
-                            GameplayDisplayCard(item: choice, compact: compact, showsSubtitle: true)
+                VStack(alignment: .leading, spacing: compact ? 10 : 14) {
+                    Text(question.prompt)
+                        .font(compact ? .title3.bold() : .title.bold())
+                        .foregroundStyle(MatherTheme.ink)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityAddTraits(.isHeader)
+
+                    ZStack {
+                        LazyVGrid(columns: choiceColumns(for: question), spacing: 12) {
+                            ForEach(question.choices) { choice in
+                                Button {
+                                    choose(choice)
+                                } label: {
+                                    GameplayDisplayCard(
+                                        item: choice,
+                                        compact: compact,
+                                        showsSubtitle: true,
+                                        selected: viewModel.isSelectedIncorrect(choice),
+                                        correct: viewModel.isSelectedCorrect(choice)
+                                    )
+                                }
+                                .buttonStyle(.plain)
+                                .disabled(viewModel.canAdvanceAfterCorrectChoice)
+                                .accessibilityLabel(accessibilityLabel(for: choice))
+                                .accessibilityHint(viewModel.isSelectedIncorrect(choice) ? "Try another answer." : "")
+                            }
                         }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Choice: \(choice.title), \(choice.subtitle)")
+
+                        if showCorrectCelebration {
+                            MultipleChoiceCorrectCelebration(compact: compact)
+                                .transition(.scale.combined(with: .opacity))
+                                .accessibilityHidden(true)
+                        }
+                    }
+
+                    if let selectedChoiceID = viewModel.selectedChoiceID {
+                        let wasCorrect = viewModel.selectedChoiceWasCorrect == true
+                        Text(wasCorrect ? "You found it!" : "Try that one again.")
+                            .font(.headline.weight(.bold))
+                            .foregroundStyle(wasCorrect ? MatherTheme.coral : MatherTheme.ink.opacity(0.72))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .accessibilityIdentifier("MultipleChoiceFeedbackText")
+                            .id(selectedChoiceID)
                     }
                 }
             } else {
@@ -44,5 +73,71 @@ struct MultipleChoiceStageView: View {
         }
         .padding(compact ? 14 : 20)
         .background(GameplayStagePanel())
+    }
+
+    @MainActor
+    private func choose(_ choice: GameplayDisplayItem) {
+        let correct = viewModel.choose(choice)
+        if correct {
+            actions.success()
+            withAnimation(.spring(response: 0.28, dampingFraction: 0.64)) {
+                showCorrectCelebration = true
+            }
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 850_000_000)
+                withAnimation(.easeOut(duration: 0.16)) {
+                    showCorrectCelebration = false
+                }
+                if viewModel.advanceAfterCorrectChoice() {
+                    onComplete(viewModel.correctCount, viewModel.mistakeCount, 0)
+                }
+            }
+        } else {
+            showCorrectCelebration = false
+            actions.failure()
+        }
+    }
+
+    private func choiceColumns(for question: GameplayMultipleChoiceQuestion) -> [GridItem] {
+        let hasLongChoice = question.choices.contains { choice in
+            choice.title.count > (compact ? 14 : 24) || choice.subtitle.count > (compact ? 18 : 30)
+        }
+        if compact && hasLongChoice {
+            return [GridItem(.flexible(), spacing: 12)]
+        }
+        return [
+            GridItem(.flexible(), spacing: 12),
+            GridItem(.flexible(), spacing: 12)
+        ]
+    }
+
+    private func accessibilityLabel(for choice: GameplayDisplayItem) -> String {
+        let label = [choice.title, choice.subtitle]
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+        return label.isEmpty ? "Choice" : "Choice: \(label)"
+    }
+}
+
+private struct MultipleChoiceCorrectCelebration: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    let compact: Bool
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(MatherTheme.warm.opacity(0.86))
+                .frame(width: compact ? 112 : 142, height: compact ? 112 : 142)
+            Image(systemName: "sparkles")
+                .font(.system(size: compact ? 48 : 62, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.coral)
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: compact ? 34 : 42, weight: .black, design: .rounded))
+                .foregroundStyle(MatherTheme.accent)
+                .offset(x: compact ? 38 : 48, y: compact ? 34 : 42)
+        }
+        .shadow(color: MatherTheme.coral.opacity(0.22), radius: 18, x: 0, y: 10)
+        .scaleEffect(reduceMotion ? 1 : 1.08)
+        .animation(reduceMotion ? nil : .spring(response: 0.26, dampingFraction: 0.58), value: reduceMotion)
     }
 }

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -93,6 +93,45 @@ struct GameplayStageViewModelTests {
         let quizResult = viewModel.choose(firstQuestion.answer)
         #expect(quizResult)
         #expect(viewModel.correctCount == 1)
+        #expect(viewModel.progressText == "1 of 4")
+        #expect(!viewModel.advanceAfterCorrectChoice())
+        #expect(viewModel.progressText == "2 of 4")
+    }
+
+    @Test
+    func multipleChoiceWrongAnswerStaysOnCurrentQuestionUntilCorrect() throws {
+        let thread = GameplaySampleThreads.countries
+        let stage = try #require(thread.stages.first { $0.kind == .multipleChoice })
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 4)
+        var viewModel = GameplayMultipleChoiceStageViewModel(thread: thread, round: round)
+        let firstQuestion = try #require(viewModel.activeQuestion)
+        let wrongChoice = try #require(firstQuestion.choices.first { !firstQuestion.isCorrect($0) })
+
+        let wrongResult = viewModel.choose(wrongChoice)
+
+        #expect(!wrongResult)
+        #expect(viewModel.activeQuestion == firstQuestion)
+        #expect(viewModel.activeIndex == 0)
+        #expect(viewModel.progressText == "1 of 4")
+        #expect(viewModel.mistakeCount == 1)
+        #expect(viewModel.correctCount == 0)
+        #expect(!viewModel.canAdvanceAfterCorrectChoice)
+        #expect(!viewModel.advanceAfterCorrectChoice())
+
+        let correctResult = viewModel.choose(firstQuestion.answer)
+
+        #expect(correctResult)
+        #expect(viewModel.activeQuestion == firstQuestion)
+        #expect(viewModel.activeIndex == 0)
+        #expect(viewModel.correctCount == 1)
+        #expect(viewModel.mistakeCount == 1)
+        #expect(viewModel.canAdvanceAfterCorrectChoice)
+
+        let completedStage = viewModel.advanceAfterCorrectChoice()
+
+        #expect(!completedStage)
+        #expect(viewModel.activeIndex == 1)
+        #expect(viewModel.activeQuestion?.id != firstQuestion.id)
         #expect(viewModel.progressText == "2 of 4")
     }
 

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -94,7 +94,8 @@ struct GameplayStageViewModelTests {
         #expect(quizResult)
         #expect(viewModel.correctCount == 1)
         #expect(viewModel.progressText == "1 of 4")
-        #expect(!viewModel.advanceAfterCorrectChoice())
+        let didFinishAfterFirstCorrectChoice = viewModel.advanceAfterCorrectChoice()
+        #expect(!didFinishAfterFirstCorrectChoice)
         #expect(viewModel.progressText == "2 of 4")
     }
 
@@ -116,7 +117,8 @@ struct GameplayStageViewModelTests {
         #expect(viewModel.mistakeCount == 1)
         #expect(viewModel.correctCount == 0)
         #expect(!viewModel.canAdvanceAfterCorrectChoice)
-        #expect(!viewModel.advanceAfterCorrectChoice())
+        let didAdvanceAfterWrongChoice = viewModel.advanceAfterCorrectChoice()
+        #expect(!didAdvanceAfterWrongChoice)
 
         let correctResult = viewModel.choose(firstQuestion.answer)
 


### PR DESCRIPTION
## Summary

- Makes multiple-choice gameplay behave like a focused flashcard Q&A: one active question remains on screen until it is answered correctly.
- Keeps wrong-answer feedback in place without advancing the current question index.
- Adds a visible selected-correct celebration state before advancing, and adapts compact answer choices to a single column when labels are long.

Closes #1070
Closes #1073

## Validation

- PASS: `git diff --check`
- BLOCKED: `xcodebuild -version` failed with `/bin/bash: line 1: xcodebuild: command not found`, so native Swift/Xcode tests could not be run in this Linux worker.
