### PR TITLE
feat(tvos): add Sum Sprint Party prototype

### DIFF
--- a/AppTV/MatherTVRootView.swift
+++ b/AppTV/MatherTVRootView.swift
@@ -1,8 +1,92 @@
 import SwiftUI
 
 struct MatherTVRootView: View {
+    @State private var selectedMode: MatherTVMode = .sumSprintParty
+
     var body: some View {
-        MemoryGalleryTVView()
+        ZStack {
+            switch selectedMode {
+            case .memoryGallery:
+                MemoryGalleryTVView()
+            case .sumSprintParty:
+                SumSprintPartyTVView()
+            }
+
+            VStack {
+                modeShelf
+                Spacer()
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.top, 28)
+        }
+    }
+
+    private var modeShelf: some View {
+        HStack(spacing: 14) {
+            ForEach(MatherTVMode.allCases) { mode in
+                Button {
+                    selectedMode = mode
+                } label: {
+                    MatherTVModeTile(mode: mode, isSelected: selectedMode == mode)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(mode.title)
+                .accessibilityHint(mode.accessibilityHint)
+                .accessibilityIdentifier("tv-mode-\(mode.id)")
+            }
+        }
+        .padding(8)
+        .background(.black.opacity(0.20), in: Capsule())
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Mather TV mode picker")
+    }
+}
+
+private struct MatherTVModeTile: View {
+    let mode: MatherTVMode
+    let isSelected: Bool
+
+    var body: some View {
+        Label(mode.title, systemImage: mode.symbolName)
+            .font(.system(size: 24, weight: .black, design: .rounded))
+            .padding(.horizontal, 24)
+            .padding(.vertical, 14)
+            .frame(width: 250)
+            .background(backgroundStyle, in: Capsule())
+            .foregroundStyle(.white)
+    }
+
+    private var backgroundStyle: some ShapeStyle {
+        if isSelected { return AnyShapeStyle(Color(red: 0.55, green: 0.88, blue: 1.0).opacity(0.24)) }
+        return AnyShapeStyle(.white.opacity(0.08))
+    }
+}
+
+private enum MatherTVMode: String, CaseIterable, Identifiable {
+    case memoryGallery
+    case sumSprintParty
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .memoryGallery: return "Memory Gallery"
+        case .sumSprintParty: return "Sum Sprint"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .memoryGallery: return "photo.on.rectangle.angled"
+        case .sumSprintParty: return "plus.forwardslash.minus"
+        }
+    }
+
+    var accessibilityHint: String {
+        switch self {
+        case .memoryGallery: return "Shows the picture matching game."
+        case .sumSprintParty: return "Shows the no timer addition answer game."
+        }
     }
 }
 

