### PR TITLE
Simplify lane detail game launchers

### DIFF
--- a/Features/Lab/LabLaneDetailView.swift
+++ b/Features/Lab/LabLaneDetailView.swift
@@ -301,8 +301,10 @@ struct LabLaneDetailView: View {
                 .foregroundStyle(MatherTheme.ink)
 
             if lane.isReady {
-                ForEach(lane.activities) { activity in
-                    activityCard(activity, lane: lane, tint: tint)
+                LazyVGrid(columns: gameLauncherColumns, spacing: 12) {
+                    ForEach(lane.activities) { activity in
+                        activityCard(activity, lane: lane, tint: tint)
+                    }
                 }
             } else {
                 Label("Games coming soon", systemImage: "sparkles")
@@ -321,11 +323,15 @@ struct LabLaneDetailView: View {
             activity: activity,
             tint: tint,
             canLaunch: activity.id.canDirectLaunch(with: sensorCapabilities),
-            layoutMode: .detail,
+            layoutMode: .grid,
             sensorCapabilities: sensorCapabilities
         ) {
             launch(activity.id)
         }
+    }
+
+    private var gameLauncherColumns: [GridItem] {
+        [GridItem(.adaptive(minimum: 132, maximum: 220), spacing: 12)]
     }
 
     private func recallSection(_ lane: CapabilityLane, tint: Color) -> some View {

--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -915,8 +915,8 @@ final class ScreenshotTests: XCTestCase {
         snapshot(app, "UXReview-LabGames-GridCards")
     }
 
-    /// Phase 3: Geometry lane detail renders GameActivityCard in detail layout.
-    func testScreenshot_UXReview_GeometryLaneDetail() {
+    /// Phase 3: Geometry lane detail renders sparse icon-name game launchers.
+    func testScreenshot_UXReview_GeometryLaneIconNameLaunchers() {
         let app = launchApp(with: [
             "-feature.audioEnabled", "NO",
             "-feature.hapticsEnabled", "NO",
@@ -926,7 +926,7 @@ final class ScreenshotTests: XCTestCase {
         ])
 
         _ = app.staticTexts["Geometry"].waitForExistence(timeout: 10)
-        snapshot(app, "UXReview-GeometryLane-DetailCards")
+        snapshot(app, "UXReview-GeometryLane-IconNameLaunchers")
     }
 
     /// Phase 4: Shape Names thread navigates through flashcards → name match stages.


### PR DESCRIPTION
## Summary
- renders lane-detail game launchers as the existing sparse icon+name grid cards
- replaces the larger detail rows with an adaptive launcher grid to reduce vertical pressure in lab detail screens
- updates the UI review screenshot test name and snapshot label for the new launcher surface

## Validation
- git diff --check
- GitHub CI is the build/test gate; local xcodebuild/xcodegen are unavailable in this Linux container

Refs #1128
Refs #1126
