### PR TITLE
Harden Bond Blast stage completion

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -62,6 +62,9 @@ final class VerticalSliceEngine {
     var showCelebration = false
     var completedSummary: SessionSummaryDraft?
 
+    private var pendingStageAdvanceTask: Task<Void, Never>?
+    private var pendingStageAdvanceToken: UUID?
+
     private let telemetryWriter: TelemetryWriter
     private let featureFlags: FeatureFlagService
     private let speechService: SpeechService
@@ -124,6 +127,7 @@ final class VerticalSliceEngine {
     var sumSprintStageCardCount: Int { sumSprintBurstState?.totalPairs ?? 0 }
 
     func show(_ route: AppRoute) {
+        cancelPendingStageAdvance()
         gameplayReturnRoute = nil
         self.route = route
     }
@@ -168,6 +172,7 @@ final class VerticalSliceEngine {
     }
 
     func startSession() {
+        cancelPendingStageAdvance()
         // Freeze the active theme from the user's current selection — unless a custom
         // theme was injected at init time (e.g. in unit tests using an arbitrary theme).
         if !hasInjectedTheme {
@@ -483,6 +488,7 @@ final class VerticalSliceEngine {
     func matchPair(id: UUID) {
         guard isBondBlastStage,
               !showCelebration,
+              pendingStageAdvanceTask == nil,
               let problem = currentProblem,
               var state = bondMatchState,
               let idx = state.pairs.firstIndex(where: { $0.id == id }),
@@ -571,11 +577,14 @@ final class VerticalSliceEngine {
     }
 
     private func completeStage(successMessage: String) {
+        guard pendingStageAdvanceTask == nil else { return }
+
+        let completedStage = currentStage
         feedbackMessage = successMessage
         speechService.speak(successMessage, enabled: featureFlags.audioEnabled)
 
-        let next = resolvedNextStage(after: currentStage)
-        recordStageTransition(from: currentStage, to: next)
+        let next = resolvedNextStage(after: completedStage)
+        recordStageTransition(from: completedStage, to: next)
 
         // A problem is complete when the next stage is .done (the last meaningful
         // stage has been cleared). This handles all paths: with/without transfer,
@@ -583,7 +592,7 @@ final class VerticalSliceEngine {
         let isProblemComplete = next == .done
         if isProblemComplete {
             recordProblemCompletion(transferCorrect: true)
-            if currentStage == .bondMatch {
+            if completedStage == .bondMatch {
                 hapticsService.bondMatchComplete(enabled: featureFlags.hapticsEnabled)
             } else {
                 hapticsService.success(enabled: featureFlags.hapticsEnabled)
@@ -596,8 +605,17 @@ final class VerticalSliceEngine {
         // is deferred into the Task so the overlay has time to render and animate.
         // celebrationDuration is injected — unit tests pass 0 to skip the wait.
         showCelebration = true
-        Task { @MainActor in
+        let transitionToken = UUID()
+        pendingStageAdvanceToken = transitionToken
+        pendingStageAdvanceTask = Task { @MainActor in
+            defer {
+                if pendingStageAdvanceToken == transitionToken {
+                    pendingStageAdvanceToken = nil
+                    pendingStageAdvanceTask = nil
+                }
+            }
             try? await Task.sleep(for: .seconds(celebrationDuration))
+            guard !Task.isCancelled, pendingStageAdvanceToken == transitionToken, currentStage == completedStage else { return }
             showCelebration = false
             currentStage = next
             currentProblemState.stage = next
@@ -607,6 +625,13 @@ final class VerticalSliceEngine {
                 prepareForStage(next)
             }
         }
+    }
+
+    private func cancelPendingStageAdvance() {
+        pendingStageAdvanceTask?.cancel()
+        pendingStageAdvanceTask = nil
+        pendingStageAdvanceToken = nil
+        showCelebration = false
     }
 
     private func prepareForStage(_ stage: SliceStage) {
@@ -694,6 +719,7 @@ final class VerticalSliceEngine {
             equationRightInput = ""
             transferLeftCount = 0
             transferRightCount = 0
+            bondMatchState = nil
             gravitySplitState = nil
             gravitySplitNeutralRoll = nil
             sumSprintBurstState = nil

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -783,6 +783,63 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
+    func bondBlastDuplicateFinalMatchOnlyCompletesProblemOnce() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = true
+
+        var completedSummary: SessionSummaryDraft?
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { completedSummary = $0 }
+        )
+        engine.startBondBlastFinale(target: 10)
+
+        let pairIds = try #require(engine.bondMatchState?.pairs.map(\.id))
+        let finalPairId = try #require(pairIds.last)
+        for id in pairIds.dropLast() {
+            engine.matchPair(id: id)
+        }
+
+        engine.matchPair(id: finalPairId)
+        engine.matchPair(id: finalPairId)
+
+        await waitFor("bond blast duplicate final match completion") { engine.route == .sessionSummary }
+        #expect(engine.currentSession.problems.count == 1)
+        #expect(completedSummary?.problemsCompleted == 1)
+    }
+
+    @Test
+    func bondBlastPendingCompletionDoesNotAdvanceAfterLeavingSession() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.makeBreakLoopV2Enabled = true
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0.05,
+            saveSummary: { _ in }
+        )
+        engine.startBondBlastFinale(target: 10)
+
+        for id in engine.bondMatchState?.pairs.map(\.id) ?? [] {
+            engine.matchPair(id: id)
+        }
+        #expect(engine.showCelebration)
+
+        engine.showHome()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(engine.route == .home)
+        #expect(engine.currentSession.problems.count == 1)
+    }
+
+    @Test
     func bondMatchNotFiredOnIntermediateProblems() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true


### PR DESCRIPTION
## Summary
- add a cancellable/revisioned pending stage-advance task so stale Bond Blast completion callbacks cannot advance after leaving or restarting a session
- make stage completion idempotent while a celebration transition is pending
- clear stale Bond Blast state when advancing to the next problem
- add regression coverage for duplicate final-match completion and leaving during a pending Bond Blast completion

## Issue notes
- Follow-up hardening for the Build 104 crash cluster.
- Refs #1086, already closed by #1088, and #1087, closed by #1089 / #1090 coverage.

## Validation
- Previous branch CI passed before rebase.
- Rebased onto `main` after #1089; PR CI is rerunning as the authoritative gate.
- Local `ganesh-mba` Xcode validation remains blocked by local CoreSimulator/iOS 26.5 platform mismatch.

## Privacy
- Uses only privacy-safe GitHub issue metadata; no raw ASC diagnostics, tester identifiers, exact devices, or signed feedback URLs copied.