--- a/AppTV/SumSprintPartyTVView.swift
+++ b/AppTV/SumSprintPartyTVView.swift
@@ -1,0 +1,376 @@
+import SwiftUI
+
+struct SumSprintPartyTVView: View {
+    @FocusState private var focusedAnswer: Int?
+    @FocusState private var nextButtonFocused: Bool
+
+    @AppStorage("tv.sumSprintParty.personalBest") private var personalBest = 0
+
+    @State private var roundIndex = 0
+    @State private var selectedAnswer: Int?
+    @State private var streak = 0
+
+    private var round: SumSprintPartyTVRound {
+        SumSprintPartyTVRound.make(index: roundIndex)
+    }
+
+    private var answeredCorrectly: Bool {
+        SumSprintPartyTVRound.isCorrect(selection: selectedAnswer, for: round)
+    }
+
+    var body: some View {
+        ZStack {
+            MatherTVBackdrop()
+
+            VStack(alignment: .leading, spacing: 36) {
+                header
+                stage
+            }
+            .frame(maxWidth: 1680, maxHeight: .infinity, alignment: .topLeading)
+            .padding(.horizontal, 90)
+            .padding(.vertical, 66)
+        }
+        .onAppear {
+            focusedAnswer = round.answerChoices.first
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Sum Sprint Party")
+                    .font(.system(size: 70, weight: .bold, design: .rounded))
+                    .foregroundStyle(.white)
+                    .accessibilityIdentifier("tv-sum-sprint-title")
+
+                Text("Four answers, no countdown. Build a calm streak together.")
+                    .font(.system(size: 30, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.74))
+                    .accessibilityIdentifier("tv-sum-sprint-no-timer-copy")
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Sum Sprint Party. Four answers. No countdown.")
+
+            Spacer(minLength: 24)
+
+            HStack(spacing: 18) {
+                metricPill(title: "Streak", value: "\(streak)", color: Color(red: 0.78, green: 0.94, blue: 0.66))
+                metricPill(title: "Best", value: "\(personalBest)", color: Color(red: 1.0, green: 0.82, blue: 0.44))
+            }
+        }
+    }
+
+    private var stage: some View {
+        HStack(alignment: .top, spacing: 42) {
+            factPanel
+
+            VStack(alignment: .leading, spacing: 22) {
+                Text("Choose the total")
+                    .font(.system(size: 32, weight: .black, design: .rounded))
+                    .foregroundStyle(.white)
+
+                answerGrid
+
+                feedbackBar
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+    }
+
+    private var factPanel: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            Text("Fact")
+                .font(.system(size: 28, weight: .bold, design: .rounded))
+                .foregroundStyle(Color(red: 0.55, green: 0.88, blue: 1.0))
+
+            Text(round.fact.promptText)
+                .font(.system(size: 82, weight: .black, design: .rounded))
+                .foregroundStyle(.white)
+                .accessibilityIdentifier("tv-sum-sprint-fact")
+
+            SumSprintPartyTokensView(fact: round.fact)
+                .frame(width: 500, height: 294)
+                .accessibilityHidden(true)
+
+            Text("Look at the two groups, then pick the total.")
+                .font(.system(size: 24, weight: .bold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.58))
+                .lineLimit(2)
+        }
+        .padding(36)
+        .frame(width: 600, height: 590, alignment: .leading)
+        .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 30, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 30, style: .continuous)
+                .stroke(.white.opacity(0.14), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(round.fact.spokenPrompt) Picture support shows \(round.fact.addendA) counters plus \(round.fact.addendB) counters.")
+        .accessibilityHint("Move right to choose the total.")
+        .accessibilityIdentifier("tv-sum-sprint-picture-prompt")
+    }
+
+    private var answerGrid: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.fixed(390), spacing: 22),
+                GridItem(.fixed(390), spacing: 22)
+            ],
+            spacing: 22
+        ) {
+            ForEach(round.answerChoices, id: \.self) { answer in
+                Button {
+                    choose(answer)
+                } label: {
+                    SumSprintPartyAnswerTile(
+                        answer: answer,
+                        isFocused: focusedAnswer == answer,
+                        state: answerState(for: answer)
+                    )
+                }
+                .buttonStyle(.plain)
+                .focused($focusedAnswer, equals: answer)
+                .disabled(selectedAnswer != nil)
+                .accessibilityLabel("\(answer)")
+                .accessibilityHint("Select \(answer) as the total.")
+                .accessibilityIdentifier("tv-sum-sprint-answer-\(answer)")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var feedbackBar: some View {
+        if let selectedAnswer {
+            HStack(spacing: 20) {
+                Image(systemName: answeredCorrectly ? "checkmark.circle.fill" : "arrow.uturn.backward.circle.fill")
+                    .font(.system(size: 38, weight: .bold))
+                    .foregroundStyle(answeredCorrectly ? Color(red: 0.78, green: 0.94, blue: 0.66) : Color(red: 1.0, green: 0.78, blue: 0.42))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(answeredCorrectly ? "Nice total!" : "Good try")
+                        .font(.system(size: 28, weight: .black, design: .rounded))
+                        .foregroundStyle(.white)
+
+                    Text(answeredCorrectly ? "\(round.fact.promptText) = \(round.correctAnswer). Keep the streak going." : "\(selectedAnswer) is not it yet. \(round.fact.promptText) = \(round.correctAnswer).")
+                        .font(.system(size: 22, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.white.opacity(0.68))
+                }
+
+                Spacer(minLength: 18)
+
+                Button {
+                    nextRound()
+                } label: {
+                    Label("Next fact", systemImage: "forward.fill")
+                        .font(.system(size: 24, weight: .black, design: .rounded))
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 18)
+                }
+                .buttonStyle(.plain)
+                .focused($nextButtonFocused)
+                .background(nextButtonFocused ? .white : Color(red: 0.55, green: 0.88, blue: 1.0).opacity(0.20), in: Capsule())
+                .foregroundStyle(nextButtonFocused ? Color(red: 0.07, green: 0.10, blue: 0.16) : .white)
+                .accessibilityIdentifier("tv-sum-sprint-next-fact")
+            }
+            .padding(24)
+            .frame(width: 802)
+            .frame(minHeight: 120)
+            .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 26, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 26, style: .continuous)
+                    .stroke(.white.opacity(0.14), lineWidth: 1)
+            )
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(feedbackAccessibilityLabel(selectedAnswer: selectedAnswer))
+        } else {
+            Text("No timer. The only counters here are your streak and your personal best.")
+                .font(.system(size: 22, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.58))
+                .frame(width: 802, alignment: .leading)
+                .frame(minHeight: 120, alignment: .leading)
+                .accessibilityIdentifier("tv-sum-sprint-calm-copy")
+        }
+    }
+
+    private func metricPill(title: String, value: String, color: Color) -> some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            Text(value)
+                .font(.system(size: 56, weight: .black, design: .rounded))
+                .foregroundStyle(color)
+
+            Text(title)
+                .font(.system(size: 23, weight: .bold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.62))
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
+        .frame(minWidth: 150, alignment: .trailing)
+        .background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title) \(value)")
+    }
+
+    private func choose(_ answer: Int) {
+        selectedAnswer = answer
+        if answer == round.correctAnswer {
+            streak += 1
+            personalBest = max(personalBest, streak)
+        } else {
+            streak = 0
+        }
+        nextButtonFocused = true
+    }
+
+    private func nextRound() {
+        let nextIndex = roundIndex + 1
+        let nextRound = SumSprintPartyTVRound.make(index: nextIndex)
+        roundIndex = nextIndex
+        selectedAnswer = nil
+        focusedAnswer = nextRound.answerChoices.first
+        nextButtonFocused = false
+    }
+
+    private func answerState(for answer: Int) -> SumSprintPartyAnswerTile.State {
+        guard let selectedAnswer else { return .idle }
+        if answer == round.correctAnswer { return .correct }
+        if answer == selectedAnswer { return .incorrect }
+        return .dimmed
+    }
+
+    private func feedbackAccessibilityLabel(selectedAnswer: Int) -> String {
+        if selectedAnswer == round.correctAnswer {
+            return "Correct. \(round.fact.promptText) equals \(round.correctAnswer). Streak \(streak)."
+        }
+        return "Not yet. \(round.fact.promptText) equals \(round.correctAnswer). Streak reset to zero."
+    }
+}
+
+private struct SumSprintPartyTokensView: View {
+    let fact: SumSprintPartyTVFact
+
+    var body: some View {
+        HStack(spacing: 22) {
+            tokenGroup(count: fact.addendA, tint: Color(red: 0.98, green: 0.73, blue: 0.34), label: "\(fact.addendA)")
+
+            Text("+")
+                .font(.system(size: 50, weight: .black, design: .rounded))
+                .foregroundStyle(.white.opacity(0.72))
+                .frame(width: 42)
+
+            tokenGroup(count: fact.addendB, tint: Color(red: 0.42, green: 0.82, blue: 0.90), label: "\(fact.addendB)")
+        }
+    }
+
+    private func tokenGroup(count: Int, tint: Color, label: String) -> some View {
+        VStack(spacing: 16) {
+            LazyVGrid(
+                columns: Array(repeating: GridItem(.fixed(28), spacing: 8), count: 5),
+                spacing: 8
+            ) {
+                ForEach(0..<count, id: \.self) { index in
+                    Circle()
+                        .fill(tint)
+                        .frame(width: 28, height: 28)
+                        .overlay(Circle().stroke(.white.opacity(index % 2 == 0 ? 0.45 : 0.18), lineWidth: 2))
+                }
+            }
+            .frame(width: 174, height: 122, alignment: .top)
+            .padding(18)
+            .background(.black.opacity(0.18), in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+
+            Text(label)
+                .font(.system(size: 34, weight: .black, design: .rounded))
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+private struct SumSprintPartyAnswerTile: View {
+    enum State {
+        case idle
+        case correct
+        case incorrect
+        case dimmed
+    }
+
+    let answer: Int
+    let isFocused: Bool
+    let state: State
+
+    var body: some View {
+        HStack(spacing: 18) {
+            statusIcon
+
+            Text("\(answer)")
+                .font(.system(size: 58, weight: .black, design: .rounded))
+                .foregroundStyle(foregroundColor)
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.75)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 28)
+        .padding(.vertical, 20)
+        .frame(width: 390, height: 150, alignment: .leading)
+        .background(backgroundStyle, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .stroke(strokeColor, lineWidth: 3)
+        )
+        .scaleEffect(isFocused ? 1.055 : 1.0)
+        .opacity(state == .dimmed ? 0.45 : 1)
+        .shadow(color: .black.opacity(isFocused ? 0.28 : 0.12), radius: isFocused ? 20 : 8, x: 0, y: isFocused ? 14 : 5)
+        .animation(.spring(response: 0.26, dampingFraction: 0.78), value: isFocused)
+        .animation(.easeInOut(duration: 0.16), value: state)
+    }
+
+    @ViewBuilder
+    private var statusIcon: some View {
+        switch state {
+        case .correct:
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 38, weight: .black))
+                .foregroundStyle(Color(red: 0.36, green: 0.63, blue: 0.30))
+        case .incorrect:
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 38, weight: .black))
+                .foregroundStyle(Color(red: 0.80, green: 0.28, blue: 0.22))
+        case .idle, .dimmed:
+            Image(systemName: "circle")
+                .font(.system(size: 34, weight: .bold))
+                .foregroundStyle(foregroundColor.opacity(0.72))
+        }
+    }
+
+    private var foregroundColor: Color {
+        isFocused ? Color(red: 0.08, green: 0.12, blue: 0.18) : .white
+    }
+
+    private var strokeColor: Color {
+        switch state {
+        case .correct: return Color(red: 0.78, green: 0.94, blue: 0.66)
+        case .incorrect: return Color(red: 1.0, green: 0.60, blue: 0.50)
+        case .idle, .dimmed:
+            return isFocused ? .white : .white.opacity(0.12)
+        }
+    }
+
+    private var backgroundStyle: some ShapeStyle {
+        if isFocused {
+            return AnyShapeStyle(.white)
+        }
+        switch state {
+        case .correct:
+            return AnyShapeStyle(Color(red: 0.20, green: 0.50, blue: 0.32).opacity(0.82))
+        case .incorrect:
+            return AnyShapeStyle(Color(red: 0.52, green: 0.17, blue: 0.17).opacity(0.78))
+        case .idle, .dimmed:
+            return AnyShapeStyle(.white.opacity(0.08))
+        }
+    }
+}
+
+#Preview {
+    SumSprintPartyTVView()
+}

