### PR TITLE
Fix SoundDetection crash path

### DIFF
--- a/Services/SoundDetectionService.swift
+++ b/Services/SoundDetectionService.swift
@@ -3,13 +3,13 @@ import Observation
 
 /// Detects hand-clap events via microphone RMS spike analysis.
 ///
-/// Uses AVAudioEngine (NOT SoundAnalysis) for low latency and zero ML model
-/// overhead. A clap signature is an RMS spike from near-silence (< 0.05) to
-/// above 0.3 within one ~46 ms buffer window.
+/// Uses an AVAudioRecorder-backed meter for low overhead and zero ML model
+/// dependency. A clap signature is an RMS spike from near-silence (< 0.05) to
+/// above 0.3 during a meter polling window.
 ///
-/// **Privacy**: Audio data is never stored or transmitted — the tap computes
+/// **Privacy**: Audio data is never stored or transmitted — metering computes
 /// only an RMS scalar. The service is started only when
-/// `featureFlags.soundReactionEnabled` is true (default: true), and stops
+/// `featureFlags.soundReactionEnabled` is true (default: false), and stops
 /// immediately when BondMatchView disappears.
 ///
 /// Requires `NSMicrophoneUsageDescription` in Info.plist.
@@ -29,8 +29,8 @@ final class SoundDetectionService {
 
     // MARK: - Private
 
-    // nonisolated(unsafe): AVAudioEngine is not Sendable, but we only ever
-    // access it from @MainActor methods (start/stop are both @MainActor).
+    // nonisolated(unsafe): AVAudioEngine is kept only for defensive teardown of
+    // older tap-backed starts; current starts use AVAudioRecorder metering.
     nonisolated(unsafe) private var audioEngine: AVAudioEngine?
     private var meterRecorder: AVAudioRecorder?
     private var isListening = false
@@ -45,89 +45,10 @@ final class SoundDetectionService {
     /// Request microphone access (if not yet granted) and begin listening.
     /// Does nothing if already listening.
     func startListening() {
-        guard !isListening else { return }
-        let audioSession = AVAudioSession.sharedInstance()
-
-        let preflight = soundMeterPreflight(for: audioSession)
-        meterStartupDiagnostics = SoundMeterStartupDiagnostics(
-            phase: .preflight,
-            authorization: preflight.authorization,
-            isInputAvailable: preflight.isInputAvailable
-        )
-
-        switch preflight.startupDecision() {
-        case .requestPermission:
-            requestMicrophonePermission { [weak self] in
-                self?.startListening()
-            }
-            return
-        case .startMeter:
-            break
-        case .fail(let state):
-            resetSoundMeter(to: state, phase: startupPhase(for: state), failure: startupFailure(for: state))
-            return
-        }
-
-        meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .activatingSession)
-        do {
-            try audioSession.setCategory(.playAndRecord, mode: .measurement, options: [.duckOthers, .defaultToSpeaker])
-            try audioSession.setActive(true, options: [])
-        } catch {
-            resetSoundMeter(to: .unavailable, phase: .sessionActivationFailed, failure: .sessionActivation)
-            return
-        }
-
-        guard audioSession.isInputAvailable, !audioSession.currentRoute.inputs.isEmpty else {
-            resetSoundMeter(to: .unavailable, phase: .routeUnavailable, failure: .routeUnavailable)
-            return
-        }
-
-        let engine = AVAudioEngine()
-        let inputNode = engine.inputNode
-        let format = inputNode.outputFormat(forBus: 0)
-        let formatSnapshot = SoundMeterAudioFormatSnapshot(format: format)
-        meterStartupDiagnostics = meterStartupDiagnostics.updating(
-            phase: .checkingInputFormat,
-            routeInputCount: audioSession.currentRoute.inputs.count,
-            format: formatSnapshot
-        )
-        // When input hardware is unavailable or the route changes, the input
-        // node can expose a zero/unknown format. Installing a tap with that
-        // format can raise an Objective-C/AudioUnit assertion instead of a
-        // catchable Swift error, so fail closed before the tap boundary.
-        guard formatSnapshot.isUsableForAudioTap else {
-            resetSoundMeter(to: .unavailable, phase: .inputFormatUnavailable, failure: .inputFormatUnavailable, format: formatSnapshot)
-            return
-        }
-
-        inputNode.removeTap(onBus: 0)
-        engine.prepare()
-        meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .installingAudioTap, format: formatSnapshot)
-        inputNode.installTap(onBus: 0, bufferSize: 2048, format: format) { [weak self] buffer, _ in
-            guard let rms = SoundDetectionService.audioTapRMS(from: buffer) else { return }
-
-            // The audio tap runs on the audio I/O thread — marshal to @MainActor.
-            Task { @MainActor [weak self] in
-                self?.evaluateRMS(rms)
-            }
-        }
-
-        meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .startingAudioEngine)
-        do {
-            try engine.start()
-            audioEngine = engine
-            isListening = true
-            meterPermissionState = .listening
-            meterStartupDiagnostics = meterStartupDiagnostics.updating(phase: .listening)
-        } catch {
-            // Silently fail: microphone permission may be denied, or the
-            // audio session may be unavailable. Bond Blast still works without clap.
-            inputNode.removeTap(onBus: 0)
-            resetSoundMeter(to: .unavailable, phase: .engineStartFailed, failure: .engineStart)
-        }
+        startRecorderBackedSoundLabMeter()
     }
 
