### PR TITLE
Stabilize loop v2 UI review target transition

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -632,10 +632,9 @@ final class ScreenshotTests: XCTestCase {
         snapshotPrefix: String,
         skipInitialConcreteSnapshot: Bool = false
     ) {
-        advanceStoryAnchorIfPresent(in: app, snapshotPrefix: snapshotPrefix, shouldSnapshot: !skipInitialConcreteSnapshot)
+        waitForLoopV2ConcreteStage(in: app, target: target, snapshotPrefix: snapshotPrefix, shouldSnapshotStoryAnchor: !skipInitialConcreteSnapshot)
 
         let concreteStageButton = concreteStageButton(for: target, in: app)
-        XCTAssertTrue(concreteStageButton.waitForExistence(timeout: 15), "Expected concrete stage for target \(target)")
         if !skipInitialConcreteSnapshot {
             snapshot(app, "\(snapshotPrefix)-Concrete")
         }
@@ -701,6 +700,39 @@ final class ScreenshotTests: XCTestCase {
             leftCard.tap()
             rightCard.tap()
         }
+    }
+
+    private func waitForLoopV2ConcreteStage(
+        in app: XCUIApplication,
+        target: Int,
+        snapshotPrefix: String,
+        shouldSnapshotStoryAnchor: Bool
+    ) {
+        let concreteStageButton = concreteStageButton(for: target, in: app)
+        let deadline = Date().addingTimeInterval(30)
+        var attemptedStoryAnchor = false
+
+        repeat {
+            if concreteStageButton.exists {
+                return
+            }
+
+            if !attemptedStoryAnchor,
+               storyAnchorIsPresent(in: app) {
+                advanceStoryAnchorIfPresent(in: app, snapshotPrefix: snapshotPrefix, shouldSnapshot: shouldSnapshotStoryAnchor)
+                attemptedStoryAnchor = true
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+        } while Date() < deadline
+
+        XCTAssertTrue(concreteStageButton.waitForExistence(timeout: 1), "Expected concrete stage for target \(target)")
+    }
+
+    private func storyAnchorIsPresent(in app: XCUIApplication) -> Bool {
+        app.otherElements["story-anchor-card"].exists
+            || app.buttons["story-anchor-start-button"].exists
+            || app.buttons["Start building"].exists
     }
 
 


### PR DESCRIPTION
## Summary
- Stabilizes the Issue #222 loop-v2 screenshot helper around inter-problem transitions.
- Waits for the next concrete target while advancing any story-anchor card that appears.
- Keeps the existing target-specific assertion, but avoids failing before target 12 has surfaced on hosted iPhone UI review.

## Evidence
- Scheduled main UI review failed on iPhone: https://github.com/ganesh47/mather/actions/runs/26713025356
- Failing assertion: Expected concrete stage for target 12
- iPad job passed; iPhone build/simulator boot succeeded and failed only in screenshot test execution.

## Validation
- git diff --check
- GitHub PR checks pending.
