### PR TITLE
Raise Angle Cannon control hit targets

### DIFF
--- a/Features/AngleCannon/AngleCannonView.swift
+++ b/Features/AngleCannon/AngleCannonView.swift
@@ -53,6 +53,7 @@ struct AngleCannonView: View {
     private let maxTiltRadians: Double = .pi / 4
     private let angleRange: ClosedRange<Double> = 10...80
     private let targetPool: [Double] = [15, 30, 45, 60, 75]
+    nonisolated static var childControlMinimumHitTarget: CGFloat { 80 }
     /// Target symbols — rendered at the landing position for delight
     private let scenarios = AngleCannonScenario.defaultScenarios
     @State private var scenario = AngleCannonScenario.defaultScenarios[0]
@@ -396,14 +397,14 @@ struct AngleCannonView: View {
             if projectileAnimating {
                 ProgressView("Watching the arc…")
                     .font(.headline.weight(.bold))
-                    .frame(minWidth: 180, minHeight: 60)
+                    .frame(minWidth: 180, minHeight: Self.childControlMinimumHitTarget)
             } else if hitTarget {
                 Button("Next →") {
                     advanceRound()
                 }
                 .font(.headline.weight(.black))
                 .foregroundStyle(.white)
-                .frame(minWidth: 140, minHeight: 60)
+                .frame(minWidth: 140, minHeight: Self.childControlMinimumHitTarget)
                 .background(MatherTheme.accent, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
                 .accessibilityIdentifier("angle-cannon-next-button")
             } else if firedAngleDeg == nil {
@@ -412,7 +413,7 @@ struct AngleCannonView: View {
                 }
                 .font(.system(size: 22, weight: .black, design: .rounded))
                 .foregroundStyle(.white)
-                .frame(minWidth: 140, minHeight: 60)
+                .frame(minWidth: 140, minHeight: Self.childControlMinimumHitTarget)
                 .background(
                     neutralRoll != nil ? MatherTheme.coral : MatherTheme.coral.opacity(0.35),
                     in: RoundedRectangle(cornerRadius: 16, style: .continuous)
@@ -427,7 +428,7 @@ struct AngleCannonView: View {
                 }
                 .font(.headline.weight(.semibold))
                 .foregroundStyle(.white)
-                .frame(minWidth: 140, minHeight: 60)
+                .frame(minWidth: 140, minHeight: Self.childControlMinimumHitTarget)
                 .background(MatherTheme.ink.opacity(0.7),
                             in: RoundedRectangle(cornerRadius: 16, style: .continuous))
                 .accessibilityIdentifier("angle-cannon-retry-button")

--- a/Tests/MatherTests/AngleCannonTests.swift
+++ b/Tests/MatherTests/AngleCannonTests.swift
@@ -158,6 +158,16 @@ struct AngleCannonTests {
             "The degree label should appear only as the successful-hit abstract reveal"
         )
     }
+
+    // MARK: - Child control hit targets
+
+    @Test
+    func childControlsMeetMinimumHitTarget() {
+        #expect(
+            AngleCannonView.childControlMinimumHitTarget >= 80,
+            "Angle Cannon child-facing controls should preserve at least 80pt touch targets"
+        )
+    }
 }
 
 @Suite("AngleCannonScenario")


### PR DESCRIPTION
## Summary
- raise Angle Cannon FIRE, Next, Try Again, and in-flight progress controls to the 80pt child hit-target minimum
- expose the control minimum as a production constant and add a focused regression check

## Validation
- git diff --check

Refs #1117