### PR TITLE
feat(tvos): add Angle Arcade prototype

### DIFF
--- a/AppTV/AngleArcadeTVView.swift
+++ b/AppTV/AngleArcadeTVView.swift
@@ -1,0 +1,292 @@
+import SwiftUI
+
+struct AngleArcadeTVView: View {
+    @FocusState private var focusedAction: AngleArcadeAction?
+    @State private var angle: Double = AngleArcadeTarget.defaultTargets[0].recommendedAngle
+    @State private var power: Double = AngleArcadeTarget.defaultTargets[0].recommendedPower
+    @State private var targetIndex = 0
+    @State private var firedShot: AngleArcadeShot?
+    @State private var hitCount = 0
+
+    private let targets = AngleArcadeTarget.defaultTargets
+
+    private var target: AngleArcadeTarget {
+        targets[targetIndex]
+    }
+
+    private var prediction: AngleArcadeShot {
+        AngleArcadeModel.shot(angle: angle, power: power, target: target)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            header
+
+            AngleArcadeFieldView(
+                target: target,
+                prediction: prediction,
+                firedShot: firedShot
+            )
+            .frame(height: 314)
+            .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .stroke(Color.white.opacity(0.14), lineWidth: 2)
+            )
+
+            controls
+        }
+        .padding(34)
+        .frame(width: 790, height: 604, alignment: .topLeading)
+        .background(Color(red: 0.05, green: 0.11, blue: 0.16).opacity(0.82), in: RoundedRectangle(cornerRadius: 30, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 30, style: .continuous)
+                .stroke(Color(red: 0.55, green: 0.88, blue: 1.0).opacity(0.24), lineWidth: 2)
+        )
+        .onAppear {
+            focusedAction = .fire
+        }
+        .onMoveCommand(perform: handleMoveCommand)
+        .onPlayPauseCommand(perform: primaryAction)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Angle Arcade")
+        .accessibilityHint("Use left and right for angle, up and down for power, then press select to fire or replay.")
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 24) {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Angle Arcade")
+                    .font(.system(size: 46, weight: .bold, design: .rounded))
+                    .foregroundStyle(.white)
+
+                Text(target.title)
+                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                    .foregroundStyle(Color(red: 0.55, green: 0.88, blue: 1.0))
+            }
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 10) {
+                ForEach(targets.indices, id: \.self) { index in
+                    Circle()
+                        .fill(index == targetIndex ? Color(red: 1.0, green: 0.76, blue: 0.30) : Color.white.opacity(0.28))
+                        .frame(width: 18, height: 18)
+                        .accessibilityHidden(true)
+                }
+            }
+            .padding(.top, 14)
+        }
+    }
+
+    private var controls: some View {
+        HStack(alignment: .center, spacing: 20) {
+            metricTile(title: "Angle", value: "\(Int(angle))°", symbolName: "arrow.left.and.right")
+            metricTile(title: "Power", value: "\(Int(power))", symbolName: "arrow.up.and.down")
+            resultTile
+
+            Spacer(minLength: 0)
+
+            Button {
+                primaryAction()
+            } label: {
+                Label(firedShot == nil ? "Fire" : "Replay", systemImage: firedShot == nil ? "paperplane.fill" : "arrow.clockwise")
+                    .font(.system(size: 25, weight: .bold, design: .rounded))
+                    .frame(width: 156, height: 74)
+            }
+            .buttonStyle(.borderedProminent)
+            .focused($focusedAction, equals: .fire)
+            .accessibilityIdentifier("angle-arcade-fire-replay-button")
+        }
+    }
+
+    private var resultTile: some View {
+        let shot = firedShot
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Round")
+                .font(.system(size: 17, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.62))
+
+            Text(shot == nil ? "\(hitCount) hits" : (shot?.hit == true ? "Hit" : "Miss"))
+                .font(.system(size: 30, weight: .bold, design: .rounded))
+                .foregroundStyle(shot?.hit == false ? Color(red: 1.0, green: 0.58, blue: 0.38) : .white)
+
+            Text(shot == nil ? "Target \(targetIndex + 1) of \(targets.count)" : "\(Int(abs(shot?.verticalDelta ?? 0))) off")
+                .font(.system(size: 17, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.62))
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+        .frame(width: 132, height: 104, alignment: .leading)
+        .background(Color.white.opacity(0.09), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+
+    private func metricTile(title: String, value: String, symbolName: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(title, systemImage: symbolName)
+                .font(.system(size: 17, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.62))
+
+            Text(value)
+                .font(.system(size: 31, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+        .frame(width: 132, height: 104, alignment: .leading)
+        .background(Color.white.opacity(0.09), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+
+    private func primaryAction() {
+        if let shot = firedShot {
+            if shot.hit {
+                targetIndex = AngleArcadeModel.nextTargetIndex(after: targetIndex, targetCount: targets.count)
+                let nextTarget = targets[targetIndex]
+                angle = nextTarget.recommendedAngle
+                power = nextTarget.recommendedPower
+            }
+            firedShot = nil
+            return
+        }
+
+        let shot = prediction
+        firedShot = shot
+        if shot.hit {
+            hitCount += 1
+        }
+    }
+
+    private func handleMoveCommand(_ direction: MoveCommandDirection) {
+        guard firedShot == nil else { return }
+        switch direction {
+        case .left:
+            angle = AngleArcadeModel.adjustedAngle(angle, direction: -1)
+        case .right:
+            angle = AngleArcadeModel.adjustedAngle(angle, direction: 1)
+        case .up:
+            power = AngleArcadeModel.adjustedPower(power, direction: 1)
+        case .down:
+            power = AngleArcadeModel.adjustedPower(power, direction: -1)
+        @unknown default:
+            break
+        }
+    }
+}
+
+private enum AngleArcadeAction: Hashable {
+    case fire
+}
+
+private struct AngleArcadeFieldView: View {
+    let target: AngleArcadeTarget
+    let prediction: AngleArcadeShot
+    let firedShot: AngleArcadeShot?
+
+    var body: some View {
+        Canvas { context, size in
+            let origin = CGPoint(x: size.width * 0.11, y: size.height * 0.83)
+            let scale = fieldScale(for: size)
+
+            drawGround(context: context, size: size)
+            drawArc(prediction.path, origin: origin, scale: scale, size: size, context: context, color: Color(red: 1.0, green: 0.53, blue: 0.42), dashed: true)
+
+            if let firedShot {
+                drawArc(firedShot.path, origin: origin, scale: scale, size: size, context: context, color: firedShot.hit ? Color(red: 0.30, green: 0.92, blue: 0.70) : Color(red: 1.0, green: 0.76, blue: 0.30), dashed: false)
+            }
+
+            drawTarget(context: context, origin: origin, scale: scale, target: target)
+            drawCannon(context: context, origin: origin, angle: firedShot?.angle ?? prediction.angle)
+            drawProjectile(context: context, origin: origin, scale: scale, shot: firedShot)
+        }
+    }
+
+    private func fieldScale(for size: CGSize) -> CGFloat {
+        min((size.width * 0.76) / 680, (size.height * 0.58) / 230)
+    }
+
+    private func screenPoint(_ point: CGPoint, origin: CGPoint, scale: CGFloat) -> CGPoint {
+        CGPoint(x: origin.x + point.x * scale, y: origin.y - point.y * scale)
+    }
+
+    private func drawGround(context: GraphicsContext, size: CGSize) {
+        var ground = Path()
+        ground.move(to: CGPoint(x: 0, y: size.height * 0.83))
+        ground.addLine(to: CGPoint(x: size.width, y: size.height * 0.83))
+        context.stroke(ground, with: .color(.white.opacity(0.18)), lineWidth: 2)
+
+        let hill = CGRect(x: size.width * 0.58, y: size.height * 0.67, width: size.width * 0.34, height: size.height * 0.22)
+        context.fill(Ellipse().path(in: hill), with: .color(Color(red: 0.22, green: 0.56, blue: 0.50).opacity(0.18)))
+    }
+
+    private func drawArc(
+        _ points: [CGPoint],
+        origin: CGPoint,
+        scale: CGFloat,
+        size: CGSize,
+        context: GraphicsContext,
+        color: Color,
+        dashed: Bool
+    ) {
+        let mapped = points.map { screenPoint($0, origin: origin, scale: scale) }
+            .filter { $0.x <= size.width + 20 && $0.y >= -20 && $0.y <= size.height + 20 }
+        guard mapped.count > 1 else { return }
+
+        var path = Path()
+        path.move(to: mapped[0])
+        for point in mapped.dropFirst() {
+            path.addLine(to: point)
+        }
+        context.stroke(
+            path,
+            with: .color(color.opacity(dashed ? 0.74 : 0.95)),
+            style: StrokeStyle(lineWidth: dashed ? 4 : 6, lineCap: .round, lineJoin: .round, dash: dashed ? [12, 10] : [])
+        )
+    }
+
+    private func drawTarget(context: GraphicsContext, origin: CGPoint, scale: CGFloat, target: AngleArcadeTarget) {
+        let center = screenPoint(CGPoint(x: target.distance, y: target.height), origin: origin, scale: scale)
+        let radius = max(24, CGFloat(target.radius) * scale)
+        let outer = CGRect(x: center.x - radius, y: center.y - radius, width: radius * 2, height: radius * 2)
+        context.fill(Circle().path(in: outer.insetBy(dx: -10, dy: -10)), with: .color(Color(red: 1.0, green: 0.76, blue: 0.30).opacity(0.16)))
+        context.stroke(Circle().path(in: outer), with: .color(Color(red: 1.0, green: 0.76, blue: 0.30)), lineWidth: 5)
+        context.stroke(Circle().path(in: outer.insetBy(dx: radius * 0.38, dy: radius * 0.38)), with: .color(.white.opacity(0.74)), lineWidth: 3)
+
+        let label = context.resolve(Text(target.title).font(.system(size: 19, weight: .bold, design: .rounded)).foregroundStyle(.white.opacity(0.86)))
+        context.draw(label, at: CGPoint(x: center.x, y: center.y - radius - 20), anchor: .center)
+    }
+
+    private func drawCannon(context: GraphicsContext, origin: CGPoint, angle: Double) {
+        let radians = angle * .pi / 180
+        let barrelLength: CGFloat = 58
+        let tip = CGPoint(
+            x: origin.x + barrelLength * CGFloat(cos(radians)),
+            y: origin.y - barrelLength * CGFloat(sin(radians))
+        )
+
+        var barrel = Path()
+        barrel.move(to: origin)
+        barrel.addLine(to: tip)
+        context.stroke(barrel, with: .color(.white.opacity(0.96)), style: StrokeStyle(lineWidth: 16, lineCap: .round))
+        context.stroke(barrel, with: .color(Color(red: 1.0, green: 0.53, blue: 0.42)), style: StrokeStyle(lineWidth: 8, lineCap: .round))
+
+        let body = CGRect(x: origin.x - 44, y: origin.y - 18, width: 82, height: 34)
+        context.fill(RoundedRectangle(cornerRadius: 15).path(in: body), with: .color(Color(red: 1.0, green: 0.76, blue: 0.30)))
+        context.fill(Circle().path(in: CGRect(x: origin.x - 36, y: origin.y + 4, width: 28, height: 28)), with: .color(Color(red: 0.05, green: 0.08, blue: 0.13)))
+        context.fill(Circle().path(in: CGRect(x: origin.x + 10, y: origin.y + 4, width: 28, height: 28)), with: .color(Color(red: 0.05, green: 0.08, blue: 0.13)))
+    }
+
+    private func drawProjectile(context: GraphicsContext, origin: CGPoint, scale: CGFloat, shot: AngleArcadeShot?) {
+        guard let shot, let last = shot.path.last else { return }
+        let point = screenPoint(last, origin: origin, scale: scale)
+        let rect = CGRect(x: point.x - 11, y: point.y - 11, width: 22, height: 22)
+        context.fill(Circle().path(in: rect), with: .color(shot.hit ? Color(red: 0.30, green: 0.92, blue: 0.70) : Color(red: 1.0, green: 0.76, blue: 0.30)))
+        context.stroke(Circle().path(in: rect.insetBy(dx: -5, dy: -5)), with: .color(.white.opacity(0.54)), lineWidth: 2)
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.black.ignoresSafeArea()
+        AngleArcadeTVView()
+    }
+}

--- a/AppTV/MatherTVRootView.swift
+++ b/AppTV/MatherTVRootView.swift
@@ -1,92 +1,132 @@
 import SwiftUI
 
 struct MatherTVRootView: View {
-    @State private var selectedMode: MatherTVMode = .sumSprintParty
+    @FocusState private var focusedAction: MatherTVAction.ID?
+    @State private var selectedAction = MatherTVAction.angle
+
+    private let actions = MatherTVAction.allCases
 
     var body: some View {
         ZStack {
-            switch selectedMode {
-            case .memoryGallery:
-                MemoryGalleryTVView()
-            case .sumSprintParty:
-                SumSprintPartyTVView()
-            }
+            MatherTVBackdrop()
 
-            VStack {
-                modeShelf
-                Spacer()
+            VStack(alignment: .leading, spacing: 42) {
+                header
+
+                HStack(alignment: .center, spacing: 34) {
+                    actionMenu
+                    selectedActionPanel
+                }
             }
-            .frame(maxWidth: .infinity, alignment: .center)
-            .padding(.top, 28)
+            .frame(maxWidth: 1480, alignment: .leading)
+            .padding(.horizontal, 92)
+            .padding(.vertical, 76)
+        }
+        .onAppear {
+            focusedAction = selectedAction.id
         }
     }
 
-    private var modeShelf: some View {
-        HStack(spacing: 14) {
-            ForEach(MatherTVMode.allCases) { mode in
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Mather TV Lab")
+                .font(.system(size: 72, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+
+            Text("A couch-ready shell for focus/select math play.")
+                .font(.system(size: 30, weight: .medium, design: .rounded))
+                .foregroundStyle(.white.opacity(0.76))
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var actionMenu: some View {
+        VStack(spacing: 24) {
+            ForEach(actions) { action in
                 Button {
-                    selectedMode = mode
+                    selectedAction = action
                 } label: {
-                    MatherTVModeTile(mode: mode, isSelected: selectedMode == mode)
+                    MatherTVActionRow(
+                        action: action,
+                        isFocused: focusedAction == action.id,
+                        isSelected: selectedAction == action
+                    )
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(mode.title)
-                .accessibilityHint(mode.accessibilityHint)
-                .accessibilityIdentifier("tv-mode-\(mode.id)")
+                .focused($focusedAction, equals: action.id)
+                .accessibilityHint(action.accessibilityHint)
+                .accessibilityIdentifier("tv-mode-\(action.id)")
             }
         }
-        .padding(8)
-        .background(.black.opacity(0.20), in: Capsule())
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel("Mather TV mode picker")
+        .frame(width: 560)
+    }
+
+    @ViewBuilder
+    private var selectedActionPanel: some View {
+        switch selectedAction {
+        case .memory:
+            MemoryGalleryTVView()
+        case .angle:
+            AngleArcadeTVView()
+        case .sprint:
+            SumSprintPartyTVView()
+        }
     }
 }
 
-private struct MatherTVModeTile: View {
-    let mode: MatherTVMode
+private struct MatherTVActionRow: View {
+    let action: MatherTVAction
+    let isFocused: Bool
     let isSelected: Bool
 
     var body: some View {
-        Label(mode.title, systemImage: mode.symbolName)
-            .font(.system(size: 24, weight: .black, design: .rounded))
-            .padding(.horizontal, 24)
-            .padding(.vertical, 14)
-            .frame(width: 250)
-            .background(backgroundStyle, in: Capsule())
-            .foregroundStyle(.white)
+        HStack(spacing: 22) {
+            Image(systemName: action.symbolName)
+                .font(.system(size: 42, weight: .bold))
+                .frame(width: 70, height: 70)
+                .foregroundStyle(isFocused ? Color(red: 0.09, green: 0.13, blue: 0.19) : .white)
+                .background(iconBackground, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(action.title)
+                    .font(.system(size: 32, weight: .bold, design: .rounded))
+                    .foregroundStyle(isFocused ? Color(red: 0.07, green: 0.10, blue: 0.16) : .white)
+
+                Text(action.subtitle)
+                    .font(.system(size: 21, weight: .medium, design: .rounded))
+                    .foregroundStyle(isFocused ? Color(red: 0.15, green: 0.20, blue: 0.29) : .white.opacity(0.65))
+                    .lineLimit(2)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(24)
+        .frame(width: 560, height: 132)
+        .background(rowBackground, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+        .overlay(rowStroke)
+        .scaleEffect(isFocused ? 1.055 : 1.0)
+        .shadow(color: .black.opacity(isFocused ? 0.35 : 0.16), radius: isFocused ? 24 : 10, x: 0, y: isFocused ? 18 : 8)
+        .animation(.spring(response: 0.28, dampingFraction: 0.78), value: isFocused)
+        .animation(.easeInOut(duration: 0.18), value: isSelected)
     }
 
-    private var backgroundStyle: some ShapeStyle {
-        if isSelected { return AnyShapeStyle(Color(red: 0.55, green: 0.88, blue: 1.0).opacity(0.24)) }
+    private var iconBackground: some ShapeStyle {
+        isFocused ? .white : .white.opacity(0.12)
+    }
+
+    private var rowBackground: some ShapeStyle {
+        if isFocused {
+            return AnyShapeStyle(.white)
+        }
+        if isSelected {
+            return AnyShapeStyle(Color(red: 0.10, green: 0.32, blue: 0.42).opacity(0.74))
+        }
         return AnyShapeStyle(.white.opacity(0.08))
     }
-}
 
-private enum MatherTVMode: String, CaseIterable, Identifiable {
-    case memoryGallery
-    case sumSprintParty
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .memoryGallery: return "Memory Gallery"
-        case .sumSprintParty: return "Sum Sprint"
-        }
-    }
-
-    var symbolName: String {
-        switch self {
-        case .memoryGallery: return "photo.on.rectangle.angled"
-        case .sumSprintParty: return "plus.forwardslash.minus"
-        }
-    }
-
-    var accessibilityHint: String {
-        switch self {
-        case .memoryGallery: return "Shows the picture matching game."
-        case .sumSprintParty: return "Shows the no timer addition answer game."
-        }
+    private var rowStroke: some View {
+        RoundedRectangle(cornerRadius: 28, style: .continuous)
+            .stroke(isSelected ? Color(red: 0.55, green: 0.88, blue: 1.0).opacity(0.78) : .white.opacity(0.12), lineWidth: 2)
     }
 }
 
@@ -111,6 +151,46 @@ struct MatherTVBackdrop: View {
                     .frame(height: 1)
             }
             .padding(.vertical, 116)
+        }
+    }
+}
+
+private enum MatherTVAction: String, CaseIterable, Identifiable {
+    case memory
+    case angle
+    case sprint
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .memory: "Memory Gallery"
+        case .angle: "Angle Arcade"
+        case .sprint: "Sum Sprint Party"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .memory: "Picture-name matching"
+        case .angle: "Predict, aim, launch"
+        case .sprint: "Big answer tiles"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .memory: "rectangle.stack.fill"
+        case .angle: "scope"
+        case .sprint: "square.grid.2x2.fill"
+        }
+    }
+
+    var accessibilityHint: String {
+        switch self {
+        case .memory: "Selects the Memory Gallery picture matching game."
+        case .angle: "Selects the Angle Arcade prototype."
+        case .sprint: "Selects the Sum Sprint Party answer game."
         }
     }
 }

--- a/Domain/AngleArcadeModel.swift
+++ b/Domain/AngleArcadeModel.swift
@@ -1,0 +1,120 @@
+import CoreGraphics
+import Foundation
+
+struct AngleArcadeTarget: Equatable, Identifiable {
+    let id: String
+    let title: String
+    let distance: Double
+    let height: Double
+    let radius: Double
+    let recommendedAngle: Double
+    let recommendedPower: Double
+
+    static let defaultTargets: [AngleArcadeTarget] = [
+        .init(
+            id: "garden-ledger",
+            title: "Garden ledge",
+            distance: 390,
+            height: 64,
+            radius: 30,
+            recommendedAngle: 35,
+            recommendedPower: 77
+        ),
+        .init(
+            id: "moon-dock",
+            title: "Moon dock",
+            distance: 520,
+            height: 110,
+            radius: 32,
+            recommendedAngle: 45,
+            recommendedPower: 85
+        ),
+        .init(
+            id: "bell-tower",
+            title: "Bell tower",
+            distance: 610,
+            height: 170,
+            radius: 36,
+            recommendedAngle: 55,
+            recommendedPower: 94
+        )
+    ]
+}
+
+struct AngleArcadeShot: Equatable {
+    let angle: Double
+    let power: Double
+    let target: AngleArcadeTarget
+    let path: [CGPoint]
+    let landingX: Double
+    let heightAtTarget: Double
+    let verticalDelta: Double
+    let hit: Bool
+}
+
+enum AngleArcadeModel {
+    static let angleRange: ClosedRange<Double> = 20...75
+    static let powerRange: ClosedRange<Double> = 40...100
+    static let angleStep: Double = 5
+    static let powerStep: Double = 5
+    static let gravity: Double = 98
+    static let velocityScale: Double = 3
+
+    static func adjustedAngle(_ angle: Double, direction: Int) -> Double {
+        clamp(angle + Double(direction) * angleStep, to: angleRange)
+    }
+
+    static func adjustedPower(_ power: Double, direction: Int) -> Double {
+        clamp(power + Double(direction) * powerStep, to: powerRange)
+    }
+
+    static func shot(
+        angle: Double,
+        power: Double,
+        target: AngleArcadeTarget,
+        sampleCount: Int = 80
+    ) -> AngleArcadeShot {
+        let safeAngle = clamp(angle, to: angleRange)
+        let safePower = clamp(power, to: powerRange)
+        let radians = safeAngle * .pi / 180
+        let velocity = safePower * velocityScale
+        let vx = max(1, velocity * cos(radians))
+        let vy = velocity * sin(radians)
+        let landingTime = max(0, (2 * vy) / gravity)
+        let landingX = vx * landingTime
+        let targetTime = target.distance / vx
+        let heightAtTarget = height(at: targetTime, verticalVelocity: vy)
+        let verticalDelta = heightAtTarget - target.height
+        let hit = abs(verticalDelta) <= target.radius
+        let count = max(2, sampleCount)
+        let path = (0..<count).map { index in
+            let progress = Double(index) / Double(count - 1)
+            let t = landingTime * progress
+            return CGPoint(x: vx * t, y: height(at: t, verticalVelocity: vy))
+        }
+
+        return AngleArcadeShot(
+            angle: safeAngle,
+            power: safePower,
+            target: target,
+            path: path,
+            landingX: landingX,
+            heightAtTarget: heightAtTarget,
+            verticalDelta: verticalDelta,
+            hit: hit
+        )
+    }
+
+    static func nextTargetIndex(after index: Int, targetCount: Int) -> Int {
+        guard targetCount > 0 else { return 0 }
+        return (index + 1) % targetCount
+    }
+
+    private static func height(at time: Double, verticalVelocity: Double) -> Double {
+        verticalVelocity * time - 0.5 * gravity * time * time
+    }
+
+    private static func clamp(_ value: Double, to range: ClosedRange<Double>) -> Double {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+}

--- a/Mather.xcodeproj/project.pbxproj
+++ b/Mather.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		0F799699251E181629E1C3F8 /* GameActivityCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D6D0061948133C7AB57A02 /* GameActivityCard.swift */; };
 		10EB0242F0C3D40604D246E8 /* SumSprintModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 576411C3ACD2B1B55F53CC89 /* SumSprintModels.swift */; };
 		112A284BDF426C840BE1B8CB /* LabLaneDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C13E59DB0E8C3C0F5D863FF /* LabLaneDetailView.swift */; };
+		12978B14FA3C86099A34FC4F /* AngleArcadeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3E9C534B6CF90AFEFC7A23 /* AngleArcadeModel.swift */; };
 		138E4B58418EE08549CF1407 /* LabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B42394C64D2D5C8DC32CE604 /* LabView.swift */; };
 		14D458B1148DC15E9444204F /* CompassAnglesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F89B7EA97FE105036E4EB5F /* CompassAnglesView.swift */; };
 		14DE12583C593EE688E0C1E6 /* MemoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A56FCB9103BAE6E2941CA3 /* MemoryView.swift */; };
@@ -30,6 +31,7 @@
 		17BE88060C10E1B1E35E439F /* CompactLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB2A42C7C5F0F36C9CBAA103 /* CompactLayoutTests.swift */; };
 		1880E12717CE04AA936CCDA9 /* GameplayStageViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6840F2651B5C50EE285F52B /* GameplayStageViewModels.swift */; };
 		19F4E103CE0765211AAF66E7 /* GroupedNumberRepresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A181025AE1DD3CABF30F968 /* GroupedNumberRepresentationTests.swift */; };
+		1A7B774DEC63CE5479722F6D /* AngleArcadeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3849D3285D292421CEA3A1A3 /* AngleArcadeModelTests.swift */; };
 		1AAC31299B73107856FF555C /* TransferIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD670E85B31C24247FA80EA7 /* TransferIntentTests.swift */; };
 		1CAB4FE9FAA2F4CD4CF15811 /* TelemetryWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D534592E2580F9BC9AF7AC2D /* TelemetryWriter.swift */; };
 		1ED4CA54DD386B5AFD07D0A2 /* LabModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F451B67C2A515584DDB54A4 /* LabModelsTests.swift */; };
