### PR TITLE
build(deps): bump paired CodeQL actions to 4.37.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81
         with:
           languages: actions
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81


### PR DESCRIPTION
## What changed

- Updates both `github/codeql-action/init` and `github/codeql-action/analyze` to the 4.37.3 commit.

## Why

Dependabot refreshed the init-only PR to 4.37.3 while the paired 4.37.2 fix was merging. CodeQL requires all of its steps in one workflow run to use the same version, so both pins must move together.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check`

This preserves the version-pairing fix while applying the latest Dependabot recommendation.