### PR TITLE
Guard Remember completion on correct answers

### DIFF
--- a/Features/Lab/LabModels.swift
+++ b/Features/Lab/LabModels.swift
@@ -281,7 +281,7 @@ struct LabRememberStageExecution: Equatable {
     }
 
     var isComplete: Bool {
-        !deck.cards.isEmpty && Set(reviewedCardIDs).isSuperset(of: deck.cards.map(\.id))
+        !deck.cards.isEmpty && correctCardIDs.isSuperset(of: deck.cards.map(\.id))
     }
 
     var usesPunitiveCountdown: Bool { deck.hasPunitiveCountdown }

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -402,6 +402,26 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(execution.progressLabel, "2 / \(deck.cards.count)")
     }
 
+    func testRememberStageExecutionDoesNotCompleteAfterIncorrectFinalAnswer() throws {
+        let deck = LabRememberStageDeck.numbersNumberBondsTo10
+        let finalIndex = deck.cards.count - 1
+        let reviewedCardIDs = deck.cards.dropLast().map(\.id)
+        let correctCardIDs = Set(reviewedCardIDs)
+        var execution = LabRememberStageExecution(
+            deck: deck,
+            currentIndex: finalIndex,
+            reviewedCardIDs: reviewedCardIDs,
+            correctCardIDs: correctCardIDs
+        )
+        let finalCard = try XCTUnwrap(execution.currentCard)
+
+        XCTAssertFalse(execution.submit(answer: "not \(finalCard.answer)"))
+
+        XCTAssertTrue(execution.reviewedCardIDs.contains(finalCard.id))
+        XCTAssertFalse(execution.correctCardIDs.contains(finalCard.id))
+        XCTAssertFalse(execution.isComplete)
+    }
+
     func testNumbersRememberStageRoutesToReusableRememberDeck() throws {
         let plan = LabConceptSessionPlan.numbersNumberBondsTo10
         let remember = try XCTUnwrap(plan.stages.first { $0.stage == .remember })


### PR DESCRIPTION
## Summary
- require every Remember card to be answered correctly before the stage can finish
- keep reviewed-card tracking for incorrect attempts, but stop using it as completion state
- add a regression test for an incorrect final-card answer

## Validation
- git diff --check
- xcodebuild unavailable in this container, so GitHub CI is the build/test gate

Refs #1117
