### PR TITLE
Fix #1117 persistence stage race slice

### DIFF
--- a/Domain/CardReviewScheduler.swift
+++ b/Domain/CardReviewScheduler.swift
@@ -30,7 +30,12 @@ struct CardReviewScheduler {
     private let clock: Clock
     private let configuration: Configuration
 
-    init(now: Date = Date(), configuration: Configuration = Configuration()) {
+    init(configuration: Configuration = Configuration()) {
+        self.clock = Date.init
+        self.configuration = configuration
+    }
+
+    init(now: Date, configuration: Configuration = Configuration()) {
         self.clock = { now }
         self.configuration = configuration
     }

--- a/Features/GameplayStages/GameplayThreadView.swift
+++ b/Features/GameplayStages/GameplayThreadView.swift
@@ -114,9 +114,10 @@ struct GameplayThreadView: View {
                     complete(stage: stage, round: round, correct: correct, mistakes: mistakes, hints: hints)
                 }
             case .multipleChoice:
-                MultipleChoiceStageView(thread: thread, stage: stage, round: round, actions: actions, compact: compact) { correct, mistakes, hints in
+                MultipleChoiceStageView(thread: thread, stage: stage, round: round, attemptID: navigation.stageAttemptID, actions: actions, compact: compact) { correct, mistakes, hints in
                     complete(stage: stage, round: round, correct: correct, mistakes: mistakes, hints: hints)
                 }
+                .id(navigation.stageAttemptID)
             }
         } else {
             Text("No stage is available yet.")

--- a/Features/GameplayStages/MultipleChoiceStageView.swift
+++ b/Features/GameplayStages/MultipleChoiceStageView.swift
@@ -2,14 +2,17 @@ import SwiftUI
 
 struct MultipleChoiceStageView: View {
     let stage: GameplayStageDefinition
+    let attemptID: String
     let actions: GameplayStageFeedbackActions
     let compact: Bool
     let onComplete: (Int, Int, Int) -> Void
     @State private var viewModel: GameplayMultipleChoiceStageViewModel
     @State private var showCorrectCelebration = false
+    @State private var delayedAdvanceTask: Task<Void, Never>?
 
-    init(thread: GameplayThreadDefinition, stage: GameplayStageDefinition, round: GameplayRoundDefinition, actions: GameplayStageFeedbackActions, compact: Bool, onComplete: @escaping (Int, Int, Int) -> Void) {
+    init(thread: GameplayThreadDefinition, stage: GameplayStageDefinition, round: GameplayRoundDefinition, attemptID: String, actions: GameplayStageFeedbackActions, compact: Bool, onComplete: @escaping (Int, Int, Int) -> Void) {
         self.stage = stage
+        self.attemptID = attemptID
         self.actions = actions
         self.compact = compact
         self.onComplete = onComplete
@@ -73,29 +76,43 @@ struct MultipleChoiceStageView: View {
         }
         .padding(compact ? 14 : 20)
         .background(GameplayStagePanel())
+        .onDisappear {
+            cancelDelayedAdvance()
+        }
     }
 
     @MainActor
     private func choose(_ choice: GameplayDisplayItem) {
+        cancelDelayedAdvance()
         let correct = viewModel.choose(choice)
         if correct {
             actions.success()
             withAnimation(.spring(response: 0.28, dampingFraction: 0.64)) {
                 showCorrectCelebration = true
             }
-            Task { @MainActor in
+            let taskAttemptID = attemptID
+            delayedAdvanceTask = Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 850_000_000)
+                guard !Task.isCancelled, taskAttemptID == attemptID else { return }
                 withAnimation(.easeOut(duration: 0.16)) {
                     showCorrectCelebration = false
                 }
+                guard !Task.isCancelled, taskAttemptID == attemptID else { return }
                 if viewModel.advanceAfterCorrectChoice() {
                     onComplete(viewModel.correctCount, viewModel.mistakeCount, 0)
                 }
+                delayedAdvanceTask = nil
             }
         } else {
             showCorrectCelebration = false
             actions.failure()
         }
+    }
+
+    @MainActor
+    private func cancelDelayedAdvance() {
+        delayedAdvanceTask?.cancel()
+        delayedAdvanceTask = nil
     }
 
     private func choiceColumns(for question: GameplayMultipleChoiceQuestion) -> [GridItem] {

--- a/Features/RectangleFactory/RectangleFactoryView.swift
+++ b/Features/RectangleFactory/RectangleFactoryView.swift
@@ -31,6 +31,7 @@ struct RectangleFactoryView: View {
     @State private var showEquation: Bool = false
     @State private var lastEquation: String = ""
     @State private var allFoundForN: Bool = false
+    @State private var completedTargetCount: Int = 0
     @State private var celebratingFactorKey: String?
 
     // MARK: - Grid constants
@@ -57,14 +58,15 @@ struct RectangleFactoryView: View {
         }
         .onAppear {
             sessionStart = .now
+            completedTargetCount = 0
             loadN(RectangleFactoryView.nSequence[0], speakPrompt: true)
         }
         .onDisappear {
-            guard sequenceIndex > 0 else { return }
+            guard completedTargetCount > 0 else { return }
             appModel.gameSessionStore.save(
                 gameName: "Rectangle Factory",
                 startedAt: sessionStart,
-                scoreValue: sequenceIndex,
+                scoreValue: completedTargetCount,
                 scoreLabel: "numbers factored"
             )
         }
@@ -650,6 +652,7 @@ struct RectangleFactoryView: View {
         let allFactors = Self.factorsOf(targetN)
         guard foundFactors.count >= allFactors.count else { return }
         allFoundForN = true
+        completedTargetCount = max(completedTargetCount, Self.completedTargetCount(sequenceIndex: sequenceIndex, allFoundForCurrentTarget: true))
         appModel.hapticsService.bondMatchComplete(enabled: appModel.featureFlags.hapticsEnabled)
         appModel.speechService.speak(
             Self.completionSpeech(for: targetN),
@@ -686,6 +689,12 @@ struct RectangleFactoryView: View {
         if speakPrompt {
             appModel.speechService.speak(Self.openingSpeech(for: n), enabled: appModel.featureFlags.audioEnabled)
         }
+    }
+
+    static func completedTargetCount(sequenceIndex: Int, allFoundForCurrentTarget: Bool) -> Int {
+        let completedBeforeCurrent = min(max(sequenceIndex, 0), nSequence.count)
+        guard allFoundForCurrentTarget else { return completedBeforeCurrent }
+        return min(completedBeforeCurrent + 1, nSequence.count)
     }
 
     private func resetFrame() {

--- a/Persistence/LabConceptSessionProgressStore.swift
+++ b/Persistence/LabConceptSessionProgressStore.swift
@@ -12,7 +12,7 @@ final class LabConceptSessionProgressStore {
     init(
         storage: ExplorerLabMasteryKeyValueStore = UserDefaults.standard,
         storageKey: String = LabConceptSessionProgressStore.defaultStorageKey,
-        activeProfileIdProvider: @escaping () -> String = { "default" },
+        activeProfileIdProvider: @escaping () -> String = { KidProfilePersistence.defaultProfileId },
         encoder: JSONEncoder = JSONEncoder(),
         decoder: JSONDecoder = JSONDecoder()
     ) {

--- a/Persistence/LabConceptSessionProgressStore.swift
+++ b/Persistence/LabConceptSessionProgressStore.swift
@@ -2,6 +2,7 @@ import Foundation
 
 final class LabConceptSessionProgressStore {
     static let defaultStorageKey = "labConceptSessionProgress.v1"
+    private static let defaultActiveProfileId = "default-profile"
 
     private let storage: ExplorerLabMasteryKeyValueStore
     private let storageKey: String
@@ -12,7 +13,7 @@ final class LabConceptSessionProgressStore {
     init(
         storage: ExplorerLabMasteryKeyValueStore = UserDefaults.standard,
         storageKey: String = LabConceptSessionProgressStore.defaultStorageKey,
-        activeProfileIdProvider: @escaping () -> String = { KidProfilePersistence.defaultProfileId },
+        activeProfileIdProvider: @escaping () -> String = { LabConceptSessionProgressStore.defaultActiveProfileId },
         encoder: JSONEncoder = JSONEncoder(),
         decoder: JSONDecoder = JSONDecoder()
     ) {

--- a/Tests/MatherTests/CardReviewSchedulerTests.swift
+++ b/Tests/MatherTests/CardReviewSchedulerTests.swift
@@ -84,6 +84,26 @@ struct CardReviewSchedulerTests {
     }
 
     @Test
+    func defaultInitializerUsesLiveClockForDueDecisions() {
+        let reviewedAt = Date().addingTimeInterval(-24 * 60 * 60 - 1)
+        let dueCard = makeCard(
+            id: "live-due",
+            laneID: .numbers,
+            conceptID: "number-bond",
+            progress: CardProgress(
+                timesSeen: 1,
+                correctCount: 1,
+                currentCorrectStreak: 1,
+                lastReviewedAt: reviewedAt,
+                lastReviewResult: .correct
+            )
+        )
+        let scheduler = CardReviewScheduler()
+
+        #expect(scheduler.isDue(dueCard))
+    }
+
+    @Test
     func reviewQueueInterleavesByLaneAndConceptWithinDueWindow() {
         let scheduler = CardReviewScheduler(now: now)
         let cards = [

--- a/Tests/MatherTests/LabModelsTests.swift
+++ b/Tests/MatherTests/LabModelsTests.swift
@@ -508,6 +508,25 @@ final class LabModelsTests: XCTestCase {
         XCTAssertEqual(second.resumeLabel(for: plan), "Start")
     }
 
+    func testLabConceptProgressStoreDefaultProfileMatchesKidProfileDefault() throws {
+        let storage = InMemoryLabConceptSessionProgressDefaults()
+        let plan = LabConceptSessionPlan.numbersNumberBondsTo10
+        let defaultStore = LabConceptSessionProgressStore(
+            storage: storage,
+            storageKey: "test.lab-progress.default-profile"
+        )
+        let appDefaultStore = LabConceptSessionProgressStore(
+            storage: storage,
+            storageKey: "test.lab-progress.default-profile",
+            activeProfileIdProvider: { KidProfilePersistence.defaultProfileId }
+        )
+
+        defaultStore.beginGuidedStage(.remember, in: plan, at: Date(timeIntervalSince1970: 3_500))
+
+        XCTAssertEqual(appDefaultStore.currentStage(for: plan), .remember)
+        XCTAssertEqual(appDefaultStore.resumeLabel(for: plan), "Continue: Remember")
+    }
+
     func testRememberStageDeckUsesNumberBondRouteWithoutCountdown() throws {
         let plan = LabConceptSessionPlan.numbersNumberBondsTo10
         let rememberStage = try XCTUnwrap(plan.stages.first { $0.stage == .remember })

--- a/Tests/MatherTests/RectangleFactoryTests.swift
+++ b/Tests/MatherTests/RectangleFactoryTests.swift
@@ -124,6 +124,12 @@ struct RectangleFactoryTests {
         #expect(composites.count >= 6)
     }
 
+    @Test func completedTargetCountIncludesSolvedCurrentTarget() {
+        #expect(RectangleFactoryView.completedTargetCount(sequenceIndex: 0, allFoundForCurrentTarget: false) == 0)
+        #expect(RectangleFactoryView.completedTargetCount(sequenceIndex: 0, allFoundForCurrentTarget: true) == 1)
+        #expect(RectangleFactoryView.completedTargetCount(sequenceIndex: 9, allFoundForCurrentTarget: true) == 10)
+    }
+
     // MARK: - Completion helpers
 
     @Test func completionStyleMarksPrimeTargets() {

--- a/Tests/MatherTests/RectangleFactoryTests.swift
+++ b/Tests/MatherTests/RectangleFactoryTests.swift
@@ -124,6 +124,7 @@ struct RectangleFactoryTests {
         #expect(composites.count >= 6)
     }
 
+    @MainActor
     @Test func completedTargetCountIncludesSolvedCurrentTarget() {
         #expect(RectangleFactoryView.completedTargetCount(sequenceIndex: 0, allFoundForCurrentTarget: false) == 0)
         #expect(RectangleFactoryView.completedTargetCount(sequenceIndex: 0, allFoundForCurrentTarget: true) == 1)


### PR DESCRIPTION
Refs #1117

## Summary
- align Lab concept progress default profile with `KidProfileStore.defaultProfileId`
- make `CardReviewScheduler()` use a live clock while preserving explicit fixed-time initializers for tests
- cancel/gate multiple-choice delayed completion tasks across retry/navigation attempt changes
- persist Rectangle Factory solved target count, including the current target before advancing and the final target

## Validation
- `git diff --check`

## Remaining #1117 Notes
- The broader persistence save/fetch failure finding remains open. This PR intentionally avoids a risky shared-store API migration; it only fixes the profile-default half of that persistence cluster and the safer independent stage/scoring/scheduler bugs.
