### PR TITLE
Add Memory ask fallback turns from fact cards

### DIFF
--- a/Features/Memory/MemoryAskConversationPolicy.swift
+++ b/Features/Memory/MemoryAskConversationPolicy.swift
@@ -191,7 +191,33 @@ final class MemoryAskConversationPolicy {
             ))
         }
 
+        if turns.count < 3 {
+            for turn in detailCardTurns(for: animal) where !turns.contains(where: { $0.id == turn.id }) {
+                turns.append(turn)
+                if turns.count == 3 { break }
+            }
+        }
+
         return Array(turns.prefix(3))
+    }
+
+    private static func detailCardTurns(for animal: MemoryAnimal) -> [MemoryAskSuggestedTurn] {
+        let name = animal.canonicalName
+        let skippedTitles = Set(["name"])
+        return animal.detailCards.compactMap { card in
+            let title = clean(card.title)
+            let value = clean(card.value)
+            guard !title.isEmpty,
+                  !value.isEmpty,
+                  !skippedTitles.contains(title.lowercased()) else { return nil }
+            let id = "fact-\(words(in: title).joined(separator: "-"))"
+            guard id != "fact-" else { return nil }
+            return MemoryAskSuggestedTurn(
+                id: id,
+                question: "What does \(title.lowercased()) tell us about \(name)?",
+                answer: "\(title): \(value)."
+            )
+        }
     }
 
     private static func clean(_ text: String) -> String {

--- a/Tests/MatherTests/MemoryAskConversationPolicyTests.swift
+++ b/Tests/MatherTests/MemoryAskConversationPolicyTests.swift
@@ -60,15 +60,26 @@ struct MemoryAskConversationPolicyTests {
     @MainActor
     @Test func fallbackUsesCustomFactCardsWhenMetadataHasNoGenericTurns() async {
         let policy = MemoryAskConversationPolicy()
-        let evaporation = MemoryDeck.waterCycle.first { $0.id == "water-cycle-evaporation" }!
-        let fruit = MemoryDeck.fruits.first { $0.detailCards.contains { $0.title == "Taste" } }!
+        let customFactOnlyCard = MemoryAnimal(
+            id: "custom-fact-only",
+            name: "Sprout",
+            picture: .text("Sprout"),
+            metadata: MemoryCardMetadata(
+                deck: .fruits,
+                category: "plant growth",
+                kind: "plant growth",
+                factCards: [
+                    MemoryFactCard(title: "Concept", value: "A seed starting to grow"),
+                    MemoryFactCard(title: "Action", value: "The first leaves push upward"),
+                    MemoryFactCard(title: "Where", value: "In warm soil")
+                ]
+            )
+        )
 
-        let waterSession = await policy.startSession(for: evaporation)
-        let fruitSession = await policy.startSession(for: fruit)
+        let session = await policy.startSession(for: customFactOnlyCard)
 
-        #expect(waterSession.suggestedTurns.contains { $0.id == "fact-concept" || $0.id == "fact-action" })
-        #expect(waterSession.suggestedTurns.contains { $0.answer.localizedCaseInsensitiveContains("Action:") })
-        #expect(fruitSession.suggestedTurns.contains { $0.id == "fact-taste" || $0.id == "fact-usually-found" })
+        #expect(session.suggestedTurns.map(\.id) == ["fact-concept", "fact-action", "fact-where"])
+        #expect(session.suggestedTurns.contains { $0.answer.localizedCaseInsensitiveContains("Action:") })
     }
 
     @MainActor

--- a/Tests/MatherTests/MemoryAskConversationPolicyTests.swift
+++ b/Tests/MatherTests/MemoryAskConversationPolicyTests.swift
@@ -45,6 +45,33 @@ struct MemoryAskConversationPolicyTests {
     }
 
     @MainActor
+    @Test func fallbackProvidesTurnsForEveryMemoryDeckCard() async {
+        let policy = MemoryAskConversationPolicy()
+
+        for deck in MemoryView.DeckSelection.allCases {
+            for animal in deck.animals {
+                let session = await policy.startSession(for: animal)
+                #expect(session.source == .deterministicFallback)
+                #expect(!session.suggestedTurns.isEmpty, "Missing ask turns for \(deck.menuLabel): \(animal.id)")
+            }
+        }
+    }
+
+    @MainActor
+    @Test func fallbackUsesCustomFactCardsWhenMetadataHasNoGenericTurns() async {
+        let policy = MemoryAskConversationPolicy()
+        let evaporation = MemoryDeck.waterCycle.first { $0.id == "water-cycle-evaporation" }!
+        let fruit = MemoryDeck.fruits.first { $0.detailCards.contains { $0.title == "Taste" } }!
+
+        let waterSession = await policy.startSession(for: evaporation)
+        let fruitSession = await policy.startSession(for: fruit)
+
+        #expect(waterSession.suggestedTurns.contains { $0.id == "fact-concept" || $0.id == "fact-action" })
+        #expect(waterSession.suggestedTurns.contains { $0.answer.localizedCaseInsensitiveContains("Action:") })
+        #expect(fruitSession.suggestedTurns.contains { $0.id == "fact-taste" || $0.id == "fact-usually-found" })
+    }
+
+    @MainActor
     @Test func availableProviderCanSupplyBoundedSuggestedTurnsOnly() async {
         let provider = StubTurnProvider(
             isAvailable: true,


### PR DESCRIPTION
## Summary
- add deterministic Memory ask fallback turns from card fact chips when generic metadata produces too few turns
- keep fallback bounded to three suggested turns and skip name-only facts
- add coverage that every Memory deck card gets at least one deterministic ask turn, including water-cycle and fruit fact-card decks

## Validation
- git diff --check
- xcodebuild unavailable in this container, so GitHub CI is the build/test gate

Refs #1117