@@ -95,6 +97,7 @@
 		6EF0C5C2A7F0FFD50254907C /* GravitySplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892C73ABB87A9BFDC46D9896 /* GravitySplitView.swift */; };
 		6F5C05185F5CEFD78EBD34BF /* SplitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A026C6F2490BFE57BBD4B6 /* SplitView.swift */; };
 		6F640A24F421DC2A0B558205 /* SumSprintEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F27A140FE20F5F42F54DD237 /* SumSprintEngineTests.swift */; };
+		6FCBEF02AFFDFDA13749BB83 /* AngleArcadeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3E9C534B6CF90AFEFC7A23 /* AngleArcadeModel.swift */; };
 		706B158BD7E09EDC4FA754A4 /* SliceSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E23D56BDC809F3EA92AFCB5 /* SliceSessionView.swift */; };
 		7152D501D6B4641F75716E04 /* StoryAnchorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848B1652547224E6778C19F0 /* StoryAnchorView.swift */; };
 		73677957CEDF883A4CC75D9E /* LabConceptSessionProgressStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92740460961DA8CA221823A6 /* LabConceptSessionProgressStore.swift */; };
@@ -196,6 +199,7 @@
 		E982982CABB43977EDECE3FF /* FactoryCardsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2094D8B8C58010318C8DEB6 /* FactoryCardsViewTests.swift */; };
 		EA514902B3549363146AF031 /* SessionHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 448A9249C8294633E1A87C43 /* SessionHistoryTests.swift */; };
 		ECD8D5A562596BB07C9DDD9E /* ClassicTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A8BF9BA66E94F09BB1AC3C /* ClassicTheme.swift */; };