--- a/Domain/SumSprintPartyTVRound.swift
+++ b/Domain/SumSprintPartyTVRound.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+struct SumSprintPartyTVFact: Identifiable, Equatable, Hashable {
+    let addendA: Int
+    let addendB: Int
+
+    var id: String { "\(addendA)+\(addendB)" }
+    var sum: Int { addendA + addendB }
+    var promptText: String { "\(addendA) + \(addendB)" }
+    var spokenPrompt: String { "What is \(addendA) plus \(addendB)?" }
+}
+
+struct SumSprintPartyTVRound: Equatable {
+    let index: Int
+    let fact: SumSprintPartyTVFact
+    let answerChoices: [Int]
+
+    var correctAnswer: Int { fact.sum }
+    var usesTimer: Bool { false }
+
+    static let choiceCount = 4
+    static let answerRange = 11...20
+
+    static let factPool: [SumSprintPartyTVFact] = {
+        var facts: [SumSprintPartyTVFact] = []
+        for sum in answerRange {
+            for addendA in 1...(sum / 2) {
+                facts.append(SumSprintPartyTVFact(addendA: addendA, addendB: sum - addendA))
+            }
+        }
+        return facts
+    }()
+
+    static func make(index: Int) -> SumSprintPartyTVRound {
+        precondition(!factPool.isEmpty, "Sum Sprint Party needs at least one fact.")
+        let normalizedIndex = positiveModulo(index, factPool.count)
+        let fact = factPool[normalizedIndex]
+        return SumSprintPartyTVRound(
+            index: normalizedIndex,
+            fact: fact,
+            answerChoices: answerChoices(for: fact)
+        )
+    }
+
+    static func answerChoices(for fact: SumSprintPartyTVFact) -> [Int] {
+        let distractors = distractors(for: fact)
+        let orderedChoices = [fact.sum] + distractors
+        return rotate(orderedChoices, by: rotationOffset(for: fact))
+    }
+
+    static func isCorrect(selection: Int?, for round: SumSprintPartyTVRound) -> Bool {
+        selection == round.correctAnswer
+    }
+
+    private static func distractors(for fact: SumSprintPartyTVFact) -> [Int] {
+        var candidates: [Int] = []
+        let deltas = [1, -1, 2, -2, 3, -3, 4, -4]
+
+        for delta in deltas {
+            let candidate = fact.sum + delta
+            if answerRange.contains(candidate), candidate != fact.sum, !candidates.contains(candidate) {
+                candidates.append(candidate)
+            }
+        }
+
+        for candidate in answerRange where candidate != fact.sum && !candidates.contains(candidate) {
+            candidates.append(candidate)
+        }
+
+        return Array(candidates.prefix(choiceCount - 1))
+    }
+
+    private static func rotationOffset(for fact: SumSprintPartyTVFact) -> Int {
+        positiveModulo(fact.addendA * 31 + fact.addendB * 17 + fact.sum, choiceCount)
+    }
+
+    private static func positiveModulo(_ value: Int, _ divisor: Int) -> Int {
+        let remainder = value % divisor
+        return remainder >= 0 ? remainder : remainder + divisor
+    }
+
+    private static func rotate(_ values: [Int], by offset: Int) -> [Int] {
+        guard !values.isEmpty else { return values }
+        let split = positiveModulo(offset, values.count)
+        return Array(values[split...]) + Array(values[..<split])
+    }
+}

