### PR TITLE
Clarify active-profile history clearing

### DIFF
--- a/Features/ParentSummary/SettingsView.swift
+++ b/Features/ParentSummary/SettingsView.swift
@@ -99,8 +99,8 @@ struct SettingsView: View {
         .alert("Clear all session data?", isPresented: $showingClearConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Clear", role: .destructive) {
-                appModel.historyStore.clearAll()
-                appModel.gameSessionStore.clearAll()
+                appModel.historyStore.clearActiveProfile()
+                appModel.gameSessionStore.clearActiveProfile()
                 appModel.telemetryWriter.clearEventsForActiveProfile()
             }
         } message: {

--- a/Persistence/GameSessionStore.swift
+++ b/Persistence/GameSessionStore.swift
@@ -68,7 +68,7 @@ final class GameSessionStore {
         return (try? modelContext.fetch(descriptor)) ?? []
     }
 
-    func clearAll() {
+    func clearActiveProfile() {
         let profileId = activeProfileIdProvider()
         let descriptor = FetchDescriptor<StoredGameSession>(
             predicate: #Predicate { $0.profileId == profileId }
@@ -76,6 +76,10 @@ final class GameSessionStore {
         guard let sessions = try? modelContext.fetch(descriptor) else { return }
         sessions.forEach { modelContext.delete($0) }
         try? modelContext.save()
+    }
+
+    func clearAll() {
+        clearActiveProfile()
     }
 
     func clearAllProfiles() {

--- a/Persistence/SessionHistoryStore.swift
+++ b/Persistence/SessionHistoryStore.swift
@@ -36,7 +36,7 @@ final class SessionHistoryStore {
         return (try? modelContext.fetch(descriptor)) ?? []
     }
 
-    func clearAll() {
+    func clearActiveProfile() {
         let profileId = activeProfileIdProvider()
         let descriptor = FetchDescriptor<StoredSessionSummary>(
             predicate: #Predicate { $0.profileId == profileId }
@@ -46,6 +46,10 @@ final class SessionHistoryStore {
             modelContext.delete(session)
         }
         try? modelContext.save()
+    }
+
+    func clearAll() {
+        clearActiveProfile()
     }
 
     func clearAllProfiles() {

--- a/Tests/MatherTests/GameplayProgressStoreTests.swift
+++ b/Tests/MatherTests/GameplayProgressStoreTests.swift
@@ -108,6 +108,39 @@ struct GameplayProgressStoreTests {
     }
 
     @Test
+    func clearActiveProfilePreservesOtherProfileGameSessions() throws {
+        let schema = Schema([StoredGameSession.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: config)
+        let context = ModelContext(container)
+        var activeProfileId = "profile-a"
+        let store = GameSessionStore(modelContext: context, activeProfileIdProvider: { activeProfileId })
+
+        store.save(
+            gameName: "Sum Sprint",
+            startedAt: Date(timeIntervalSince1970: 9_000),
+            scoreValue: 4,
+            scoreLabel: "profile A"
+        )
+        activeProfileId = "profile-b"
+        store.save(
+            gameName: "Room Quest",
+            startedAt: Date(timeIntervalSince1970: 10_000),
+            scoreValue: 7,
+            scoreLabel: "profile B"
+        )
+
+        activeProfileId = "profile-a"
+        store.clearActiveProfile()
+
+        let fetched = try context.fetch(FetchDescriptor<StoredGameSession>())
+        #expect(fetched.count == 1)
+        #expect(fetched[0].profileId == "profile-b")
+        #expect(fetched[0].gameName == "Room Quest")
+        #expect(fetched[0].scoreLabel == "profile B")
+    }
+
+    @Test
     func appSchemaIncludesGameplayProgressModels() throws {
         let schema = Schema([
             StoredSessionSummary.self,

--- a/Tests/MatherTests/SessionHistoryTests.swift
+++ b/Tests/MatherTests/SessionHistoryTests.swift
@@ -87,6 +87,28 @@ struct SessionHistoryStoreTests {
     }
 
     @Test
+    func clearActiveProfilePreservesOtherProfileSummaries() throws {
+        let schema = Schema([StoredSessionSummary.self])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
+        let container = try ModelContainer(for: schema, configurations: config)
+        let context = ModelContext(container)
+        var activeProfileId = "profile-a"
+        let store = SessionHistoryStore(modelContext: context, activeProfileIdProvider: { activeProfileId })
+
+        store.save(makeDraft(sessionId: "a-session"))
+        activeProfileId = "profile-b"
+        store.save(makeDraft(sessionId: "b-session"))
+
+        activeProfileId = "profile-a"
+        store.clearActiveProfile()
+
+        let fetched = try context.fetch(FetchDescriptor<StoredSessionSummary>())
+        #expect(fetched.count == 1)
+        #expect(fetched[0].profileId == "profile-b")
+        #expect(fetched[0].sessionId == "b-session")
+    }
+
+    @Test
     func saveMultipleSessionsAreAllPersisted() throws {
         let (store, context) = try makeInMemoryStore()
         store.save(makeDraft(sessionId: "aaa", problemsCompleted: 3))


### PR DESCRIPTION
## Summary
- add explicit active-profile clear APIs for session and game history stores
- route Settings destructive reset through the active-profile APIs
- add regressions proving inactive-profile Make & Break and game sessions survive active-profile reset

Refs #1117

## Validation
- git diff --check
- local Xcode tools unavailable in this container; GitHub CI is the validation gate