+		ED8BB99A44A3C701068F03D6 /* AngleArcadeTVView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11274D795B3AD4EF9BCDCFC2 /* AngleArcadeTVView.swift */; };
 		EF44551359C1EF6A68E0542C /* GroupedNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F3E611E8AE4A6487A373E5C /* GroupedNumberView.swift */; };
 		EF711D2300E02AA521E096B8 /* TwoFingerProtractorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5664E2D1E683B5945DB14EC8 /* TwoFingerProtractorView.swift */; };
 		F132D0108E586BDB792A9446 /* SmartPlayProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BA0898F456D9EF08C10E16A /* SmartPlayProvider.swift */; };
@@ -236,6 +240,7 @@
 		0E23D56BDC809F3EA92AFCB5 /* SliceSessionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliceSessionView.swift; sourceTree = "<group>"; };
 		0F3E611E8AE4A6487A373E5C /* GroupedNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedNumberView.swift; sourceTree = "<group>"; };
 		1045712502442FED9B5B13C9 /* RoomQuestScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomQuestScanner.swift; sourceTree = "<group>"; };
+		11274D795B3AD4EF9BCDCFC2 /* AngleArcadeTVView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AngleArcadeTVView.swift; sourceTree = "<group>"; };
 		123D7243C121679FDB225E40 /* MixMatchRecallViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixMatchRecallViewTests.swift; sourceTree = "<group>"; };
 		12757B691EB1421D33AAADD3 /* LabRouteRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabRouteRegressionTests.swift; sourceTree = "<group>"; };
 		128EAA2ABCC936C76AD253C9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -259,6 +264,7 @@
 		2AACE02B6A0FE6EC8AC6D1A0 /* MemoryAskConversationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryAskConversationPolicyTests.swift; sourceTree = "<group>"; };
 		2B263A7CB3EDD62F58160FDF /* PairingChallengeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingChallengeTests.swift; sourceTree = "<group>"; };
 		2BA0898F456D9EF08C10E16A /* SmartPlayProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPlayProvider.swift; sourceTree = "<group>"; };
+		2C3E9C534B6CF90AFEFC7A23 /* AngleArcadeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AngleArcadeModel.swift; sourceTree = "<group>"; };
 		2D4426E080AAAFB9A2BE2164 /* MemoryViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryViewTests.swift; sourceTree = "<group>"; };
 		2D8CC8DF5EFFD5DA3DAA8E60 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		2E8D900636FFCAF5EABA2774 /* RouteQuestModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteQuestModels.swift; sourceTree = "<group>"; };
@@ -271,6 +277,7 @@
 		36ECB3EFD8245E65E2F31BD1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		37DCF6B189D5EC4C0B6099AA /* SumSprintEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumSprintEngine.swift; sourceTree = "<group>"; };
 		383EE87126C22A00D3232A1E /* NumberStoryModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberStoryModels.swift; sourceTree = "<group>"; };
+		3849D3285D292421CEA3A1A3 /* AngleArcadeModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AngleArcadeModelTests.swift; sourceTree = "<group>"; };
 		3ABD019864C46683CF30CA35 /* GameplayThreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayThreadView.swift; sourceTree = "<group>"; };
 		3AD7C916626C1EDE3808C9E0 /* MemoryContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryContent.swift; sourceTree = "<group>"; };
 		3B2892D2B5CEF3CA073DD5FF /* ResponsiveLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponsiveLayout.swift; sourceTree = "<group>"; };
@@ -498,6 +505,7 @@
 		164629017D683675FC8851CF /* AppTV */ = {
 			isa = PBXGroup;
 			children = (
+				11274D795B3AD4EF9BCDCFC2 /* AngleArcadeTVView.swift */,
 				CE5FA612478F9C2A6066CB46 /* MatherTVApp.swift */,
 				5C4A94DB04A905680599FB7C /* MatherTVRootView.swift */,
 				F27EF90A13CB6C3832CF3D58 /* MemoryGalleryTVView.swift */,
@@ -532,6 +540,7 @@
 		25FB5EFDA536B37D6A1D2832 /* MatherTests */ = {
 			isa = PBXGroup;
 			children = (
+				3849D3285D292421CEA3A1A3 /* AngleArcadeModelTests.swift */,
 				D69ADFE340625CE2247C439C /* AngleCannonTests.swift */,
 				E63765A2998A3C2FD04B62AC /* ArrayPreludeModelsTests.swift */,
 				7E3256A636C3B109D53BE146 /* BondMatchViewTests.swift */,
@@ -640,6 +649,7 @@
 		4356714DEE880CBB965F848D /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				2C3E9C534B6CF90AFEFC7A23 /* AngleArcadeModel.swift */,
 				B6B469EA6DCDB375AF9BC3CD /* ArrayPreludeModels.swift */,
 				479CE24CCC2244CAA1135B24 /* CapabilityLane.swift */,
 				8C221EA39753544B4F0EE9E7 /* CapabilityModels.swift */,
@@ -1007,6 +1017,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				12978B14FA3C86099A34FC4F /* AngleArcadeModel.swift in Sources */,
+				ED8BB99A44A3C701068F03D6 /* AngleArcadeTVView.swift in Sources */,
 				E2B69F661245B146169C0F71 /* MatherTVApp.swift in Sources */,
 				38B62455FD9BBCFF0114106C /* MatherTVRootView.swift in Sources */,
 				D1E040DCC6D9CF2985A53CE1 /* MemoryContent.swift in Sources */,
@@ -1021,6 +1033,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1A7B774DEC63CE5479722F6D /* AngleArcadeModelTests.swift in Sources */,
 				FCCD21AF414D3FAFDA10A9A4 /* AngleCannonTests.swift in Sources */,
 				08341A75D0D385BC7222C172 /* ArrayPreludeModelsTests.swift in Sources */,
 				84CB43226EBB48F26DDF03A8 /* BondMatchViewTests.swift in Sources */,
@@ -1103,6 +1116,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6FCBEF02AFFDFDA13749BB83 /* AngleArcadeModel.swift in Sources */,
 				0A87802FC06B98D73B797D40 /* AngleCannonView.swift in Sources */,
 				A3E583B00B7BE54D5F3E0535 /* AppModel.swift in Sources */,
 				067AD3849B44423F0AB55906 /* ArrayPreludeModels.swift in Sources */,

--- a/Tests/MatherTests/AngleArcadeModelTests.swift
+++ b/Tests/MatherTests/AngleArcadeModelTests.swift
@@ -1,0 +1,74 @@
+import Testing
+@testable import Mather
+
+struct AngleArcadeModelTests {
+    @Test
+    func defaultTargetsProvideAtLeastThreePositions() {
+        let targets = AngleArcadeTarget.defaultTargets
+        #expect(targets.count >= 3)
+        #expect(Set(targets.map(\.id)).count == targets.count)
+        #expect(Set(targets.map(\.distance)).count >= 3)
+        #expect(targets.allSatisfy { $0.radius > 0 })
+    }
+
+    @Test
+    func dPadAngleControlStepsAndClamps() {
+        #expect(AngleArcadeModel.adjustedAngle(45, direction: 1) == 50)
+        #expect(AngleArcadeModel.adjustedAngle(45, direction: -1) == 40)
+        #expect(AngleArcadeModel.adjustedAngle(74, direction: 1) == 75)
+        #expect(AngleArcadeModel.adjustedAngle(21, direction: -1) == 20)
+    }
+
+    @Test
+    func dPadPowerControlStepsAndClamps() {
+        #expect(AngleArcadeModel.adjustedPower(80, direction: 1) == 85)
+        #expect(AngleArcadeModel.adjustedPower(80, direction: -1) == 75)
+        #expect(AngleArcadeModel.adjustedPower(98, direction: 1) == 100)
+        #expect(AngleArcadeModel.adjustedPower(42, direction: -1) == 40)
+    }
+
+    @Test
+    func recommendedLaunchesHitAllDefaultTargets() {
+        for target in AngleArcadeTarget.defaultTargets {
+            let shot = AngleArcadeModel.shot(
+                angle: target.recommendedAngle,
+                power: target.recommendedPower,
+                target: target
+            )
+            #expect(shot.hit, "\(target.id) should be hittable by its recommended launch")
+            #expect(abs(shot.verticalDelta) <= target.radius)
+            #expect(!shot.path.isEmpty)
+        }
+    }
+
+    @Test
+    func landingIsDeterministicForSameAnglePowerAndTarget() {
+        let target = AngleArcadeTarget.defaultTargets[1]
+        let first = AngleArcadeModel.shot(angle: 45, power: 85, target: target)
+        let second = AngleArcadeModel.shot(angle: 45, power: 85, target: target)
+
+        #expect(first == second)
+        #expect(abs(first.landingX - 663.52) < 0.1)
+        #expect(abs(first.heightAtTarget - 112.48) < 0.1)
+    }
+
+    @Test
+    func missReportsSignedVerticalDelta() {
+        let target = AngleArcadeTarget.defaultTargets[1]
+        let lowShot = AngleArcadeModel.shot(angle: 25, power: 55, target: target)
+        let highShot = AngleArcadeModel.shot(angle: 65, power: 100, target: target)
+
+        #expect(!lowShot.hit)
+        #expect(lowShot.verticalDelta < 0)
+        #expect(!highShot.hit)
+        #expect(highShot.verticalDelta > 0)
+    }
+
+    @Test
+    func targetCycleWrapsDeterministically() {
+        let count = AngleArcadeTarget.defaultTargets.count
+        #expect(AngleArcadeModel.nextTargetIndex(after: 0, targetCount: count) == 1)
+        #expect(AngleArcadeModel.nextTargetIndex(after: count - 1, targetCount: count) == 0)
+        #expect(AngleArcadeModel.nextTargetIndex(after: 4, targetCount: 0) == 0)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -54,6 +54,7 @@ targets:
       - path: Domain/MemoryContent.swift
       - path: Domain/MemoryGalleryTVRound.swift
       - path: Domain/SumSprintPartyTVRound.swift
+      - path: Domain/AngleArcadeModel.swift
       - path: App/Assets.xcassets
     settings:
       base:


### PR DESCRIPTION
## Summary
- adds a playable tvOS Angle Arcade prototype to the Mather TV shell
- supports remote/D-pad angle and power adjustment, fire/replay, prediction arc, actual arc, and three deterministic targets
- adds shared projectile math plus deterministic angle/power/landing tests

Closes #1180

## Validation
- PASS: `xcodebuild -project Mather.xcodeproj -scheme MatherTV -destination "platform=tvOS Simulator,name=Apple TV 4K (3rd generation)" -derivedDataPath /tmp/mather-angle-arcade-derived-final2 build` on `studio`
- PASS: `xcodebuild -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPad (A16)" -derivedDataPath /tmp/mather-angle-arcade-derived-ios-build build` on `studio`
- PASS: `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPad (A16)" -derivedDataPath /tmp/mather-angle-arcade-derived-unit-only -skip-testing:MatherUITests -only-testing:MatherTests/AngleArcadeModelTests` on `studio` (7 tests)

## Screenshot
- Workspace artifact: `artifacts/screenshots/mather-appletv-angle-arcade-slice-d-2026-06-20.png`

## Notes
- A first unit-test attempt without `-skip-testing:MatherUITests` failed before unit execution because the hosted app/test session exited during bootstrap; the unit-only retry passed.
- This branch is based on current remote `origin/main` at `5b6b976`; the Slice C merge hash mentioned in the worker prompt was not present on remote main when fetched before PR creation.