### PR TITLE
Test Symmetry Fold production angle mapping

### DIFF
--- a/Features/SymmetryFold/SymmetryFoldView.swift
+++ b/Features/SymmetryFold/SymmetryFoldView.swift
@@ -148,7 +148,7 @@ struct SymmetryFoldView: View {
 
     // MARK: - Constants
 
-    private let maxTiltRadians: Double = .pi / 4
+    private static let maxTiltRadians: Double = .pi / 4
     private static let holdDuration: Double = 0.8
     private static let challengeDuration: Double = 8.0
 
@@ -177,7 +177,7 @@ struct SymmetryFoldView: View {
         .onChange(of: appModel.motionService.tiltRoll) { _, roll in
             guard let neutral = neutralRoll, !success else { return }
             let delta = roll - neutral
-            let newFold = max(0.0, min(-delta / maxTiltRadians, 1.0))
+            let newFold = Self.foldAngle(tiltRoll: roll, neutralRoll: neutral)
             foldAngle = newFold
             updateWrongDirectionCue(delta: delta)
             updateHoldProgress(for: newFold)
@@ -641,6 +641,11 @@ struct SymmetryFoldView: View {
 
     nonisolated static func successSpeech(for shapeName: String) -> String {
         "Perfectly folded! The line of symmetry makes both sides of the \(shapeName) match."
+    }
+
+    nonisolated static func foldAngle(tiltRoll: Double, neutralRoll: Double) -> Double {
+        let delta = tiltRoll - neutralRoll
+        return max(0.0, min(-delta / maxTiltRadians, 1.0))
     }
 
     nonisolated static var nearMatchHint: String {

--- a/Features/SymmetryFold/SymmetryFoldView.swift
+++ b/Features/SymmetryFold/SymmetryFoldView.swift
@@ -148,7 +148,7 @@ struct SymmetryFoldView: View {
 
     // MARK: - Constants
 
-    private static let maxTiltRadians: Double = .pi / 4
+    nonisolated private static let maxTiltRadians: Double = .pi / 4
     private static let holdDuration: Double = 0.8
     private static let challengeDuration: Double = 8.0
 

--- a/Tests/MatherTests/SymmetryFoldTests.swift
+++ b/Tests/MatherTests/SymmetryFoldTests.swift
@@ -7,22 +7,14 @@ import Testing
 /// foldAngle = clamp(-delta / (pi/4), 0, 1). These tests verify that mapping.
 struct SymmetryFoldTests {
 
-    // The fold-angle computation is extracted here as a pure function to keep
-    // tests lightweight — no SwiftUI or UIKit dependency needed.
-    private func foldAngle(tiltRoll: Double, neutralRoll: Double) -> Double {
-        let maxTilt = Double.pi / 4
-        let delta = tiltRoll - neutralRoll
-        return max(0.0, min(-delta / maxTilt, 1.0))
-    }
-
     // MARK: - Neutral roll tests
 
     @Test
     func neutralRollProducesZeroFoldAngle() {
         // At the neutral position (delta = 0), the shape should be fully open.
-        #expect(foldAngle(tiltRoll: 0.5, neutralRoll: 0.5) == 0.0)
-        #expect(foldAngle(tiltRoll: -0.3, neutralRoll: -0.3) == 0.0)
-        #expect(foldAngle(tiltRoll: 0.0, neutralRoll: 0.0) == 0.0)
+        #expect(SymmetryFoldView.foldAngle(tiltRoll: 0.5, neutralRoll: 0.5) == 0.0)
+        #expect(SymmetryFoldView.foldAngle(tiltRoll: -0.3, neutralRoll: -0.3) == 0.0)
+        #expect(SymmetryFoldView.foldAngle(tiltRoll: 0.0, neutralRoll: 0.0) == 0.0)
     }
 
     // MARK: - Left tilt increases fold angle
@@ -31,7 +23,7 @@ struct SymmetryFoldTests {
     func leftTiltIncreasesFoldAngle() {
         // Left tilt = roll decreases from neutral (negative delta).
         // neutral = 0; tiltRoll = -pi/8 (left, half of max) → foldAngle = 0.5
-        let angle = foldAngle(tiltRoll: -.pi / 8, neutralRoll: 0)
+        let angle = SymmetryFoldView.foldAngle(tiltRoll: -.pi / 8, neutralRoll: 0)
         #expect(angle > 0.0)
         #expect(angle < 1.0)
         #expect(abs(angle - 0.5) < 0.01, "Half-max tilt should give ~0.5 fold angle")
@@ -40,7 +32,7 @@ struct SymmetryFoldTests {
     @Test
     func rightTiltProducesZeroFoldAngle() {
         // Right tilt = roll increases from neutral (positive delta) → clamps to 0.
-        let angle = foldAngle(tiltRoll: .pi / 8, neutralRoll: 0)
+        let angle = SymmetryFoldView.foldAngle(tiltRoll: .pi / 8, neutralRoll: 0)
         #expect(angle == 0.0, "Right tilt should not fold the shape")
     }
 
@@ -49,18 +41,18 @@ struct SymmetryFoldTests {
     @Test
     func foldAngleClampedToZeroOneRange() {
         // Beyond max tilt: should clamp to 1.0, not exceed it.
-        let beyondMax = foldAngle(tiltRoll: -.pi, neutralRoll: 0)
+        let beyondMax = SymmetryFoldView.foldAngle(tiltRoll: -.pi, neutralRoll: 0)
         #expect(beyondMax == 1.0, "Extreme left tilt should clamp fold angle to 1.0")
 
         // Beyond right: should clamp to 0.0.
-        let beyondRight = foldAngle(tiltRoll: .pi, neutralRoll: 0)
+        let beyondRight = SymmetryFoldView.foldAngle(tiltRoll: .pi, neutralRoll: 0)
         #expect(beyondRight == 0.0, "Extreme right tilt should clamp fold angle to 0.0")
     }
 
     @Test
     func fullMaxTiltProducesFullyFoldedAngle() {
         // Exactly pi/4 left of neutral = foldAngle exactly 1.0.
-        let angle = foldAngle(tiltRoll: -.pi / 4, neutralRoll: 0)
+        let angle = SymmetryFoldView.foldAngle(tiltRoll: -.pi / 4, neutralRoll: 0)
         #expect(abs(angle - 1.0) < 0.001, "Max left tilt (pi/4) should produce fold angle 1.0")
     }
 
@@ -75,9 +67,9 @@ struct SymmetryFoldTests {
         let neutral2 = 0.5
         let neutral3 = -0.8
 
-        let a1 = foldAngle(tiltRoll: neutral1 + delta, neutralRoll: neutral1)
-        let a2 = foldAngle(tiltRoll: neutral2 + delta, neutralRoll: neutral2)
-        let a3 = foldAngle(tiltRoll: neutral3 + delta, neutralRoll: neutral3)
+        let a1 = SymmetryFoldView.foldAngle(tiltRoll: neutral1 + delta, neutralRoll: neutral1)
+        let a2 = SymmetryFoldView.foldAngle(tiltRoll: neutral2 + delta, neutralRoll: neutral2)
+        let a3 = SymmetryFoldView.foldAngle(tiltRoll: neutral3 + delta, neutralRoll: neutral3)
 
         #expect(abs(a1 - a2) < 0.001, "Same delta must produce the same fold angle regardless of neutral")
         #expect(abs(a2 - a3) < 0.001, "Same delta must produce the same fold angle regardless of neutral")
@@ -89,7 +81,7 @@ struct SymmetryFoldTests {
     func foldAngleAt95PercentTriggerSuccess() {
         // 95% of max tilt = delta = -0.95 * pi/4
         let roll = -0.95 * .pi / 4
-        let angle = foldAngle(tiltRoll: roll, neutralRoll: 0)
+        let angle = SymmetryFoldView.foldAngle(tiltRoll: roll, neutralRoll: 0)
         #expect(angle >= 0.95, "95% tilt should produce fold angle >= 0.95")
     }
 
@@ -97,7 +89,7 @@ struct SymmetryFoldTests {
     func foldAngleBelowThresholdDoesNotTriggerSuccess() {
         // 80% of max tilt should NOT reach the success threshold.
         let roll = -0.80 * .pi / 4
-        let angle = foldAngle(tiltRoll: roll, neutralRoll: 0)
+        let angle = SymmetryFoldView.foldAngle(tiltRoll: roll, neutralRoll: 0)
         #expect(angle < 0.95, "80% tilt should produce fold angle < 0.95")
     }
 


### PR DESCRIPTION
## Summary
- extract SymmetryFoldView.foldAngle from the inline motion-handling formula
- route production tilt updates through the helper
- update SymmetryFoldTests to exercise the production helper instead of a test-local formula copy

## Validation
- rg confirmed SymmetryFoldTests no longer define a private foldAngle copy
- git diff --check

Local Swift/Xcode is unavailable in this runner; GitHub Actions is the compile/test gate.

Part of #1117.