### PR TITLE
Let child session start skip parent unlock

### DIFF
--- a/Features/VerticalSlice1/HomeView.swift
+++ b/Features/VerticalSlice1/HomeView.swift
@@ -208,7 +208,7 @@ struct HomeView: View {
     }
 
     private func requestParentAction(_ action: ParentHomeAction) {
-        if appModel.featureFlags.testModeEnabled {
+        if appModel.featureFlags.testModeEnabled || !action.requiresParentUnlock {
             runParentAction(action)
             return
         }
@@ -246,6 +246,15 @@ private enum ParentHomeAction {
     case sessionSetup
     case parentSummary
     case settings
+
+    var requiresParentUnlock: Bool {
+        switch self {
+        case .sessionSetup:
+            return false
+        case .parentSummary, .settings:
+            return true
+        }
+    }
 
     var unlockRequest: ParentUnlockRequest {
         switch self {

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -61,14 +61,16 @@ final class CompactLayoutTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(parentControls.frame.minY, nextUp.frame.maxY, "Expected parent controls to read as secondary controls after child actions")
     }
 
-    func testParentLockedActionsUseHoldUnlockOutsideTestMode() throws {
+    func testChildSessionStartSkipsParentUnlockButParentControlsStayLocked() throws {
         let app = launchWithoutParentBypass()
         XCTAssertTrue(app.staticTexts["Mather"].waitForExistence(timeout: 10))
 
         app.buttons["Play"].tap()
-        XCTAssertTrue(app.staticTexts["Parent unlock"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.staticTexts["A parent unlock is required before changing session setup."].exists)
-        app.buttons["parent-unlock-cancel-button"].tap()
+        XCTAssertTrue(app.staticTexts["Session setup"].waitForExistence(timeout: 10))
+        XCTAssertFalse(app.staticTexts["Parent unlock"].exists)
+
+        app.buttons["Back to Home"].tap()
+        XCTAssertTrue(app.staticTexts["Mather"].waitForExistence(timeout: 10))
 
         XCTAssertTrue(app.buttons["Settings"].waitForExistence(timeout: 5))
         app.buttons["Settings"].tap()


### PR DESCRIPTION
## Summary
- lets the child-facing Targets/Next up session-start path open Session setup without the parent hold sheet
- keeps Settings and Parent Summary behind the parent unlock
- updates the compact UI regression to cover the new split between child session start and parent-only controls

## Validation
- git diff --check
- GitHub CI is the build/test gate; local xcodebuild is unavailable in this Linux container

Refs #1127
