### PR TITLE
Make stage cards visual first

### DIFF
--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -451,6 +451,7 @@ enum GameplayStageContentBuilder {
             let property = entity.properties.first { $0.id == item.propertyID } ?? entity.properties.first
             let recallPrompt = nameRecallPrompt(thread: thread, property: property, kind: round.kind)
             let visualNameMatch = usesVisualNameMatch(thread: thread, property: property, kind: round.kind)
+            let visualPropertyPrompt = usesVisualPropertyPrompt(thread: thread, property: property, kind: round.kind)
             let left = GameplayDisplayItem(
                 id: "\(item.id)-left",
                 entityID: entity.id,
@@ -464,12 +465,12 @@ enum GameplayStageContentBuilder {
             let right = GameplayDisplayItem(
                 id: "\(item.id)-right",
                 entityID: entity.id,
-                title: visualNameMatch ? entity.name : (property?.value ?? entity.name),
-                subtitle: property.map { visualNameMatch ? nameRecallSubtitle(thread: thread) : (recallPrompt == nil ? propertyTypeTitle($0.typeID, in: thread) : nameRecallSubtitle(thread: thread)) } ?? "Name",
+                title: rightTitle(entity: entity, property: property, visualNameMatch: visualNameMatch),
+                subtitle: rightSubtitle(thread: thread, property: property, recallPrompt: recallPrompt, visualNameMatch: visualNameMatch),
                 visualKey: visualNameMatch ? nil : visualKey(for: property, fallbackEntity: entity),
                 visualAssetName: visualNameMatch ? nil : property?.visualAssetName,
                 visualShapeKey: visualNameMatch ? nil : property?.visualShapeKey,
-                presentation: visualNameMatch ? .titleOnly : .visualWithTitle
+                presentation: rightPresentation(visualNameMatch: visualNameMatch, visualPropertyPrompt: visualPropertyPrompt)
             )
             return GameplayMatchPair(id: item.id, left: left, right: right)
         }
@@ -564,13 +565,35 @@ enum GameplayStageContentBuilder {
     }
 
     private static func usesVisualNameMatch(thread: GameplayThreadDefinition, property: GameplayProperty?, kind: GameplayStageKind) -> Bool {
-        guard kind == .easyMemory else { return false }
         switch (thread.id, property?.typeID) {
         case ("countries", "flag"), ("electronics", "part"), ("world-animals", "name"), ("world-birds", "name"):
-            return true
+            return kind == .easyMemory
+        case ("shapes", "name"):
+            return kind == .easyMemory || kind == .bondBlast
         default:
             return false
         }
+    }
+
+    private static func usesVisualPropertyPrompt(thread: GameplayThreadDefinition, property: GameplayProperty?, kind: GameplayStageKind) -> Bool {
+        kind != .easyMemory && thread.id == "countries" && property?.typeID == "flag"
+    }
+
+    private static func rightTitle(entity: GameplayEntity, property: GameplayProperty?, visualNameMatch: Bool) -> String {
+        visualNameMatch ? entity.name : (property?.value ?? entity.name)
+    }
+
+    private static func rightSubtitle(thread: GameplayThreadDefinition, property: GameplayProperty?, recallPrompt: String?, visualNameMatch: Bool) -> String {
+        guard let property else { return "Name" }
+        if visualNameMatch { return nameRecallSubtitle(thread: thread) }
+        if recallPrompt != nil { return nameRecallSubtitle(thread: thread) }
+        return propertyTypeTitle(property.typeID, in: thread)
+    }
+
+    private static func rightPresentation(visualNameMatch: Bool, visualPropertyPrompt: Bool) -> GameplayDisplayItem.Presentation {
+        if visualNameMatch { return .titleOnly }
+        if visualPropertyPrompt { return .visualOnly }
+        return .visualWithTitle
     }
 
     private static func visualKey(for property: GameplayProperty?, fallbackEntity entity: GameplayEntity) -> String? {
@@ -635,5 +658,9 @@ enum GameplayStageRenderSupport {
 
     static func maximumContentWidth(compact: Bool) -> CGFloat {
         compact ? .infinity : 920
+    }
+
+    static func showsStagePrompt(kind: GameplayStageKind, compact: Bool) -> Bool {
+        !(compact && kind == .easyMemory)
     }
 }

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -4,17 +4,20 @@ struct GameplayStageTitle: View {
     let title: String
     let prompt: String
     let detail: String
+    let showsPrompt: Bool
 
-    init(stage: GameplayStageDefinition, detail: String) {
+    init(stage: GameplayStageDefinition, detail: String, showsPrompt: Bool = true) {
         self.title = stage.title
         self.prompt = stage.prompt
         self.detail = detail
+        self.showsPrompt = showsPrompt
     }
 
-    init(title: String, prompt: String, detail: String = "") {
+    init(title: String, prompt: String, detail: String = "", showsPrompt: Bool = true) {
         self.title = title
         self.prompt = prompt
         self.detail = detail
+        self.showsPrompt = showsPrompt
     }
 
     var body: some View {
@@ -24,10 +27,14 @@ struct GameplayStageTitle: View {
                     .font(.title2.bold())
                     .foregroundStyle(MatherTheme.ink)
                     .accessibilityAddTraits(.isHeader)
-                Text(prompt)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(MatherTheme.ink.opacity(0.72))
+                if showsPrompt {
+                    Text(prompt)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.ink.opacity(0.72))
+                }
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel([title, prompt].filter { !$0.isEmpty }.joined(separator: ". "))
             Spacer()
             if !detail.isEmpty {
                 Text(detail)
@@ -420,6 +427,7 @@ struct GameplayPairingStageShell: View {
     let title: String
     let prompt: String
     let compact: Bool
+    var showsStagePrompt = true
     @Binding var viewModel: GameplayMatchStageViewModel
     let actions: GameplayStageFeedbackActions
     let onComplete: (Int, Int, Int) -> Void
@@ -429,7 +437,7 @@ struct GameplayPairingStageShell: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 12 : 18) {
-            GameplayStageTitle(title: title, prompt: prompt, detail: viewModel.turnProgressText)
+            GameplayStageTitle(title: title, prompt: prompt, detail: viewModel.turnProgressText, showsPrompt: showsStagePrompt)
             GameplayTurnGuidance(text: viewModel.turnGuidanceText, compact: compact)
             GameplayMatchStatusStrip(
                 matchedText: viewModel.matchedProgressText,

--- a/Features/GameplayStages/GameplayThreadView.swift
+++ b/Features/GameplayStages/GameplayThreadView.swift
@@ -71,6 +71,7 @@ struct GameplayThreadView: View {
                 .padding(compact ? 14 : 24)
                 .frame(maxWidth: .infinity)
             }
+            .safeAreaPadding(.bottom, compact ? 18 : 10)
             .background(MatherTheme.background.ignoresSafeArea())
         }
         .navigationTitle(thread.title)

--- a/Features/GameplayStages/MemoryStageView.swift
+++ b/Features/GameplayStages/MemoryStageView.swift
@@ -16,6 +16,14 @@ struct MemoryStageView: View {
     }
 
     var body: some View {
-        GameplayPairingStageShell(title: stage.title, prompt: stage.prompt, compact: compact, viewModel: $viewModel, actions: actions, onComplete: onComplete)
+        GameplayPairingStageShell(
+            title: stage.title,
+            prompt: stage.prompt,
+            compact: compact,
+            showsStagePrompt: GameplayStageRenderSupport.showsStagePrompt(kind: stage.kind, compact: compact),
+            viewModel: $viewModel,
+            actions: actions,
+            onComplete: onComplete
+        )
     }
 }

--- a/Tests/MatherTests/CountryGameplayThreadTests.swift
+++ b/Tests/MatherTests/CountryGameplayThreadTests.swift
@@ -88,6 +88,11 @@ struct CountryGameplayThreadTests {
 
         let flip = try round(kind: .flipMemory, thread: thread)
         #expect(flip.items.allSatisfy { ["flag", "capital", "currency"].contains($0.propertyTypeID ?? "") })
+        let flipPairs = GameplayStageContentBuilder.matchPairs(thread: thread, round: flip)
+        let flipFlagCards = flipPairs.filter { $0.id.contains("-flag") }.map(\.right)
+        #expect(!flipFlagCards.isEmpty)
+        #expect(flipFlagCards.allSatisfy { $0.presentation == .visualOnly })
+        #expect(flipFlagCards.allSatisfy { $0.subtitle == "Flag" })
 
         let bondBlast = try round(kind: .bondBlast, thread: thread)
         #expect(bondBlast.items.count == 10)
@@ -167,6 +172,41 @@ struct CountryGameplayThreadTests {
         #expect(!mapShapeAnswers.isEmpty)
         #expect(mapShapeAnswers.allSatisfy { $0.visualShapeKey == $0.entityID })
         #expect(mapShapeAnswers.allSatisfy { $0.visualAssetName == nil })
+    }
+
+    @Test
+    func flagQuizChoicesShowVisualOnlyFlagsWhileKeepingAccessibleNames() throws {
+        let thread = CountryGameplayThread.thread
+        let selectedIDs = ["country-india", "country-japan", "country-france", "country-egypt"]
+        let items = try selectedIDs.map { entityID in
+            let entity = try #require(thread.entities.first { $0.id == entityID })
+            let flag = try #require(entity.properties.first { $0.typeID == "flag" })
+            return GameplayRoundItem(
+                id: "quiz-\(entityID)-flag",
+                entityID: entityID,
+                propertyID: flag.id,
+                propertyTypeID: flag.typeID
+            )
+        }
+        let round = GameplayRoundDefinition(
+            id: "country-flag-visual-only",
+            stageID: "multiple-choice",
+            kind: .multipleChoice,
+            items: items,
+            seed: 1074
+        )
+
+        let questions = GameplayStageContentBuilder.multipleChoiceQuestions(thread: thread, round: round, choicesPerQuestion: 4)
+
+        #expect(!questions.isEmpty)
+        #expect(questions.allSatisfy { question in
+            question.choices.allSatisfy { choice in
+                choice.presentation == .visualOnly
+                    && choice.subtitle == "Flag"
+                    && (choice.visualKey != nil || choice.visualAssetName != nil)
+                    && choice.spokenText.contains("flag")
+            }
+        })
     }
 
     @Test

--- a/Tests/MatherTests/GameplayStageViewModelsTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelsTests.swift
@@ -139,6 +139,14 @@ struct GameplayStageViewModelsTests {
         #expect(GameplayStageRenderSupport.cardMinimumWidth(availableWidth: 390, compact: true) >= 132)
         #expect(GameplayStageRenderSupport.cardMinimumWidth(availableWidth: 820, compact: false) == 180)
     }
+
+    @Test
+    func compactEasyMemoryCollapsesExplanatoryStagePrompt() {
+        #expect(!GameplayStageRenderSupport.showsStagePrompt(kind: .easyMemory, compact: true))
+        #expect(GameplayStageRenderSupport.showsStagePrompt(kind: .easyMemory, compact: false))
+        #expect(GameplayStageRenderSupport.showsStagePrompt(kind: .flipMemory, compact: true))
+        #expect(GameplayStageRenderSupport.showsStagePrompt(kind: .multipleChoice, compact: true))
+    }
 }
 
 struct GameplayThreadCatalogRegressionTests {

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -199,9 +199,19 @@ struct GameplayThreadContentTests {
         #expect(namePairs.count == 4)
         #expect(namePairs.allSatisfy { $0.left.title == "Name this shape" })
         #expect(namePairs.allSatisfy { $0.left.title != $0.right.title })
+        #expect(namePairs.allSatisfy { $0.left.presentation == .visualOnly })
         #expect(namePairs.allSatisfy { $0.right.subtitle == "Shape name" })
-        #expect(namePairs.allSatisfy { $0.right.visualKey != nil && $0.right.visualKey != "Aa" })
+        #expect(namePairs.allSatisfy { $0.right.presentation == .titleOnly })
+        #expect(namePairs.allSatisfy { $0.right.visualKey == nil && $0.right.visualAssetName == nil })
         #expect(nameStage.maximumItemCount >= 8)
+
+        let bondStage = try #require(thread.stages.first { $0.id == "shapes-bond-blast" })
+        let bondRound = GameplayRoundDefinition(id: "shape-bond-names-test", stageID: bondStage.id, kind: bondStage.kind, items: nameItems, seed: 1069)
+        let bondPairs = GameplayStageContentBuilder.matchPairs(thread: thread, round: bondRound)
+
+        #expect(bondPairs.allSatisfy { $0.left.title == "Name this shape" })
+        #expect(bondPairs.allSatisfy { $0.left.presentation == .visualOnly })
+        #expect(bondPairs.allSatisfy { $0.right.presentation == .titleOnly })
     }
 
 }


### PR DESCRIPTION
## Summary\n- Make visual-recognition cards render as visual-only prompts for shape-name stages and country flag stages, while keeping answer/name cards text-visible.\n- Preserve accessible spoken/VoiceOver names through existing card titles/subtitles even when visible labels are hidden.\n- Collapse the Easy Memory stage prompt on compact learner screens and keep bottom safe-area padding for controls.\n\nCloses #1069\nCloses #1074\nCloses #1075\n\n## Validation\n- PASS: git diff --check\n- BLOCKED: xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' CODE_SIGNING_ALLOWED=NO -only-testing:MatherTests/GameplayThreadContentTests -only-testing:MatherTests/CountryGameplayThreadTests -only-testing:MatherTests/GameplayStageViewModelsTests\n  - Blocker: /bin/bash: line 1: xcodebuild: command not found\n