### PR TITLE
[codex] Add World Animals staged diet curriculum

### DIFF
--- a/Domain/GameplayThreadContent+WorldAnimals.swift
+++ b/Domain/GameplayThreadContent+WorldAnimals.swift
@@ -7,11 +7,12 @@ extension GameplayThreadCatalog {
         category: GameplayCategory(
             id: "geography-world",
             title: "Geography + World",
-            subtitle: "Animal homes, sounds, movements, colors, and kinds around the world"
+            subtitle: "Animal names, homes, food clues, sounds, movements, colors, and kinds around the world"
         ),
         propertyTypes: [
             GameplayPropertyType(id: "name", displayName: "Name", prompt: "Find the animal name."),
             GameplayPropertyType(id: "habitat", displayName: "Home", prompt: "Find where this animal can live."),
+            GameplayPropertyType(id: "diet", displayName: "Food", prompt: "Find what this animal mostly eats."),
             GameplayPropertyType(id: "movement", displayName: "Moves", prompt: "Find how this animal moves."),
             GameplayPropertyType(id: "sound", displayName: "Sound", prompt: "Find the animal sound."),
             GameplayPropertyType(id: "colors", displayName: "Colors", prompt: "Find the animal colors."),
@@ -21,9 +22,11 @@ extension GameplayThreadCatalog {
             worldAnimalEntity(from: memoryAnimal)
         },
         stages: [
-            GameplayStageDefinition(id: "world-animals-flashcards", kind: .flashcards, title: "Animal Cards", prompt: "Meet animals and notice where they live.", maximumItemCount: 12),
-            GameplayStageDefinition(id: "world-animals-easy-memory", kind: .easyMemory, title: "Animal Match", prompt: "Start with one focused round matching each animal picture to its name.", propertyTypeIDs: ["name"], maximumItemCount: 8),
-            GameplayStageDefinition(id: "world-animals-bond-blast", kind: .bondBlast, title: "Animal Blast", prompt: "Connect each animal with its home, movement, sound, colors, and kind.", propertyTypeIDs: ["habitat", "movement", "sound", "colors", "kind"], maximumItemCount: 12),
+            GameplayStageDefinition(id: "world-animals-flashcards", kind: .flashcards, title: "Animal Cards", prompt: "Meet animals, names, homes, and food clues.", maximumItemCount: 12),
+            GameplayStageDefinition(id: "world-animals-name-match", kind: .easyMemory, title: "Name Match", prompt: "Start by matching each animal picture to its name.", propertyTypeIDs: ["name"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "world-animals-habitat-match", kind: .flipMemory, title: "Habitat Match", prompt: "Remember which home clue belongs with each animal.", propertyTypeIDs: ["habitat"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "world-animals-diet-quiz", kind: .multipleChoice, title: "Food Quiz", prompt: "Pick whether each animal mostly eats plants, meat, or both.", propertyTypeIDs: ["diet"], maximumItemCount: 8),
+            GameplayStageDefinition(id: "world-animals-bond-blast", kind: .bondBlast, title: "Animal Blast", prompt: "Connect each animal with its name, home, food clue, movement, sound, colors, and kind.", propertyTypeIDs: ["name", "habitat", "diet", "movement", "sound", "colors", "kind"], maximumItemCount: 12),
         ],
         progressionPolicy: GameplayProgressionPolicy(minimumAccuracyToAdvance: 0.70, retryMissedItemsFirst: true)
     )
@@ -40,6 +43,7 @@ extension GameplayThreadCatalog {
             properties: [
                 GameplayProperty(id: "\(safeID)-name", typeID: "name", value: memoryAnimal.name, explanation: "\(memoryAnimal.name) is this animal's name.", visualKey: memoryAnimal.emoji, visualAssetName: memoryAnimal.imageAssetName),
                 memoryProperty(entityID: safeID, typeID: "habitat", value: metadata.habitat, fallback: "animal homes", explanationPrefix: "This animal can live in"),
+                GameplayProperty(id: "\(safeID)-diet", typeID: "diet", value: worldAnimalDiet(for: memoryAnimal.id), explanation: "\(memoryAnimal.name) \(worldAnimalDietExplanation(for: memoryAnimal.id))."),
                 memoryProperty(entityID: safeID, typeID: "movement", value: metadata.movement, fallback: "moves in its own way", explanationPrefix: "This animal"),
                 memoryProperty(entityID: safeID, typeID: "sound", value: metadata.sound, fallback: "quiet animal clue", explanationPrefix: "Listen for"),
                 memoryProperty(entityID: safeID, typeID: "colors", value: metadata.colors, fallback: "animal colors", explanationPrefix: "Look for"),
@@ -56,5 +60,27 @@ extension GameplayThreadCatalog {
             value: displayValue,
             explanation: "\(explanationPrefix) \(displayValue)."
         )
+    }
+
+    static func worldAnimalDiet(for id: String) -> String {
+        switch id {
+        case "cat":
+            return "Carnivore: mostly eats meat"
+        case "dog", "pig", "duck", "rooster", "turkey", "goldfish":
+            return "Omnivore: eats plants and animals"
+        default:
+            return "Herbivore: mostly eats plants"
+        }
+    }
+
+    static func worldAnimalDietExplanation(for id: String) -> String {
+        switch id {
+        case "cat":
+            return "is a carnivore, so it mostly eats meat"
+        case "dog", "pig", "duck", "rooster", "turkey", "goldfish":
+            return "is an omnivore, so it can eat plants and animals"
+        default:
+            return "is a herbivore, so it mostly eats plants"
+        }
     }
 }

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -270,7 +270,11 @@ struct WorldCreatureGameplayThreadTests {
             let propertyTypeIDs = Set(thread.propertyTypes.map(\.id))
 
             #expect(!thread.entities.isEmpty)
-            #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .bondBlast])
+            if threadID == .worldAnimals {
+                #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .flipMemory, .multipleChoice, .bondBlast])
+            } else {
+                #expect(thread.stages.map(\.kind) == [.flashcards, .easyMemory, .bondBlast])
+            }
             #expect(thread.entities.allSatisfy { !$0.properties.isEmpty })
             #expect(thread.entities.allSatisfy { entity in
                 Set(entity.properties.map(\.typeID)).isSubset(of: propertyTypeIDs)
@@ -310,7 +314,8 @@ struct WorldCreatureGameplayThreadTests {
     @Test
     func worldAnimalsEasyMemoryStartsWithPictureNameRound() throws {
         let thread = GameplayThreadCatalog.worldAnimals
-        let stage = try #require(thread.stages.first { $0.kind == .easyMemory })
+        let stage = try #require(thread.stages.first { $0.id == "world-animals-name-match" })
+        #expect(stage.title == "Name Match")
         #expect(stage.propertyTypeIDs == ["name"])
         #expect(stage.prompt.localizedCaseInsensitiveContains("picture"))
         #expect(stage.prompt.localizedCaseInsensitiveContains("name"))
@@ -324,6 +329,52 @@ struct WorldCreatureGameplayThreadTests {
         #expect(pairs.allSatisfy { $0.right.presentation == .titleOnly })
         #expect(Set(pairs.map { $0.right.title.lowercased() }).count == pairs.count)
     }
+
+    @Test
+    func worldAnimalsProgressesThroughNameHabitatDietAndMixedStages() throws {
+        let thread = GameplayThreadCatalog.worldAnimals
+        let propertyTypeIDs = Set(thread.propertyTypes.map(\.id))
+
+        #expect(propertyTypeIDs.isSuperset(of: ["name", "habitat", "diet"]))
+        #expect(thread.stages.map(\.id) == [
+            "world-animals-flashcards",
+            "world-animals-name-match",
+            "world-animals-habitat-match",
+            "world-animals-diet-quiz",
+            "world-animals-bond-blast"
+        ])
+        #expect(thread.stages.map(\.title) == [
+            "Animal Cards",
+            "Name Match",
+            "Habitat Match",
+            "Food Quiz",
+            "Animal Blast"
+        ])
+
+        let habitatStage = try #require(thread.stages.first { $0.id == "world-animals-habitat-match" })
+        let dietStage = try #require(thread.stages.first { $0.id == "world-animals-diet-quiz" })
+        let mixedStage = try #require(thread.stages.first { $0.id == "world-animals-bond-blast" })
+
+        #expect(habitatStage.kind == .flipMemory)
+        #expect(habitatStage.propertyTypeIDs == ["habitat"])
+        #expect(dietStage.kind == .multipleChoice)
+        #expect(dietStage.propertyTypeIDs == ["diet"])
+        #expect(mixedStage.propertyTypeIDs == ["name", "habitat", "diet", "movement", "sound", "colors", "kind"])
+
+        let dietValues = Set(thread.entities.compactMap { entity in
+            entity.properties.first { $0.typeID == "diet" }?.value
+        })
+
+        #expect(dietValues == Set([
+            "Herbivore: mostly eats plants",
+            "Carnivore: mostly eats meat",
+            "Omnivore: eats plants and animals"
+        ]))
+        #expect(thread.entities.allSatisfy { entity in
+            Set(["name", "habitat", "diet"]).isSubset(of: Set(entity.properties.map(\.typeID)))
+        })
+    }
+
     @Test
     func worldBirdsEasyMemoryStartsWithDeterministicPictureNameRoundWithoutDuplicateVisibleAnswers() throws {
         let thread = GameplayThreadCatalog.worldBirds

--- a/Tests/MatherTests/LabRouteRegressionTests.swift
+++ b/Tests/MatherTests/LabRouteRegressionTests.swift
@@ -65,7 +65,9 @@ struct LabRouteRegressionTests {
             #expect(activityID.appRoute == .gameplayThread(threadID))
             let stageKinds = GameplayThreadCatalog.thread(for: threadID).stages.map(\.kind)
             #expect(!stageKinds.isEmpty)
-            if threadID == .worldAnimals || threadID == .worldBirds {
+            if threadID == .worldAnimals {
+                #expect(stageKinds == [.flashcards, .easyMemory, .flipMemory, .multipleChoice, .bondBlast])
+            } else if threadID == .worldBirds {
                 #expect(stageKinds == [.flashcards, .easyMemory, .bondBlast])
             } else {
                 #expect(stageKinds == [.flashcards, .easyMemory, .flipMemory, .bondBlast, .multipleChoice])


### PR DESCRIPTION
## Summary
- expands World Animals into explicit Name Match, Habitat Match, Food Quiz, and mixed Animal Blast stages
- adds a diet property with child-safe carnivore/herbivore/omnivore copy
- updates content tests so #1123 is covered by stage order, property coverage, and diet values

## Validation
- git diff --check
- xcodebuild unavailable on this Linux host; GitHub CI is the Swift build/test gate

Closes #1123