### PR TITLE
Improve UI review artifact hygiene

### DIFF
--- a/.github/workflows/ios-ui-review-main.yml
+++ b/.github/workflows/ios-ui-review-main.yml
@@ -40,6 +40,12 @@ jobs:
             brew install xcodegen
           fi
 
+      - name: Install media tools
+        run: |
+          if ! command -v ffmpeg >/dev/null 2>&1; then
+            brew install ffmpeg
+          fi
+
       - name: Generate project
         run: xcodegen generate
 
@@ -144,32 +150,12 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          mkdir -p ci-screenshots
-          BUNDLE="UITestResults-${DEVICE_FAMILY}.xcresult"
-
-          if [[ -d "$BUNDLE" ]]; then
-            # Xcode 16+: bulk-export all attachments then move PNGs to flat directory.
-            # The --type directory flag bypasses the xcresulttool JSON manifest format,
-            # which changed in Xcode 16 and broke per-attachment payloadRef extraction.
-            xcrun xcresulttool export \
-              --path "$BUNDLE" \
-              --output-path ci-screenshots/exported \
-              --type directory 2>/dev/null || true
-            find ci-screenshots/exported -name "*.png" -exec mv {} ci-screenshots/ \; 2>/dev/null || true
-            rm -rf ci-screenshots/exported
-            COUNT=$(find ci-screenshots -name "*.png" | wc -l | tr -d ' ')
-            echo "Extracted $COUNT PNG(s) from xcresult bundle"
-          else
-            echo "No xcresult bundle found at $BUNDLE, skipping extraction"
-          fi
-
-          SIM_ID=$(xcrun simctl list devices booted \
-            | grep -E '\([-A-F0-9]+\)' | head -1 \
-            | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
-          if [[ -n "$SIM_ID" ]]; then
-            xcrun simctl io "$SIM_ID" screenshot \
-              "ci-screenshots/simulator-final-state-${DEVICE_FAMILY}.png" 2>/dev/null || true
-          fi
+          ci_scripts/collect_ui_review_artifacts.sh \
+            "UITestResults-${DEVICE_FAMILY}.xcresult" \
+            "ci-videos/ui-tests-${DEVICE_FAMILY}.mp4" \
+            ci-screenshots \
+            ci-device-state \
+            ci-contact-sheets
 
       - name: Shutdown simulator
         if: always()
@@ -193,6 +179,24 @@ jobs:
         with:
           name: ui-review-screenshots-${{ matrix.device-family }}-${{ github.run_number }}
           path: ci-screenshots/
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Upload device state screenshots
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-review-device-state-${{ matrix.device-family }}-${{ github.run_number }}
+          path: ci-device-state/
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Upload video contact sheets
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-review-contact-sheets-${{ matrix.device-family }}-${{ github.run_number }}
+          path: ci-contact-sheets/
           if-no-files-found: ignore
           retention-days: 30
 

--- a/ci_scripts/collect_ui_review_artifacts.sh
+++ b/ci_scripts/collect_ui_review_artifacts.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEVICE_FAMILY="${DEVICE_FAMILY:-iphone}"
+BUNDLE="${1:-UITestResults-${DEVICE_FAMILY}.xcresult}"
+VIDEO="${2:-ci-videos/ui-tests-${DEVICE_FAMILY}.mp4}"
+SCREENSHOT_DIR="${3:-ci-screenshots}"
+DEVICE_STATE_DIR="${4:-ci-device-state}"
+CONTACT_SHEET_DIR="${5:-ci-contact-sheets}"
+
+mkdir -p "$SCREENSHOT_DIR" "$DEVICE_STATE_DIR" "$CONTACT_SHEET_DIR"
+
+extract_screenshots() {
+  if [[ ! -d "$BUNDLE" ]]; then
+    echo "No xcresult bundle found at $BUNDLE, skipping screenshot extraction"
+    return 0
+  fi
+
+  local export_dir="$SCREENSHOT_DIR/exported"
+  rm -rf "$export_dir"
+  mkdir -p "$export_dir"
+
+  # Xcode 16+: bulk-export attachments as a directory. The exported filenames
+  # preserve enough attachment context for review while avoiding xcresult JSON
+  # schema churn across Xcode releases.
+  xcrun xcresulttool export \
+    --path "$BUNDLE" \
+    --output-path "$export_dir" \
+    --type directory 2>/dev/null || true
+
+  local count=0
+  while IFS= read -r -d '' png; do
+    count=$((count + 1))
+    local base
+    base="$(basename "$png")"
+    cp "$png" "$SCREENSHOT_DIR/${DEVICE_FAMILY}-${count}-${base}"
+  done < <(find "$export_dir" -name "*.png" -print0 | sort -z)
+
+  rm -rf "$export_dir"
+  echo "Extracted $count in-app PNG screenshot(s) from $BUNDLE"
+}
+
+capture_device_state() {
+  if ! command -v xcrun >/dev/null 2>&1; then
+    echo "xcrun is unavailable; skipping device-state screenshot"
+    return 0
+  fi
+
+  local sim_id="${SIM_DESTINATION#id=}"
+  if [[ -z "${sim_id:-}" || "$sim_id" == "$SIM_DESTINATION" ]]; then
+    sim_id="$(xcrun simctl list devices booted \
+      | grep -E '\\([-A-F0-9]+\\)' | head -1 \
+      | sed -E 's/.*\\(([A-F0-9-]+)\\).*/\\1/' || true)"
+  fi
+
+  if [[ -z "${sim_id:-}" ]]; then
+    echo "No booted simulator found for device-state screenshot"
+    return 0
+  fi
+
+  # Keep simulator/home-screen state out of the in-app screenshot artifact so
+  # review screenshots cannot confuse Mather with the UI test host app.
+  xcrun simctl io "$sim_id" screenshot \
+    "$DEVICE_STATE_DIR/device-home-state-${DEVICE_FAMILY}.png" 2>/dev/null || true
+}
+
+make_contact_sheet() {
+  if [[ ! -s "$VIDEO" ]]; then
+    echo "No UI review video found at $VIDEO, skipping contact sheet"
+    return 0
+  fi
+
+  if ! command -v ffmpeg >/dev/null 2>&1; then
+    echo "ffmpeg is unavailable; uploading video without contact sheet"
+    return 0
+  fi
+
+  local sheet="$CONTACT_SHEET_DIR/ui-review-contact-sheet-${DEVICE_FAMILY}.jpg"
+  ffmpeg -hide_banner -loglevel error -y \
+    -i "$VIDEO" \
+    -vf "fps=1/4,scale=360:-1,tile=3x4" \
+    -frames:v 1 \
+    "$sheet" || {
+      echo "Unable to generate contact sheet from $VIDEO"
+      rm -f "$sheet"
+      return 0
+    }
+
+  echo "Generated contact sheet: $sheet"
+}
+
+write_manifest() {
+  local manifest="$SCREENSHOT_DIR/manifest-${DEVICE_FAMILY}.txt"
+  {
+    echo "Mather UI review artifact manifest"
+    echo "device_family=$DEVICE_FAMILY"
+    echo "result_bundle=$BUNDLE"
+    echo "video=$VIDEO"
+    echo
+    echo "in_app_screenshots:"
+    find "$SCREENSHOT_DIR" -maxdepth 1 -name "*.png" -print | sort
+    echo
+    echo "device_state_screenshots:"
+    find "$DEVICE_STATE_DIR" -maxdepth 1 -name "*.png" -print | sort
+    echo
+    echo "contact_sheets:"
+    find "$CONTACT_SHEET_DIR" -maxdepth 1 \( -name "*.jpg" -o -name "*.png" \) -print | sort
+  } > "$manifest"
+}
+
+extract_screenshots
+capture_device_state
+make_contact_sheet
+write_manifest


### PR DESCRIPTION
## Summary
- split simulator/device-home screenshots out of the in-app UI review screenshots artifact
- add a reusable UI review artifact collector with a manifest
- generate and upload video contact-sheet artifacts for faster UX review

Refs #1105

## Validation
- bash -n ci_scripts/collect_ui_review_artifacts.sh
- collector script smoke-tested with missing artifacts
- git diff --check
- workflow YAML parsed locally