### PR TITLE
Fix Sum Sprint duplicate matching and timer layout

### DIFF
--- a/Domain/SliceModels.swift
+++ b/Domain/SliceModels.swift
@@ -450,12 +450,17 @@ struct SumSprintBurstState: Equatable {
 
     static func cardsFormValidMatch(_ lhs: SumSprintBurstCard, _ rhs: SumSprintBurstCard) -> Bool {
         if let promptTotal = lhs.content.promptTotal, let sumValue = rhs.content.sumValue {
-            return promptTotal == sumValue
+            return promptTotal == sumValue && cardsHaveCompatiblePairIdentity(lhs, rhs)
         }
         if let promptTotal = rhs.content.promptTotal, let sumValue = lhs.content.sumValue {
-            return promptTotal == sumValue
+            return promptTotal == sumValue && cardsHaveCompatiblePairIdentity(rhs, lhs)
         }
         return false
+    }
+
+    private static func cardsHaveCompatiblePairIdentity(_ prompt: SumSprintBurstCard, _ sum: SumSprintBurstCard) -> Bool {
+        guard case .decoratedSum = sum.content else { return true }
+        return prompt.pairId == sum.pairId
     }
 
     static func make(for problem: SliceProblem) -> SumSprintBurstState {

--- a/Features/SumSprint/SumSprintSessionView.swift
+++ b/Features/SumSprint/SumSprintSessionView.swift
@@ -43,20 +43,6 @@ struct SumSprintSessionView: View {
                 }
             }
 
-            // Countdown ring — top-right corner, only when timed mode active
-            if engine.difficulty != .relaxed {
-                VStack {
-                    HStack {
-                        Spacer()
-                        countdownRing
-                            .padding(.top, 12)
-                            .padding(.trailing, ResponsiveLayout.contentPadding(for: horizontalSizeClass))
-                    }
-                    Spacer()
-                }
-                .allowsHitTesting(false)
-            }
-
             // Correct feedback overlay
             if engine.showCorrectFeedback {
                 feedbackOverlay(symbol: "✓", color: MatherTheme.accent)
@@ -93,9 +79,10 @@ struct SumSprintSessionView: View {
                     }
                 }
                 Spacer()
-                // Space reserved for countdown ring in timed modes
                 if engine.difficulty != .relaxed {
-                    Color.clear.frame(width: 64, height: 1)
+                    countdownRing
+                        .frame(width: 64, height: 64)
+                        .allowsHitTesting(false)
                 }
                 Button {
                     engine.exitToHome()

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -718,27 +718,22 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
-    func sumSprintAcceptsEquivalentTotalCardsWhenTotalsRepeat() {
+    func sumSprintRejectsDecoratedDuplicateTotalsFromOtherPairs() {
         let state = SumSprintBurstState.make(for: SliceProblem(target: 5, decompositionA: 1, decompositionB: 4))
 
         let prompt = state.cards.first { card in
             if case .prompt("1 + 4") = card.content { return true }
             return false
         }!
+        let matchingTotal = state.cards.first { card in
+            card.pairId == prompt.pairId && card.content.sumValue == 5
+        }!
         let equivalentTotalFromOtherPair = state.cards.first { card in
             card.pairId != prompt.pairId && card.content.sumValue == 5
         }!
 
-        #expect(SumSprintBurstState.cardsFormValidMatch(prompt, equivalentTotalFromOtherPair))
-
-        var crossMatchedState = state
-        let promptIndex = crossMatchedState.cards.firstIndex(where: { $0.id == prompt.id })!
-        let totalIndex = crossMatchedState.cards.firstIndex(where: { $0.id == equivalentTotalFromOtherPair.id })!
-        crossMatchedState.cards[promptIndex].isMatched = true
-        crossMatchedState.cards[totalIndex].isMatched = true
-
-        #expect(crossMatchedState.matchedPairs == 1)
-        #expect(!crossMatchedState.isComplete)
+        #expect(SumSprintBurstState.cardsFormValidMatch(prompt, matchingTotal))
+        #expect(!SumSprintBurstState.cardsFormValidMatch(prompt, equivalentTotalFromOtherPair))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- require decorated duplicate-total Sum Sprint cards to match their generated prompt pair
- move the timed countdown ring into the header slot so it no longer overlays the Home button
- update the duplicate-total regression test to cover same-pair success and cross-pair rejection

Refs #1117

## Validation
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "platform=iOS Simulator,name=iPhone 17,OS=26.5" CODE_SIGNING_ALLOWED=NO` on `studio`: `MatherTests` completed 292 tests passed.
- The broader run then entered unrelated UI tests and hit simulator/app connection failures in `CompactLayoutTests`; it was interrupted after the unit suite completed to avoid holding the worker open.
- `xcodegen generate` on `studio` could not run because `xcodegen` was not installed on PATH; this slice did not change project structure.