### PR TITLE
Polish compact home and guided layouts

### DIFF
--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -183,22 +183,25 @@ struct LabLaneDetailView: View {
                         .foregroundStyle(MatherTheme.ink)
                         .lineLimit(2)
                         .minimumScaleFactor(0.82)
+                        .fixedSize(horizontal: false, vertical: true)
 
                 Spacer(minLength: 0)
 
                 Button {
                     start(plan)
                 } label: {
-                    Label(startLabel(for: plan), systemImage: appModel.labConceptSessionProgressStore.hasProgress(for: plan) ? "arrow.clockwise.circle.fill" : "play.fill")
+                    Label(visibleStartLabel(for: plan), systemImage: appModel.labConceptSessionProgressStore.hasProgress(for: plan) ? "arrow.clockwise.circle.fill" : "play.fill")
                         .font(.caption.weight(.black))
                         .foregroundStyle(.white)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 10)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.9)
+                        .frame(minWidth: 92, minHeight: 44)
                         .background(tint, in: Capsule())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("\(startLabel(for: plan)) \(plan.title)")
                 .accessibilityHint("This is the primary next action for the guided path. Games remain directly playable below.")
+                .accessibilityIdentifier("guided-plan-action-\(plan.id)")
             }
 
             if let progress {
@@ -250,6 +253,7 @@ struct LabLaneDetailView: View {
         .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
         .accessibilityElement(children: .contain)
         .accessibilityLabel("\(presentation.hiddenDetailAccessibilityLabel) Primary action: \(startLabel(for: plan)).")
+        .accessibilityIdentifier("guided-plan-card-\(plan.id)")
     }
 
     private func stagePlanCard(_ stage: LabSessionStagePlan, progress: LabConceptSessionProgress?, tint: Color) -> some View {
@@ -547,6 +551,12 @@ struct LabLaneDetailView: View {
 
     private func startLabel(for plan: LabConceptSessionPlan) -> String {
         appModel.labConceptSessionProgressStore.resumeLabel(for: plan)
+    }
+
+    private func visibleStartLabel(for plan: LabConceptSessionPlan) -> String {
+        appModel.labConceptSessionProgressStore.hasProgress(for: plan)
+            ? plan.continueAffordanceLabel
+            : plan.startAffordanceLabel
     }
 
     private func progressState(for stage: GuidedLabStage, progress: LabConceptSessionProgress?) -> String? {

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -8,32 +8,25 @@ struct HomeView: View {
     var body: some View {
         ZStack {
             MatherTheme.background.ignoresSafeArea()
-            ScrollView {
-                VStack(spacing: 20) {
-                    Text("Mather")
-                        .font(.system(size: 48, weight: .black, design: .rounded))
-                        .foregroundStyle(MatherTheme.ink)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+            GeometryReader { proxy in
+                ScrollView {
+                    VStack(spacing: ResponsiveLayout.isWide(horizontalSizeClass) ? 20 : 14) {
+                        Text("Mather")
+                            .font(.system(size: ResponsiveLayout.isWide(horizontalSizeClass) ? 48 : 44, weight: .black, design: .rounded))
+                            .foregroundStyle(MatherTheme.ink)
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
-                    childLauncherGrid
+                        childLauncherGrid
 
-                    HStack(spacing: 14) {
-                        Button("Parent Summary") {
-                            appModel.engine.showParentSummary()
-                        }
-                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.warm.opacity(0.65)))
+                        childQuickStartBand
 
-                        Button("Settings") {
-                            appModel.engine.showSettings()
-                        }
-                        .buttonStyle(SecondaryTileButtonStyle(fill: MatherTheme.softBlue.opacity(0.55)))
+                        parentControlsBand
                     }
-
-                    Spacer(minLength: 0)
+                    .padding(ResponsiveLayout.contentPadding(for: horizontalSizeClass))
+                    .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
+                    .frame(maxWidth: .infinity)
+                    .frame(minHeight: proxy.size.height, alignment: .top)
                 }
-                .padding(ResponsiveLayout.contentPadding(for: horizontalSizeClass))
-                .frame(maxWidth: ResponsiveLayout.contentMaxWidth(for: horizontalSizeClass))
-                .frame(maxWidth: .infinity)
             }
         }
     }
@@ -114,6 +107,93 @@ struct HomeView: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier(accessibilityIdentifier)
+        .accessibilityLabel(title)
+    }
+
+    private var childQuickStartBand: some View {
+        Button {
+            appModel.pickProfileThenRun { appModel.engine.showSessionConfig() }
+        } label: {
+            HStack(spacing: 14) {
+                Image(systemName: "play.circle.fill")
+                    .font(.system(size: 34, weight: .black))
+                    .foregroundStyle(MatherTheme.accent)
+                    .frame(width: 52, height: 52)
+                    .background(MatherTheme.accent.opacity(0.12), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Next up")
+                        .font(.headline.weight(.black))
+                        .foregroundStyle(MatherTheme.ink)
+                    Text("Start a short Targets round")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(MatherTheme.cardSubtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.right.circle.fill")
+                    .font(.title2.weight(.black))
+                    .foregroundStyle(MatherTheme.accent)
+                    .accessibilityHidden(true)
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, minHeight: 92, alignment: .leading)
+            .background(MatherTheme.card.opacity(0.88), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 20, style: .continuous)
+                    .strokeBorder(MatherTheme.accent.opacity(0.16), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("home-child-next-up")
+        .accessibilityLabel("Next up, start a short Targets round")
+    }
+
+    private var parentControlsBand: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("Parent controls", systemImage: "person.2.fill")
+                .font(.subheadline.weight(.black))
+                .foregroundStyle(MatherTheme.cardSubtitle)
+
+            HStack(spacing: 10) {
+                parentControlButton(
+                    title: "Parent Summary",
+                    icon: "chart.bar.fill",
+                    tint: MatherTheme.warm
+                ) {
+                    appModel.engine.showParentSummary()
+                }
+
+                parentControlButton(
+                    title: "Settings",
+                    icon: "gearshape.fill",
+                    tint: MatherTheme.softBlue
+                ) {
+                    appModel.engine.showSettings()
+                }
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MatherTheme.panel.opacity(0.58), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("home-parent-controls")
+    }
+
+    private func parentControlButton(title: String, icon: String, tint: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Label(title, systemImage: icon)
+                .font(.subheadline.weight(.black))
+                .foregroundStyle(MatherTheme.ink)
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+                .frame(maxWidth: .infinity, minHeight: 52)
+                .background(tint.opacity(0.18), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(.plain)
         .accessibilityLabel(title)
     }
 }

--- a/Features/VerticalSlice1/SessionConfigView.swift
+++ b/Features/VerticalSlice1/SessionConfigView.swift
@@ -38,7 +38,7 @@ struct SessionConfigView: View {
                         .frame(minHeight: horizontalSizeClass == .regular ? max(proxy.size.height - 24, 0) : nil, alignment: .center)
                         .padding(.horizontal, 24)
                         .padding(.top, horizontalSizeClass == .regular ? 20 : 14)
-                        .padding(.bottom, 32)
+                        .padding(.bottom, horizontalSizeClass == .regular ? 32 : 84)
                     }
                     .scrollIndicators(.visible)
                 }

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -40,6 +40,44 @@ final class CompactLayoutTests: XCTestCase {
         XCTAssertTrue(geometry.isHittable, "Expected the second Lab stream card to be reachable on compact iPhone")
     }
 
+    func testHomeCompactUsesFirstViewportBelowChildTiles() throws {
+        guard UIDevice.current.userInterfaceIdiom == .phone else {
+            throw XCTSkip("Compact home first-viewport regression only runs on iPhone simulators")
+        }
+
+        let app = launchWithVS1()
+        XCTAssertTrue(app.staticTexts["Mather"].waitForExistence(timeout: 10))
+
+        let games = app.buttons["GamesEntry"]
+        let nextUp = app.buttons["home-child-next-up"]
+        let parentControls = app.otherElements["home-parent-controls"]
+
+        XCTAssertTrue(games.waitForExistence(timeout: 5))
+        XCTAssertTrue(nextUp.waitForExistence(timeout: 5))
+        XCTAssertTrue(parentControls.waitForExistence(timeout: 5))
+        XCTAssertTrue(nextUp.isHittable, "Expected child-first next-up action to occupy the compact home lower viewport")
+        XCTAssertGreaterThanOrEqual(nextUp.frame.minY, games.frame.maxY, "Expected the lower band to sit after child launcher tiles")
+        XCTAssertGreaterThanOrEqual(parentControls.frame.minY, nextUp.frame.maxY, "Expected parent controls to read as secondary controls after child actions")
+    }
+
+    func testGeometryGuidedPathCardsUseReadableShortActionsOnIPhone() throws {
+        guard UIDevice.current.userInterfaceIdiom == .phone else {
+            throw XCTSkip("Compact guided path regression only runs on iPhone simulators")
+        }
+
+        let app = launchGeometryLane()
+        XCTAssertTrue(app.staticTexts["Guided path"].waitForExistence(timeout: 10))
+
+        let shapeCard = app.otherElements["guided-plan-card-geometry-shape-names"]
+        let shapeAction = app.buttons["guided-plan-action-geometry-shape-names"]
+        XCTAssertTrue(shapeCard.waitForExistence(timeout: 5))
+        XCTAssertTrue(shapeAction.waitForExistence(timeout: 5))
+        XCTAssertTrue(shapeAction.staticTexts["Start"].exists, "Expected guided path CTA to use short visible copy")
+        XCTAssertGreaterThanOrEqual(shapeAction.frame.height, 44, "Expected guided path CTA to keep a 44 pt hit target")
+        XCTAssertGreaterThanOrEqual(shapeAction.frame.width, 44, "Expected guided path CTA to keep a 44 pt hit target")
+        XCTAssertTrue(shapeAction.label.contains("Start Shape Lab"), "Expected the accessibility label to keep the full guided path context")
+    }
+
     func testBondBlastTargetTwelveKeepsLowAndMiddlePairsReachableOnIPhone() throws {
         guard UIDevice.current.userInterfaceIdiom == .phone else {
             throw XCTSkip("Compact Bond Blast reachability regression only runs on iPhone simulators")
@@ -166,6 +204,15 @@ final class CompactLayoutTests: XCTestCase {
         }
         XCTAssertTrue(start.waitForExistence(timeout: 5))
         XCTAssertTrue(start.isHittable, "Expected Start Session to be reachable by scrolling on compact setup")
+        for _ in 0..<3 where app.buttons["start-session-button"].frame.maxY > app.frame.maxY - 24 {
+            app.swipeUp()
+        }
+        let spacedStart = app.buttons["start-session-button"]
+        XCTAssertLessThanOrEqual(
+            spacedStart.frame.maxY,
+            app.frame.maxY - 24,
+            "Expected Start Session to keep comfortable bottom spacing above the compact safe area"
+        )
 
         let back = app.buttons["back-to-home-button"]
         if !back.isHittable {
@@ -375,13 +422,28 @@ final class CompactLayoutTests: XCTestCase {
         return app
     }
 
+    private func launchGeometryLane() -> XCUIApplication {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.testModeEnabled", "YES",
+            "-feature.skipProfilePicker", "YES",
+            "-uiTest.startRoute", "geometryLane"
+        ]
+        app.launch()
+        return app
+    }
+
     private func launchWithVS1() -> XCUIApplication {
         continueAfterFailure = false
         let app = XCUIApplication()
         app.launchArguments = [
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
-            "-feature.testModeEnabled", "YES"
+            "-feature.testModeEnabled", "YES",
+            "-feature.skipProfilePicker", "YES"
         ]
         app.launch()
         return app


### PR DESCRIPTION
## Summary
- Shortens guided-path CTA copy to Start/Continue while keeping full accessibility context and 44 pt action targets.
- Adds compact home lower-viewport content with a child-first next-up action and calmer parent controls.
- Adds extra compact session setup bottom inset so Start Session can scroll above the home indicator.

Fixes #1107.
Fixes #1109.
Fixes #1110.
Refs #1105.

## #1105 remaining
This PR does not implement parent gate or session-lock acceptance. Remaining #1105 decisions:
- Parent gate style: hold-to-unlock vs arithmetic prompt vs long press.
- Whether all session setup should be parent-only.
- Whether child mode should default to locked after a session starts.

## Validation
- Remote Mac: `xcodebuild build-for-testing -project Mather.xcodeproj -scheme Mather -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO`
- Remote Mac iPhone 16 Pro simulator: `xcodebuild test-without-building ... -only-testing:MatherUITests/CompactLayoutTests/testGeometryGuidedPathCardsUseReadableShortActionsOnIPhone -only-testing:MatherUITests/CompactLayoutTests/testHomeCompactUsesFirstViewportBelowChildTiles -only-testing:MatherUITests/CompactLayoutTests/testSessionSetupCompactTargetCapUsesSingleScrollablePresetControl`
  - Guided-path and home tests passed together.
  - Session setup test passed on clean rerun after one XCTest accessibility snapshot flake in the previous three-test run.
