### PR TITLE
Fix Gravity Split and Bond interaction regressions

### DIFF
--- a/Domain/VerticalSliceEngine.swift
+++ b/Domain/VerticalSliceEngine.swift
@@ -43,6 +43,7 @@ final class VerticalSliceEngine {
     private var sessionStartedAt: Date = .now
     private var problemStartedAt: Date = .now
     private let sessionTimeLimitSeconds: TimeInterval = 7 * 60
+    private let gravitySplitTiltStep: Double = 0.16
 
     var concreteWarmCount = 0
     var concreteAccentCount = 0
@@ -524,8 +525,37 @@ final class VerticalSliceEngine {
     // MARK: - Gravity Split actions
 
     func adjustGravitySplitByTilt(_ tiltRoll: Double) {
-        guard currentStage == .gravitySplit else { return }
-        gravitySplitNeutralRoll = tiltRoll
+        guard currentStage == .gravitySplit,
+              var state = gravitySplitState,
+              !state.isLocked else { return }
+
+        guard let neutralRoll = gravitySplitNeutralRoll else {
+            gravitySplitNeutralRoll = tiltRoll
+            return
+        }
+
+        let rollDelta = tiltRoll - neutralRoll
+        let steps = Int((abs(rollDelta) / gravitySplitTiltStep).rounded(.down))
+        guard steps > 0 else { return }
+
+        let previousLeft = state.leftCount
+        let previousRight = state.rightCount
+        if rollDelta < 0 {
+            state.adjustLeft(by: steps - state.leftCount)
+        } else {
+            state.adjustRight(by: steps - state.rightCount)
+        }
+        gravitySplitState = state
+
+        if state.leftCount != previousLeft || state.rightCount != previousRight {
+            hapticsService.counterSettle(enabled: featureFlags.hapticsEnabled)
+            hapticsService.counterSlide(enabled: featureFlags.hapticsEnabled)
+        }
+
+        if state.isLocked, let problem = currentProblem {
+            hapticsService.balanceLock(enabled: featureFlags.hapticsEnabled)
+            completeStage(successMessage: successMessage(for: .gravitySplit, problem: problem))
+        }
     }
 
     func adjustGravitySplitByTap(delta: Int, side: TransferSide = .left) {

--- a/Features/VerticalSlice1/BondMatchView.swift
+++ b/Features/VerticalSlice1/BondMatchView.swift
@@ -51,6 +51,7 @@ struct BondMatchView: View {
     /// Cancels stale mismatch animation resets when Bond Blast exits or restarts.
     @State private var mismatchResetTask: Task<Void, Never>? = nil
     @State private var mismatchResetRevision = 0
+    @State private var consumedCurrentClap = false
 
     enum DragReleaseResolution: Equatable {
         case cancel
@@ -113,12 +114,18 @@ struct BondMatchView: View {
             onShakeHandled()
         }
         .onChange(of: clapDetected) { _, clapped in
-            guard clapped, state.isComplete else { return }
-            onClapHandled()
+            handleClapChange(clapped)
+        }
+        .onChange(of: state.isComplete) { _, isComplete in
+            guard isComplete else { return }
+            handleCompletionChange()
         }
         .sensoryFeedback(.success, trigger: state.matchCount)
         .accessibilityLabel("\(vocabulary.accessibilityLabel) \(state.matchCount) of \(state.pairs.count) matched.")
-        .onDisappear { cancelMismatchReset() }
+        .onDisappear {
+            cancelMismatchReset()
+            consumedCurrentClap = false
+        }
     }
 
     // MARK: - Subviews
@@ -468,5 +475,28 @@ struct BondMatchView: View {
 
     nonisolated static func shouldAcceptDelayedMismatchReset(scheduledRevision: Int, currentRevision: Int) -> Bool {
         scheduledRevision == currentRevision
+    }
+
+    private func handleClapChange(_ clapped: Bool) {
+        guard clapped else {
+            consumedCurrentClap = false
+            return
+        }
+        consumeClapIfNeeded()
+    }
+
+    private func handleCompletionChange() {
+        guard clapDetected else { return }
+        consumeClapIfNeeded()
+    }
+
+    private func consumeClapIfNeeded() {
+        guard Self.shouldConsumeClap(clapDetected: clapDetected, alreadyConsumed: consumedCurrentClap) else { return }
+        consumedCurrentClap = true
+        onClapHandled()
+    }
+
+    nonisolated static func shouldConsumeClap(clapDetected: Bool, alreadyConsumed: Bool) -> Bool {
+        clapDetected && !alreadyConsumed
     }
 }

--- a/Features/VerticalSlice1/GravitySplitView.swift
+++ b/Features/VerticalSlice1/GravitySplitView.swift
@@ -23,6 +23,7 @@ struct GravitySplitView: View {
     // MARK: - Local animation state
 
     @State private var lockScale: CGFloat = 1.0
+    @State private var lockedAutoAdvanceTask: Task<Void, Never>? = nil
 
     // MARK: - Derived
 
@@ -62,11 +63,18 @@ struct GravitySplitView: View {
             guard shook else { return }
             onShakeHandled()
         }
+        .onAppear {
+            updateLockedAutoAdvance(isLocked: state.isLocked)
+        }
         .onChange(of: state.isLocked) { _, locked in
+            updateLockedAutoAdvance(isLocked: locked)
             guard locked else { return }
             withAnimation(.spring(response: 0.38, dampingFraction: 0.48)) {
                 lockScale = 1.06
             }
+        }
+        .onDisappear {
+            cancelLockedAutoAdvance()
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(
@@ -616,6 +624,25 @@ struct GravitySplitView: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private func updateLockedAutoAdvance(isLocked: Bool) {
+        guard isLocked else {
+            cancelLockedAutoAdvance()
+            return
+        }
+        guard lockedAutoAdvanceTask == nil else { return }
+        lockedAutoAdvanceTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(600))
+            guard !Task.isCancelled else { return }
+            lockedAutoAdvanceTask = nil
+            onSubmit()
+        }
+    }
+
+    private func cancelLockedAutoAdvance() {
+        lockedAutoAdvanceTask?.cancel()
+        lockedAutoAdvanceTask = nil
     }
 }
 

--- a/Features/VerticalSlice1/SplitView.swift
+++ b/Features/VerticalSlice1/SplitView.swift
@@ -142,7 +142,10 @@ struct SplitView: View {
         .padding(.horizontal, 12)
         .background(fill.opacity(0.12))
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
-        .onTapGesture { onAdjust(delta) }
+        .onTapGesture {
+            guard let adjustment = Self.bucketTapAdjustment(isLocked: isLocked, delta: delta) else { return }
+            onAdjust(adjustment)
+        }
     }
 
     // Lay out filled dots in rows of 5. Very large story targets can otherwise
@@ -164,5 +167,9 @@ struct SplitView: View {
             remaining -= rowSize
         }
         return rows
+    }
+
+    nonisolated static func bucketTapAdjustment(isLocked: Bool, delta: Int) -> Int? {
+        isLocked ? nil : delta
     }
 }

--- a/Tests/MatherTests/BondMatchViewTests.swift
+++ b/Tests/MatherTests/BondMatchViewTests.swift
@@ -80,6 +80,12 @@ struct BondMatchViewTests {
         #expect(BondMatchView.rightOrderNeedsReset(existingRightValues: [5, 4, 3], pairRightValues: [7, 6, 5, 4]))
     }
 
+    @Test func clapEventsAreConsumedEvenBeforeCompletion() {
+        #expect(BondMatchView.shouldConsumeClap(clapDetected: true, alreadyConsumed: false))
+        #expect(!BondMatchView.shouldConsumeClap(clapDetected: true, alreadyConsumed: true))
+        #expect(!BondMatchView.shouldConsumeClap(clapDetected: false, alreadyConsumed: false))
+    }
+
     @Test func unmatchedRightShufflePreservesMatchedRowsAndDoesNotDropValues() {
         let shuffled = BondMatchView.shuffledUnmatchedRightValues(
             existingRightValues: [5, 4, 3],
@@ -90,4 +96,16 @@ struct BondMatchViewTests {
         #expect(shuffled == [3, 4, 5])
     }
 
+}
+
+struct SplitViewTests {
+    @Test func lockedBucketTapDoesNotAdjustSplit() {
+        #expect(SplitView.bucketTapAdjustment(isLocked: true, delta: 1) == nil)
+        #expect(SplitView.bucketTapAdjustment(isLocked: true, delta: -1) == nil)
+    }
+
+    @Test func unlockedBucketTapKeepsRequestedAdjustment() {
+        #expect(SplitView.bucketTapAdjustment(isLocked: false, delta: 1) == 1)
+        #expect(SplitView.bucketTapAdjustment(isLocked: false, delta: -1) == -1)
+    }
 }

--- a/Tests/MatherTests/VerticalSliceEngineTests.swift
+++ b/Tests/MatherTests/VerticalSliceEngineTests.swift
@@ -1105,6 +1105,39 @@ struct VerticalSliceEngineTests {
     }
 
     @Test
+    func gravitySplitTiltAdjustsCountsAndCanAdvancePuzzle() async throws {
+        let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
+        flags.testModeEnabled = true
+        flags.vs1GravitySplitEnabled = true
+        flags.makeBreakLoopV2Enabled = false
+
+        let engine = VerticalSliceEngine(
+            featureFlags: flags,
+            telemetryWriter: TelemetryWriter(),
+            speechService: SpeechService(),
+            celebrationDuration: 0,
+            saveSummary: { _ in }
+        )
+        engine.startSession()
+        try await advanceToGravitySplit(engine)
+
+        guard let problem = engine.currentProblem else { return }
+
+        engine.adjustGravitySplitByTilt(0)
+        engine.adjustGravitySplitByTilt(-Double(problem.decompositionA) * 0.18)
+        #expect(engine.gravitySplitState?.leftCount == problem.decompositionA)
+        #expect(engine.gravitySplitState?.rightCount == 0)
+        #expect(engine.currentStage == .gravitySplit)
+
+        engine.adjustGravitySplitByTilt(Double(problem.decompositionB) * 0.18)
+        await waitFor("gravity split advances after tilt lock") {
+            engine.currentStage != .gravitySplit
+        }
+
+        #expect(engine.currentStage != .gravitySplit)
+    }
+
+    @Test
     func gravitySplitStartsFromZeroAndUnsolved() async throws {
         let flags = FeatureFlagService(defaults: UserDefaults(suiteName: #function)!)
         flags.testModeEnabled = true


### PR DESCRIPTION
## Summary
- consume Bond Blast clap events even before completion so stale early claps cannot block the completion clap
- add locked Gravity Split auto-advance scheduling and real tilt-driven split adjustments
- prevent locked SplitView bucket taps from mutating the split

## Validation
- `xcodebuild test -project Mather.xcodeproj -scheme Mather -destination "id=44625752-9C3D-45D3-9CF6-816085B49EA2" CODE_SIGNING_ALLOWED=NO -only-testing:MatherTests -skip-testing:MatherTests/SumSprintEngineTests/timeoutMarksCardAsTimedOut` on `studio` passed: 694 tests in 79 suites
- A prior full `MatherTests` run without the skip compiled and ran the new tests, but `SumSprintEngineTests.timeoutMarksCardAsTimedOut` failed once; rerunning with the same target showed that test passing, so I treated it as an existing timer flake and did not change Sum Sprint in this slice.

Refs #1117
