### PR TITLE
Fix build 104 Bond Blast crash cluster

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -467,14 +467,14 @@ final class VerticalSliceEngine {
 
     /// Called by BondMatchView when the child begins dragging or taps a left card.
     func bondDragStarted(pairId: UUID) {
-        guard isBondBlastStage else { return }
+        guard isBondBlastStage, !showCelebration else { return }
         hapticsService.cardPickup(enabled: featureFlags.hapticsEnabled)
         logBondMatchTelemetry("pair_drag_started", extra: ["pair_id": pairId.uuidString])
     }
 
     /// Called by BondMatchView when a dragged card is hovering near a snap target.
     func bondNearTarget() {
-        guard isBondBlastStage else { return }
+        guard isBondBlastStage, !showCelebration else { return }
         hapticsService.cardNearSnap(enabled: featureFlags.hapticsEnabled)
     }
 
@@ -482,9 +482,11 @@ final class VerticalSliceEngine {
     /// Advances to `.done` when all pairs are matched.
     func matchPair(id: UUID) {
         guard isBondBlastStage,
+              !showCelebration,
               let problem = currentProblem,
               var state = bondMatchState,
-              let idx = state.pairs.firstIndex(where: { $0.id == id }) else { return }
+              let idx = state.pairs.firstIndex(where: { $0.id == id }),
+              !state.pairs[idx].isMatched else { return }
 
         state.pairs[idx].isMatched = true
         let pair = state.pairs[idx]
@@ -505,7 +507,7 @@ final class VerticalSliceEngine {
 
     /// Called when the child drops a card on the wrong target.
     func mismatchPair() {
-        guard isBondBlastStage, let problem = currentProblem else { return }
+        guard isBondBlastStage, !showCelebration, let problem = currentProblem else { return }
         logBondMatchTelemetry("pair_mismatch", extra: [:])
         hapticsService.cardSnapMismatch(enabled: featureFlags.hapticsEnabled)
         let msg = "Try again! Find two numbers that make \(problem.target)."

--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -100,7 +100,10 @@ struct BondMatchView: View {
         .frame(maxWidth: 760)
         .frame(maxWidth: .infinity, alignment: .center)
         .onAppear {
-            setupShuffledOrder()
+            reconcileShuffledOrder()
+        }
+        .onChange(of: state.pairs.map(\.right)) { _, _ in
+            reconcileShuffledOrder()
         }
         .onChange(of: shakeDetected) { _, shook in
             guard shook else { return }
@@ -411,17 +414,35 @@ struct BondMatchView: View {
 
     // MARK: - Private helpers
 
-    private func setupShuffledOrder() {
-        shuffledRightValues = state.pairs.map(\.right).shuffled()
+    private func reconcileShuffledOrder() {
+        let rightValues = state.pairs.map(\.right)
+        guard Self.rightOrderNeedsReset(existingRightValues: shuffledRightValues, pairRightValues: rightValues) else { return }
+        shuffledRightValues = rightValues.shuffled()
+    }
+
+    nonisolated static func rightOrderNeedsReset(existingRightValues: [Int], pairRightValues: [Int]) -> Bool {
+        existingRightValues.count != pairRightValues.count || Set(existingRightValues) != Set(pairRightValues)
+    }
+
+    nonisolated static func shuffledUnmatchedRightValues(
+        existingRightValues: [Int],
+        matchedRightValues: Set<Int>,
+        shuffle: ([Int]) -> [Int] = { $0.shuffled() }
+    ) -> [Int] {
+        var unmatched = shuffle(existingRightValues.filter { !matchedRightValues.contains($0) })
+        return existingRightValues.map { value in
+            guard !matchedRightValues.contains(value) else { return value }
+            return unmatched.isEmpty ? value : unmatched.removeFirst()
+        }
     }
 
     /// Re-shuffle only the unmatched right values in place.
     private func shuffleUnmatchedRight() {
-        let matched   = Set(state.pairs.filter(\.isMatched).map(\.right))
-        var unmatched = shuffledRightValues.filter { !matched.contains($0) }.shuffled()
-        shuffledRightValues = shuffledRightValues.map { val in
-            matched.contains(val) ? val : unmatched.removeFirst()
-        }
+        let matched = Set(state.pairs.filter(\.isMatched).map(\.right))
+        shuffledRightValues = Self.shuffledUnmatchedRightValues(
+            existingRightValues: shuffledRightValues,
+            matchedRightValues: matched
+        )
     }
 
     private func triggerMismatch(for value: Int) {

--- a/Tests/MatherTests/BondMatchViewTests.swift
+++ b/Tests/MatherTests/BondMatchViewTests.swift
@@ -74,4 +74,20 @@ struct BondMatchViewTests {
         #expect(BondMatchView.shouldAcceptDelayedMismatchReset(scheduledRevision: 4, currentRevision: 4))
         #expect(!BondMatchView.shouldAcceptDelayedMismatchReset(scheduledRevision: 4, currentRevision: 5))
     }
+
+    @Test func rightOrderResetDetectsNewBondBlastTargetValues() {
+        #expect(!BondMatchView.rightOrderNeedsReset(existingRightValues: [5, 4, 3], pairRightValues: [3, 5, 4]))
+        #expect(BondMatchView.rightOrderNeedsReset(existingRightValues: [5, 4, 3], pairRightValues: [7, 6, 5, 4]))
+    }
+
+    @Test func unmatchedRightShufflePreservesMatchedRowsAndDoesNotDropValues() {
+        let shuffled = BondMatchView.shuffledUnmatchedRightValues(
+            existingRightValues: [5, 4, 3],
+            matchedRightValues: [4],
+            shuffle: { Array($0.reversed()) }
+        )
+
+        #expect(shuffled == [3, 4, 5])
+    }
+
 }

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -528,6 +528,35 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
+    func duplicateBondMatchCompletionIsIgnoredDuringCelebration() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = true
+
+        var completedSummary: SessionSummaryDraft?
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { completedSummary = $0 }
+        )
+
+        engine.startBondBlastFinale(target: 2)
+        guard let pairId = engine.bondMatchState?.pairs.first?.id else {
+            Issue.record("Expected a single Bond Blast pair for target 2")
+            return
+        }
+
+        engine.matchPair(id: pairId)
+        engine.matchPair(id: pairId)
+
+        await waitFor("bond blast finale summary") { engine.route == .sessionSummary }
+        #expect(completedSummary?.problemsCompleted == 1)
+        #expect(engine.currentSession.problems.count == 1)
+    }
+
+    @Test
     func bondMatchCompletesSessionWhenAllPairsMatched() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true


### PR DESCRIPTION
## Summary
- harden Bond Blast against duplicate/re-entrant final pair completion during the celebration transition
- ignore already matched pair IDs and suppress Bond Blast haptics/telemetry while transition is pending
- reconcile shuffled right-column values when the active Bond Blast pair set changes
- add regression coverage for duplicate final-pair completion and right-column shuffle helpers

## TestFlight issue notes
- Fixes #1087 (Targets crash feedback, build 104). This branch is based on `main` after #1084 / `v2.6.51`, which already contains the Targets delayed-callback hardening for this build-104 crash class, and after #1088, which closed #1086 with Bond Blast mismatch-reset hardening.
- Refs #1086 as part of the same build-104 crash cluster; #1086 is already closed by #1088.

## Validation
- `git diff --check`
- Attempted remote Xcode validation on `ganesh-mba`, but local Xcode/Simulator platform is currently blocked before a reliable simulator test run by device-support mismatch: `CoreSimulator is out of date. Current version (1051.50.0) is older than build version (1051.54.0)` / iOS 26.5 platform not installed. PR CI is the authoritative Xcode gate.

## Privacy
- No raw App Store Connect crash diagnostics, tester identity fields, exact device identifiers, or signed feedback URLs copied into this PR.
