### PR TITLE
Require current problem in session-dependent tests

### DIFF
--- a/Tests/MatherTests/TransferExactRebuildTests.swift
+++ b/Tests/MatherTests/TransferExactRebuildTests.swift
@@ -19,7 +19,7 @@ struct TransferExactRebuildTests {
         let engine = makeEngine()
 
         engine.startSession()
-        guard let problem = engine.currentProblem else { return }
+        let problem = try #require(engine.currentProblem)
 
         try await advanceToTransfer(engine, problem: problem)
 
@@ -37,7 +37,7 @@ struct TransferExactRebuildTests {
         let engine = makeEngine()
 
         engine.startSession()
-        guard let problem = engine.currentProblem else { return }
+        let problem = try #require(engine.currentProblem)
 
         try await advanceToTransfer(engine, problem: problem)
 
@@ -110,10 +110,7 @@ struct TransferExactRebuildTests {
             return currentProblem
         }
 
-        guard let currentProblem = engine.currentProblem else {
-            Issue.record("No current problem to advance from.")
-            return SliceProblem(target: 0, decompositionA: 0, decompositionB: 0)
-        }
+        let currentProblem = try #require(engine.currentProblem)
 
         engine.adjustConcrete(by: currentProblem.target)
         engine.submitCurrentStage()

--- a/Tests/MatherTests/TransferIntentTests.swift
+++ b/Tests/MatherTests/TransferIntentTests.swift
@@ -19,7 +19,7 @@ struct TransferIntentTests {
         let engine = makeEngine()
         engine.startSession()
 
-        guard let problem = engine.currentProblem else { return }
+        let problem = try #require(engine.currentProblem)
         try await advanceToTransfer(engine, problem: problem)
 
         #expect(engine.feedbackMessage.contains("\(problem.decompositionA)"))
@@ -46,10 +46,10 @@ struct TransferIntentTests {
     }
 
     @Test
-    func transferSideAdjustmentClampsEachSideIndependently() {
+    func transferSideAdjustmentClampsEachSideIndependently() throws {
         let engine = makeEngine()
         engine.startSession()
-        guard let problem = engine.currentProblem else { return }
+        let problem = try #require(engine.currentProblem)
 
         engine.adjustTransfer(by: problem.target + 5, side: .left)
         engine.adjustTransfer(by: -3, side: .left)
@@ -67,7 +67,7 @@ struct TransferIntentTests {
         let engine = makeEngine()
         engine.startSession()
 
-        guard let problem = engine.currentProblem else { return }
+        let problem = try #require(engine.currentProblem)
         try await advanceToTransfer(engine, problem: problem)
 
         engine.adjustTransfer(by: problem.decompositionA, side: .left)

--- a/Tests/MatherTests/VehicleSpecTests.swift
+++ b/Tests/MatherTests/VehicleSpecTests.swift
@@ -165,7 +165,7 @@ struct VehicleSpecTests {
         )
         engine.startSession()
         let firstNoun = engine.activeTheme.counterNoun
-        guard let problem = engine.currentProblem else { return }
+        let problem = try #require(engine.currentProblem)
 
         // Complete all 4 CPA stages.
         engine.adjustConcrete(by: problem.target)


### PR DESCRIPTION
## Summary
- replace silent currentProblem guard returns in clawpatch-cited session tests with Swift Testing #require failures
- make the transfer side-adjustment test throwing so setup failure is reported
- remove the non-symmetric transfer helper's dummy SliceProblem fallback

## Validation
- rg confirmed the cited silent currentProblem exits were removed from TransferExactRebuildTests, TransferIntentTests, and VehicleSpecTests
- git diff --check

Local Swift/Xcode is unavailable in this runner; GitHub Actions is the compile/test gate.

Part of #1117.