-    /// Stop listening and tear down the audio tap.
+    /// Stop listening and tear down microphone metering.
     func stopListening() {
         pendingMeterPermissionRequestID = nil
         pendingMeterStartAction = nil

--- a/Shared/FeatureFlags.swift
+++ b/Shared/FeatureFlags.swift
@@ -21,6 +21,7 @@ final class FeatureFlagService {
         static let makeBreakLoopV2Enabled = "feature.makeBreakLoopV2Enabled"
         static let motionControlsEnabled = "feature.motionControlsEnabled"
         static let soundReactionEnabled = "feature.soundReactionEnabled"
+        static let soundReactionResetMigrationVersion = "feature.soundReactionResetMigrationVersion"
         static let roomQuestSafetyAcknowledged = "feature.roomQuestSafetyAcknowledged"
         static let roomQuestMarkerSetupEnabled = "feature.roomQuestMarkerSetupEnabled"
         static let roomQuestReferenceCaptureEnabled = "feature.roomQuestReferenceCaptureEnabled"
@@ -74,7 +75,7 @@ final class FeatureFlagService {
         didSet { defaults.set(motionControlsEnabled, forKey: Keys.motionControlsEnabled) }
     }
 
-    /// Enables AVAudioEngine clap detection in Bond Blast.
+    /// Enables optional microphone clap detection in Bond Blast.
     /// Defaults to false; parent can opt in after reviewing microphone behavior.
     var soundReactionEnabled: Bool {
         didSet { defaults.set(soundReactionEnabled, forKey: Keys.soundReactionEnabled) }
@@ -147,10 +148,19 @@ final class FeatureFlagService {
     }
 
     private let defaults: UserDefaults
+    private static let currentSoundReactionResetMigrationVersion = 1
 
     private static func hasLaunchArgumentOverride(for key: String) -> Bool {
         ProcessInfo.processInfo.arguments.contains(key) ||
             ProcessInfo.processInfo.arguments.contains("-\(key)")
+    }
+
+    private static func migrateSoundReactionPreferenceIfNeeded(defaults: UserDefaults) {
+        guard !hasLaunchArgumentOverride(for: Keys.soundReactionEnabled) else { return }
+        guard defaults.integer(forKey: Keys.soundReactionResetMigrationVersion) < currentSoundReactionResetMigrationVersion else { return }
+
+        defaults.set(false, forKey: Keys.soundReactionEnabled)
+        defaults.set(currentSoundReactionResetMigrationVersion, forKey: Keys.soundReactionResetMigrationVersion)
     }
 
     init(defaults: UserDefaults = .standard) {
@@ -182,6 +192,7 @@ final class FeatureFlagService {
             Keys.placeMatchVisionMatch: Double(PlaceMatchThresholds.default.visionMatchDistance),
             Keys.placeMatchVisionClose: Double(PlaceMatchThresholds.default.visionCloseDistance),
         ])
+        Self.migrateSoundReactionPreferenceIfNeeded(defaults: defaults)
         verticalSlice1Enabled = defaults.bool(forKey: Keys.verticalSlice1Enabled)
         testModeEnabled = defaults.bool(forKey: Keys.testModeEnabled)
         audioEnabled = defaults.bool(forKey: Keys.audioEnabled)

--- a/Tests/MatherTests/FeatureFlagTests.swift
+++ b/Tests/MatherTests/FeatureFlagTests.swift
@@ -74,6 +74,32 @@ struct FeatureFlagTests {
         let flags2 = FeatureFlagService(defaults: defaults)
         #expect(!flags2.soundReactionEnabled)
     }
+
+    @Test func staleSoundReactionOptInIsResetOnceOnUpgrade() {
+        let suiteName = "FeatureFlagTests.staleSoundReactionOptInIsResetOnceOnUpgrade"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set(true, forKey: "feature.soundReactionEnabled")
+
+        let flags = FeatureFlagService(defaults: defaults)
+
+        #expect(!flags.soundReactionEnabled)
+        #expect(!defaults.bool(forKey: "feature.soundReactionEnabled"))
+        #expect(defaults.integer(forKey: "feature.soundReactionResetMigrationVersion") == 1)
+    }
+
+    @Test func soundReactionParentOptInPersistsAfterResetMigration() {
+        let suiteName = "FeatureFlagTests.soundReactionParentOptInPersistsAfterResetMigration"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        _ = FeatureFlagService(defaults: defaults)
+        let flags1 = FeatureFlagService(defaults: defaults)
+        flags1.soundReactionEnabled = true
+
+        let flags2 = FeatureFlagService(defaults: defaults)
+        #expect(flags2.soundReactionEnabled)
+    }
 }
 
 // MARK: - Route Quest rollout

--- a/Tests/MatherTests/SoundDetectionServiceTests.swift
+++ b/Tests/MatherTests/SoundDetectionServiceTests.swift
@@ -4,16 +4,12 @@ import Testing
 
 /// Tests for SoundDetectionService.
 ///
-/// The primary regression target is the `installTap` crash when
-/// `inputNode.inputFormat(forBus:)` returns a zero-sample-rate format.
-/// This happens when SpeechService has set the AVAudioSession category to
-/// `.playback`, which disables microphone hardware — the input format becomes
-/// invalid (sampleRate=0) and passing it to `installTap` raises an exception.
+/// The primary regression target is microphone startup safety. Bond Blast clap
+/// detection now uses the same recorder-backed meter path as Sound Lab so it
+/// does not install an AVAudioEngine tap on the audio I/O thread.
 ///
-/// Fix: guard `format.sampleRate > 0` before calling `installTap`.
-///
-/// Because AVAudioEngine requires real audio hardware, these tests exercise the
-/// service's state machine and guard logic directly without driving the engine.
+/// Because live microphone startup requires real audio hardware, these tests
+/// exercise the service's state machine and guard logic without driving input.
 @MainActor
 struct SoundDetectionServiceTests {
 
@@ -115,9 +111,8 @@ struct SoundDetectionServiceTests {
         #expect(service.meterPermissionState == .notStarted)
     }
 
-    // startListening() calls AVAudioEngine.start() which requires real audio hardware.
-    // AVAudioEngine crashes the test host on the simulator (AURemoteIO -10851), so
-    // these tests only run on device where the guard logic matters most.
+    // startListening() starts live microphone metering, so these tests only run
+    // on device where the guard logic matters most.
     #if !targetEnvironment(simulator)
 
     @Test


### PR DESCRIPTION
## Summary
- route Bond Blast clap detection through the recorder-backed meter path instead of installing an AVAudioEngine input tap
- add a one-time migration that resets stale persisted `soundReactionEnabled=true` values unless a launch override is present
- cover the migration behavior with FeatureFlagService tests and refresh SoundDetectionService test wording

## Validation
- `git diff --check`
- remote Xcode validation on `mbs` blocked: SSH returned `No route to host`; using PR CI as validation surface

Fixes #1170