### PR TITLE
Add electronics gameplay illustration assets

### DIFF
--- a/App/Assets.xcassets/ElectronicsBattery.imageset/Contents.json
+++ b/App/Assets.xcassets/ElectronicsBattery.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "filename": "ElectronicsBattery.svg"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  },
+  "properties": {
+    "preserves-vector-representation": true
+  }
+}

--- a/App/Assets.xcassets/ElectronicsBattery.imageset/ElectronicsBattery.svg
+++ b/App/Assets.xcassets/ElectronicsBattery.imageset/ElectronicsBattery.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Pretend battery illustration">
+  <rect width="256" height="256" rx="48" fill="#F7FBFF"/>
+  <circle cx="206" cy="50" r="24" fill="#FFE9A8" opacity="0.75"/>
+  <rect x="55" y="85" width="138" height="86" rx="18" fill="#7ADCB4" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><rect x="194" y="110" width="18" height="36" rx="6" fill="#7ADCB4" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><line x1="86" y1="128" x2="112" y2="128" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><line x1="151" y1="116" x2="151" y2="140" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><line x1="139" y1="128" x2="163" y2="128" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M73 185c36 24 94 24 130 0" fill="none" stroke="#F59E0B" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/App/Assets.xcassets/ElectronicsBulb.imageset/Contents.json
+++ b/App/Assets.xcassets/ElectronicsBulb.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "filename": "ElectronicsBulb.svg"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  },
+  "properties": {
+    "preserves-vector-representation": true
+  }
+}

--- a/App/Assets.xcassets/ElectronicsBulb.imageset/ElectronicsBulb.svg
+++ b/App/Assets.xcassets/ElectronicsBulb.imageset/ElectronicsBulb.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Bulb illustration">
+  <rect width="256" height="256" rx="48" fill="#F7FBFF"/>
+  <circle cx="206" cy="50" r="24" fill="#FFE9A8" opacity="0.75"/>
+  <path d="M128 40c-42 0-72 31-72 70 0 24 12 43 31 57 10 8 15 17 15 29h52c0-12 5-21 15-29 19-14 31-33 31-57 0-39-30-70-72-70z" fill="#FFE177" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M101 197h54M106 219h44" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M102 121c10-18 42-18 52 0" fill="none" stroke="#F59E0B" stroke-width="8"/><path d="M82 62 66 46M174 62l16-16M128 31V14" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/App/Assets.xcassets/ElectronicsClosedCircuit.imageset/Contents.json
+++ b/App/Assets.xcassets/ElectronicsClosedCircuit.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "filename": "ElectronicsClosedCircuit.svg"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  },
+  "properties": {
+    "preserves-vector-representation": true
+  }
+}

--- a/App/Assets.xcassets/ElectronicsClosedCircuit.imageset/ElectronicsClosedCircuit.svg
+++ b/App/Assets.xcassets/ElectronicsClosedCircuit.imageset/ElectronicsClosedCircuit.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Closed circuit with lit bulb illustration">
+  <rect width="256" height="256" rx="48" fill="#F7FBFF"/>
+  <circle cx="206" cy="50" r="24" fill="#FFE9A8" opacity="0.75"/>
+  <path d="M68 148c0-48 26-82 60-82s60 34 60 82-26 70-60 70-60-22-60-70z" fill="none" stroke="#2F80ED" stroke-width="12"/><rect x="87" y="181" width="82" height="34" rx="10" fill="#7ADCB4" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M105 181v-36h46v36" fill="none" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><circle cx="128" cy="101" r="31" fill="#FFE177" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M113 102c8-12 22-12 30 0" fill="none" stroke="#F59E0B" stroke-width="7"/><path d="M52 79h28M66 65v28M176 56l14-14M202 90h24" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/App/Assets.xcassets/ElectronicsOpenCircuit.imageset/Contents.json
+++ b/App/Assets.xcassets/ElectronicsOpenCircuit.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "filename": "ElectronicsOpenCircuit.svg"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  },
+  "properties": {
+    "preserves-vector-representation": true
+  }
+}

