### PR TITLE
Fix electronics artwork scaling

### DIFF
--- a/Shared/ElectronicsCircuitArtwork.swift
+++ b/Shared/ElectronicsCircuitArtwork.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
 struct ElectronicsCircuitArtwork: View {
-    static let canvasSize: CGFloat = 120
+    nonisolated static let canvasSize: CGFloat = 120
 
     let key: ElectronicsArtworkKey
     var tint: Color = MatherTheme.accent
 
-    static func fittingScale(for proposedSize: CGSize) -> CGFloat {
+    nonisolated static func fittingScale(for proposedSize: CGSize) -> CGFloat {
         let availableSize = min(proposedSize.width, proposedSize.height)
         guard availableSize > 0 else { return 0 }
         return availableSize / canvasSize

--- a/Shared/ElectronicsCircuitArtwork.swift
+++ b/Shared/ElectronicsCircuitArtwork.swift
@@ -1,34 +1,27 @@
 import SwiftUI
 
 struct ElectronicsCircuitArtwork: View {
+    static let canvasSize: CGFloat = 120
+
     let key: ElectronicsArtworkKey
     var tint: Color = MatherTheme.accent
 
+    static func fittingScale(for proposedSize: CGSize) -> CGFloat {
+        let availableSize = min(proposedSize.width, proposedSize.height)
+        guard availableSize > 0 else { return 0 }
+        return availableSize / canvasSize
+    }
+
     var body: some View {
         GeometryReader { proxy in
-            let size = min(proxy.size.width, proxy.size.height)
-            let lineWidth = max(3, size * 0.055)
+            let lineWidth = Self.canvasSize * 0.055
             ZStack {
-                switch key {
-                case .battery:
-                    battery(lineWidth: lineWidth)
-                case .bulb:
-                    bulb(lineWidth: lineWidth)
-                case .wire:
-                    wire(lineWidth: lineWidth)
-                case .switchControl:
-                    switchControl(lineWidth: lineWidth)
-                case .closedCircuit:
-                    circuit(closed: true, lineWidth: lineWidth)
-                case .openCircuit:
-                    circuit(closed: false, lineWidth: lineWidth)
-                case .safeCircuit:
-                    safeCircuit(lineWidth: lineWidth)
-                case .outletSafety:
-                    outletSafety(lineWidth: lineWidth)
-                }
+                artwork(lineWidth: lineWidth)
             }
+            .frame(width: Self.canvasSize, height: Self.canvasSize)
+            .scaleEffect(Self.fittingScale(for: proxy.size))
             .frame(width: proxy.size.width, height: proxy.size.height)
+            .clipped()
         }
         .aspectRatio(1, contentMode: .fit)
         .accessibilityHidden(true)
@@ -37,6 +30,28 @@ struct ElectronicsCircuitArtwork: View {
     private var wireColor: Color { MatherTheme.panelDeep.opacity(0.82) }
     private var glowColor: Color { MatherTheme.warm }
     private var dangerColor: Color { MatherTheme.coral }
+
+    @ViewBuilder
+    private func artwork(lineWidth: CGFloat) -> some View {
+        switch key {
+        case .battery:
+            battery(lineWidth: lineWidth)
+        case .bulb:
+            bulb(lineWidth: lineWidth)
+        case .wire:
+            wire(lineWidth: lineWidth)
+        case .switchControl:
+            switchControl(lineWidth: lineWidth)
+        case .closedCircuit:
+            circuit(closed: true, lineWidth: lineWidth)
+        case .openCircuit:
+            circuit(closed: false, lineWidth: lineWidth)
+        case .safeCircuit:
+            safeCircuit(lineWidth: lineWidth)
+        case .outletSafety:
+            outletSafety(lineWidth: lineWidth)
+        }
+    }
 
     @ViewBuilder
     private func battery(lineWidth: CGFloat) -> some View {

--- a/Tests/MatherTests/GameplayThreadContentTests.swift
+++ b/Tests/MatherTests/GameplayThreadContentTests.swift
@@ -4,6 +4,18 @@ import Testing
 
 struct GameplayThreadContentTests {
     @Test
+    func electronicsArtworkScaleFitsCompactCardProposals() {
+        #expect(abs(ElectronicsCircuitArtwork.fittingScale(for: CGSize(width: 48, height: 80)) - 0.4) < 0.0001)
+        #expect(abs(ElectronicsCircuitArtwork.fittingScale(for: CGSize(width: 104, height: 96)) - 0.8) < 0.0001)
+    }
+
+    @Test
+    func electronicsArtworkScaleHandlesCollapsedProposals() {
+        #expect(ElectronicsCircuitArtwork.fittingScale(for: CGSize(width: 0, height: 48)) == 0)
+        #expect(ElectronicsCircuitArtwork.fittingScale(for: CGSize(width: 48, height: 0)) == 0)
+    }
+
+    @Test
     func fruitsThreadHasCuratedEntityAndPropertyCoverage() {
         let thread = GameplayThreadCatalog.fruits
 


### PR DESCRIPTION
## Summary
- Scales ElectronicsCircuitArtwork from a fixed 120 pt internal canvas into the proposed view size.
- Clips the scaled artwork to the card-provided bounds so compact grid icons cannot draw outside the icon box.
- Adds focused unit coverage for compact and collapsed sizing proposals.

## Root cause
The artwork read GeometryReader size only for stroke width, while its child shapes still used fixed 72-116 pt frames and offsets. In GameActivityCard grid mode, the electronics artwork receives about 48x48 pt after padding, so fixed-size children could overflow neighboring card content.

## Validation
- git diff --check
- Not run locally: xcodebuild/swift are unavailable on this Linux host; GitHub Actions should run the Apple test/build matrix.