### PR TITLE
Fix CodeQL action 4.37 version pairing

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9
         with:
           languages: actions
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9


### PR DESCRIPTION
## Summary
- Bump both CodeQL init and analyze actions to the same 4.37.0 pinned SHA.
- Resolves the version-split failure currently affecting Dependabot PRs #1210 and #1211.

## Evidence
- #1210 failed Analyze Actions Workflows with: Loaded a configuration file for version '4.37.0', but running version '4.36.3'.
- #1211 failed Analyze Actions Workflows with the inverse mismatch.
- This PR applies both Dependabot updates together so init/analyze run the same action version.

## Validation
- GitHub PR checks will validate actionlint, dependency review, Build & Test, and CodeQL.