--- a/Mather.xcodeproj/project.pbxproj
+++ b/Mather.xcodeproj/project.pbxproj
@@ -48,12 +48,15 @@
 		2EEF996C071A5985EBA9646B /* SpeechService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57321A0556CEB2A30DE5A7A7 /* SpeechService.swift */; };
 		30A171142A2C7ECF758109BE /* ResponsiveLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2892D2B5CEF3CA073DD5FF /* ResponsiveLayout.swift */; };
 		329C9965E6D9AD988934EB70 /* MemoryGalleryTVRoundTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 778D14CAED9677C6F12D3617 /* MemoryGalleryTVRoundTests.swift */; };
+		3317FEF0838DE009DAEF51B7 /* SumSprintPartyTVRoundTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A4D019E0AB8DA7749332EA /* SumSprintPartyTVRoundTests.swift */; };
+		334DF049B90427A9C94FAA13 /* SumSprintPartyTVRound.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D6A8BEC102AC062724068D /* SumSprintPartyTVRound.swift */; };
 		34DE37BF5680E415897E050B /* GameplaySampleThreads.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EADCE17D35CAE2DE5B7C4BA /* GameplaySampleThreads.swift */; };
 		35FD0D94E4C550D6A69EDA3B /* MixMatchRecallViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123D7243C121679FDB225E40 /* MixMatchRecallViewTests.swift */; };
 		388F1605AC5009767EFB7F00 /* ResponsiveLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C9FAF248AB426DF0FD1555 /* ResponsiveLayoutTests.swift */; };
 		38B62455FD9BBCFF0114106C /* MatherTVRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C4A94DB04A905680599FB7C /* MatherTVRootView.swift */; };
 		3A2191B9DC40AAD1D0915808 /* SensorCapabilityService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157718747997491EAA58488C /* SensorCapabilityService.swift */; };
 		3D43E7A118690E1610686ED2 /* RoomQuestStationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D3FA86EA00E9865ECE7DC64 /* RoomQuestStationStore.swift */; };
+		3DB94C6E2105D6F2729BDF16 /* SumSprintPartyTVView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BF76EBB16876D2F9CA900B /* SumSprintPartyTVView.swift */; };
 		3E59F97481BC7A8C37F81395 /* SumSprintEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37DCF6B189D5EC4C0B6099AA /* SumSprintEngine.swift */; };
 		3F7CA345284169CF6C6F9796 /* ElectronicsCircuitArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718F5CC2C2AE96EAA9331421 /* ElectronicsCircuitArtwork.swift */; };
 		406C3FEA95214CE100610901 /* GravityArtistTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B095D79E7B14DFBAAEDC223 /* GravityArtistTests.swift */; };
@@ -72,6 +75,7 @@
 		4CB8E6289BE2BD95813E3B9A /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8CC8DF5EFFD5DA3DAA8E60 /* LocationService.swift */; };
 		4D1AA6EA86EADDD1EBCD1F2C /* GameplayStageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F76B8BE6B3409EDE0B4CBF /* GameplayStageViewModelTests.swift */; };
 		5032EE3DF5732E53D7FE3B3A /* LearningLoopModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7991456D37C3C6C4B262BDE /* LearningLoopModels.swift */; };
