### PR TITLE
Align Compass final turn copy

### DIFF
--- a/Features/CompassAngles/CompassAnglesView.swift
+++ b/Features/CompassAngles/CompassAnglesView.swift
@@ -140,7 +140,7 @@ let compassWalkTurnLevels: [CompassWalkTurnLevel] = [
     CompassWalkTurnLevel(id: 2, walkDirection: .right, steps: 2, targetDeg: 180),
     CompassWalkTurnLevel(id: 3, walkDirection: .forward, steps: 4, targetDeg: 45),
     CompassWalkTurnLevel(id: 4, walkDirection: .left, steps: 2, targetDeg: -90),
-    CompassWalkTurnLevel(id: 5, walkDirection: .forward, steps: 3, targetDeg: 270)
+    CompassWalkTurnLevel(id: 5, walkDirection: .forward, steps: 3, targetDeg: -90)
 ]
 
 // MARK: - Main view

--- a/Tests/MatherTests/CompassAnglesTests.swift
+++ b/Tests/MatherTests/CompassAnglesTests.swift
@@ -117,6 +117,13 @@ struct CompassAnglesTests {
         #expect(CompassAnglesView.bodyRelativeHint(for: 180).contains("Keep turning"))
     }
 
+    @Test func finalLevelUsesLeftTurnCopyForLeftTurnSnapTarget() {
+        let finalLevel = compassWalkTurnLevels.last
+        #expect(finalLevel?.targetDeg == -90)
+        #expect(finalLevel?.turnHint == "Then turn left 90°.")
+        #expect(finalLevel?.instruction.contains("turn left 90 degrees") == true)
+    }
+
 }
 
 @Suite("Compass Walk + Turn sequencing")


### PR DESCRIPTION
## Summary
- change the final Compass Walk level target from 270 degrees to the equivalent -90 degree left-turn target
- add a regression test that the final level says "turn left 90" in child-facing copy

## Validation
- git diff --check
- xcodebuild unavailable in this container, so GitHub CI is the build/test gate

Refs #1117