--- a/App/Assets.xcassets/ElectronicsOpenCircuit.imageset/ElectronicsOpenCircuit.svg
+++ b/App/Assets.xcassets/ElectronicsOpenCircuit.imageset/ElectronicsOpenCircuit.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Open circuit with gap illustration">
+  <rect width="256" height="256" rx="48" fill="#F7FBFF"/>
+  <circle cx="206" cy="50" r="24" fill="#FFE9A8" opacity="0.75"/>
+  <path d="M70 132a58 58 0 0 1 93-46" fill="none" stroke="#2F80ED" stroke-width="12" stroke-linecap="round"/><path d="M184 120a58 58 0 0 1-98 52" fill="none" stroke="#2F80ED" stroke-width="12" stroke-linecap="round"/><circle cx="74" cy="132" r="14" fill="#F59E0B" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><circle cx="184" cy="120" r="14" fill="#F59E0B" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M108 105h40" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M116 184h32" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M151 64l39 39M190 64l-39 39" stroke="#E85D75" stroke-width="12" stroke-linecap="round"/>
+</svg>

--- a/App/Assets.xcassets/ElectronicsOutletSafety.imageset/Contents.json
+++ b/App/Assets.xcassets/ElectronicsOutletSafety.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "filename": "ElectronicsOutletSafety.svg"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  },
+  "properties": {
+    "preserves-vector-representation": true
+  }
+}

--- a/App/Assets.xcassets/ElectronicsOutletSafety.imageset/ElectronicsOutletSafety.svg
+++ b/App/Assets.xcassets/ElectronicsOutletSafety.imageset/ElectronicsOutletSafety.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Outlet safety illustration">
+  <rect width="256" height="256" rx="48" fill="#F7FBFF"/>
+  <circle cx="206" cy="50" r="24" fill="#FFE9A8" opacity="0.75"/>
+  <rect x="72" y="44" width="112" height="150" rx="28" fill="#FFFFFF" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><circle cx="108" cy="111" r="10" fill="#243B53"/><circle cx="148" cy="111" r="10" fill="#243B53"/><path d="M128 139v20" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M62 197l132-132" stroke="#E85D75" stroke-width="18" stroke-linecap="round"/><circle cx="128" cy="128" r="88" fill="none" stroke="#E85D75" stroke-width="14"/><path d="M53 49l20 20M203 49l-20 20" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/App/Assets.xcassets/ElectronicsSafeCircuit.imageset/Contents.json
+++ b/App/Assets.xcassets/ElectronicsSafeCircuit.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "filename": "ElectronicsSafeCircuit.svg"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  },
+  "properties": {
+    "preserves-vector-representation": true
+  }
+}

--- a/App/Assets.xcassets/ElectronicsSafeCircuit.imageset/ElectronicsSafeCircuit.svg
+++ b/App/Assets.xcassets/ElectronicsSafeCircuit.imageset/ElectronicsSafeCircuit.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Safe pretend circuit illustration">
+  <rect width="256" height="256" rx="48" fill="#F7FBFF"/>
+  <circle cx="206" cy="50" r="24" fill="#FFE9A8" opacity="0.75"/>
+  <circle cx="128" cy="126" r="78" fill="#D9FBE8" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M91 126l25 25 53-59" fill="none" stroke="#22966B" stroke-width="17" stroke-linecap="round" stroke-linejoin="round"/><path d="M61 199c36 27 98 29 134 0" fill="none" stroke="#2F80ED" stroke-width="10" stroke-linecap="round"/><rect x="74" y="43" width="48" height="24" rx="8" fill="#7ADCB4" stroke="#243B53" stroke-width="8"/><circle cx="178" cy="54" r="14" fill="#FFE177" stroke="#243B53" stroke-width="8"/>
+</svg>

