### PR TITLE
[codex] Raise profile emoji picker touch targets

### DIFF
--- a/Features/Profile/ProfilePickerView.swift
+++ b/Features/Profile/ProfilePickerView.swift
@@ -152,14 +152,17 @@ struct ProfilePickerView: View {
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.secondary)
 
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 52), spacing: 8)], spacing: 8) {
+            LazyVGrid(columns: ResponsiveLayout.profileEmojiPickerColumns(), spacing: 12) {
                 ForEach(KidProfileStore.emojiChoices, id: \.self) { emoji in
                     Button {
                         newEmoji = emoji
                     } label: {
                         Text(emoji)
                             .font(.system(size: 32))
-                            .frame(width: 52, height: 52)
+                            .frame(
+                                width: ResponsiveLayout.profileEmojiPickerMinimumTouchTarget,
+                                height: ResponsiveLayout.profileEmojiPickerMinimumTouchTarget
+                            )
                             .background(newEmoji == emoji ? MatherTheme.accent.opacity(0.2) : MatherTheme.card)
                             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                             .overlay(

--- a/Shared/ResponsiveLayout.swift
+++ b/Shared/ResponsiveLayout.swift
@@ -73,6 +73,12 @@ enum ResponsiveLayout {
         return [GridItem(.adaptive(minimum: minimum, maximum: maximum), spacing: 16)]
     }
 
+    static var profileEmojiPickerMinimumTouchTarget: CGFloat { 80 }
+
+    static func profileEmojiPickerColumns() -> [GridItem] {
+        [GridItem(.adaptive(minimum: profileEmojiPickerMinimumTouchTarget), spacing: 12)]
+    }
+
 
     static func memoryCardMinimumWidth(for difficulty: MemoryDifficulty) -> CGFloat {
         switch difficulty {

--- a/Tests/MatherTests/ResponsiveLayoutTests.swift
+++ b/Tests/MatherTests/ResponsiveLayoutTests.swift
@@ -16,6 +16,11 @@ struct ResponsiveLayoutTests {
         #expect(ResponsiveLayout.profilePickerMaxWidth(for: .compact) == .infinity)
     }
 
+    @MainActor @Test func profileEmojiPickerUsesChildSizedTouchTargets() {
+        #expect(ResponsiveLayout.profileEmojiPickerMinimumTouchTarget == 80)
+        #expect(ResponsiveLayout.profileEmojiPickerColumns().count == 1)
+    }
+
     @MainActor @Test func contentPaddingAndWidthsStayTabletAware() {
         #expect(ResponsiveLayout.contentPadding(for: .compact) == 24)
         #expect(ResponsiveLayout.contentPadding(for: .regular) == 48)


### PR DESCRIPTION
## Summary
- Raise the add-profile emoji picker grid and button frames from 52pt to the app's 80pt child-facing touch target.
- Move the emoji picker size/column rule into ResponsiveLayout so the grid and button frame share the same contract.
- Add ResponsiveLayout coverage for the 80pt emoji picker target.

## Validation
- `git diff --check` passed locally.
- Local Swift/Xcode tests could not run on this Linux host: `swift`, `xcodegen`, and `xcodebuild` are unavailable.
- Draft PR should use GitHub macOS CI for build/test validation.

Refs #1117
