### PR TITLE
Isolate feature flags on the main actor

### DIFF
--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Observation
 
+@MainActor
 @Observable
 final class FeatureFlagService {
     private enum Keys {

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import Mather
 
+@MainActor
 struct FeatureFlagTests {
 
     @Test func selectedThemeIdDefaultsToClassic() {


### PR DESCRIPTION
## Summary
- Marks FeatureFlagService as @MainActor so its @Observable mutable state and UserDefaults writes are explicitly isolated to the UI actor.

## Root cause
FeatureFlagService is observed and mutated from SwiftUI flows, but it was a mutable @Observable reference type without actor isolation. Swift 6 could not protect off-main reads/writes or persistence side effects.

## Validation
- git diff --check
- Not run locally: xcodebuild/swift are unavailable on this Linux host; GitHub Actions should run the Apple compile/test matrix.