### PR TITLE
Fix game session save semantics

### DIFF
--- a/App/AppModel.swift
+++ b/App/AppModel.swift
@@ -215,5 +215,14 @@ final class AppModel {
             )
             self?.completePendingLabGameplay(with: summary)
         }
+        roomQuestEngine.onSessionComplete = { [weak gameSessionStore] summary in
+            gameSessionStore?.save(
+                gameName: "Room Quest",
+                startedAt: summary.startedAt,
+                scoreValue: summary.collectedTokenCount,
+                scoreLabel: "tokens collected",
+                detail: summary.abstractCorrect ? "transfer correct" : "transfer retry"
+            )
+        }
     }
 }

--- a/App/RootView.swift
+++ b/App/RootView.swift
@@ -44,18 +44,6 @@ struct RootView: View {
                         )) { _ in
                             RoomQuestScannerSheet(scanner: appModel.roomQuestScanner)
                         }
-                        .onDisappear {
-                            let tokens = appModel.roomQuestEngine.stations
-                                .filter { $0.verificationMethod != nil }
-                                .map(\.quantity).reduce(0, +)
-                            guard tokens > 0 else { return }
-                            appModel.gameSessionStore.save(
-                                gameName: "Room Quest",
-                                startedAt: appModel.roomQuestEngine.sessionStartedAt,
-                                scoreValue: tokens,
-                                scoreLabel: "tokens collected"
-                            )
-                        }
                 case .rectangleFactory:
                     RectangleFactoryView(appModel: appModel)
                 case .factoryCards:

--- a/Domain/RoomQuestEngine.swift
+++ b/Domain/RoomQuestEngine.swift
@@ -14,6 +14,14 @@ enum RoomPhase: Equatable {
     indirect case paused(resumingTo: RoomPhase)     // hard pause — any phase
 }
 
