### PR TITLE
Fix Geometry lane screenshot assertion

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -958,7 +958,7 @@ final class ScreenshotTests: XCTestCase {
             "-uiTest.startRoute", "geometryLane"
         ])
 
-        requireExists(app.staticTexts["Geometry"], timeout: 10)
+        requireExists(app.staticTexts["Geometry Lab"], timeout: 10)
         snapshot(app, "UXReview-GeometryLane-IconNameLaunchers")
     }
 


### PR DESCRIPTION
## Summary
- update the Geometry lane UI screenshot test to wait for the current `Geometry Lab` title
- record the post-release iOS UI Review failure root cause from run 26760994194

## Validation
- git diff --check

Refs #1117