### PR TITLE
build(deps): bump CodeQL action pins to 4.36.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a
         with:
           languages: actions
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a


### PR DESCRIPTION
## Summary
- updates both pinned CodeQL init and analyze actions to the 4.36.3 commit
- replaces split Dependabot PRs #1201 and #1202, which fail because init/analyze run with mismatched action versions

## Validation
- local actionlint check reported no issues
- GitHub PR checks will validate the combined workflow pins