### PR TITLE
Harden Bond Blast mismatch reset lifecycle

### DIFF
--- a/Features/GameplayStages/BondBlastStageView.swift
+++ b/Features/GameplayStages/BondBlastStageView.swift
@@ -42,6 +42,8 @@ struct ReusableBondBlastBoard: View {
     let onComplete: (Int, Int, Int) -> Void
 
     @State private var mismatchedRightID: String?
+    @State private var mismatchResetTask: Task<Void, Never>?
+    @State private var mismatchResetRevision = 0
     @State private var autoProgressTask: Task<Void, Never>?
     @State private var autoProgressSignature: String?
 
@@ -111,7 +113,10 @@ struct ReusableBondBlastBoard: View {
         .padding(compact ? 14 : 20)
         .background(GameplayStagePanel())
         .accessibilityLabel("\(title). \(viewModel.correctCount) of \(viewModel.pairs.count) bonds matched.")
-        .onDisappear { cancelAutoProgress() }
+        .onDisappear {
+            cancelAutoProgress()
+            cancelMismatchReset()
+        }
     }
 
 
@@ -260,11 +265,28 @@ struct ReusableBondBlastBoard: View {
     }
 
     private func triggerMismatch(for itemID: String) {
+        mismatchResetTask?.cancel()
+        mismatchResetRevision &+= 1
+        let revision = mismatchResetRevision
         mismatchedRightID = itemID
-        Task { @MainActor in
+        mismatchResetTask = Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(450))
+            guard !Task.isCancelled,
+                  Self.shouldAcceptDelayedMismatchReset(scheduledRevision: revision, currentRevision: mismatchResetRevision) else { return }
             mismatchedRightID = nil
+            mismatchResetTask = nil
         }
+    }
+
+    private func cancelMismatchReset() {
+        mismatchResetRevision &+= 1
+        mismatchResetTask?.cancel()
+        mismatchResetTask = nil
+        mismatchedRightID = nil
+    }
+
+    nonisolated static func shouldAcceptDelayedMismatchReset(scheduledRevision: Int, currentRevision: Int) -> Bool {
+        scheduledRevision == currentRevision
     }
 
     nonisolated static func shouldRevealRightCard(selectedPairID: String?, pairID: String, isMatched: Bool) -> Bool {

--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -48,6 +48,9 @@ struct BondMatchView: View {
     @State private var shuffledRightValues: [Int] = []
     /// Right-value that is currently wobbling after a mismatch.
     @State private var mismatchedRightValue: Int? = nil
+    /// Cancels stale mismatch animation resets when Bond Blast exits or restarts.
+    @State private var mismatchResetTask: Task<Void, Never>? = nil
+    @State private var mismatchResetRevision = 0
 
     enum DragReleaseResolution: Equatable {
         case cancel
@@ -112,6 +115,7 @@ struct BondMatchView: View {
         }
         .sensoryFeedback(.success, trigger: state.matchCount)
         .accessibilityLabel("\(vocabulary.accessibilityLabel) \(state.matchCount) of \(state.pairs.count) matched.")
+        .onDisappear { cancelMismatchReset() }
     }
 
     // MARK: - Subviews
@@ -421,10 +425,27 @@ struct BondMatchView: View {
     }
 
     private func triggerMismatch(for value: Int) {
+        mismatchResetTask?.cancel()
+        mismatchResetRevision &+= 1
+        let revision = mismatchResetRevision
         mismatchedRightValue = value
-        Task { @MainActor in
+        mismatchResetTask = Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(450))
+            guard !Task.isCancelled,
+                  Self.shouldAcceptDelayedMismatchReset(scheduledRevision: revision, currentRevision: mismatchResetRevision) else { return }
             mismatchedRightValue = nil
+            mismatchResetTask = nil
         }
+    }
+
+    private func cancelMismatchReset() {
+        mismatchResetRevision &+= 1
+        mismatchResetTask?.cancel()
+        mismatchResetTask = nil
+        mismatchedRightValue = nil
+    }
+
+    nonisolated static func shouldAcceptDelayedMismatchReset(scheduledRevision: Int, currentRevision: Int) -> Bool {
+        scheduledRevision == currentRevision
     }
 }

--- a/Tests/MatherTests/BondMatchViewTests.swift
+++ b/Tests/MatherTests/BondMatchViewTests.swift
@@ -69,4 +69,9 @@ struct BondMatchViewTests {
         #expect(pairs.allSatisfy { $0.left <= $0.right })
         #expect(pairs.allSatisfy { $0.left + $0.right == 1000 })
     }
+
+    @Test func delayedMismatchResetRejectsStaleBondBlastRevisions() {
+        #expect(BondMatchView.shouldAcceptDelayedMismatchReset(scheduledRevision: 4, currentRevision: 4))
+        #expect(!BondMatchView.shouldAcceptDelayedMismatchReset(scheduledRevision: 4, currentRevision: 5))
+    }
 }

--- a/Tests/MatherTests/GameplayStageViewModelTests.swift
+++ b/Tests/MatherTests/GameplayStageViewModelTests.swift
@@ -308,6 +308,12 @@ struct GameplayStageParityRegressionTests {
     }
 
     @Test
+    func reusableBondBlastDelayedMismatchResetRejectsStaleRevisions() {
+        #expect(ReusableBondBlastBoard.shouldAcceptDelayedMismatchReset(scheduledRevision: 8, currentRevision: 8))
+        #expect(!ReusableBondBlastBoard.shouldAcceptDelayedMismatchReset(scheduledRevision: 8, currentRevision: 9))
+    }
+
+    @Test
     func waterBondBlastAcceptsArbitraryGameplayMatchPairDataInFocusedTurns() {
         let thread = GameplayThreadCatalog.waterCycle
         let stage = thread.stages.first { $0.kind == .bondBlast }!


### PR DESCRIPTION
## Summary
- harden Bond Blast delayed mismatch reset tasks with cancellable task handles and revision guards
- cancel pending mismatch resets when Bond Blast boards disappear
- add regression coverage for stale mismatch reset rejection in both reusable and VS1 Bond Blast paths

Fixes #1086.
Refs #1087; the Targets report appears related to the already-merged #1083/#1084 lifecycle fix in v2.6.51, so this PR focuses on the remaining Bond Blast delayed-callback crash class.

## Validation
- `git diff --check`
- Remote XcodeGen project generation on `ganesh-mba` with temporary XcodeGen 2.45.4 under `/tmp` succeeded
- Attempted focused remote Xcode validation on `ganesh-mba`: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "id=3A1BD382-28BD-4285-83B4-B6913DF496C4" -only-testing:MatherTests/BondMatchViewTests -only-testing:MatherTests/GameplayStageParityRegressionTests/reusableBondBlastDelayedMismatchResetRejectsStaleRevisions CODE_SIGNING_ALLOWED=NO` — blocked by local CoreSimulator/Xcode runtime mismatch (`CoreSimulator 1051.50.0` older than Xcode 26.5 expected `1051.54.0`)
- Attempted `build-for-testing` with `generic/platform=iOS Simulator` — blocked by the same local simulator runtime mismatch during asset-catalog compilation
- PR CI is the authoritative Xcode gate for this branch

## Privacy
- Uses only privacy-safe TestFlight metadata from GitHub issues; no raw ASC diagnostics, tester identity, exact device identifiers, or raw crash logs copied.
