### PR TITLE
Fix build 103 Sound Lab flow and compact chrome

### DIFF
--- a/Domain/CountryGameplayThread.swift
+++ b/Domain/CountryGameplayThread.swift
@@ -222,7 +222,7 @@ enum CountryGameplayThread {
         ],
         stages: [
             GameplayStageDefinition(id: "flashcards", kind: .flashcards, title: "Look + Learn", prompt: "Meet each country, flag, capital, map clue, language, and money.", maximumItemCount: 8),
-            GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Start with one focused round matching each flag to its country name.", propertyTypeIDs: ["flag"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Match flags to names.", propertyTypeIDs: ["flag"], maximumItemCount: 8),
             GameplayStageDefinition(id: "flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Flip and remember flags, capitals, and currencies.", propertyTypeIDs: ["flag", "capital", "currency"], maximumItemCount: 8),
             GameplayStageDefinition(id: "bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect each country to mixed facts.", propertyTypeIDs: ["capital", "currency", "continent", "language", "map-shape"], maximumItemCount: 10),
             GameplayStageDefinition(id: "multiple-choice", kind: .multipleChoice, title: "Quiz", prompt: "Pick the best country fact.", propertyTypeIDs: ["capital", "currency", "flag", "map-shape", "continent", "language"], maximumItemCount: 12)

