### PR TITLE
Fix fallback story vocabulary pressure language

### DIFF
--- a/Domain/NumberStoryStageVocabulary.swift
+++ b/Domain/NumberStoryStageVocabulary.swift
@@ -59,12 +59,12 @@ struct NumberStoryStageVocabulary: Equatable {
             )
         case .sumSprint:
             return NumberStoryStageVocabulary(
-                title: "Sum Sprint",
+                title: "Story Matches",
                 targetReminder: "Make \(target)",
-                instruction: "Tap a sum sentence, then tap its total.",
+                instruction: "Tap a story number sentence, then tap its total.",
                 leftLabel: "Sentence",
                 rightLabel: "Total",
-                accessibilityLabel: "Sum Sprint. Match each sum sentence to its total."
+                accessibilityLabel: "Story Matches. Match each story number sentence to its total."
             )
         case .bondBlast:
             return NumberStoryStageVocabulary(

--- a/Tests/MatherTests/NumberStoryStageVocabularyTests.swift
+++ b/Tests/MatherTests/NumberStoryStageVocabularyTests.swift
@@ -85,9 +85,14 @@ struct NumberStoryStageVocabularyTests {
                         .vocabulary(for: prompt, stage: stage)
                         .searchableText
                         .lowercased()
+                    let fallbackText = NumberStoryStageVocabulary
+                        .fallback(stage: stage, target: problem.target)
+                        .searchableText
+                        .lowercased()
 
                     for term in bannedTerms {
                         #expect(!text.contains(term))
+                        #expect(!fallbackText.contains(term))
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- renames fallback Sum Sprint story-stage vocabulary to Story Matches
- updates fallback instructions and accessibility text to avoid banned pressure language
- extends the pressure-language regression test to cover fallback vocabulary

## Validation
- `git diff -- Domain/NumberStoryStageVocabulary.swift Tests/MatherTests/NumberStoryStageVocabularyTests.swift`
- Local `xcodegen generate` could not run because `xcodegen` is not installed on this host; using GitHub CI for full validation.

Addresses part of #1117.