### PR TITLE
Add Mather clawpatch validation config

### DIFF
--- a/.clawpatch/README.md
+++ b/.clawpatch/README.md
@@ -1,0 +1,15 @@
+# Mather clawpatch setup
+
+This directory keeps the repo-specific clawpatch configuration durable.
+
+Mather uses `project.yml` as the source of truth for the Xcode project. Do not hand-edit `Mather.xcodeproj`; regenerate it with `xcodegen generate` and verify the generated project is committed with `git diff --exit-code Mather.xcodeproj`.
+
+The configured validation commands mirror the GitHub Actions unit-test lane:
+
+- run `xcodegen generate`
+- verify the generated Xcode project is clean
+- resolve package dependencies
+- build for testing on an iOS simulator
+- run `MatherTests`
+
+If clawpatch reports Apple mapper issues such as malformed test-suite labels or weak source-to-test adjacency, treat those as mapper/upstream limitations unless a repo-local override is added intentionally. Repo changes should still follow the normal Mather branch, PR, CI, and release path.

--- a/.clawpatch/config.json
+++ b/.clawpatch/config.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "stateDir": ".clawpatch",
+  "include": [
+    "**/*"
+  ],
+  "exclude": [
+    "node_modules/**",
+    "dist/**",
+    "build/**",
+    "target/**",
+    ".build/**",
+    ".git/**",
+    ".clawpatch/**"
+  ],
+  "provider": {
+    "name": "codex",
+    "model": null
+  },
+  "commands": {
+    "typecheck": "xcodegen generate && git diff --exit-code Mather.xcodeproj && xcodebuild -project Mather.xcodeproj -resolvePackageDependencies -scheme Mather && xcodebuild build-for-testing -project Mather.xcodeproj -scheme Mather -destination \"generic/platform=iOS Simulator\" CODE_SIGNING_ALLOWED=NO",
+    "lint": null,
+    "format": null,
+    "test": "xcodegen generate && git diff --exit-code Mather.xcodeproj && xcodebuild test -project Mather.xcodeproj -scheme Mather -destination \"platform=iOS Simulator,name=iPhone 16,OS=latest\" -only-testing MatherTests CODE_SIGNING_ALLOWED=NO"
+  },
+  "review": {
+    "maxContextFiles": 24,
+    "maxOwnedFiles": 12,
+    "maxFindingsPerFeature": 10,
+    "minConfidenceToFix": "medium"
+  },
+  "git": {
+    "requireCleanWorktreeForFix": true,
+    "commit": false,
+    "openPr": false
+  }
+}


### PR DESCRIPTION
## Summary
- add durable `.clawpatch/config.json` with Mather XcodeGen, generated-project, build-for-testing, and MatherTests validation commands
- document the generated-project guardrail and mapper/upstream caveat in `.clawpatch/README.md`

## Verification
- `jq . .clawpatch/config.json`

Fixes #1115