### PR TITLE
fix: eliminate four crash-prone patterns (post-1174 sweep)

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -872,7 +872,9 @@ final class VerticalSliceEngine {
             transferCorrect: transferCorrect
         )
         currentSession.problems.append(problemSession)
-        try? telemetryWriter.append(problemSession.events[0])
+        if let event = problemSession.events.first {
+            try? telemetryWriter.append(event)
+        }
     }
 
     private func promptForCurrentStage() -> String {

--- a/Persistence/TelemetryWriter.swift
+++ b/Persistence/TelemetryWriter.swift
@@ -14,7 +14,12 @@ final class TelemetryWriter {
     convenience init() {
         let schema = Schema([StoredTelemetryEvent.self])
         let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
-        let container = try! ModelContainer(for: schema, configurations: config)
+        let container: ModelContainer
+        do {
+            container = try ModelContainer(for: schema, configurations: config)
+        } catch {
+            fatalError("In-memory TelemetryWriter container failed to initialize: \(error)")
+        }
         self.init(modelContext: ModelContext(container), activeProfileIdProvider: { KidProfileStore.defaultProfileId })
     }
 

--- a/Services/MotionService.swift
+++ b/Services/MotionService.swift
@@ -129,8 +129,8 @@ final class MotionService {
         if referenceAttitude == nil {
             referenceAttitude = motion.attitude.copy() as? CMAttitude
         }
-        if let ref = referenceAttitude {
-            let current = motion.attitude.copy() as! CMAttitude
+        if let ref = referenceAttitude,
+           let current = motion.attitude.copy() as? CMAttitude {
             current.multiply(byInverseOf: ref)
             relativeYaw = Self.bodyRelativeYawDegrees(fromCoreMotionYawRadians: current.yaw)
             relativeYawResponsive = true

--- a/Services/SpeechService.swift
+++ b/Services/SpeechService.swift
@@ -32,16 +32,18 @@ final class SpeechService {
             try configureAudioSession(mode: .spokenAudio)
             lastSpeechDiagnostic = nil
         } catch {
-            lastSpeechDiagnostic = "Audio session setup failed: \(error.localizedDescription)"
-            print("[Mather][SpeechService] \(lastSpeechDiagnostic!)")
+            let msg = "Audio session setup failed: \(error.localizedDescription)"
+            lastSpeechDiagnostic = msg
+            print("[Mather][SpeechService] \(msg)")
         }
     }
 
     func speak(_ text: String, enabled: Bool) {
         guard !text.isEmpty else { return }
         guard enabled else {
-            lastSpeechDiagnostic = "Speech skipped because audio prompts are disabled."
-            print("[Mather][SpeechService] \(lastSpeechDiagnostic!)")
+            let msg = "Speech skipped because audio prompts are disabled."
+            lastSpeechDiagnostic = msg
+            print("[Mather][SpeechService] \(msg)")
             return
         }
         lastSpokenText = text
@@ -72,8 +74,9 @@ final class SpeechService {
 
     func playSoundExample(_ example: SoundExampleKind, enabled: Bool) {
         guard enabled else {
-            lastSpeechDiagnostic = "Sound example skipped because audio prompts are disabled."
-            print("[Mather][SpeechService] \(lastSpeechDiagnostic!)")
+            let msg = "Sound example skipped because audio prompts are disabled."
+            lastSpeechDiagnostic = msg
+            print("[Mather][SpeechService] \(msg)")
             return
         }
 
@@ -93,8 +96,9 @@ final class SpeechService {
             lastSpokenText = nil
             player.play()
         } catch {
-            lastSpeechDiagnostic = "Sound example playback failed: \(error.localizedDescription)"
-            print("[Mather][SpeechService] \(lastSpeechDiagnostic!)")
+            let msg = "Sound example playback failed: \(error.localizedDescription)"
+            lastSpeechDiagnostic = msg
+            print("[Mather][SpeechService] \(msg)")
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #1174 (deep UI crash sweep). Static analysis of the full production source found four remaining crash-prone patterns:

- **TelemetryWriter** (`Persistence/TelemetryWriter.swift:17`): `try!` on `ModelContainer` init. Replaced with `do/catch + fatalError` so a failure produces a diagnostic message instead of an opaque crash.
- **SpeechService** (`Services/SpeechService.swift` ×4): `lastSpeechDiagnostic!` force-unwrap in print statements. Safe in current flow (non-nil assigned immediately above), but fragile on refactor. Captured into a local `let` to eliminate the optional entirely.
- **MotionService** (`Services/MotionService.swift:133`): `as! CMAttitude` force-cast from `NSCopying.copy()` which bridges to `Any`. Changed to `as?` guard — mismatched runtime type silently skips one motion frame rather than crashing.
- **VerticalSliceEngine** (`Domain/VerticalSliceEngine.swift:875`): `events[0]` subscript on a `ProblemSession`. Currently safe (events always has exactly 1 element at init), but latent crash if initialisation changes. Changed to `events.first`.

All other patterns flagged during analysis (channels[0], remaining[0], pairs[1], neutralRoll!, value!, precondition in ArrayPreludeModels) were verified safe by surrounding guard/nil-check logic — no changes made.

## Test plan

- [ ] CI build passes (Swift 6 strict concurrency — no new warnings)
- [ ] Unit test suite passes (`ProblemGeneratorTests`, `SliceStateMachineTests`, `VerticalSliceEngineTests`)
- [ ] Crash sweep CI workflow passes (22-feature UI sweep from #1174)
- [ ] `grep` confirms zero `try!`, `as! CMAttitude`, `lastSpeechDiagnostic!`, `events[0]` remain in production source

🤖 Generated with [Claude Code](https://claude.com/claude-code)