### PR TITLE
Guard Room Quest exits and stale step callbacks

### DIFF
--- a/Features/RoomQuest/RoomSessionView.swift
+++ b/Features/RoomQuest/RoomSessionView.swift
@@ -109,10 +109,10 @@ struct RoomSessionView: View {
             RoomSetupView(engine: engine)
 
         case .routeNode(let idx):
-            RouteQuestNodeView(engine: engine, nodeIndex: idx)
+            RouteQuestNodeView(engine: engine, nodeIndex: idx, onRequestAbandon: { requestAbandonSession(reason: $0) })
 
         case .spot(let idx):
-            SpotPromptView(engine: engine, spotIndex: idx)
+            SpotPromptView(engine: engine, spotIndex: idx, onRequestAbandon: { requestAbandonSession(reason: $0) })
 
         case .returning:
             ReturningView(engine: engine, onRequestAbandon: { requestAbandonSession(reason: $0) })
@@ -263,6 +263,7 @@ struct RoomSessionView: View {
 private struct RouteQuestNodeView: View {
     @Bindable var engine: RoomQuestEngine
     let nodeIndex: Int
+    let onRequestAbandon: (String) -> Void
 
     private var node: RouteQuestNode? {
         engine.currentRouteNode
@@ -272,7 +273,7 @@ private struct RouteQuestNodeView: View {
         if let node {
             switch node.kind {
             case .station:
-                SpotPromptView(engine: engine, spotIndex: nodeIndex)
+                SpotPromptView(engine: engine, spotIndex: nodeIndex, onRequestAbandon: onRequestAbandon)
             default:
                 routeInstructionView(for: node)
             }

--- a/Features/RoomQuest/SpotPromptView.swift
+++ b/Features/RoomQuest/SpotPromptView.swift
@@ -7,6 +7,7 @@ import UIKit
 struct SpotPromptView: View {
     @Bindable var engine: RoomQuestEngine
     let spotIndex: Int
+    let onRequestAbandon: (String) -> Void
 
     private var station: RoomQuestStation? {
         engine.currentStation
@@ -92,7 +93,7 @@ struct SpotPromptView: View {
                 }
 
                 roomChromeButton(title: "Home", systemImage: "house.circle.fill", accessibilityID: "room-home-button") {
-                    engine.onExitToHome?()
+                    onRequestAbandon("parent_home")
                 }
             }
             .padding(24)

--- a/Services/StepCountService.swift
+++ b/Services/StepCountService.swift
@@ -45,6 +45,7 @@ final class StepCountService {
     private let noStepUpdateFallbackDelay: Duration
     private var noStepUpdateFallbackTask: Task<Void, Never>?
     private var startDate: Date?
+    private var activeSessionID: UUID?
 
     private(set) var progress = StepWalkProgress(requiredSteps: 1)
     private(set) var mode: StepCountMode = .idle
@@ -75,6 +76,8 @@ final class StepCountService {
         stop()
         progress = StepWalkProgress(requiredSteps: requiredSteps)
         startDate = Date()
+        let sessionID = UUID()
+        activeSessionID = sessionID
 
         guard isStepCountingAvailable else {
             mode = .manualFallback(reason: "Step sensing is not available here. Tap each small step instead.")
@@ -82,10 +85,11 @@ final class StepCountService {
         }
 
         mode = .pedometer
-        scheduleNoStepUpdateFallback()
+        scheduleNoStepUpdateFallback(for: sessionID)
         startPedometerUpdates(startDate ?? Date()) { [weak self] data, error in
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                guard self.activeSessionID == sessionID else { return }
                 if error != nil {
                     self.useManualFallback(reason: "Motion permission was not available. Tap each small step instead.")
                     return
@@ -105,6 +109,7 @@ final class StepCountService {
         noStepUpdateFallbackTask = nil
         pedometer.stopUpdates()
         startDate = nil
+        activeSessionID = nil
         mode = .idle
     }
 
@@ -112,6 +117,7 @@ final class StepCountService {
         noStepUpdateFallbackTask?.cancel()
         noStepUpdateFallbackTask = nil
         pedometer.stopUpdates()
+        activeSessionID = nil
         mode = .manualFallback(reason: reason)
     }
 
@@ -129,12 +135,13 @@ final class StepCountService {
         progress.setCountedSteps(steps)
     }
 
-    private func scheduleNoStepUpdateFallback() {
+    private func scheduleNoStepUpdateFallback(for sessionID: UUID) {
         noStepUpdateFallbackTask?.cancel()
         let delay = noStepUpdateFallbackDelay
         noStepUpdateFallbackTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: delay)
             guard !Task.isCancelled, let self else { return }
+            guard self.activeSessionID == sessionID else { return }
             guard case .pedometer = self.mode, self.progress.countedSteps == 0 else { return }
             self.useManualFallback(reason: "If step sensing does not start, tap after each small careful step.")
         }

--- a/Tests/MatherTests/CompassAnglesTests.swift
+++ b/Tests/MatherTests/CompassAnglesTests.swift
@@ -225,4 +225,65 @@ struct CompassWalkTurnTests {
         #expect(service.isComplete)
         service.stop()
     }
+
+    @MainActor
+    @Test func stepCountServiceIgnoresStalePedometerCallbacksAfterRestart() async {
+        var handlers: [PedometerUpdateHandler] = []
+        let service = StepCountService(
+            stepCountingAvailable: { true },
+            startPedometerUpdates: { _, handler in
+                handlers.append(handler)
+            },
+            noStepUpdateFallbackDelay: .seconds(60)
+        )
+
+        service.start(requiredSteps: 2)
+        service.applyCountedSteps(1)
+        service.start(requiredSteps: 3)
+
+        #expect(handlers.count == 2)
+        #expect(service.mode == .pedometer)
+        #expect(service.countedSteps == 0)
+
+        handlers[0](nil, TestPedometerError.stale)
+        await Task.yield()
+
+        #expect(service.mode == .pedometer)
+        #expect(service.countedSteps == 0)
+
+        handlers[1](nil, TestPedometerError.current)
+        await Task.yield()
+
+        if case .manualFallback(let reason) = service.mode {
+            #expect(reason.contains("Motion permission"))
+        } else {
+            Issue.record("Expected the active pedometer callback to move to manual fallback")
+        }
+    }
+
+    @MainActor
+    @Test func stepCountServiceIgnoresCallbacksAfterStop() async {
+        var handler: PedometerUpdateHandler?
+        let service = StepCountService(
+            stepCountingAvailable: { true },
+            startPedometerUpdates: { _, callback in
+                handler = callback
+            },
+            noStepUpdateFallbackDelay: .seconds(60)
+        )
+
+        service.start(requiredSteps: 2)
+        service.stop()
+
+        handler?(nil, TestPedometerError.stale)
+        await Task.yield()
+
+        #expect(service.mode == .idle)
+        #expect(service.countedSteps == 0)
+    }
+
+    private enum TestPedometerError: Error {
+        case stale
+        case current
+    }
 }

--- a/Tests/MatherUITests/RoomQuestUITests.swift
+++ b/Tests/MatherUITests/RoomQuestUITests.swift
@@ -170,6 +170,26 @@ final class RoomQuestUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Mather"].waitForExistence(timeout: 5))
     }
 
+    func testRoomQuestSpotHomeUsesAbandonConfirmation() {
+        let app = launchWithRoomQuestAndSafetyAck()
+        _ = app.staticTexts["Mather"].waitForExistence(timeout: 5)
+
+        openRoomQuest(app)
+        _ = app.staticTexts["Set up the room"].waitForExistence(timeout: 5)
+        completeSetupViaManualFallback(app)
+
+        XCTAssertTrue(app.staticTexts["Red Rocket"].waitForExistence(timeout: 5))
+        XCTAssertTrue(waitForSpotStage(app, timeout: 10))
+
+        app.buttons["room-home-button"].tap()
+        XCTAssertTrue(app.alerts["End Room Quest?"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.alerts["End Room Quest?"].buttons["Keep playing"].exists)
+        XCTAssertTrue(app.alerts["End Room Quest?"].buttons["End session"].exists)
+
+        app.alerts["End Room Quest?"].buttons["End session"].tap()
+        XCTAssertTrue(app.staticTexts["Mather"].waitForExistence(timeout: 5))
+    }
+
     // MARK: - Global settings handoff
 
     func testSettingsKeepsMinimalRoomQuestEntryThatReturnsToSetup() {


### PR DESCRIPTION
## Summary
- route Room Quest spot Home actions through the shared abandon confirmation flow
- ignore stale pedometer callbacks after a StepCountService restart or stop
- add UI/unit coverage for spot Home confirmation and stale step callbacks

## Verification
- Not run locally in Linux worker; CI is the Xcode validation gate.

Refs #1117