### PR TITLE
Harden SoundDetection audio tap buffer handling

### DIFF
--- a/Services/SoundDetectionService.swift
+++ b/Services/SoundDetectionService.swift
@@ -104,22 +104,11 @@ final class SoundDetectionService {
         engine.prepare()
         meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .installingAudioTap, format: formatSnapshot)
         inputNode.installTap(onBus: 0, bufferSize: 2048, format: format) { [weak self] buffer, _ in
-            guard let channelData = buffer.floatChannelData?[0] else { return }
-            let frameCount = Int(buffer.frameLength)
-            guard frameCount > 0 else { return }
-            var sumOfSquares: Float = 0
-            var finiteSampleCount = 0
-            for i in 0..<frameCount {
-                let sample = channelData[i]
-                guard sample.isFinite else { continue }
-                sumOfSquares += sample * sample
-                finiteSampleCount += 1
-            }
-            let rms = finiteSampleCount > 0 ? (sumOfSquares / Float(finiteSampleCount)).squareRoot() : 0
+            guard let rms = SoundDetectionService.audioTapRMS(from: buffer) else { return }
 
             // The audio tap runs on the audio I/O thread — marshal to @MainActor.
             Task { @MainActor [weak self] in
-                self?.evaluateRMS(rms.isFinite ? rms : 0)
+                self?.evaluateRMS(rms)
             }
         }
 
@@ -182,6 +171,25 @@ final class SoundDetectionService {
 
     func stopSoundLabMeter() {
         stopListening()
+    }
+
+    static func audioTapRMS(from buffer: AVAudioPCMBuffer) -> Float? {
+        let frameCount = min(Int(buffer.frameLength), Int(buffer.frameCapacity))
+        guard frameCount > 0, buffer.format.channelCount > 0 else { return nil }
+        guard let channels = buffer.floatChannelData else { return nil }
+
+        let channelData = channels[0]
+        var sumOfSquares: Float = 0
+        var finiteSampleCount = 0
+        for i in 0..<frameCount {
+            let sample = channelData[i]
+            guard sample.isFinite else { continue }
+            sumOfSquares += sample * sample
+            finiteSampleCount += 1
+        }
+        guard finiteSampleCount > 0 else { return 0 }
+        let rms = (sumOfSquares / Float(finiteSampleCount)).squareRoot()
+        return rms.isFinite ? rms : 0
     }
 
     private func evaluateRMS(_ rms: Float) {

--- a/Tests/MatherTests/SoundDetectionServiceTests.swift
+++ b/Tests/MatherTests/SoundDetectionServiceTests.swift
@@ -79,6 +79,31 @@ struct SoundDetectionServiceTests {
         #expect(diagnostics.failure == nil)
     }
 
+    @Test
+    func audioTapRMSIgnoresEmptyBuffers() {
+        let format = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 44_100, channels: 1, interleaved: false)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 0)!
+        buffer.frameLength = 0
+
+        #expect(SoundDetectionService.audioTapRMS(from: buffer) == nil)
+    }
+
+    @Test
+    func audioTapRMSSanitizesNonFiniteSamples() {
+        let format = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: 44_100, channels: 1, interleaved: false)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4)!
+        buffer.frameLength = 4
+        let samples = buffer.floatChannelData![0]
+        samples[0] = 0.3
+        samples[1] = .nan
+        samples[2] = .infinity
+        samples[3] = 0.4
+
+        let rms = SoundDetectionService.audioTapRMS(from: buffer)
+        #expect(rms != nil)
+        #expect(abs(rms! - 0.35355338) < 0.0001)
+    }
+
     // MARK: - startListening / stopListening idempotency
 
     @Test


### PR DESCRIPTION
## Summary
- Use the refreshed #1097 crash summary to target the app frame now visible in `SoundDetectionService.startListening()`'s audio tap callback.
- Move tap-buffer RMS extraction into a guarded helper so empty buffers, zero-channel buffers, missing float data, and non-finite samples fail closed before touching sample memory.
- Add focused tests for empty and non-finite audio tap buffers.

## Validation
- `git diff --check`
- Attempted local targeted xcodebuild, but this host does not have `xcodebuild` installed (`command not found`). CI must validate the iOS test target.

Fixes #1097
