### PR TITLE
Add parent unlock controls and encryption flag

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -18,6 +18,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>NSMotionUsageDescription</key>
 	<string>Mather counts a few small careful steps during motion games. If motion access is unavailable, your child can use tap-to-count instead.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -5,6 +5,9 @@ struct HomeView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Bindable var appModel: AppModel
 
+    @State private var pendingParentUnlock: ParentUnlockRequest?
+    @State private var pendingParentAction: ParentHomeAction?
+
     var body: some View {
         ZStack {
             MatherTheme.background.ignoresSafeArea()
@@ -29,6 +32,13 @@ struct HomeView: View {
                 }
             }
         }
+        .sheet(item: $pendingParentUnlock) { request in
+            ParentUnlockSheet(
+                request: request,
+                onCancel: { clearParentUnlock() },
+                onUnlock: { unlockPendingParentAction() }
+            )
+        }
     }
 
     // MARK: - Child launcher
@@ -41,7 +51,7 @@ struct HomeView: View {
                 gradient: [MatherTheme.warm, MatherTheme.accent],
                 accessibilityIdentifier: "Play"
             ) {
-                appModel.pickProfileThenRun { appModel.engine.showSessionConfig() }
+                requestParentAction(.sessionSetup)
             }
             childLauncherTile(
                 title: "Labs",
@@ -112,7 +122,7 @@ struct HomeView: View {
 
     private var childQuickStartBand: some View {
         Button {
-            appModel.pickProfileThenRun { appModel.engine.showSessionConfig() }
+            requestParentAction(.sessionSetup)
         } label: {
             HStack(spacing: 14) {
                 Image(systemName: "play.circle.fill")
@@ -164,7 +174,7 @@ struct HomeView: View {
                     icon: "chart.bar.fill",
                     tint: MatherTheme.warm
                 ) {
-                    appModel.engine.showParentSummary()
+                    requestParentAction(.parentSummary)
                 }
 
                 parentControlButton(
@@ -172,7 +182,7 @@ struct HomeView: View {
                     icon: "gearshape.fill",
                     tint: MatherTheme.softBlue
                 ) {
-                    appModel.engine.showSettings()
+                    requestParentAction(.settings)
                 }
             }
         }
@@ -195,5 +205,71 @@ struct HomeView: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(title)
+    }
+
+    private func requestParentAction(_ action: ParentHomeAction) {
+        if appModel.featureFlags.testModeEnabled {
+            runParentAction(action)
+            return
+        }
+        pendingParentAction = action
+        pendingParentUnlock = action.unlockRequest
+    }
+
+    private func unlockPendingParentAction() {
+        guard let action = pendingParentAction else {
+            clearParentUnlock()
+            return
+        }
+        clearParentUnlock()
+        runParentAction(action)
+    }
+
+    private func clearParentUnlock() {
+        pendingParentUnlock = nil
+        pendingParentAction = nil
+    }
+
+    private func runParentAction(_ action: ParentHomeAction) {
+        switch action {
+        case .sessionSetup:
+            appModel.pickProfileThenRun { appModel.engine.showSessionConfig() }
+        case .parentSummary:
+            appModel.engine.showParentSummary()
+        case .settings:
+            appModel.engine.showSettings()
+        }
+    }
+}
+
+private enum ParentHomeAction {
+    case sessionSetup
+    case parentSummary
+    case settings
+
+    var unlockRequest: ParentUnlockRequest {
+        switch self {
+        case .sessionSetup:
+            return ParentUnlockRequest(
+                id: "session-setup",
+                title: "Session setup",
+                detail: "A parent unlock is required before changing session setup.",
+                unlockLabel: "Hold to open session setup"
+            )
+        case .parentSummary:
+            return ParentUnlockRequest(
+                id: "parent-summary",
+                title: "Parent Summary",
+                detail: "A parent unlock is required before opening progress and history.",
+                unlockLabel: "Hold to open Parent Summary"
+            )
+        case .settings:
+            return ParentUnlockRequest(
+                id: "settings",
+                title: "Settings",
+                detail: "A parent unlock is required before changing app settings.",
+                unlockLabel: "Hold to open Settings"
+            )
+        }
     }
 }

--- a/Features/VerticalSlice1/SessionConfigView.swift
+++ b/Features/VerticalSlice1/SessionConfigView.swift
@@ -72,8 +72,18 @@ struct SessionConfigView: View {
     private var setupCard: some View {
         CardSurface {
             VStack(alignment: .leading, spacing: 16) {
-                Text("Session setup")
-                    .font(.title.weight(.black))
+                HStack(alignment: .firstTextBaseline, spacing: 10) {
+                    Text("Session setup")
+                        .font(.title.weight(.black))
+
+                    Label("Parent only", systemImage: "lock.shield.fill")
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(MatherTheme.softBlue)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(MatherTheme.softBlue.opacity(0.12), in: Capsule())
+                        .accessibilityIdentifier("session-setup-parent-only-badge")
+                }
                 Text("Keep sessions short and consistent.")
                     .font(.headline)
                     .foregroundStyle(MatherTheme.ink.opacity(0.6))

--- a/Features/VerticalSlice1/SessionSummaryView.swift
+++ b/Features/VerticalSlice1/SessionSummaryView.swift
@@ -5,6 +5,8 @@ struct SessionSummaryView: View {
     @State private var scale: CGFloat = 0.7
     @State private var opacity: Double = 0
     @State private var confettiBurst = false
+    @State private var pendingParentUnlock: ParentUnlockRequest?
+    @State private var pendingParentAction: ParentSummaryAction?
 
     private var summary: SessionSummaryDraft? { appModel.engine.completedSummary }
     private var problemsSolvedText: String {
@@ -66,7 +68,7 @@ struct SessionSummaryView: View {
 
                 VStack(spacing: 12) {
                     Button("Play again") {
-                        appModel.engine.showSessionConfig()
+                        requestParentAction(.sessionSetup)
                     }
                     .buttonStyle(PrimaryActionButtonStyle())
                     .accessibilityIdentifier("session-summary-play-again-button")
@@ -82,7 +84,7 @@ struct SessionSummaryView: View {
                     .accessibilityIdentifier("session-summary-done-button")
 
                     Button("Parent summary") {
-                        appModel.engine.showParentSummary()
+                        requestParentAction(.parentSummary)
                     }
                     .font(.subheadline.weight(.bold))
                     .foregroundStyle(.secondary)
@@ -100,6 +102,13 @@ struct SessionSummaryView: View {
             withAnimation(.easeOut(duration: 0.9)) {
                 confettiBurst = true
             }
+        }
+        .sheet(item: $pendingParentUnlock) { request in
+            ParentUnlockSheet(
+                request: request,
+                onCancel: { clearParentUnlock() },
+                onUnlock: { unlockPendingParentAction() }
+            )
         }
     }
 
@@ -156,5 +165,61 @@ struct SessionSummaryView: View {
             }
         }
         .allowsHitTesting(false)
+    }
+
+    private func requestParentAction(_ action: ParentSummaryAction) {
+        if appModel.featureFlags.testModeEnabled {
+            runParentAction(action)
+            return
+        }
+        pendingParentAction = action
+        pendingParentUnlock = action.unlockRequest
+    }
+
+    private func unlockPendingParentAction() {
+        guard let action = pendingParentAction else {
+            clearParentUnlock()
+            return
+        }
+        clearParentUnlock()
+        runParentAction(action)
+    }
+
+    private func clearParentUnlock() {
+        pendingParentUnlock = nil
+        pendingParentAction = nil
+    }
+
+    private func runParentAction(_ action: ParentSummaryAction) {
+        switch action {
+        case .sessionSetup:
+            appModel.engine.showSessionConfig()
+        case .parentSummary:
+            appModel.engine.showParentSummary()
+        }
+    }
+}
+
+private enum ParentSummaryAction {
+    case sessionSetup
+    case parentSummary
+
+    var unlockRequest: ParentUnlockRequest {
+        switch self {
+        case .sessionSetup:
+            return ParentUnlockRequest(
+                id: "summary-session-setup",
+                title: "Play again",
+                detail: "A parent unlock is required before changing setup for another session.",
+                unlockLabel: "Hold to open session setup"
+            )
+        case .parentSummary:
+            return ParentUnlockRequest(
+                id: "summary-parent-summary",
+                title: "Parent Summary",
+                detail: "A parent unlock is required before opening progress and history.",
+                unlockLabel: "Hold to open Parent Summary"
+            )
+        }
     }
 }

--- a/Features/VerticalSlice1/VS1SharedUI.swift
+++ b/Features/VerticalSlice1/VS1SharedUI.swift
@@ -224,3 +224,84 @@ struct VS1StageRail: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
+
+struct ParentUnlockRequest: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let detail: String
+    let unlockLabel: String
+}
+
+struct ParentUnlockSheet: View {
+    let request: ParentUnlockRequest
+    var onCancel: () -> Void
+    var onUnlock: () -> Void
+
+    var body: some View {
+        VStack(spacing: 18) {
+            Image(systemName: "lock.shield.fill")
+                .font(.system(size: 44, weight: .black))
+                .foregroundStyle(MatherTheme.softBlue)
+                .frame(width: 72, height: 72)
+                .background(MatherTheme.softBlue.opacity(0.14), in: Circle())
+
+            VStack(spacing: 8) {
+                Text("Parent unlock")
+                    .font(.title2.weight(.black))
+                    .foregroundStyle(MatherTheme.ink)
+                Text(request.detail)
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(MatherTheme.cardSubtitle)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HoldToUnlockButton(title: request.unlockLabel, action: onUnlock)
+
+            Button("Cancel", action: onCancel)
+                .font(.headline.weight(.black))
+                .foregroundStyle(MatherTheme.softBlue)
+                .frame(maxWidth: .infinity, minHeight: 48)
+                .background(MatherTheme.softBlue.opacity(0.12), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("parent-unlock-cancel-button")
+        }
+        .padding(24)
+        .presentationDetents([.height(360)])
+        .presentationDragIndicator(.visible)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("parent-unlock-sheet")
+    }
+}
+
+private struct HoldToUnlockButton: View {
+    let title: String
+    var action: () -> Void
+
+    @State private var isPressing = false
+
+    var body: some View {
+        Button(action: {}) {
+            Label(title, systemImage: isPressing ? "lock.open.fill" : "lock.fill")
+                .font(.headline.weight(.black))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, minHeight: 58)
+                .background(MatherTheme.accent, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .overlay(DarkModeCTAOverlay())
+                .scaleEffect(isPressing ? 0.98 : 1.0)
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("parent-unlock-hold-button")
+        .accessibilityLabel(title)
+        .onLongPressGesture(
+            minimumDuration: 0.9,
+            maximumDistance: 48,
+            pressing: { pressing in
+                withAnimation(.easeOut(duration: 0.12)) {
+                    isPressing = pressing
+                }
+            },
+            perform: action
+        )
+    }
+}

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -61,6 +61,23 @@ final class CompactLayoutTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(parentControls.frame.minY, nextUp.frame.maxY, "Expected parent controls to read as secondary controls after child actions")
     }
 
+    func testParentLockedActionsUseHoldUnlockOutsideTestMode() throws {
+        let app = launchWithoutParentBypass()
+        XCTAssertTrue(app.staticTexts["Mather"].waitForExistence(timeout: 10))
+
+        app.buttons["Play"].tap()
+        XCTAssertTrue(app.staticTexts["Parent unlock"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["A parent unlock is required before changing session setup."].exists)
+        app.buttons["parent-unlock-cancel-button"].tap()
+
+        XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 5))
+        app.buttons["Settings"].tap()
+        let unlockButton = app.buttons["parent-unlock-hold-button"]
+        XCTAssertTrue(unlockButton.waitForExistence(timeout: 5))
+        unlockButton.press(forDuration: 1.1)
+        XCTAssertTrue(app.staticTexts["Settings"].waitForExistence(timeout: 10))
+    }
+
     func testGeometryGuidedPathCardsUseReadableShortActionsOnIPhone() throws {
         guard UIDevice.current.userInterfaceIdiom == .phone else {
             throw XCTSkip("Compact guided path regression only runs on iPhone simulators")
@@ -444,6 +461,19 @@ final class CompactLayoutTests: XCTestCase {
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
             "-feature.testModeEnabled", "YES",
+            "-feature.skipProfilePicker", "YES"
+        ]
+        app.launch()
+        return app
+    }
+
+    private func launchWithoutParentBypass() -> XCUIApplication {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.testModeEnabled", "NO",
             "-feature.skipProfilePicker", "YES"
         ]
         app.launch()

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -205,7 +205,7 @@ final class ScreenshotTests: XCTestCase {
         let app = launchFamilySettingsWithSeededHistory(count: 7)
         _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
 
-        app.buttons["Settings"].tap()
+        openParentLockedSettings(in: app)
         _ = app.staticTexts["Settings"].waitForExistence(timeout: 10)
         XCTAssertTrue(app.staticTexts["7 saved locally across all games"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.buttons["settings-view-full-history"].exists)
@@ -572,6 +572,15 @@ final class ScreenshotTests: XCTestCase {
         }
 
         XCTAssertTrue(makePrompt.waitForExistence(timeout: 15), "Expected concrete stage after tapping Start Session")
+    }
+
+    private func openParentLockedSettings(in app: XCUIApplication) {
+        app.buttons["Settings"].tap()
+        if app.staticTexts["Parent unlock"].waitForExistence(timeout: 2) {
+            let unlockButton = app.buttons["parent-unlock-hold-button"]
+            XCTAssertTrue(unlockButton.waitForExistence(timeout: 5))
+            unlockButton.press(forDuration: 1.1)
+        }
     }
 
     /// Attaches a full-screen screenshot to the test result with `.keepAlways` lifetime.


### PR DESCRIPTION
## Summary
- Add hold-to-unlock parent gate for session setup, Parent Summary, and Settings from home, with the same gate on post-session adult actions.
- Mark session setup as parent-only while preserving UI-test bypass through existing test mode.
- Add ITSAppUsesNonExemptEncryption=false to App/Info.plist.

## Validation
- git diff --check
- remote plutil -lint App/Info.plist on ganesh-mba
- remote xcodebuild build-for-testing on ganesh-mba, iPhone 16 Pro iOS 18.3.1
- remote focused UI test: MatherUITests/CompactLayoutTests/testParentLockedActionsUseHoldUnlockOutsideTestMode

Refs #1105 for the parent-control/encryption slice. The broader UX umbrella remains open for follow-up work that is not part of this PR.