### PR TITLE
Resume Sum Sprint timer after wrong answers

### DIFF
--- a/Domain/SumSprintEngine.swift
+++ b/Domain/SumSprintEngine.swift
@@ -241,6 +241,7 @@ final class SumSprintEngine {
         applyLeitnerUpdate(factKey: card.fact.factKey, correct: false, firstTry: false)
 
         showIncorrectFeedback = true
+        let cardID = cards[currentCardIndex].id
         feedbackTask = Task { @MainActor [weak self] in
             guard let self else { return }
             if self.feedbackDuration > 0 {
@@ -249,6 +250,11 @@ final class SumSprintEngine {
             guard !Task.isCancelled else { return }
             self.showIncorrectFeedback = false
             self.feedbackTask = nil
+            guard self.phase == .session,
+                  self.cards.indices.contains(self.currentCardIndex),
+                  self.cards[self.currentCardIndex].id == cardID
+            else { return }
+            self.startCardTimer()
         }
     }
 

--- a/Tests/MatherTests/SumSprintEngineTests.swift
+++ b/Tests/MatherTests/SumSprintEngineTests.swift
@@ -408,6 +408,11 @@ struct SumSprintEngineTests {
         #expect(engine.currentCardIndex == 0)
         #expect(engine.showIncorrectFeedback == false)
         #expect(engine.showTimeoutFeedback == false)
+        #expect(engine.cardTimeRemaining > 0)
+
+        let restartedRemaining = engine.cardTimeRemaining
+        try await Task.sleep(for: .milliseconds(250))
+        #expect(engine.cardTimeRemaining < restartedRemaining)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- restart the current card timer after incorrect-answer feedback clears
- guard the delayed restart so stale feedback tasks cannot restart a different card/session
- extend the near-expiry wrong-answer regression to prove the timer resumes and counts down again

## Validation
- git diff --check
- xcodebuild unavailable in this container, so GitHub CI is the build/test gate

Refs #1117
