### PR TITLE
[codex] Fix Two-Finger Protractor touch overlay

### DIFF
--- a/Features/TwoFingerProtractor/TwoFingerProtractorView.swift
+++ b/Features/TwoFingerProtractor/TwoFingerProtractorView.swift
@@ -333,11 +333,13 @@ struct TwoFingerProtractorView: View {
                             if showDegreeLabel {
                                 degreeLabel
                                     .transition(.scale.combined(with: .opacity))
+                                    .allowsHitTesting(false)
                             }
 
                             // Hint when no fingers
                             if touch1 == nil {
                                 hintOverlay
+                                    .allowsHitTesting(false)
                             }
                         }
                     }
@@ -555,7 +557,7 @@ struct TwoFingerProtractorView: View {
                 .padding(.horizontal, 24)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
-            Text("Place two fingers to measure an angle")
+            Text(bottomInstruction)
                 .font(.caption)
                 .foregroundStyle(.tertiary)
                 .padding(.bottom, 16)
@@ -598,6 +600,19 @@ struct TwoFingerProtractorView: View {
         .padding(24)
         .background(MatherTheme.card.opacity(0.9))
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+    }
+
+    private var bottomInstruction: String {
+        if matched {
+            return "Great angle. Move on when you're ready."
+        }
+        if touch1 != nil && touch2 == nil {
+            return "Add one more finger to measure the angle."
+        }
+        if touch1 != nil && touch2 != nil {
+            return "Move your fingers until the angle matches the target."
+        }
+        return "Place two fingers to measure an angle"
     }
 
     // MARK: - Canvas drawing

--- a/Tests/MatherTests/TwoFingerProtractorTests.swift
+++ b/Tests/MatherTests/TwoFingerProtractorTests.swift
@@ -145,6 +145,15 @@ struct TwoFingerProtractorTests {
         #expect(!drifted.matched)
         #expect(!drifted.newlyMatched)
     }
+
+    @Test func matchTransitionDoesNotRecountWhileStillMatched() {
+        let stillMatched = ProtractorMath.matchTransition(previouslyMatched: true,
+                                                         measured: 91,
+                                                         target: 90,
+                                                         tolerance: 5)
+        #expect(stillMatched.matched)
+        #expect(!stillMatched.newlyMatched)
+    }
 }
 
 @Suite("ProtractorScenes")


### PR DESCRIPTION
## Summary
- Fixes the Two-Finger Protractor overlay intercepting the initial multi-touch gesture.
- Keeps the success/degree label from eating follow-up touches while the child adjusts their fingers.
- Updates the bottom instruction so it reflects one-finger, two-finger, and matched states instead of always saying "Place two fingers."

## Root cause
The no-finger hint card was rendered above the full-canvas UIKit multi-touch capture layer. Because SwiftUI views receive hit-testing by default, the hint could block the first two-finger gesture in the center of the activity. That matches TestFlight issue #1163: the screenshot shows the right-angle protractor screen while the user says "Angle is not working."

## Validation
- `git diff --check` passed locally.
- Local Swift/Xcode tests could not run on this Linux host: `swift`, `xcodegen`, and `xcodebuild` are unavailable here.
- Draft PR is intended to use GitHub macOS CI for build/test validation.

Fixes #1163