+struct RoomQuestSessionSummary: Equatable {
+    let startedAt: Date
+    let endedAt: Date
+    let target: Int
+    let collectedTokenCount: Int
+    let abstractCorrect: Bool
+}
+
 @MainActor
 @Observable
 final class RoomQuestEngine {
@@ -53,7 +61,10 @@ final class RoomQuestEngine {
     private let scanner: RoomQuestScanner
     private let stationStore: RoomQuestStationStore
     var onExitToHome: (() -> Void)?
+    var onSessionComplete: (@MainActor (RoomQuestSessionSummary) -> Void)?
     private(set) var sessionStartedAt: Date = .now
+    private(set) var collectedTokenCount = 0
+    private var collectedStationRoles: Set<RoomQuestStationRole> = []
 
     private(set) var scanState: RoomQuestScanState = .idle
 
@@ -92,6 +103,8 @@ final class RoomQuestEngine {
         loadSavedReferenceState()
         setupStartedAt = .now
         sessionStartedAt = .now
+        collectedTokenCount = 0
+        collectedStationRoles = []
         route = nil
         routeProgress = nil
         phase = featureFlags.roomQuestSafetyAcknowledged ? .setup : .safetyAck
@@ -428,6 +441,7 @@ final class RoomQuestEngine {
     func markSpotVisited(index: Int) {
         guard let station = stations[safe: index] else { return }
         let quantity = station.quantity
+        collectTokens(for: station.role, quantity: quantity)
         try? telemetryWriter.append(SliceEvent(
             type: .roomQuestSpotVisited,
             payload: [
@@ -598,6 +612,7 @@ final class RoomQuestEngine {
     }
 
     func submitTransfer() {
+        guard phase == .onScreenTransfer else { return }
         guard let p = problem else { return }
         let correct = transferLeftCount == p.decompositionA && transferRightCount == p.decompositionB
         finishSession(abstractCorrect: correct)
@@ -673,16 +688,30 @@ final class RoomQuestEngine {
 
     private func finishSession(abstractCorrect: Bool) {
         guard let p = problem else { return }
+        let endedAt = Date.now
         try? telemetryWriter.append(SliceEvent(
             type: .roomQuestCompleted,
             payload: ["target": String(p.target), "abstract_correct": String(abstractCorrect)]
         ))
         phase = .complete
         feedbackMessage = abstractCorrect ? "Well done! You made \(p.target)." : "Good try!"
+        onSessionComplete?(RoomQuestSessionSummary(
+            startedAt: sessionStartedAt,
+            endedAt: endedAt,
+            target: p.target,
+            collectedTokenCount: collectedTokenCount,
+            abstractCorrect: abstractCorrect
+        ))
         if abstractCorrect {
             hapticsService.success(enabled: featureFlags.hapticsEnabled)
             flashCelebration()
         }
+    }
+
+    private func collectTokens(for role: RoomQuestStationRole, quantity: Int) {
+        guard !collectedStationRoles.contains(role) else { return }
+        collectedStationRoles.insert(role)
+        collectedTokenCount += quantity
     }
 
     private func enterRouteNode(index: Int) {
@@ -739,6 +768,9 @@ final class RoomQuestEngine {
             ))
         }
         if completed != nil {
+            if case .station(let role, let quantity) = node.kind {
+                collectTokens(for: role, quantity: quantity)
+            }
             let completionPayload = RouteQuestTelemetry.payload(
                 route: route,
                 node: node,

--- a/Persistence/GameSessionStore.swift
+++ b/Persistence/GameSessionStore.swift
@@ -20,8 +20,25 @@ final class GameSessionStore {
         scoreLabel: String,
         detail: String? = nil
     ) {
+        let profileId = activeProfileIdProvider()
+        let descriptor = FetchDescriptor<StoredGameSession>(
+            predicate: #Predicate { session in
+                session.profileId == profileId
+                    && session.gameName == gameName
+                    && session.startedAt == startedAt
+            },
+            sortBy: [SortDescriptor(\StoredGameSession.startedAt, order: .reverse)]
+        )
+
+        if let matchingSessions = try? modelContext.fetch(descriptor),
+           !matchingSessions.isEmpty {
+            matchingSessions.dropFirst().forEach { modelContext.delete($0) }
+            try? modelContext.save()
+            return
+        }
+
         let session = StoredGameSession(
-            profileId: activeProfileIdProvider(),
+            profileId: profileId,
             gameName: gameName,
             startedAt: startedAt,
             durationSeconds: Date().timeIntervalSince(startedAt),

--- a/Tests/MatherTests/GameplayProgressStoreTests.swift
+++ b/Tests/MatherTests/GameplayProgressStoreTests.swift
@@ -83,6 +83,31 @@ struct GameplayProgressStoreTests {
     }
 
     @Test
+    func duplicateGameSessionSavesForSameProfileGameAndStartCreateOneRow() throws {
+        let (context, profileId) = try makeGameplayProgressContext()
+        let gameSessionStore = GameSessionStore(modelContext: context, activeProfileIdProvider: { profileId })
+        let started = Date(timeIntervalSince1970: 7_000)
+
+        gameSessionStore.save(
+            gameName: "Room Quest",
+            startedAt: started,
+            scoreValue: 5,
+            scoreLabel: "tokens collected"
+        )
+        gameSessionStore.save(
+            gameName: "Room Quest",
+            startedAt: started,
+            scoreValue: 99,
+            scoreLabel: "inflated duplicate"
+        )
+
+        let gameSessions = gameSessionStore.sessions(forGame: "Room Quest")
+        #expect(gameSessions.count == 1)
+        #expect(gameSessions[0].scoreValue == 5)
+        #expect(gameSessions[0].scoreLabel == "tokens collected")
+    }
+
+    @Test
     func appSchemaIncludesGameplayProgressModels() throws {
         let schema = Schema([
             StoredSessionSummary.self,

--- a/Tests/MatherTests/RoomQuestEngineTests.swift
+++ b/Tests/MatherTests/RoomQuestEngineTests.swift
@@ -682,6 +682,72 @@ struct RoomQuestEngineTests {
         #expect(engine.phase == .complete)
     }
 
+    @Test
+    func roomQuestCompletionCallbackFiresOnlyAfterTransferWithCollectedTokens() {
+        let engine = makeEngine()
+        engine.startSession()
+        guard let p = engine.problem else { return }
+        var summaries: [RoomQuestSessionSummary] = []
+        engine.onSessionComplete = { summaries.append($0) }
+
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
+        engine.markSetupComplete()
+        #expect(summaries.isEmpty)
+
+        engine.markSpotVisited(index: 0)
+        engine.markSpotVisited(index: 1)
+        engine.markReturned()
+        engine.submitPictorial()
+        engine.equationLeftInput = String(p.decompositionA)
+        engine.equationRightInput = String(p.decompositionB)
+        engine.submitAbstract()
+        engine.transferLeftCount = p.decompositionA
+        engine.transferRightCount = p.decompositionB
+        engine.submitTransfer()
+
+        #expect(summaries.count == 1)
+        #expect(summaries[0].startedAt == engine.sessionStartedAt)
+        #expect(summaries[0].target == p.target)
+        #expect(summaries[0].collectedTokenCount == p.decompositionA + p.decompositionB)
+        #expect(summaries[0].abstractCorrect)
+    }
+
+    @Test
+    func routeQuestCompletionCallbackUsesCompletedStationTokens() {
+        let motionService = MotionService()
+        let engine = makeEngine(routeQuestEnabled: true, motionService: motionService)
+        engine.startSession()
+        guard let p = engine.problem else { return }
+        var summaries: [RoomQuestSessionSummary] = []
+        engine.onSessionComplete = { summaries.append($0) }
+
+        engine.registerStation(.redRocket)
+        engine.registerStation(.blueBubble)
+        engine.markSetupComplete()
+        engine.confirmRouteStart()
+        motionService.applyRelativeYaw(45)
+        engine.checkRouteTurn()
+        engine.confirmRouteSteps()
+        engine.acceptCurrentSpotWithParentConsent()
+        motionService.applyRelativeYaw(-90)
+        engine.checkRouteTurn()
+        engine.confirmRouteSteps()
+        engine.acceptCurrentSpotWithParentConsent()
+        engine.confirmRouteReturnHome()
+        engine.submitPictorial()
+        engine.equationLeftInput = String(p.decompositionA)
+        engine.equationRightInput = String(p.decompositionB)
+        engine.submitAbstract()
+        engine.transferLeftCount = p.decompositionA
+        engine.transferRightCount = p.decompositionB
+        engine.submitTransfer()
+
+        #expect(summaries.count == 1)
+        #expect(summaries[0].collectedTokenCount == p.decompositionA + p.decompositionB)
+        #expect(summaries[0].abstractCorrect)
+    }
+
     // MARK: - Pause / resume
 
     @Test


### PR DESCRIPTION
## Summary
- make `GameSessionStore.save` idempotent for repeated saves with the same active profile, game name, and session start
- remove Room Quest teardown saving from `RootView.onDisappear`
- save Room Quest from semantic engine completion through `AppModel`, using actual collected station work
- add focused persistence and Room Quest completion callback tests

Fixes #1103.

## Validation
- `git diff --check HEAD~1 HEAD`
- `ssh ganesh-mba 'xcodebuild -list -project Mather.xcodeproj'`
- `ssh ganesh-mba 'xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 16 Pro,OS=18.3.1" -skip-testing:MatherUITests'`
  - result: failed due `RoomQuestEngineTests.verifyCurrentSpotWithCameraUnlocksAndAdvances()` crashing with signal kill
  - confirmed new `GameplayProgressStoreTests/duplicateGameSessionSavesForSameProfileGameAndStartCreateOneRow()` passed
- `ssh ganesh-mba 'xcodebuild test ... -only-testing:MatherTests/GameplayProgressStoreTests -only-testing:MatherTests/RoomQuestEngineTests'`
  - result: compiled, then simulator killed the app before XCTest connected on iPhone 17 / iOS 26.5