+		521C2782BA0163B3216ACD9B /* SumSprintPartyTVRound.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D6A8BEC102AC062724068D /* SumSprintPartyTVRound.swift */; };
 		53EB2EBB27E37A71B6205534 /* GameplayStageModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 788A6A49D5B41AEFB50725EA /* GameplayStageModels.swift */; };
 		547A424F8ABA1E591352CAA8 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F5E1261557B57C9FD31842 /* SettingsView.swift */; };
 		54CBAF0A5868D81125A2E2FD /* TwoFingerProtractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0DE2E6D7D0A282D3DB930BC /* TwoFingerProtractorTests.swift */; };
@@ -133,10 +137,6 @@
 		A1289C7C722DE12CC1720FCC /* GroupedNumberRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C398DF4D3007D587BC30FF3 /* GroupedNumberRepresentation.swift */; };
 		A2C06BF6454B822874F8221F /* RoomQuestScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1045712502442FED9B5B13C9 /* RoomQuestScanner.swift */; };
 		A3608BF3DBB1D294B4BE1BB5 /* SumSprintGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29BA55590AB9BAD7D586B7D /* SumSprintGenerator.swift */; };
-		A11810000000000000000003 /* SumSprintPartyTVRound.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11810000000000000000004 /* SumSprintPartyTVRound.swift */; };
-		A11810000000000000000005 /* SumSprintPartyTVRound.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11810000000000000000004 /* SumSprintPartyTVRound.swift */; };
-		A11810000000000000000006 /* SumSprintPartyTVRoundTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11810000000000000000007 /* SumSprintPartyTVRoundTests.swift */; };
-		A11810000000000000000008 /* SumSprintPartyTVView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11810000000000000000002 /* SumSprintPartyTVView.swift */; };
 		A3E583B00B7BE54D5F3E0535 /* AppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4C11FE8A80968AE7EA69CC /* AppModel.swift */; };
 		A4B5AFA2FA430D40BDBDD100 /* ExplorerLabMasteryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FCE7B3840A8A5977FF70D9 /* ExplorerLabMasteryStoreTests.swift */; };
 		A580D6F96249197C9148D59D /* HapticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F29980CE5E67E05A4F30F /* HapticsService.swift */; };
@@ -356,9 +356,6 @@
 		A0833BD6044A10DF3735ABE7 /* VehicleSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VehicleSpecTests.swift; sourceTree = "<group>"; };
 		A1B4A5B93ABCEBAB19EC49F6 /* SpacedRepetitionScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacedRepetitionScheduler.swift; sourceTree = "<group>"; };
 		A1E1666C2BD5A8EE21A76C6D /* SliceTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliceTheme.swift; sourceTree = "<group>"; };
-		A11810000000000000000002 /* SumSprintPartyTVView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumSprintPartyTVView.swift; sourceTree = "<group>"; };
-		A11810000000000000000004 /* SumSprintPartyTVRound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumSprintPartyTVRound.swift; sourceTree = "<group>"; };
-		A11810000000000000000007 /* SumSprintPartyTVRoundTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumSprintPartyTVRoundTests.swift; sourceTree = "<group>"; };
 		A5C80ECCAE5D25201666CBD0 /* SliceStateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliceStateMachineTests.swift; sourceTree = "<group>"; };
 		A5D6D0061948133C7AB57A02 /* GameActivityCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameActivityCard.swift; sourceTree = "<group>"; };
 		AEC179A2D9FE9BB537E4CCD7 /* VehicleSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VehicleSpec.swift; sourceTree = "<group>"; };
@@ -371,6 +368,7 @@
 		B6B469EA6DCDB375AF9BC3CD /* ArrayPreludeModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayPreludeModels.swift; sourceTree = "<group>"; };
 		B9F8B3A242D38D5AA75D613C /* LabRememberStageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabRememberStageView.swift; sourceTree = "<group>"; };
 		BD8A34215EE8D8788E7185EB /* MatherTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatherTheme.swift; sourceTree = "<group>"; };
+		C2D6A8BEC102AC062724068D /* SumSprintPartyTVRound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumSprintPartyTVRound.swift; sourceTree = "<group>"; };
 		C5C0EC27EA8E30BDA854CE9E /* RoomQuestEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomQuestEngineTests.swift; sourceTree = "<group>"; };
 		C6840F2651B5C50EE285F52B /* GameplayStageViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayStageViewModels.swift; sourceTree = "<group>"; };
 		C6F76B8BE6B3409EDE0B4CBF /* GameplayStageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplayStageViewModelTests.swift; sourceTree = "<group>"; };
@@ -392,6 +390,7 @@
 		D4C3639AE166C4F815BCA5C7 /* MatherUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MatherUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D534592E2580F9BC9AF7AC2D /* TelemetryWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelemetryWriter.swift; sourceTree = "<group>"; };
 		D5A56FCB9103BAE6E2941CA3 /* MemoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryView.swift; sourceTree = "<group>"; };
+		D5BF76EBB16876D2F9CA900B /* SumSprintPartyTVView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumSprintPartyTVView.swift; sourceTree = "<group>"; };
 		D69ADFE340625CE2247C439C /* AngleCannonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AngleCannonTests.swift; sourceTree = "<group>"; };
 		D712A5CFB9DF5D02473835DD /* MemoryVarietyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryVarietyTests.swift; sourceTree = "<group>"; };
 		D9B1E5A35013B8C3C3E62687 /* NumberStoryStageVocabulary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberStoryStageVocabulary.swift; sourceTree = "<group>"; };
@@ -413,6 +412,7 @@
 		ECFA05754CC31E013A31DED6 /* LearningCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LearningCard.swift; sourceTree = "<group>"; };
 		ECFF09E7C4882057E1DFE232 /* GameplayThreadContent+Shapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GameplayThreadContent+Shapes.swift"; sourceTree = "<group>"; };
 		EF0EF97B257AB73DD5B1F273 /* FlipMemoryStageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlipMemoryStageView.swift; sourceTree = "<group>"; };
+		F1A4D019E0AB8DA7749332EA /* SumSprintPartyTVRoundTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumSprintPartyTVRoundTests.swift; sourceTree = "<group>"; };
 		F2094D8B8C58010318C8DEB6 /* FactoryCardsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactoryCardsViewTests.swift; sourceTree = "<group>"; };
 		F24A213AAF0604928B164968 /* FlashcardStageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashcardStageView.swift; sourceTree = "<group>"; };
 		F27A140FE20F5F42F54DD237 /* SumSprintEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumSprintEngineTests.swift; sourceTree = "<group>"; };
@@ -501,7 +501,7 @@
 				CE5FA612478F9C2A6066CB46 /* MatherTVApp.swift */,
 				5C4A94DB04A905680599FB7C /* MatherTVRootView.swift */,
 				F27EF90A13CB6C3832CF3D58 /* MemoryGalleryTVView.swift */,
