### PR TITLE
Pin gameplay controls above compact safe area

### DIFF
--- a/App/MatherApp.swift
+++ b/App/MatherApp.swift
@@ -80,6 +80,8 @@ private extension MatherApp {
             appModel.engine.showLabLane(.geometry)
         case "watercycle", "water-cycle", "watercyclethread", "water-cycle-thread":
             appModel.engine.showWaterCycle()
+        case "countries", "countrycards", "country-cards", "countrycardsthread", "country-cards-thread":
+            appModel.engine.showCountriesGameplayThread()
         case "watercyclelab", "water-cycle-lab", "legacy-watercycle", "legacy-water-cycle":
             appModel.engine.showLegacyWaterCycleLab()
         case "bondblast", "bond-blast", "bondblastfinale", "bond-blast-finale":

--- a/Features/GameplayStages/GameplayThreadView.swift
+++ b/Features/GameplayStages/GameplayThreadView.swift
@@ -66,12 +66,23 @@ struct GameplayThreadView: View {
                     activeStage(compact: compact)
                         .id(navigation.stageAttemptID)
                         .frame(maxWidth: GameplayStageRenderSupport.maximumContentWidth(compact: compact))
-                    controls(compact: compact)
                 }
                 .padding(compact ? 14 : 24)
+                .padding(.bottom, compact ? 86 : 78)
                 .frame(maxWidth: .infinity)
             }
-            .safeAreaPadding(.bottom, compact ? 18 : 10)
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                controls(compact: compact)
+                    .padding(.horizontal, compact ? 14 : 24)
+                    .padding(.top, compact ? 8 : 10)
+                    .padding(.bottom, compact ? 10 : 12)
+                    .background(.ultraThinMaterial)
+                    .overlay(alignment: .top) {
+                        Rectangle()
+                            .fill(MatherTheme.panelDeep.opacity(0.12))
+                            .frame(height: 1)
+                    }
+            }
             .background(MatherTheme.background.ignoresSafeArea())
         }
         .navigationTitle(thread.title)
@@ -248,6 +259,7 @@ struct GameplayThreadView: View {
             .font(.subheadline.weight(.semibold).monospacedDigit())
             .foregroundStyle(MatherTheme.ink.opacity(0.8))
             .accessibilityLabel(navigation.stageResults.isEmpty ? "Learning stage in progress" : "Current score \(summary.scorePoints)")
+            .accessibilityIdentifier("GameplayStageScoreLabel")
     }
 }
 

--- a/Tests/MatherUITests/CompactLayoutTests.swift
+++ b/Tests/MatherUITests/CompactLayoutTests.swift
@@ -354,6 +354,24 @@ final class CompactLayoutTests: XCTestCase {
         XCTAssertTrue(app.buttons["water-cycle-reset"].waitForExistence(timeout: 5))
     }
 
+    func testCountryCardsCompactGameplayControlsStayPinned() throws {
+        guard UIDevice.current.userInterfaceIdiom == .phone else {
+            throw XCTSkip("Compact Country Cards controls regression only runs on iPhone simulators")
+        }
+
+        let app = launchCountryCardsThread()
+        XCTAssertTrue(app.staticTexts["Country Cards"].waitForExistence(timeout: 10))
+
+        let retry = app.buttons["GameplayStageRetryButton"]
+        let score = app.staticTexts["GameplayStageScoreLabel"]
+        XCTAssertTrue(retry.waitForExistence(timeout: 5))
+        XCTAssertTrue(score.waitForExistence(timeout: 5))
+        XCTAssertTrue(retry.isHittable, "Expected Retry to stay pinned without scrolling on compact Country Cards")
+        XCTAssertTrue(score.isHittable, "Expected Score/Learning label to stay pinned without scrolling on compact Country Cards")
+        XCTAssertLessThanOrEqual(retry.frame.maxY, app.frame.maxY, "Expected pinned controls to stay inside the viewport")
+        XCTAssertLessThanOrEqual(score.frame.maxY, app.frame.maxY, "Expected pinned score label to stay inside the viewport")
+    }
+
 
     private func advanceStoryAnchorIfPresent(_ app: XCUIApplication) {
         let startBuilding = app.buttons["story-anchor-start-button"]
@@ -451,6 +469,20 @@ final class CompactLayoutTests: XCTestCase {
             "-feature.testModeEnabled", "YES",
             "-feature.skipProfilePicker", "YES",
             "-uiTest.startRoute", "geometryLane"
+        ]
+        app.launch()
+        return app
+    }
+
+    private func launchCountryCardsThread() -> XCUIApplication {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "-feature.audioEnabled", "NO",
+            "-feature.hapticsEnabled", "NO",
+            "-feature.testModeEnabled", "YES",
+            "-feature.skipProfilePicker", "YES",
+            "-uiTest.startRoute", "countryCards"
         ]
         app.launch()
         return app


### PR DESCRIPTION
## Summary
- pin gameplay Retry/Score controls in a bottom safe-area inset so compact card stages do not require scrolling to reach completion controls
- add a Country Cards UI-test launch route for direct compact gameplay coverage
- add a compact Country Cards regression that verifies Retry and Score/Learning stay hittable inside the first viewport

Refs #1126

## Validation
- git diff --check
- Local xcodebuild/xcodegen are unavailable in this Linux container; GitHub CI is the build/test gate.