--- a/Domain/GameplayStageModels.swift
+++ b/Domain/GameplayStageModels.swift
@@ -161,7 +161,7 @@ struct GameplayThreadDefinition: Identifiable, Codable, Equatable {
 
     static let defaultStages: [GameplayStageDefinition] = [
         GameplayStageDefinition(id: "flashcards", kind: .flashcards, title: "Look + Learn", prompt: "Meet each card.", maximumItemCount: 6),
-        GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Match with the cards still visible.", maximumItemCount: 6),
+        GameplayStageDefinition(id: "easy-memory", kind: .easyMemory, title: "Easy Memory", prompt: "Match visible cards.", maximumItemCount: 6),
         GameplayStageDefinition(id: "flip-memory", kind: .flipMemory, title: "Flip Memory", prompt: "Remember where the matches are.", maximumItemCount: 6),
         GameplayStageDefinition(id: "bond-blast", kind: .bondBlast, title: "Bond Blast", prompt: "Connect names, pictures, and facts.", maximumItemCount: 6),
         GameplayStageDefinition(id: "multiple-choice", kind: .multipleChoice, title: "Quiz", prompt: "Pick the best answer.")

--- a/Domain/GameplayStageViewModels.swift
+++ b/Domain/GameplayStageViewModels.swift
@@ -418,13 +418,31 @@ struct GameplayMultipleChoiceStageViewModel: Equatable {
         return "\(min(activeIndex + 1, questions.count)) of \(questions.count)"
     }
 
+    var selectedChoiceIsCorrect: Bool {
+        guard let question = activeQuestion,
+              let selectedChoiceID,
+              let choice = question.choices.first(where: { $0.id == selectedChoiceID })
+        else { return false }
+        return question.isCorrect(choice)
+    }
+
     mutating func choose(_ choice: GameplayDisplayItem) -> Bool {
         guard let question = activeQuestion else { return false }
+        if selectedChoiceIsCorrect { return true }
         selectedChoiceID = choice.id
         let correct = question.isCorrect(choice)
-        if correct { correctCount += 1 } else { mistakeCount += 1 }
-        activeIndex += 1
+        if correct {
+            correctCount += 1
+        } else {
+            mistakeCount += 1
+        }
         return correct
+    }
+
+    mutating func advanceAfterCorrectAnswer() {
+        guard selectedChoiceIsCorrect else { return }
+        activeIndex += 1
+        selectedChoiceID = nil
     }
 }
 

--- a/Domain/GameplayThreadContent+WorldAnimals.swift
+++ b/Domain/GameplayThreadContent+WorldAnimals.swift
@@ -22,7 +22,7 @@ extension GameplayThreadCatalog {
         },
         stages: [
             GameplayStageDefinition(id: "world-animals-flashcards", kind: .flashcards, title: "Animal Cards", prompt: "Meet animals and notice where they live.", maximumItemCount: 12),
-            GameplayStageDefinition(id: "world-animals-easy-memory", kind: .easyMemory, title: "Animal Match", prompt: "Start with one focused round matching each animal picture to its name.", propertyTypeIDs: ["name"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "world-animals-easy-memory", kind: .easyMemory, title: "Animal Match", prompt: "Match pictures to names.", propertyTypeIDs: ["name"], maximumItemCount: 8),
             GameplayStageDefinition(id: "world-animals-bond-blast", kind: .bondBlast, title: "Animal Blast", prompt: "Connect each animal with its home, movement, sound, colors, and kind.", propertyTypeIDs: ["habitat", "movement", "sound", "colors", "kind"], maximumItemCount: 12),
         ],
         progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.70, retryMissedItemsFirst: true)

--- a/Domain/GameplayThreadContent+WorldBirds.swift
+++ b/Domain/GameplayThreadContent+WorldBirds.swift
@@ -22,7 +22,7 @@ extension GameplayThreadCatalog {
         },
         stages: [
             GameplayStageDefinition(id: "world-birds-flashcards", kind: .flashcards, title: "Bird Cards", prompt: "Meet colorful birds from different world habitats.", maximumItemCount: 12),
-            GameplayStageDefinition(id: "world-birds-easy-memory", kind: .easyMemory, title: "Bird Match", prompt: "Start with one focused round matching each bird picture to its name.", propertyTypeIDs: ["name"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "world-birds-easy-memory", kind: .easyMemory, title: "Bird Match", prompt: "Match pictures to names.", propertyTypeIDs: ["name"], maximumItemCount: 8),
             GameplayStageDefinition(id: "world-birds-bond-blast", kind: .bondBlast, title: "Bird Blast", prompt: "Connect each bird with its home, colors, size, lifespan, and weight.", propertyTypeIDs: ["home", "colors", "size", "lifespan", "weight"], maximumItemCount: 12),
         ],
         progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.70, retryMissedItemsFirst: true)

--- a/Features/GameplayStages/BondBlastStageView.swift
+++ b/Features/GameplayStages/BondBlastStageView.swift
@@ -50,7 +50,8 @@ struct ReusableBondBlastBoard: View {
             GameplayStageTitle(
                 title: title,
                 prompt: instructionText,
-                detail: "\(viewModel.turnProgressText) • \(viewModel.correctCount)/\(viewModel.pairs.count)"
+                detail: "\(viewModel.turnProgressText) • \(viewModel.correctCount)/\(viewModel.pairs.count)",
+                compact: compact
             )
 
             HStack(alignment: .top, spacing: compact ? 10 : 16) {

--- a/Features/GameplayStages/FlashcardStageView.swift
+++ b/Features/GameplayStages/FlashcardStageView.swift
@@ -18,7 +18,7 @@ struct FlashcardStageView: View {
 
     var body: some View {
         VStack(spacing: compact ? 12 : 18) {
-            GameplayStageTitle(stage: stage, detail: viewModel.progressText)
+            GameplayStageTitle(stage: stage, detail: viewModel.progressText, compact: compact)
             if let card = viewModel.activeCard {
                 Button {
                     viewModel.markExposure()

--- a/Features/GameplayStages/GameplayStageSharedViews.swift
+++ b/Features/GameplayStages/GameplayStageSharedViews.swift
@@ -4,17 +4,20 @@ struct GameplayStageTitle: View {
     let title: String
     let prompt: String
     let detail: String
+    let compact: Bool
 
-    init(stage: GameplayStageDefinition, detail: String) {
+    init(stage: GameplayStageDefinition, detail: String, compact: Bool = false) {
         self.title = stage.title
         self.prompt = stage.prompt
         self.detail = detail
+        self.compact = compact
     }
 
-    init(title: String, prompt: String, detail: String = "") {
+    init(title: String, prompt: String, detail: String = "", compact: Bool = false) {
         self.title = title
         self.prompt = prompt
         self.detail = detail
+        self.compact = compact
     }
 
     var body: some View {
@@ -29,7 +32,7 @@ struct GameplayStageTitle: View {
                     .foregroundStyle(MatherTheme.ink.opacity(0.72))
             }
             Spacer()
-            if !detail.isEmpty {
+            if !compact && !detail.isEmpty {
                 Text(detail)
                     .font(.caption.weight(.bold).monospacedDigit())
                     .foregroundStyle(MatherTheme.accent)
@@ -429,13 +432,15 @@ struct GameplayPairingStageShell: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 12 : 18) {
-            GameplayStageTitle(title: title, prompt: prompt, detail: viewModel.turnProgressText)
+            GameplayStageTitle(title: title, prompt: prompt, detail: viewModel.turnProgressText, compact: compact)
             GameplayTurnGuidance(text: viewModel.turnGuidanceText, compact: compact)
-            GameplayMatchStatusStrip(
-                matchedText: viewModel.matchedProgressText,
-                roundText: viewModel.currentRoundRequirementText,
-                compact: compact
-            )
+            if !compact {
+                GameplayMatchStatusStrip(
+                    matchedText: viewModel.matchedProgressText,
+                    roundText: viewModel.currentRoundRequirementText,
+                    compact: compact
+                )
+            }
             LazyVGrid(columns: columns, spacing: 12) {
                 ForEach(viewModel.activePairs) { pair in
                     let state = viewModel.cardState(forLeft: pair)

--- a/Features/GameplayStages/GameplayThreadView.swift
+++ b/Features/GameplayStages/GameplayThreadView.swift
@@ -207,24 +207,28 @@ struct GameplayThreadView: View {
                         .foregroundStyle(MatherTheme.ink)
                 }
                 Spacer()
-                Text("Stage \(min(navigation.activeStageIndex + 1, max(thread.stages.count, 1)))/\(thread.stages.count)")
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(MatherTheme.ink)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(Capsule().fill(MatherTheme.card))
+                if !compact {
+                    Text("Stage \(min(navigation.activeStageIndex + 1, max(thread.stages.count, 1)))/\(thread.stages.count)")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(MatherTheme.ink)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(Capsule().fill(MatherTheme.card))
+                }
             }
-            HStack(spacing: 10) {
-                ProgressView(value: navigation.progressFraction(for: thread))
-                    .tint(MatherTheme.accent)
-                    .frame(maxWidth: .infinity)
-                    .accessibilityLabel("Gameplay thread progress")
-                    .accessibilityValue("Stage \(min(navigation.activeStageIndex + 1, max(thread.stages.count, 1))) of \(thread.stages.count)")
-                Text("\(Int((navigation.progressFraction(for: thread) * 100).rounded()))%")
-                    .font(.caption.weight(.black))
-                    .foregroundStyle(MatherTheme.cardSubtitle)
-                    .monospacedDigit()
-                    .accessibilityHidden(true)
+            if !compact {
+                HStack(spacing: 10) {
+                    ProgressView(value: navigation.progressFraction(for: thread))
+                        .tint(MatherTheme.accent)
+                        .frame(maxWidth: .infinity)
+                        .accessibilityLabel("Gameplay thread progress")
+                        .accessibilityValue("Stage \(min(navigation.activeStageIndex + 1, max(thread.stages.count, 1))) of \(thread.stages.count)")
+                    Text("\(Int((navigation.progressFraction(for: thread) * 100).rounded()))%")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .monospacedDigit()
+                        .accessibilityHidden(true)
+                }
             }
         }
     }
@@ -235,8 +239,10 @@ struct GameplayThreadView: View {
                 .buttonStyle(GameplayStageControlButtonStyle(kind: .secondary, compact: compact))
                 .accessibilityLabel("Retry current stage")
                 .accessibilityIdentifier("GameplayStageRetryButton")
-            Spacer(minLength: 0)
-            scoreText
+            if !compact {
+                Spacer(minLength: 0)
+                scoreText
+            }
         }
     }
 

--- a/Features/GameplayStages/MultipleChoiceStageView.swift
+++ b/Features/GameplayStages/MultipleChoiceStageView.swift
@@ -6,6 +6,7 @@ struct MultipleChoiceStageView: View {
     let compact: Bool
     let onComplete: (Int, Int, Int) -> Void
     @State private var viewModel: GameplayMultipleChoiceStageViewModel
+    @State private var celebratingChoiceID: String?
 
     init(thread: GameplayThreadDefinition, stage: GameplayStageDefinition, round: GameplayRoundDefinition, actions: GameplayStageFeedbackActions, compact: Bool, onComplete: @escaping (Int, Int, Int) -> Void) {
         self.stage = stage
@@ -17,7 +18,7 @@ struct MultipleChoiceStageView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: compact ? 12 : 18) {
-            GameplayStageTitle(stage: stage, detail: viewModel.progressText)
+            GameplayStageTitle(stage: stage, detail: viewModel.progressText, compact: compact)
             if let question = viewModel.activeQuestion {
                 Text(question.prompt)
                     .font(compact ? .title3.bold() : .title.bold())
@@ -26,15 +27,27 @@ struct MultipleChoiceStageView: View {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: compact ? 142 : 190), spacing: 12)], spacing: 12) {
                     ForEach(question.choices) { choice in
                         Button {
-                            let correct = viewModel.choose(choice)
-                            if correct { actions.success() } else { actions.failure() }
-                            if viewModel.isComplete { onComplete(viewModel.correctCount, viewModel.mistakeCount, 0) }
+                            handleChoice(choice)
                         } label: {
-                            GameplayDisplayCard(item: choice, compact: compact, showsSubtitle: true)
+                            GameplayDisplayCard(
+                                item: choice,
+                                compact: compact,
+                                showsSubtitle: !compact,
+                                selected: viewModel.selectedChoiceID == choice.id,
+                                correct: celebratingChoiceID == choice.id
+                            )
                         }
                         .buttonStyle(.plain)
+                        .disabled(viewModel.selectedChoiceIsCorrect)
                         .accessibilityLabel("Choice: \(choice.title), \(choice.subtitle)")
                     }
+                }
+                if let selectedChoiceID = viewModel.selectedChoiceID,
+                   let selected = question.choices.first(where: { $0.id == selectedChoiceID }) {
+                    Text(question.isCorrect(selected) ? "Nice — next question coming up!" : "Try again — choose a different card.")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(question.isCorrect(selected) ? MatherTheme.accent : MatherTheme.coral)
+                        .accessibilityIdentifier("MultipleChoiceStageFeedback")
                 }
             } else {
                 Text("Quiz complete")
@@ -44,5 +57,22 @@ struct MultipleChoiceStageView: View {
         }
         .padding(compact ? 14 : 20)
         .background(GameplayStagePanel())
+    }
+
+    private func handleChoice(_ choice: GameplayDisplayItem) {
+        let correct = viewModel.choose(choice)
+        if correct {
+            actions.success()
+            celebratingChoiceID = choice.id
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 550_000_000)
+                guard celebratingChoiceID == choice.id else { return }
+                viewModel.advanceAfterCorrectAnswer()
+                celebratingChoiceID = nil
+                if viewModel.isComplete { onComplete(viewModel.correctCount, viewModel.mistakeCount, 0) }
+            }
+        } else {
+            actions.failure()
+        }
     }
 }

--- a/Features/LearningLoop/LearningLoopViews.swift
+++ b/Features/LearningLoop/LearningLoopViews.swift
@@ -147,52 +147,138 @@ struct SoundConceptFlashcardCarouselView: View {
 struct ConceptQuizRoundView: View {
     let questions: [ConceptQuizQuestion]
     @Binding var answersByQuestionId: [String: String]
+    @State private var activeIndex = 0
+    @State private var selectedChoice: String?
+    @State private var celebratingQuestionId: String?
+
+    private var safeIndex: Int {
+        guard !questions.isEmpty else { return 0 }
+        return min(max(activeIndex, 0), questions.count - 1)
+    }
+
+    private var activeQuestion: ConceptQuizQuestion? {
+        guard questions.indices.contains(safeIndex) else { return nil }
+        return questions[safeIndex]
+    }
+
+    private var progressText: String {
+        guard !questions.isEmpty else { return "0 of 0" }
+        return "Question \(safeIndex + 1) of \(questions.count)"
+    }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text("Quiz")
-                .font(.title2.weight(.black))
-                .foregroundStyle(MatherTheme.ink)
-            ForEach(questions) { question in
-                VStack(alignment: .leading, spacing: 10) {
-                    Text(question.prompt)
-                        .font(.headline.weight(.black))
-                        .foregroundStyle(MatherTheme.ink)
-                    HStack(spacing: 8) {
-                        ForEach(question.choices, id: \.self) { choice in
-                            Button {
-                                answersByQuestionId[question.id] = choice
-                            } label: {
-                                Text(choice)
-                                    .font(.subheadline.weight(.bold))
-                                    .lineLimit(1)
-                                    .minimumScaleFactor(0.7)
-                                    .padding(.vertical, 10)
-                                    .padding(.horizontal, 12)
-                                    .frame(maxWidth: .infinity)
-                                    .background(choiceFill(for: choice, in: question))
-                                    .foregroundStyle(MatherTheme.ink)
-                                    .clipShape(Capsule())
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("\(choice) answer")
-                        }
+        CardSurface {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top, spacing: 10) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Quiz")
+                            .font(.title2.weight(.black))
+                            .foregroundStyle(MatherTheme.ink)
+                        Text(progressText)
+                            .font(.caption.weight(.black).monospacedDigit())
+                            .foregroundStyle(MatherTheme.accent)
                     }
-                    if let selected = answersByQuestionId[question.id] {
-                        Text(question.isCorrect(selected) ? question.feedback : "Try again — look back at the learn cards.")
-                            .font(.caption.weight(.bold))
-                            .foregroundStyle(question.isCorrect(selected) ? .green : MatherTheme.coral)
+                    Spacer()
+                    if isComplete {
+                        Label("Done", systemImage: "checkmark.seal.fill")
+                            .font(.caption.weight(.black))
+                            .foregroundStyle(MatherTheme.accent)
                     }
                 }
-                .padding(14)
-                .background(MatherTheme.card)
-                .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+
+                if let question = activeQuestion, !isComplete {
+                    activeQuestionCard(question)
+                } else {
+                    Text("Quiz complete — great listening detective work!")
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                        .padding(14)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(MatherTheme.softBlue.opacity(0.28))
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                }
+            }
+        }
+        .sensoryFeedback(.success, trigger: celebratingQuestionId)
+        .onChange(of: questions.count) { _, _ in
+            activeIndex = min(activeIndex, max(questions.count - 1, 0))
+            selectedChoice = nil
+            celebratingQuestionId = nil
+        }
+    }
+
+    private var isComplete: Bool {
+        !questions.isEmpty && activeIndex >= questions.count
+    }
+
+    private func activeQuestionCard(_ question: ConceptQuizQuestion) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(question.prompt)
+                .font(.headline.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+                .accessibilityAddTraits(.isHeader)
+            VStack(spacing: 8) {
+                ForEach(question.choices, id: \.self) { choice in
+                    Button {
+                        choose(choice, for: question)
+                    } label: {
+                        HStack(spacing: 8) {
+                            Text(choice)
+                                .font(.subheadline.weight(.bold))
+                                .lineLimit(2)
+                                .minimumScaleFactor(0.76)
+                            Spacer(minLength: 0)
+                            if selectedChoice == choice {
+                                Image(systemName: question.isCorrect(choice) ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                    .font(.headline.weight(.black))
+                            }
+                        }
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 14)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(choiceFill(for: choice, in: question))
+                        .foregroundStyle(MatherTheme.ink)
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .scaleEffect(celebratingQuestionId == question.id && selectedChoice == choice ? 1.04 : 1.0)
+                        .animation(.spring(response: 0.24, dampingFraction: 0.62), value: celebratingQuestionId)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(celebratingQuestionId == question.id)
+                    .accessibilityLabel("\(choice) answer")
+                }
+            }
+            if let selectedChoice {
+                Text(question.isCorrect(selectedChoice) ? question.feedback : "Try again — this question stays here until you find the safe answer.")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(question.isCorrect(selectedChoice) ? .green : MatherTheme.coral)
+                    .accessibilityIdentifier("SoundVolumeQuizFeedback")
+            }
+        }
+        .padding(14)
+        .background(MatherTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+
+    private func choose(_ choice: String, for question: ConceptQuizQuestion) {
+        guard celebratingQuestionId == nil else { return }
+        selectedChoice = choice
+        answersByQuestionId[question.id] = choice
+        if question.isCorrect(choice) {
+            withAnimation(.spring(response: 0.24, dampingFraction: 0.62)) {
+                celebratingQuestionId = question.id
+            }
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 650_000_000)
+                guard celebratingQuestionId == question.id else { return }
+                activeIndex = min(activeIndex + 1, questions.count)
+                selectedChoice = nil
+                celebratingQuestionId = nil
             }
         }
     }
 
     private func choiceFill(for choice: String, in question: ConceptQuizQuestion) -> Color {
-        guard let selected = answersByQuestionId[question.id], selected == choice else {
+        guard selectedChoice == choice else {
             return MatherTheme.softBlue.opacity(0.45)
         }
         return question.isCorrect(choice) ? .green.opacity(0.28) : MatherTheme.coral.opacity(0.28)
@@ -758,6 +844,16 @@ struct SoundVolumeLabView: View {
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(PrimaryActionButtonStyle())
+            .disabled(!canAdvanceCurrentActivity)
+        }
+    }
+
+    private var canAdvanceCurrentActivity: Bool {
+        switch activityStage {
+        case .quiz:
+            return SoundVolumeContent.quizQuestions.allSatisfy { answersByQuestionId[$0.id] == $0.correctChoice }
+        default:
+            return true
         }
     }
 

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -93,7 +93,30 @@ struct GameplayStageViewModelTests {
         let quizResult = viewModel.choose(firstQuestion.answer)
         #expect(quizResult)
         #expect(viewModel.correctCount == 1)
+        #expect(viewModel.progressText == "1 of 4")
+        viewModel.advanceAfterCorrectAnswer()
         #expect(viewModel.progressText == "2 of 4")
+    }
+
+
+    @Test
+    func multipleChoiceWrongAnswerStaysOnSameQuestionUntilCorrectAdvance() {
+        let thread = GameplaySampleThreads.countries
+        let stage = thread.stages.first { $0.kind == .multipleChoice }!
+        let round = SpacedRepetitionScheduler.makeRound(thread: thread, stage: stage, seed: 8)
+        var viewModel = GameplayMultipleChoiceStageViewModel(thread: thread, round: round)
+        let firstQuestion = viewModel.activeQuestion!
+        let wrongChoice = firstQuestion.choices.first { !firstQuestion.isCorrect($0) }!
+
+        #expect(!viewModel.choose(wrongChoice))
+        #expect(viewModel.mistakeCount == 1)
+        #expect(viewModel.activeQuestion?.id == firstQuestion.id)
+        #expect(viewModel.progressText == "1 of 4")
+
+        #expect(viewModel.choose(firstQuestion.answer))
+        #expect(viewModel.activeQuestion?.id == firstQuestion.id)
+        viewModel.advanceAfterCorrectAnswer()
+        #expect(viewModel.activeQuestion?.id != firstQuestion.id)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Show Sound Lab quiz as one active question card at a time, with wrong-answer feedback that keeps the learner on the same question.
- Celebrate correct Sound Lab and gameplay quiz answers before advancing exactly one question.
- Reduce compact gameplay chrome/metrics and shorten Easy Memory prompts so child-facing controls have more room.

Closes #1070
Closes #1072
Closes #1073
Closes #1075

## Tests
- `git diff --check`
- `swift test` could not run in this Linux environment: `swift: command not found` (requires Swift/Xcode toolchain)