-				A11810000000000000000002 /* SumSprintPartyTVView.swift */,
+				D5BF76EBB16876D2F9CA900B /* SumSprintPartyTVView.swift */,
 			);
 			path = AppTV;
 			sourceTree = "<group>";
@@ -585,7 +585,7 @@
 				5116EC9E8413634D723C411E /* SoundDetectionServiceTests.swift */,
 				F27A140FE20F5F42F54DD237 /* SumSprintEngineTests.swift */,
 				CCCDFB3421635BB25E3A75BB /* SumSprintGeneratorTests.swift */,
-				A11810000000000000000007 /* SumSprintPartyTVRoundTests.swift */,
+				F1A4D019E0AB8DA7749332EA /* SumSprintPartyTVRoundTests.swift */,
 				01760190560F16DE73232743 /* SwiftDataStoreRecoveryTests.swift */,
 				FF16532EBA54CB39C1397E00 /* SymmetryFoldTests.swift */,
 				288594261DFE5DC67971E64C /* ThemeTests.swift */,
@@ -676,7 +676,7 @@
 				37DCF6B189D5EC4C0B6099AA /* SumSprintEngine.swift */,
 				D29BA55590AB9BAD7D586B7D /* SumSprintGenerator.swift */,
 				576411C3ACD2B1B55F53CC89 /* SumSprintModels.swift */,
-				A11810000000000000000004 /* SumSprintPartyTVRound.swift */,
+				C2D6A8BEC102AC062724068D /* SumSprintPartyTVRound.swift */,
 				B049757C9324E4EA88DAB861 /* TimerChallengePolicy.swift */,
 				AEC179A2D9FE9BB537E4CCD7 /* VehicleSpec.swift */,
 				9435179B05EDA7984881930C /* VehicleTheme.swift */,
@@ -1012,8 +1012,8 @@
 				D1E040DCC6D9CF2985A53CE1 /* MemoryContent.swift in Sources */,
 				E0DFF8477AF3DDFAE66A6CA7 /* MemoryGalleryTVRound.swift in Sources */,
 				B11B601A2020C7CEE086EB4E /* MemoryGalleryTVView.swift in Sources */,
-				A11810000000000000000003 /* SumSprintPartyTVRound.swift in Sources */,
-				A11810000000000000000008 /* SumSprintPartyTVView.swift in Sources */,
+				521C2782BA0163B3216ACD9B /* SumSprintPartyTVRound.swift in Sources */,
+				3DB94C6E2105D6F2729BDF16 /* SumSprintPartyTVView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1074,7 +1074,7 @@
 				B12859476E7412137808484E /* SoundDetectionServiceTests.swift in Sources */,
 				6F640A24F421DC2A0B558205 /* SumSprintEngineTests.swift in Sources */,
 				461CE6B56C4B4F4C6A818ED9 /* SumSprintGeneratorTests.swift in Sources */,
-				A11810000000000000000006 /* SumSprintPartyTVRoundTests.swift in Sources */,
+				3317FEF0838DE009DAEF51B7 /* SumSprintPartyTVRoundTests.swift in Sources */,
 				5C75510CC0980CAE5178DA62 /* SwiftDataStoreRecoveryTests.swift in Sources */,
 				E426438A88308DA0F76D1197 /* SymmetryFoldTests.swift in Sources */,
 				0F6FA7E841C46BF9E7897795 /* ThemeTests.swift in Sources */,
@@ -1209,7 +1209,7 @@
 				3E59F97481BC7A8C37F81395 /* SumSprintEngine.swift in Sources */,
 				A3608BF3DBB1D294B4BE1BB5 /* SumSprintGenerator.swift in Sources */,
 				10EB0242F0C3D40604D246E8 /* SumSprintModels.swift in Sources */,
-				A11810000000000000000005 /* SumSprintPartyTVRound.swift in Sources */,
+				334DF049B90427A9C94FAA13 /* SumSprintPartyTVRound.swift in Sources */,
 				15787BD39C82C1965DA839A0 /* SumSprintSessionView.swift in Sources */,
 				4ABC4A6418596E71AD701541 /* SumSprintSummaryView.swift in Sources */,
 				DCFB2717CCB80A298F9A2D36 /* SwiftDataStoreRecovery.swift in Sources */,

