### PR TITLE
Add GitHub Pages app and privacy pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Mather is an Apple-platform learning playground for kids ages **2–12**.
 
-The product is moving from a flat set of math mini-games into a **capability-based Explorer Lab**: kids choose what they want to grow — numbers, geometry, physics, maps/world knowledge, and future chemistry/electronics — then choose how they want to play: learn, explore, review, challenge, or timed.
+- **App information:** https://ganesh47.github.io/mather/
+- **Privacy:** https://ganesh47.github.io/mather/privacy.html
+
+The product is moving from a flat set of math mini-games into a **capability-based Explorer Lab**: kids choose what they want to grow — numbers, geometry, physics, geography/world knowledge, and future chemistry/electronics — then choose how they want to play: learn, explore, review, challenge, or timed.
 
 The core design principle is simple: **make real concepts feel like play**. Mather uses touch, motion, audio, haptics, room movement, cards, and device sensors to turn abstract learning into concrete experiences.
 
@@ -46,15 +49,18 @@ See the current umbrella tracker: [Spec: Reorganize Explorer Lab into capability
 
 Current Explorer Lab/gameplay work includes:
 
+- **Explorer Lab shell** — capability-lane navigation for Numbers, Geometry, Physics, Geography/World, and future science lanes
+
 - **Make & Break** — concept-first number composition and staged learning
 - **Bond Blast** — fast pairing mechanic loved by kids; should be generalized
 - **Sum Sprint** — spaced-repetition fluency and recall
-- **Room Quest** — embodied room-scale play with marker/sensor-aware direction
+- **Room Quest** — embodied room-scale play with marker/sensor-aware direction and optional camera/location-assisted place matching
 - **Symmetry Fold** — geometry through fold/tilt interaction
 - **Rectangle Factory** — arrays, factors, and early number theory
 - **Angle Cannon / Gravity Artist** — physics prediction and motion intuition
 - **Two-Finger Protractor / Compass Walk** — embodied angles, direction, and measurement
 - **Memory / Mix-Match** — moving from standalone play into embedded recall cards
+- **Sound / sensor experiments** — optional motion, sound, haptics, and device-capability-aware fallbacks
 - **Reusable five-stage gameplay threads** — countries, fruits, and water cycle now share the same Flashcards → Easy Memory → Flip Memory → Bond Blast → Multiple Choice flow, with direct Explorer Lab entries, score/time summaries, and persisted spaced-repetition progress
 
 Useful specs and research live under `wiki/`, especially:
@@ -100,8 +106,18 @@ xcodebuild test -project Mather.xcodeproj -scheme Mather -destination 'platform=
 
 CI and workflow work should preserve the security posture documented in `.github/workflows/` and active PRs/issues.
 
+## GitHub Pages
+
+The public app information and privacy pages live under `docs/` and are intended to be served by GitHub Pages at:
+
+- https://ganesh47.github.io/mather/
+- https://ganesh47.github.io/mather/privacy.html
+
+Keep these pages in sync whenever privacy-sensitive features change, especially sensors, storage, Smart Play, TestFlight diagnostics, or parent controls.
+
 ## Release readiness notes
 
+- Recent build 104 crash-hardening work tightened delayed callback/lifecycle handling in Bond Blast and Angle Cannon/Targets flows.
 - Issue #912 Slice H polish routes country cards, fruit cards, and water cycle through the reusable gameplay-thread surface.
 - The legacy water-cycle lab route remains intentionally available for explicit legacy/UI-test launches, while Explorer Lab and direct water-cycle launches delegate to `GameplayThreadView`.
 - Release screenshots should cover `-uiTest.startRoute waterCycle`, country cards, and fruit cards on compact phone and iPad layouts once CI/simulator infrastructure is available.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,11 @@
+title: Mather
+description: App information and privacy details for Mather, an iPhone and iPad learning playground for children.
+url: "https://ganesh47.github.io"
+baseurl: "/mather"
+
+markdown: kramdown
+plugins: []
+
+exclude:
+  - Gemfile
+  - Gemfile.lock

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% if page.title %}{{ page.title }} · {% endif %}Mather</title>
+  <meta name="description" content="Mather app information and privacy details.">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #fffaf0;
+      --card: #ffffff;
+      --ink: #1d1a16;
+      --muted: #6c6257;
+      --accent: #087f5b;
+      --line: #eadfce;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #151310;
+        --card: #211e19;
+        --ink: #fff7e8;
+        --muted: #cabda9;
+        --accent: #69db9c;
+        --line: #3a3329;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: ui-rounded, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+      background: radial-gradient(circle at top left, color-mix(in srgb, var(--accent) 14%, transparent), transparent 30rem), var(--bg);
+      color: var(--ink);
+    }
+    header, main, footer { width: min(960px, calc(100% - 32px)); margin: 0 auto; }
+    header { padding: 32px 0 16px; display: flex; justify-content: space-between; gap: 16px; align-items: center; }
+    nav a { margin-left: 16px; color: var(--accent); font-weight: 700; text-decoration: none; }
+    main { background: color-mix(in srgb, var(--card) 94%, transparent); border: 1px solid var(--line); border-radius: 28px; padding: clamp(24px, 4vw, 48px); box-shadow: 0 18px 50px rgba(0,0,0,0.08); }
+    h1 { font-size: clamp(2.2rem, 6vw, 4rem); line-height: 1; margin-top: 0; }
+    h2 { margin-top: 2rem; }
+    a { color: var(--accent); }
+    code { background: color-mix(in srgb, var(--line) 70%, transparent); padding: 0.15em 0.35em; border-radius: 0.35em; }
+    footer { color: var(--muted); padding: 24px 0 40px; font-size: 0.95rem; }
+    .brand { font-weight: 900; letter-spacing: -0.03em; color: var(--ink); text-decoration: none; }
+  </style>
+</head>
+<body>
+  <header>
+    <a class="brand" href="{{ '/' | relative_url }}">Mather</a>
+    <nav aria-label="Main navigation">
+      <a href="{{ '/' | relative_url }}">App info</a>
+      <a href="{{ '/privacy.html' | relative_url }}">Privacy</a>
+      <a href="https://github.com/ganesh47/mather">GitHub</a>
+    </nav>
+  </header>
+  <main>
+    {{ content }}
+  </main>
+  <footer>
+    Mather is in active development and TestFlight validation. Privacy details reflect the current repository implementation.
+  </footer>
+</body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,45 @@
+---
+title: Mather
+layout: default
+---
+
+# Mather
+
+**Mather** is an iPhone and iPad learning playground for children ages **2–12**. It turns early math, geometry, physics, geography, and recall practice into short hands-on games that use touch, cards, motion, audio, haptics, and safe sensor-aware play.
+
+Mather is currently in active development and TestFlight validation.
+
+## What children can do
+
+Mather is organized around an **Explorer Lab** model: children choose a learning lane, then play through staged activities that move from concrete action to pictorial models, abstract naming, recall, and transfer.
+
+Current and active gameplay areas include:
+
+- **Numbers Lab** — Make & Break, Bond Blast, Sum Sprint, number stories, equations, and early fact fluency.
+- **Geometry Lab** — Symmetry Fold, Two-Finger Protractor, shape and angle intuition.
+- **Physics Lab** — Angle Cannon, Gravity Artist, motion and prediction activities.
+- **Geography / World Lab** — country cards, animal/bird matching, and map/world recall threads.
+- **Discovery Cards** — reusable flashcard, memory, matching, and multiple-choice flows for spaced review.
+- **Room Quest** — optional room-scale play with camera/location-assisted place matching when enabled.
+
+## Product principles
+
+- **Real concepts should feel like play.** Children learn by touching, dragging, matching, tilting, listening, and moving.
+- **Deterministic gameplay comes first.** Smart hints and generated story prompts are fallback helpers, not the source of truth.
+- **Parents stay in control.** Audio, haptics, motion controls, sound reaction features, and saved child progress are configurable in-app.
+- **Privacy by design.** Learning progress and telemetry are stored on device in the current app implementation; sensitive raw TestFlight/crash feedback is not published in this repository.
+
+## Availability
+
+Mather is not broadly distributed yet. Builds are validated through TestFlight/Xcode Cloud and GitHub CI while the Explorer Lab architecture matures.
+
+Developers can inspect the source code at:
+
+<https://github.com/ganesh47/mather>
+
+## Privacy
+
+Read the current privacy information here:
+
+[Privacy Policy](privacy.html)
+

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,75 @@
+---
+title: Mather Privacy Policy
+layout: default
+---
+
+# Mather Privacy Policy
+
+_Last updated: 2026-05-12_
+
+Mather is a children’s learning app in active development. This page describes the privacy posture of the current codebase and TestFlight-era app behavior.
+
+## Short version
+
+Mather is designed to be **local-first** and **child-safe**:
+
+- The app does **not** sell personal information.
+- The app does **not** show third-party advertising.
+- The app does **not** use cross-app tracking.
+- Learning progress, profiles, session summaries, and gameplay telemetry are stored on the device in the current implementation.
+- Sensor features are used only for gameplay and have fallback paths when unavailable or disabled.
+
+## Information the app may store on device
+
+Mather may save local data so a child can resume play and a parent can review progress:
+
+- child profile nickname/emoji selected in the app;
+- gameplay session summaries;
+- mastery/progress records;
+- spaced-repetition exposure records;
+- local telemetry events such as completed stages, attempts, timing summaries, and feature settings used for a session;
+- Room Quest reference data if a parent sets up room/place-based play.
+
+This data is stored locally on the device using Apple platform storage such as SwiftData/UserDefaults in the current codebase.
+
+## Sensors and permissions
+
+Some activities can use device capabilities to make learning physical and playful:
+
+- **Motion / Fitness** for tilt, shake, direction, and step-style activities.
+- **Microphone** for optional sound-reaction play such as clap detection or a sound meter. Audio is processed locally for simple signal values; raw audio is not stored or transmitted by the current implementation.
+- **Camera** for optional Room Quest scanning/reference photos.
+- **Location** for optional Room Quest place matching when parents enable that setup.
+- **Speech/audio output** for spoken prompts and sound examples.
+- **Haptics** for tactile feedback.
+
+When a sensor is unavailable, disabled, or permission-gated, Mather aims to provide an honest fallback instead of marking the child wrong.
+
+## Network and third parties
+
+The current app code is designed around local gameplay and local persistence. The repository uses GitHub, Xcode Cloud, and App Store Connect/TestFlight for development, CI, release, and tester feedback workflows.
+
+TestFlight and App Store Connect may collect crash reports, diagnostics, and tester feedback under Apple’s terms and privacy practices. Public GitHub issues intentionally avoid raw crash payloads, tester identity/contact details, exact device identifiers, and signed Apple feedback URLs.
+
+## Children’s privacy
+
+Mather is intended for children and is built with a conservative privacy posture:
+
+- no behavioral advertising;
+- no data selling;
+- no social features for children;
+- no public leaderboards;
+- parent-facing controls for saved progress and feature toggles;
+- local-first learning records.
+
+Parents can clear saved summaries and telemetry for the active child profile from in-app settings where supported by the current build.
+
+## Changes
+
+This policy may change as Mather evolves. Material privacy changes should be reflected in this page and in app/release notes before broad distribution.
+
+## Contact
+
+For privacy questions or bug reports, open an issue in the repository:
+
+<https://github.com/ganesh47/mather/issues>


### PR DESCRIPTION
## Summary
- add GitHub Pages-ready app information page under `docs/`
- add privacy policy covering local-first storage, child privacy posture, sensors/permissions, and TestFlight diagnostics handling
- refresh README with current Explorer Lab/gameplay details and links to the public app/privacy pages

## Validation
- `git diff --check`
- verified new docs files are non-empty and front matter/layout files are present

## Notes
- GitHub Pages is not currently enabled for the repository (`/pages` API returned 404 before this branch). After merge, enable Pages from `main` / `docs` so `https://ganesh47.github.io/mather/` serves these pages.