### PR TITLE
Simplify labs catalog surfaces

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -483,7 +483,7 @@ struct ExplorerPathPresentation: Identifiable, Equatable {
             artMotif: "guided compass path",
             title: "Labs",
             subtitle: "Pick a learning stream, then follow a calm staged path when one is ready.",
-            callToAction: "Pick a stream"
+            callToAction: "Open streams"
         ),
         ExplorerPathPresentation(
             id: .games,
@@ -495,6 +495,15 @@ struct ExplorerPathPresentation: Identifiable, Equatable {
             callToAction: "Play now"
         ),
     ]
+}
+
+struct ExplorerCatalogRoutePresentation: Equatable {
+    let selectedPath: ExplorerPathID
+
+    var showsPathSelector: Bool { false }
+    var showsLabsStreamPrompt: Bool { false }
+    var showsDirectGames: Bool { selectedPath == .games }
+    var showsLabStreams: Bool { selectedPath == .labs }
 }
 
 enum GuidedLabStage: String, CaseIterable, Codable, Hashable, Identifiable {

--- a/Features/Lab/LabView.swift
+++ b/Features/Lab/LabView.swift
@@ -17,6 +17,9 @@ struct LabView: View {
     private let lanes = CapabilityLane.labSubjectStreams
     private let guidedPaths = GuidedLabPath.phaseOne
     private let gameEntries = ExplorerGameRegistry.directLaunchEntries
+    private var catalogPresentation: ExplorerCatalogRoutePresentation {
+        ExplorerCatalogRoutePresentation(selectedPath: selectedPath)
+    }
 
     var body: some View {
         ZStack {
@@ -29,11 +32,8 @@ struct LabView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: compactGrid ? 16 : 20) {
                         header
-                        pathSelector(compact: compactGrid)
 
-                        if selectedPath == .labs {
-                            labsStreamHeader(compact: compactGrid)
-
+                        if catalogPresentation.showsLabStreams {
                             LazyVGrid(columns: labColumns(for: proxy.size.width), spacing: compactGrid ? 14 : 16) {
                                 ForEach(lanes) { lane in
                                     laneCard(lane, compact: compactGrid)
@@ -41,7 +41,7 @@ struct LabView: View {
                             }
 
                             guidedLabsIntro(compact: compactGrid)
-                        } else {
+                        } else if catalogPresentation.showsDirectGames {
                             directGamesSection(compact: compactGrid, width: proxy.size.width)
                         }
                     }
@@ -90,9 +90,11 @@ struct LabView: View {
                 Text("Explorer Lab")
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(MatherTheme.cardSubtitle)
-                Text(selectedPath == .labs ? "Pick a stream to explore" : "Jump straight into a game")
-                    .font(.caption.weight(.bold))
-                    .foregroundStyle(MatherTheme.accent)
+                if catalogPresentation.showsDirectGames {
+                    Text("Jump straight into a game")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(MatherTheme.accent)
+                }
             }
             Spacer()
             Button {
@@ -107,86 +109,6 @@ struct LabView: View {
         }
     }
 
-    private func pathSelector(compact: Bool) -> some View {
-        let columns = compact
-            ? [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
-            : [GridItem(.flexible(), spacing: 16), GridItem(.flexible(), spacing: 16)]
-
-        return LazyVGrid(columns: columns, spacing: compact ? 12 : 16) {
-            ForEach(ExplorerPathPresentation.all) { path in
-                Button {
-                    withAnimation(.spring(response: 0.28, dampingFraction: 0.88)) {
-                        selectedPath = path.id
-                    }
-                } label: {
-                    explorerPathCard(path, isSelected: selectedPath == path.id, compact: compact)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Explorer path: \(path.title). \(path.subtitle)")
-                .accessibilityHint(path.callToAction)
-            }
-        }
-    }
-
-    private func explorerPathCard(_ path: ExplorerPathPresentation, isSelected: Bool, compact: Bool) -> some View {
-        let tint = path.id == .labs ? MatherTheme.accent : MatherTheme.warm
-
-        return VStack(spacing: compact ? 8 : 10) {
-            explorerArtwork(path, tint: tint, compact: compact)
-            Text(path.title)
-                .font(.system(size: compact ? 22 : 26, weight: .black, design: .rounded))
-                .foregroundStyle(MatherTheme.ink)
-                .lineLimit(1)
-                .minimumScaleFactor(0.78)
-                .multilineTextAlignment(.center)
-
-            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                .font(.title3.weight(.black))
-                .foregroundStyle(tint)
-                .accessibilityHidden(true)
-        }
-        .padding(compact ? 12 : 16)
-        .frame(maxWidth: .infinity, minHeight: compact ? 132 : 136, alignment: .center)
-        .background(
-            LinearGradient(
-                colors: [tint.opacity(isSelected ? 0.18 : 0.08), MatherTheme.card],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            ),
-            in: RoundedRectangle(cornerRadius: 22, style: .continuous)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .stroke(tint.opacity(isSelected ? 0.50 : 0.16), lineWidth: isSelected ? 2 : 1)
-        )
-    }
-
-    private func labsStreamHeader(compact: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Pick a stream")
-                        .font(.title3.weight(.black))
-                        .foregroundStyle(MatherTheme.ink)
-                    Text("Pick one card. Details open next.")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                Spacer(minLength: 0)
-            }
-
-        }
-        .padding(14)
-        .background(MatherTheme.card.opacity(0.86), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(MatherTheme.accent.opacity(0.18), lineWidth: 1)
-        )
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Pick a stream: \(CapabilityLane.subjectStreamSummary)")
-    }
-
     private func guidedLabsIntro(compact: Bool) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top) {
@@ -194,7 +116,7 @@ struct LabView: View {
                     Text("Guided path")
                         .font(.headline.weight(.black))
                         .foregroundStyle(MatherTheme.ink)
-                    Text("Optional staged learning appears after the subject picker so other streams stay visible.")
+                    Text("Optional staged learning appears after the stream cards so other streams stay visible.")
                         .font(.caption.weight(.semibold))
                         .foregroundStyle(MatherTheme.cardSubtitle)
                 }
@@ -228,27 +150,6 @@ struct LabView: View {
             }
         }
         .accessibilityLabel(GuidedLabStage.allCases.map(\.rawValue).joined(separator: " to "))
-    }
-
-    private func explorerArtwork(_ path: ExplorerPathPresentation, tint: Color, compact: Bool) -> some View {
-        ZStack(alignment: .bottomTrailing) {
-            RoundedRectangle(cornerRadius: compact ? 16 : 18, style: .continuous)
-                .fill(
-                    LinearGradient(
-                        colors: [tint.opacity(0.26), tint.opacity(0.08), MatherTheme.card.opacity(0.9)],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                )
-            Image(systemName: path.symbolName)
-                .font(.system(size: compact ? 22 : 28, weight: .black))
-                .foregroundStyle(tint)
-            Text(path.emoji)
-                .font(.system(size: compact ? 16 : 20))
-                .offset(x: 3, y: 4)
-        }
-        .frame(width: compact ? 46 : 56, height: compact ? 46 : 56)
-        .accessibilityLabel(path.artworkAccessibilityLabel)
     }
 
     private func stageArtwork(_ stage: GuidedLabStage, tint: Color, compact: Bool) -> some View {

--- a/Shared/GameActivityCard.swift
+++ b/Shared/GameActivityCard.swift
@@ -88,29 +88,16 @@ struct GameActivityCard: View {
     private var detailBody: some View {
         HStack(alignment: .center, spacing: 14) {
             detailVisualBox
-            VStack(alignment: .leading, spacing: 4) {
-                Text(activity.title)
-                    .font(.title3.weight(.black))
-                    .foregroundStyle(canLaunch ? MatherTheme.ink : MatherTheme.ink.opacity(0.55))
-                    .lineLimit(2)
-                    .minimumScaleFactor(0.82)
-                Text(activity.tagline)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(MatherTheme.cardSubtitle)
-                    .lineLimit(2)
-                sensorAffordanceRow
-                if !canLaunch {
-                    Text("Try this on a device with motion sensing. Nothing is counted as wrong.")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(MatherTheme.cardSubtitle)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
+            Text(activity.title)
+                .font(.title3.weight(.black))
+                .foregroundStyle(canLaunch ? MatherTheme.ink : MatherTheme.ink.opacity(0.55))
+                .lineLimit(2)
+                .minimumScaleFactor(0.82)
+                .multilineTextAlignment(.leading)
             Spacer(minLength: 6)
-            detailPlayButton
         }
         .padding(16)
-        .frame(maxWidth: .infinity, minHeight: 112, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: 96, alignment: .leading)
         .background(MatherTheme.card, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 20, style: .continuous)
@@ -135,19 +122,6 @@ struct GameActivityCard: View {
         }
         .frame(width: 104, height: 96)
         .accessibilityLabel(activity.artworkAccessibilityLabel)
-    }
-
-    private var detailPlayButton: some View {
-        ZStack {
-            Circle()
-                .fill(canLaunch ? tint : MatherTheme.cardSubtitle.opacity(0.35))
-            Image(systemName: canLaunch ? "play.fill" : "lock.open.trianglebadge.exclamationmark")
-                .font(.title2.weight(.black))
-                .foregroundStyle(.white)
-                .offset(x: canLaunch ? 2 : 0)
-        }
-        .frame(width: 64, height: 64)
-        .accessibilityHidden(true)
     }
 
     @ViewBuilder
@@ -213,46 +187,10 @@ struct GameActivityCard: View {
         }
     }
 
-    private var sensorAffordanceRow: some View {
-        LabDetailFlowLayout(spacing: 4) {
-            ForEach(activity.id.sensorAffordances(with: sensorCapabilities)) { affordance in
-                Label {
-                    Text(affordance.displayLabel)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.72)
-                } icon: {
-                    Image(systemName: sensorIcon(for: affordance.need, isAvailable: affordance.isAvailable))
-                }
-                .font(.caption2.weight(.bold))
-                .foregroundStyle(affordance.isAvailable ? tint : MatherTheme.cardSubtitle)
-                .padding(.horizontal, 7)
-                .padding(.vertical, 4)
-                .background(
-                    (affordance.isAvailable ? tint.opacity(0.10) : MatherTheme.panel.opacity(0.72)),
-                    in: Capsule()
-                )
-                .accessibilityLabel(affordance.accessibilityLabel)
-                .accessibilityHint(affordance.accessibilityHint)
-            }
-        }
-    }
-
     private var sensorSummary: String {
         activity.id
             .sensorAffordances(with: sensorCapabilities)
             .map(\.displayLabel)
             .joined(separator: ". ")
-    }
-
-    private func sensorIcon(for need: LabSensorNeed, isAvailable: Bool) -> String {
-        if !isAvailable { return "exclamationmark.triangle.fill" }
-        switch need {
-        case .noSpecialSensor: return "hand.tap.fill"
-        case .motion: return "gyroscope"
-        case .compass: return "location.north.line.fill"
-        case .cameraMarkerMode: return "camera.viewfinder"
-        case .stepCounting: return "figure.walk"
-        case .haptics: return "waveform"
-        }
     }
 }

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -182,7 +182,7 @@ final class LabModelsTests: XCTestCase {
 
         XCTAssertEqual(labs.title, "Labs")
         XCTAssertTrue(labs.subtitle.contains("Pick a learning stream"))
-        XCTAssertEqual(labs.callToAction, "Pick a stream")
+        XCTAssertEqual(labs.callToAction, "Open streams")
         XCTAssertEqual(labs.symbolName, "sparkles.rectangle.stack.fill")
         XCTAssertTrue(labs.artworkAccessibilityLabel.contains("Labs"))
 
@@ -192,6 +192,21 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(games.callToAction, "Play now")
         XCTAssertEqual(games.symbolName, "gamecontroller.fill")
         XCTAssertTrue(games.artworkAccessibilityLabel.contains("Games"))
+    }
+
+    func testExplorerCatalogRoutesHidePathSelectorWhilePreservingGamesRoute() {
+        let labs = ExplorerCatalogRoutePresentation(selectedPath: .labs)
+        let games = ExplorerCatalogRoutePresentation(selectedPath: .games)
+
+        XCTAssertFalse(labs.showsPathSelector)
+        XCTAssertFalse(labs.showsLabsStreamPrompt)
+        XCTAssertTrue(labs.showsLabStreams)
+        XCTAssertFalse(labs.showsDirectGames)
+
+        XCTAssertFalse(games.showsPathSelector)
+        XCTAssertFalse(games.showsLabsStreamPrompt)
+        XCTAssertFalse(games.showsLabStreams)
+        XCTAssertTrue(games.showsDirectGames)
     }
 
     func testGuidedStageArtworkMetadataAvoidsEmbeddedTextDependency() {

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -29,7 +29,8 @@ final class CompactLayoutTests: XCTestCase {
 
         let app = launchExplorerLab()
         XCTAssertTrue(app.staticTexts["Explorer Lab"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.staticTexts["Pick a stream to explore"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.staticTexts["Pick a stream to explore"].exists)
+        XCTAssertFalse(app.staticTexts["Pick a stream"].exists)
         XCTAssertFalse(app.staticTexts["Choose a subject stream first"].exists)
 
         let numbers = app.buttons["lab-stream-card-numbers"]


### PR DESCRIPTION
## Summary
- simplify the home Labs route so it goes straight to stream cards without the Labs/Games selector or visible "Pick a stream" helper prompt
- keep the direct Games route available through `labGames` and backed by route presentation coverage
- reduce lane-detail game cards to visual artwork plus title only while preserving launch accessibility and disabled-state behavior

Closes #1106
Closes #1108

## Validation
- `git diff --check`
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:MatherTests/LabModelsTests/testExplorerCatalogRoutesHidePathSelectorWhilePreservingGamesRoute CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:MatherUITests/CompactLayoutTests/testExplorerLabStreamPickerUsesSimpleReadableCardsOnIPhone CODE_SIGNING_ALLOWED=NO`