### PR TITLE
Fix Issue 222 UI review target 6 Sum Sprint expectation

### DIFF
--- a/Tests/MatherUITests/ScreenshotTests.swift
+++ b/Tests/MatherUITests/ScreenshotTests.swift
@@ -314,7 +314,9 @@ final class ScreenshotTests: XCTestCase {
             concreteCellIndex: 5,
             leftPanCount: 3,
             rightPanCount: 3,
-            expectedSumSprintPairs: 2,
+            // Target 6 now exposes three deterministic Sum Sprint pairs before
+            // advancing to the Bond Blast finale.
+            expectedSumSprintPairs: 3,
             bondPairs: [(1, 5), (2, 4), (3, 3)],
             snapshotPrefix: "Issue222-Target6"
         )


### PR DESCRIPTION
## Summary
- Updates the Issue #222 UI screenshot review to clear three deterministic Sum Sprint pairs for target 6 before expecting Bond Blast.
- Matches the observed CI flow, where target 6 remains in Sum Sprint after two matches and the existing Bond Blast validation already expects three target-6 bonds.

## Validation
- Reproduced failure on main run 29222842829 and failed-job rerun: iPhone ScreenshotTests.testScreenshot_Issue222LoopV2_AcrossFourTargetsIncludingTwelve timed out waiting for Bond Blast after two target-6 Sum Sprint matches.
- PR checks pending.