--- a/App/Assets.xcassets/ElectronicsSwitch.imageset/Contents.json
+++ b/App/Assets.xcassets/ElectronicsSwitch.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "filename": "ElectronicsSwitch.svg"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  },
+  "properties": {
+    "preserves-vector-representation": true
+  }
+}

--- a/App/Assets.xcassets/ElectronicsSwitch.imageset/ElectronicsSwitch.svg
+++ b/App/Assets.xcassets/ElectronicsSwitch.imageset/ElectronicsSwitch.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Switch illustration">
+  <rect width="256" height="256" rx="48" fill="#F7FBFF"/>
+  <circle cx="206" cy="50" r="24" fill="#FFE9A8" opacity="0.75"/>
+  <rect x="48" y="152" width="160" height="32" rx="16" fill="#B7C9E2" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><circle cx="74" cy="168" r="18" fill="#F7FBFF" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><circle cx="184" cy="168" r="18" fill="#F7FBFF" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><line x1="80" y1="151" x2="160" y2="88" stroke="#2F80ED" stroke-width="14" stroke-linecap="round"/><circle cx="160" cy="88" r="13" fill="#2F80ED"/><path d="M56 70h42M77 49v42" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><path d="M158 49h42" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/App/Assets.xcassets/ElectronicsWire.imageset/Contents.json
+++ b/App/Assets.xcassets/ElectronicsWire.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "filename": "ElectronicsWire.svg"
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  },
+  "properties": {
+    "preserves-vector-representation": true
+  }
+}