--- a/Mather.xcodeproj/project.pbxproj
+++ b/Mather.xcodeproj/project.pbxproj
@@ -133,6 +133,10 @@
 		A1289C7C722DE12CC1720FCC /* GroupedNumberRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C398DF4D3007D587BC30FF3 /* GroupedNumberRepresentation.swift */; };
 		A2C06BF6454B822874F8221F /* RoomQuestScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1045712502442FED9B5B13C9 /* RoomQuestScanner.swift */; };
 		A3608BF3DBB1D294B4BE1BB5 /* SumSprintGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29BA55590AB9BAD7D586B7D /* SumSprintGenerator.swift */; };
+		A11810000000000000000003 /* SumSprintPartyTVRound.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11810000000000000000004 /* SumSprintPartyTVRound.swift */; };
+		A11810000000000000000005 /* SumSprintPartyTVRound.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11810000000000000000004 /* SumSprintPartyTVRound.swift */; };
+		A11810000000000000000006 /* SumSprintPartyTVRoundTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11810000000000000000007 /* SumSprintPartyTVRoundTests.swift */; };
+		A11810000000000000000008 /* SumSprintPartyTVView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11810000000000000000002 /* SumSprintPartyTVView.swift */; };
 		A3E583B00B7BE54D5F3E0535 /* AppModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4C11FE8A80968AE7EA69CC /* AppModel.swift */; };
 		A4B5AFA2FA430D40BDBDD100 /* ExplorerLabMasteryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FCE7B3840A8A5977FF70D9 /* ExplorerLabMasteryStoreTests.swift */; };
 		A580D6F96249197C9148D59D /* HapticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B3F29980CE5E67E05A4F30F /* HapticsService.swift */; };
@@ -352,6 +356,9 @@
 		A0833BD6044A10DF3735ABE7 /* VehicleSpecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VehicleSpecTests.swift; sourceTree = "<group>"; };
 		A1B4A5B93ABCEBAB19EC49F6 /* SpacedRepetitionScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacedRepetitionScheduler.swift; sourceTree = "<group>"; };
 		A1E1666C2BD5A8EE21A76C6D /* SliceTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliceTheme.swift; sourceTree = "<group>"; };
+		A11810000000000000000002 /* SumSprintPartyTVView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumSprintPartyTVView.swift; sourceTree = "<group>"; };
+		A11810000000000000000004 /* SumSprintPartyTVRound.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumSprintPartyTVRound.swift; sourceTree = "<group>"; };
+		A11810000000000000000007 /* SumSprintPartyTVRoundTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumSprintPartyTVRoundTests.swift; sourceTree = "<group>"; };
 		A5C80ECCAE5D25201666CBD0 /* SliceStateMachineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliceStateMachineTests.swift; sourceTree = "<group>"; };
 		A5D6D0061948133C7AB57A02 /* GameActivityCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameActivityCard.swift; sourceTree = "<group>"; };
 		AEC179A2D9FE9BB537E4CCD7 /* VehicleSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VehicleSpec.swift; sourceTree = "<group>"; };
@@ -494,6 +501,7 @@
 				CE5FA612478F9C2A6066CB46 /* MatherTVApp.swift */,
 				5C4A94DB04A905680599FB7C /* MatherTVRootView.swift */,
 				F27EF90A13CB6C3832CF3D58 /* MemoryGalleryTVView.swift */,
+				A11810000000000000000002 /* SumSprintPartyTVView.swift */,
 			);
 			path = AppTV;
 			sourceTree = "<group>";
@@ -577,6 +585,7 @@
 				5116EC9E8413634D723C411E /* SoundDetectionServiceTests.swift */,
 				F27A140FE20F5F42F54DD237 /* SumSprintEngineTests.swift */,
 				CCCDFB3421635BB25E3A75BB /* SumSprintGeneratorTests.swift */,
+				A11810000000000000000007 /* SumSprintPartyTVRoundTests.swift */,
 				01760190560F16DE73232743 /* SwiftDataStoreRecoveryTests.swift */,
 				FF16532EBA54CB39C1397E00 /* SymmetryFoldTests.swift */,
 				288594261DFE5DC67971E64C /* ThemeTests.swift */,
@@ -667,6 +676,7 @@
 				37DCF6B189D5EC4C0B6099AA /* SumSprintEngine.swift */,
 				D29BA55590AB9BAD7D586B7D /* SumSprintGenerator.swift */,
 				576411C3ACD2B1B55F53CC89 /* SumSprintModels.swift */,
+				A11810000000000000000004 /* SumSprintPartyTVRound.swift */,
 				B049757C9324E4EA88DAB861 /* TimerChallengePolicy.swift */,
 				AEC179A2D9FE9BB537E4CCD7 /* VehicleSpec.swift */,
 				9435179B05EDA7984881930C /* VehicleTheme.swift */,
@@ -1002,6 +1012,8 @@
 				D1E040DCC6D9CF2985A53CE1 /* MemoryContent.swift in Sources */,
 				E0DFF8477AF3DDFAE66A6CA7 /* MemoryGalleryTVRound.swift in Sources */,
 				B11B601A2020C7CEE086EB4E /* MemoryGalleryTVView.swift in Sources */,
+				A11810000000000000000003 /* SumSprintPartyTVRound.swift in Sources */,
+				A11810000000000000000008 /* SumSprintPartyTVView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1062,6 +1074,7 @@
 				B12859476E7412137808484E /* SoundDetectionServiceTests.swift in Sources */,
 				6F640A24F421DC2A0B558205 /* SumSprintEngineTests.swift in Sources */,
 				461CE6B56C4B4F4C6A818ED9 /* SumSprintGeneratorTests.swift in Sources */,
