### PR TITLE
Mask face-down memory label card accessibility

### DIFF
--- a/Features/Memory/MemoryView.swift
+++ b/Features/Memory/MemoryView.swift
@@ -1701,7 +1701,7 @@ struct MemoryView: View {
         return LearningCardViewModel(
             id: card.id.uuidString,
             display: display,
-            accessibilityLabel: accessibilityLabel(for: card),
+            accessibilityLabel: accessibilityLabel(for: card, difficulty: difficulty),
             accessibilityHint: accessibilityHint(for: card, difficulty: difficulty),
             isFaceDown: difficulty.faceDown && !card.isSelected && !card.isMatched,
             isSelected: card.isSelected,

--- a/Tests/MatherTests/MemoryViewTests.swift
+++ b/Tests/MatherTests/MemoryViewTests.swift
@@ -326,10 +326,13 @@ struct MemoryViewTests {
     @Test func faceDownMemoryCardsDoNotExposeHiddenAnswerToAccessibility() {
         let bird = MemoryDeck.birds[0]
         let hidden = MemoryCard(pairId: bird.id, content: .picture(bird))
+        let hiddenLabel = MemoryCard(pairId: bird.id, content: .label(bird))
         let selected = MemoryCard(pairId: bird.id, content: .picture(bird), isSelected: true)
 
         #expect(MemoryView.accessibilityLabel(for: hidden, difficulty: .hard) == "Face down memory card")
         #expect(MemoryView.accessibilityHint(for: hidden, difficulty: .hard) == "Tap to turn this card over.")
+        #expect(MemoryView.accessibilityLabel(for: hiddenLabel, difficulty: .hard) == "Face down memory card")
+        #expect(MemoryView.accessibilityHint(for: hiddenLabel, difficulty: .hard) == "Tap to turn this card over.")
         #expect(MemoryView.accessibilityLabel(for: selected, difficulty: .hard).contains(bird.canonicalName))
         #expect(MemoryView.accessibilityLabel(for: selected, difficulty: .hard).contains("selected"))
     }

--- a/Tests/MatherTests/MixMatchRecallViewTests.swift
+++ b/Tests/MatherTests/MixMatchRecallViewTests.swift
@@ -64,7 +64,7 @@ struct MixMatchRecallViewTests {
         let model = MemoryView.learningCardModel(for: pictureCard, difficulty: .hard, isIncorrect: true)
 
         #expect(model.display == .asset("MemoryFlagIndia"))
-        #expect(model.accessibilityLabel == "Flag of India")
+        #expect(model.accessibilityLabel == "Flag of India, selected")
         #expect(model.accessibilityHint == "Tap to choose this card.")
         #expect(model.isFaceDown == false)
         #expect(model.isSelected == true)

--- a/Tests/MatherTests/MixMatchRecallViewTests.swift
+++ b/Tests/MatherTests/MixMatchRecallViewTests.swift
@@ -74,7 +74,8 @@ struct MixMatchRecallViewTests {
         let hiddenModel = MemoryView.learningCardModel(for: hiddenLabelCard, difficulty: .hard, isIncorrect: false)
 
         #expect(hiddenModel.display == .text("India"))
-        #expect(hiddenModel.accessibilityLabel == "India")
+        #expect(hiddenModel.accessibilityLabel == "Face down memory card")
+        #expect(hiddenModel.accessibilityHint == "Tap to turn this card over.")
         #expect(hiddenModel.isFaceDown == true)
     }
 }


### PR DESCRIPTION
## Summary
- use the difficulty-aware MemoryView accessibility label in learning-card models
- keep hard-mode face-down label cards from exposing their hidden answer through the adapter
- add label-card coverage beside the existing picture-card no-leak test

## Validation
- rg confirmed the updated adapter and hidden-card expectations
- git diff --check

Local Swift/Xcode is unavailable in this runner; GitHub Actions is the compile/test gate.

Part of #1117.