--- a/App/Assets.xcassets/ElectronicsWire.imageset/ElectronicsWire.svg
+++ b/App/Assets.xcassets/ElectronicsWire.imageset/ElectronicsWire.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Wire illustration">
+  <rect width="256" height="256" rx="48" fill="#F7FBFF"/>
+  <circle cx="206" cy="50" r="24" fill="#FFE9A8" opacity="0.75"/>
+  <path d="M42 148c25-62 72 58 103-5 28-56 52-10 69 25" fill="none" stroke="#2F80ED" stroke-width="18" stroke-linecap="round"/><path d="M42 148c25-62 72 58 103-5 28-56 52-10 69 25" fill="none" stroke="#243B53" stroke-width="28" stroke-linecap="round" opacity="0.18"/><circle cx="42" cy="148" r="16" fill="#F59E0B" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/><circle cx="214" cy="168" r="16" fill="#F59E0B" stroke="#243B53" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Domain/GameplayThreadCatalog.swift
+++ b/Domain/GameplayThreadCatalog.swift
@@ -166,45 +166,45 @@ extension GameplayThreadCatalog {
             GameplayPropertyType(id: "rule", displayName: "Rule", prompt: "Find the safe circuit rule."),
         ],
         entities: [
-            GameplayEntity(id: "electronics-battery", name: "Battery", summary: "A pretend game battery gives a tiny circuit its power.", visualKey: "🔋", properties: [
-                GameplayProperty(id: "electronics-battery-part", typeID: "part", value: "Battery", explanation: "The battery is the safe pretend power part in this game.", visualKey: "🔋"),
-                GameplayProperty(id: "electronics-battery-job", typeID: "job", value: "Gives power", explanation: "The pretend battery can help the light turn on."),
-                GameplayProperty(id: "electronics-battery-rule", typeID: "rule", value: "Game batteries are pretend", explanation: "Batteries in this game are pretend and safe to play with on the screen."),
+            GameplayEntity(id: "electronics-battery", name: "Battery", summary: "A pretend game battery gives a tiny circuit its power.", visualAssetName: "ElectronicsBattery", properties: [
+                GameplayProperty(id: "electronics-battery-part", typeID: "part", value: "Battery", explanation: "The battery is the safe pretend power part in this game.", visualAssetName: "ElectronicsBattery"),
+                GameplayProperty(id: "electronics-battery-job", typeID: "job", value: "Gives power", explanation: "The pretend battery can help the light turn on.", visualAssetName: "ElectronicsBattery"),
+                GameplayProperty(id: "electronics-battery-rule", typeID: "rule", value: "Game batteries are pretend", explanation: "Batteries in this game are pretend and safe to play with on the screen.", visualAssetName: "ElectronicsSafeCircuit"),
             ]),
-            GameplayEntity(id: "electronics-bulb", name: "Bulb", summary: "A bulb or light turns on when the pretend circuit is closed.", visualKey: "💡", properties: [
-                GameplayProperty(id: "electronics-bulb-part", typeID: "part", value: "Bulb or light", explanation: "The bulb is the light-making part.", visualKey: "💡"),
-                GameplayProperty(id: "electronics-bulb-job", typeID: "job", value: "Makes light", explanation: "The light can shine when the path is complete."),
-                GameplayProperty(id: "electronics-bulb-rule", typeID: "rule", value: "Light on in closed circuit", explanation: "The light turns on when the wire path makes a full loop."),
+            GameplayEntity(id: "electronics-bulb", name: "Bulb", summary: "A bulb or light turns on when the pretend circuit is closed.", visualAssetName: "ElectronicsBulb", properties: [
+                GameplayProperty(id: "electronics-bulb-part", typeID: "part", value: "Bulb or light", explanation: "The bulb is the light-making part.", visualAssetName: "ElectronicsBulb"),
+                GameplayProperty(id: "electronics-bulb-job", typeID: "job", value: "Makes light", explanation: "The light can shine when the path is complete.", visualAssetName: "ElectronicsBulb"),
+                GameplayProperty(id: "electronics-bulb-rule", typeID: "rule", value: "Light on in closed circuit", explanation: "The light turns on when the wire path makes a full loop.", visualAssetName: "ElectronicsClosedCircuit"),
             ]),
-            GameplayEntity(id: "electronics-wire", name: "Wire", summary: "A wire makes the path from the battery to the light and back.", visualKey: "➰", properties: [
-                GameplayProperty(id: "electronics-wire-part", typeID: "part", value: "Wire", explanation: "A wire is the path part.", visualKey: "➰"),
-                GameplayProperty(id: "electronics-wire-job", typeID: "job", value: "Makes a path", explanation: "A wire joins the battery, switch, and light."),
-                GameplayProperty(id: "electronics-wire-rule", typeID: "rule", value: "Path must meet both ends", explanation: "The wire path needs to meet both ends of the pretend battery."),
+            GameplayEntity(id: "electronics-wire", name: "Wire", summary: "A wire makes the path from the battery to the light and back.", visualAssetName: "ElectronicsWire", properties: [
+                GameplayProperty(id: "electronics-wire-part", typeID: "part", value: "Wire", explanation: "A wire is the path part.", visualAssetName: "ElectronicsWire"),
+                GameplayProperty(id: "electronics-wire-job", typeID: "job", value: "Makes a path", explanation: "A wire joins the battery, switch, and light.", visualAssetName: "ElectronicsWire"),
+                GameplayProperty(id: "electronics-wire-rule", typeID: "rule", value: "Path must meet both ends", explanation: "The wire path needs to meet both ends of the pretend battery.", visualAssetName: "ElectronicsClosedCircuit"),
             ]),
-            GameplayEntity(id: "electronics-switch", name: "Switch", summary: "A switch opens or closes the pretend circuit path.", visualKey: "⏻", properties: [
-                GameplayProperty(id: "electronics-switch-part", typeID: "part", value: "Switch", explanation: "The switch is the open-close part.", visualKey: "⏻"),
-                GameplayProperty(id: "electronics-switch-job", typeID: "job", value: "Opens or closes", explanation: "A switch can connect the path or make a gap."),
-                GameplayProperty(id: "electronics-switch-rule", typeID: "rule", value: "Closed switch can turn on", explanation: "When the switch closes, the path can be complete."),
+            GameplayEntity(id: "electronics-switch", name: "Switch", summary: "A switch opens or closes the pretend circuit path.", visualAssetName: "ElectronicsSwitch", properties: [
+                GameplayProperty(id: "electronics-switch-part", typeID: "part", value: "Switch", explanation: "The switch is the open-close part.", visualAssetName: "ElectronicsSwitch"),
+                GameplayProperty(id: "electronics-switch-job", typeID: "job", value: "Opens or closes", explanation: "A switch can connect the path or make a gap.", visualAssetName: "ElectronicsSwitch"),
+                GameplayProperty(id: "electronics-switch-rule", typeID: "rule", value: "Closed switch can turn on", explanation: "When the switch closes, the path can be complete.", visualAssetName: "ElectronicsClosedCircuit"),
             ]),
-            GameplayEntity(id: "electronics-closed-circuit", name: "Closed Circuit", summary: "A closed circuit is a full loop from battery to light and back.", visualKey: "↻", properties: [
-                GameplayProperty(id: "electronics-closed-circuit-part", typeID: "part", value: "Closed loop", explanation: "The wire path comes all the way back."),
-                GameplayProperty(id: "electronics-closed-circuit-job", typeID: "job", value: "Lets power reach the light", explanation: "A full loop lets the pretend battery help the light."),
-                GameplayProperty(id: "electronics-closed-circuit-rule", typeID: "rule", value: "Bulb on", explanation: "A complete path can turn the bulb on."),
+            GameplayEntity(id: "electronics-closed-circuit", name: "Closed Circuit", summary: "A closed circuit is a full loop from battery to light and back.", visualAssetName: "ElectronicsClosedCircuit", properties: [
+                GameplayProperty(id: "electronics-closed-circuit-part", typeID: "part", value: "Closed loop", explanation: "The wire path comes all the way back.", visualAssetName: "ElectronicsClosedCircuit"),
+                GameplayProperty(id: "electronics-closed-circuit-job", typeID: "job", value: "Lets power reach the light", explanation: "A full loop lets the pretend battery help the light.", visualAssetName: "ElectronicsClosedCircuit"),
+                GameplayProperty(id: "electronics-closed-circuit-rule", typeID: "rule", value: "Bulb on", explanation: "A complete path can turn the bulb on.", visualAssetName: "ElectronicsClosedCircuit"),
             ]),
-            GameplayEntity(id: "electronics-open-circuit", name: "Open Circuit", summary: "An open circuit has a gap, so the pretend light stays off.", visualKey: "⛔", properties: [
-                GameplayProperty(id: "electronics-open-circuit-part", typeID: "part", value: "Broken path", explanation: "A gap breaks the circuit path."),
-                GameplayProperty(id: "electronics-open-circuit-job", typeID: "job", value: "Keeps light off", explanation: "The pretend power cannot go around a path with a gap."),
-                GameplayProperty(id: "electronics-open-circuit-rule", typeID: "rule", value: "Bulb off", explanation: "A broken path keeps the bulb off."),
+            GameplayEntity(id: "electronics-open-circuit", name: "Open Circuit", summary: "An open circuit has a gap, so the pretend light stays off.", visualAssetName: "ElectronicsOpenCircuit", properties: [
+                GameplayProperty(id: "electronics-open-circuit-part", typeID: "part", value: "Broken path", explanation: "A gap breaks the circuit path.", visualAssetName: "ElectronicsOpenCircuit"),
+                GameplayProperty(id: "electronics-open-circuit-job", typeID: "job", value: "Keeps light off", explanation: "The pretend power cannot go around a path with a gap.", visualAssetName: "ElectronicsOpenCircuit"),
+                GameplayProperty(id: "electronics-open-circuit-rule", typeID: "rule", value: "Bulb off", explanation: "A broken path keeps the bulb off.", visualAssetName: "ElectronicsOpenCircuit"),
             ]),
-            GameplayEntity(id: "electronics-safe-circuit", name: "Safe Game Circuit", summary: "The circuits here are pretend screen circuits made for play.", visualKey: "✅", properties: [
-                GameplayProperty(id: "electronics-safe-circuit-part", typeID: "part", value: "Pretend circuit", explanation: "This game uses pretend parts on the screen.", visualKey: "✅"),
-                GameplayProperty(id: "electronics-safe-circuit-job", typeID: "job", value: "Safe to try here", explanation: "It is safe to tap and try the circuit parts in this game."),
-                GameplayProperty(id: "electronics-safe-circuit-rule", typeID: "rule", value: "Screen play is safe", explanation: "Build circuits in the game, not with real plug points."),
+            GameplayEntity(id: "electronics-safe-circuit", name: "Safe Game Circuit", summary: "The circuits here are pretend screen circuits made for play.", visualAssetName: "ElectronicsSafeCircuit", properties: [
+                GameplayProperty(id: "electronics-safe-circuit-part", typeID: "part", value: "Pretend circuit", explanation: "This game uses pretend parts on the screen.", visualAssetName: "ElectronicsSafeCircuit"),
+                GameplayProperty(id: "electronics-safe-circuit-job", typeID: "job", value: "Safe to try here", explanation: "It is safe to tap and try the circuit parts in this game.", visualAssetName: "ElectronicsSafeCircuit"),
+                GameplayProperty(id: "electronics-safe-circuit-rule", typeID: "rule", value: "Screen play is safe", explanation: "Build circuits in the game, not with real plug points.", visualAssetName: "ElectronicsSafeCircuit"),
             ]),
-            GameplayEntity(id: "electronics-outlet-safety", name: "Outlet Safety", summary: "Plug points and outlets are grown-up only. Ask a grown-up and do not touch them.", visualKey: "🛑", properties: [
-                GameplayProperty(id: "electronics-outlet-safety-part", typeID: "part", value: "Plug point or outlet", explanation: "A plug point or outlet is for grown-ups.", visualKey: "🛑"),
-                GameplayProperty(id: "electronics-outlet-safety-job", typeID: "job", value: "Ask a grown-up", explanation: "Ask a grown-up before anything near a plug point or outlet."),
-                GameplayProperty(id: "electronics-outlet-safety-rule", typeID: "rule", value: "Do not touch outlets", explanation: "Do not touch plug points or outlets. Use the safe pretend battery in this game."),
+            GameplayEntity(id: "electronics-outlet-safety", name: "Outlet Safety", summary: "Plug points and outlets are grown-up only. Ask a grown-up and do not touch them.", visualAssetName: "ElectronicsOutletSafety", properties: [
+                GameplayProperty(id: "electronics-outlet-safety-part", typeID: "part", value: "Plug point or outlet", explanation: "A plug point or outlet is for grown-ups.", visualAssetName: "ElectronicsOutletSafety"),
+                GameplayProperty(id: "electronics-outlet-safety-job", typeID: "job", value: "Ask a grown-up", explanation: "Ask a grown-up before anything near a plug point or outlet.", visualAssetName: "ElectronicsOutletSafety"),
+                GameplayProperty(id: "electronics-outlet-safety-rule", typeID: "rule", value: "Do not touch outlets", explanation: "Do not touch plug points or outlets. Use the safe pretend battery in this game.", visualAssetName: "ElectronicsOutletSafety"),
             ]),
         ],
         stages: [

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -78,6 +78,24 @@ struct GameplayThreadContentTests {
             "Outlet Safety",
         ]))
 
+        let expectedAssetNames: Set<String> = [
+            "ElectronicsBattery",
+            "ElectronicsBulb",
+            "ElectronicsWire",
+            "ElectronicsSwitch",
+            "ElectronicsClosedCircuit",
+            "ElectronicsOpenCircuit",
+            "ElectronicsSafeCircuit",
+            "ElectronicsOutletSafety",
+        ]
+        #expect(Set(thread.entities.compactMap(\.visualAssetName)) == expectedAssetNames)
+        #expect(thread.entities.allSatisfy { $0.visualKey == nil })
+        #expect(thread.entities.allSatisfy { entity in
+            entity.properties.allSatisfy { property in
+                property.visualAssetName.map(expectedAssetNames.contains) == true && property.visualKey == nil
+            }
+        })
+
         let propertyValues = thread.entities.flatMap { $0.properties.map(\.value) }
         for requiredValue in [
             "Game batteries are pretend",

--- a/wiki/Specs/Issue-1071-Electronics-Asset-Provenance.md
+++ b/wiki/Specs/Issue-1071-Electronics-Asset-Provenance.md
@@ -1,0 +1,28 @@
+# Issue 1071 Electronics Asset Provenance
+
+Circuit Spark uses first-party vector artwork so electronics gameplay cards do not depend on emoji rendering.
+
+## Asset set
+
+The checked-in asset catalog images are SVG sources stored in `App/Assets.xcassets/*Electronics*.imageset` with vector preservation enabled:
+
+- `ElectronicsBattery` — pretend screen battery
+- `ElectronicsBulb` — light bulb
+- `ElectronicsWire` — curved wire path
+- `ElectronicsSwitch` — open/close switch
+- `ElectronicsOpenCircuit` — loop with a gap
+- `ElectronicsClosedCircuit` — complete loop with lit bulb
+- `ElectronicsSafeCircuit` — safe pretend screen circuit
+- `ElectronicsOutletSafety` — outlet with do-not-touch safety mark
+
+## Reproducible source prompt
+
+Use this prompt to regenerate matching vector-style source art if the set needs to be refreshed:
+
+> Create a consistent set of kid-friendly flat vector SVG illustrations for an iOS learning app called Mather. Use a rounded 256×256 viewBox, pale blue/white background, thick navy rounded outlines, soft fills, and no text. Keep the concepts elementary and safe: pretend battery, bulb, wire, switch, open circuit with a gap, closed circuit with lit bulb, safe pretend screen circuit with a check, and outlet safety with a clear do-not-touch mark. Avoid photorealism, brand marks, scary danger language, sparks, shocks, flames, or real-world wiring instructions.
+
+## Implementation notes
+
+- The SVGs are hand-authored first-party assets based on the prompt above; no third-party source art is included.
+- `GameplayThreadCatalog.electronics` maps every electronics entity and property to `visualAssetName` so SwiftUI `Image(assetName)` renders the illustration before any fallback text.
+- Emoji `visualKey` values were removed from the electronics gameplay cards; VoiceOver labels remain derived from card titles and subtitles.


### PR DESCRIPTION
## Summary
- Adds first-party vector SVG asset-catalog illustrations for Circuit Spark electronics concepts: battery, bulb, wire, switch, open circuit, closed circuit, safe circuit, and outlet safety.
- Wires electronics entities and properties to `visualAssetName` and removes electronics emoji `visualKey` fallback while preserving text-based VoiceOver labels.
- Documents reproducible source prompt/provenance in `wiki/Specs/Issue-1071-Electronics-Asset-Provenance.md`.

Closes #1071.

## Validation
- `git diff --cached --check` before commit: passed.
- Python validation: parsed all new electronics SVG XML, checked asset catalog `Contents.json` filenames/vector preservation, and verified all 8 expected asset names exist.
- Python validation: verified `GameplayThreadCatalog.electronics` contains no `visualKey:` entries and references all expected electronics asset names.

## Blocked / not run
- `xcodebuild -project Mather.xcodeproj -scheme Mather -destination 'generic/platform=iOS Simulator' test` could not run in this Linux environment because `xcodebuild` is not installed.
