### PR TITLE
Persist solved Symmetry Fold level count

### DIFF
--- a/Features/SymmetryFold/SymmetryFoldView.swift
+++ b/Features/SymmetryFold/SymmetryFoldView.swift
@@ -190,11 +190,16 @@ struct SymmetryFoldView: View {
             holdTask?.cancel()
             challengeTask?.cancel()
             appModel.motionService.stopUpdates()
-            guard currentLevel > 1 else { return }
+            let completedLevelCount = Self.completedLevelCount(
+                currentLevel: currentLevel,
+                totalLevels: levels.count,
+                currentLevelSucceeded: success
+            )
+            guard completedLevelCount > 0 else { return }
             appModel.gameSessionStore.save(
                 gameName: "Symmetry Fold",
                 startedAt: sessionStart,
-                scoreValue: currentLevel - 1,
+                scoreValue: completedLevelCount,
                 scoreLabel: "levels"
             )
         }
@@ -665,6 +670,16 @@ struct SymmetryFoldView: View {
     nonisolated static func mirrorMissionLabel(currentLevel: Int, totalLevels: Int) -> String {
         let collected = max(0, min(currentLevel - 1, totalLevels))
         return "Mirror mission • \(collected)/\(totalLevels) badges"
+    }
+
+    nonisolated static func completedLevelCount(
+        currentLevel: Int,
+        totalLevels: Int,
+        currentLevelSucceeded: Bool
+    ) -> Int {
+        let completedBeforeCurrent = max(0, currentLevel - 1)
+        let completed = completedBeforeCurrent + (currentLevelSucceeded ? 1 : 0)
+        return max(0, min(completed, totalLevels))
     }
 
     nonisolated static func challengeCountdownText(for secondsRemaining: Double) -> String {

--- a/Tests/MatherTests/SymmetryFoldTests.swift
+++ b/Tests/MatherTests/SymmetryFoldTests.swift
@@ -128,6 +128,21 @@ struct SymmetryFoldTests {
     }
 
     @Test
+    func completedLevelCountIncludesSolvedCurrentLevel() {
+        #expect(SymmetryFoldView.completedLevelCount(currentLevel: 1, totalLevels: 6, currentLevelSucceeded: false) == 0)
+        #expect(SymmetryFoldView.completedLevelCount(currentLevel: 1, totalLevels: 6, currentLevelSucceeded: true) == 1)
+        #expect(SymmetryFoldView.completedLevelCount(currentLevel: 4, totalLevels: 6, currentLevelSucceeded: false) == 3)
+        #expect(SymmetryFoldView.completedLevelCount(currentLevel: 4, totalLevels: 6, currentLevelSucceeded: true) == 4)
+    }
+
+    @Test
+    func completedLevelCountPersistsFinalSolvedLevel() {
+        #expect(SymmetryFoldView.completedLevelCount(currentLevel: 6, totalLevels: 6, currentLevelSucceeded: false) == 5)
+        #expect(SymmetryFoldView.completedLevelCount(currentLevel: 6, totalLevels: 6, currentLevelSucceeded: true) == 6)
+        #expect(SymmetryFoldView.completedLevelCount(currentLevel: 99, totalLevels: 6, currentLevelSucceeded: true) == 6)
+    }
+
+    @Test
     func challengeCountdownRoundsUpAndClamps() {
         #expect(SymmetryFoldView.challengeCountdownText(for: 7.01) == "8s left")
         #expect(SymmetryFoldView.challengeCountdownText(for: 0.2) == "1s left")


### PR DESCRIPTION
## Summary
- compute saved Symmetry Fold score from completed levels, including the current level when it has succeeded
- preserve the zero-save behavior before any badge is earned
- add focused coverage for first-level success, mid-session progress, final-level success, and clamping

## Validation
- rg confirmed the session save now uses completedLevelCount instead of currentLevel - 1
- git diff --check

Local Swift/Xcode is unavailable in this runner; GitHub Actions is the compile/test gate.

Part of #1117.