+				A11810000000000000000006 /* SumSprintPartyTVRoundTests.swift in Sources */,
 				5C75510CC0980CAE5178DA62 /* SwiftDataStoreRecoveryTests.swift in Sources */,
 				E426438A88308DA0F76D1197 /* SymmetryFoldTests.swift in Sources */,
 				0F6FA7E841C46BF9E7897795 /* ThemeTests.swift in Sources */,
@@ -1196,6 +1209,7 @@
 				3E59F97481BC7A8C37F81395 /* SumSprintEngine.swift in Sources */,
 				A3608BF3DBB1D294B4BE1BB5 /* SumSprintGenerator.swift in Sources */,
 				10EB0242F0C3D40604D246E8 /* SumSprintModels.swift in Sources */,
+				A11810000000000000000005 /* SumSprintPartyTVRound.swift in Sources */,
 				15787BD39C82C1965DA839A0 /* SumSprintSessionView.swift in Sources */,
 				4ABC4A6418596E71AD701541 /* SumSprintSummaryView.swift in Sources */,
 				DCFB2717CCB80A298F9A2D36 /* SwiftDataStoreRecovery.swift in Sources */,

--- a/Tests/MatherTests/SumSprintPartyTVRoundTests.swift
+++ b/Tests/MatherTests/SumSprintPartyTVRoundTests.swift
@@ -1,0 +1,60 @@
+import Testing
+@testable import Mather
+
+struct SumSprintPartyTVRoundTests {
+    @Test
+    func factPoolCoversSumSprintTotalsWithoutDuplicateFacts() {
+        let facts = SumSprintPartyTVRound.factPool
+        let ids = facts.map(\.id)
+
+        #expect(Set(facts.map(\.sum)) == Set(11...20))
+        #expect(ids.count == Set(ids).count)
+        #expect(facts.allSatisfy { $0.addendA <= $0.addendB })
+    }
+
+    @Test
+    func answerChoicesIncludeCorrectAnswerAndThreeUniqueDistractors() {
+        let fact = SumSprintPartyTVFact(addendA: 6, addendB: 7)
+        let choices = SumSprintPartyTVRound.answerChoices(for: fact)
+
+        #expect(choices.count == 4)
+        #expect(Set(choices).count == 4)
+        #expect(choices.contains(13))
+        #expect(choices.allSatisfy { (11...20).contains($0) })
+    }
+
+    @Test
+    func distractorGenerationIsDeterministic() {
+        let fact = SumSprintPartyTVFact(addendA: 6, addendB: 7)
+
+        #expect(SumSprintPartyTVRound.answerChoices(for: fact) == [12, 15, 13, 14])
+        #expect(SumSprintPartyTVRound.answerChoices(for: fact) == [12, 15, 13, 14])
+    }
+
+    @Test
+    func edgeSumsStillReceiveFourChoices() {
+        let lowFact = SumSprintPartyTVFact(addendA: 1, addendB: 10)
+        let highFact = SumSprintPartyTVFact(addendA: 10, addendB: 10)
+
+        #expect(SumSprintPartyTVRound.answerChoices(for: lowFact) == [11, 12, 13, 14])
+        #expect(SumSprintPartyTVRound.answerChoices(for: highFact) == [20, 19, 18, 17])
+    }
+
+    @Test
+    func partyRoundHasNoPressureTimerByDefault() {
+        let round = SumSprintPartyTVRound.make(index: 0)
+
+        #expect(round.usesTimer == false)
+        #expect(round.answerChoices.count == 4)
+    }
+
+    @Test
+    func roundIndexWrapsDeterministically() {
+        let first = SumSprintPartyTVRound.make(index: 0)
+        let wrapped = SumSprintPartyTVRound.make(index: SumSprintPartyTVRound.factPool.count)
+        let negative = SumSprintPartyTVRound.make(index: -SumSprintPartyTVRound.factPool.count)
+
+        #expect(first == wrapped)
+        #expect(first == negative)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -53,6 +53,7 @@ targets:
           - "**/*.swift"
       - path: Domain/MemoryContent.swift
       - path: Domain/MemoryGalleryTVRound.swift
+      - path: Domain/SumSprintPartyTVRound.swift
       - path: App/Assets.xcassets
     settings:
       base:


### PR DESCRIPTION
## Summary
- add a low-pressure Sum Sprint Party tvOS prototype with a fact prompt, pictorial addend groups, and four large answer tiles
- track only current streak and personal best; no countdown/timer UI is enabled by default
- add deterministic Sum Sprint Party round/distractor tests and wire the new tvOS source into XcodeGen/project files

Closes #1181.

## Validation
- studio: `xcodebuild -scheme MatherTV -destination "platform=tvOS Simulator,name=Apple TV 4K (3rd generation)" -derivedDataPath /tmp/mather-tvos-sum-sprint-party-validation/DerivedData-tv build`
- studio: `xcodebuild test -scheme Mather -destination "platform=iOS Simulator,name=iPad (A16)" -derivedDataPath /tmp/mather-tvos-sum-sprint-party-validation/DerivedData-ios -only-testing:MatherTests/SumSprintPartyTVRoundTests`
- studio: launched `com.ganesh47.MatherTV` on Apple TV 4K simulator and captured a 4K screenshot

## Notes
- `xcodegen` is not on the current noninteractive PATH on `studio`; project.yml and the committed pbxproj were updated together by hand for this slice.