### PR TITLE
Use readable Room Quest chrome labels

### DIFF
--- a/Features/RoomQuest/RoomSessionView.swift
+++ b/Features/RoomQuest/RoomSessionView.swift
@@ -579,7 +579,7 @@ private func roomReturningChromeButton(title: String, systemImage: String, acces
             .background(.white.opacity(0.9), in: Capsule())
     }
     .accessibilityIdentifier(accessibilityID)
-    .accessibilityLabel(accessibilityID)
+    .accessibilityLabel(title)
     .accessibilityAddTraits(.isButton)
 }
 

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -231,7 +231,7 @@ private func roomChromeButton(title: String, systemImage: String, accessibilityI
             .background(.black.opacity(0.18), in: Capsule())
     }
     .accessibilityIdentifier(accessibilityID)
-    .accessibilityLabel(accessibilityID)
+    .accessibilityLabel(title)
     .accessibilityAddTraits(.isButton)
 }
 


### PR DESCRIPTION
## Summary
- keep Room Quest spot and returning chrome UI-test identifiers intact
- expose the visible Home/Pause titles as VoiceOver labels instead of implementation IDs

## Validation
- git diff --check

Refs #1117