### PR TITLE
Fix tvOS single-game UX and add TestFlight CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
       - name: Verify generated project is committed
         run: git diff --exit-code Mather.xcodeproj
 
+      - name: Build tvOS app
+        run: |
+          xcodebuild build \
+            -project Mather.xcodeproj \
+            -scheme MatherTV \
+            -destination "generic/platform=tvOS Simulator" \
+            CODE_SIGNING_ALLOWED=NO
+
       - name: Choose simulator destination
         run: |
           set -euo pipefail

--- a/.github/workflows/tvos-testflight.yml
+++ b/.github/workflows/tvos-testflight.yml
@@ -1,0 +1,121 @@
+name: tvOS TestFlight
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Marketing version to publish (for example, 2.6.94)
+        required: true
+        default: "2.6.94"
+        type: string
+      build_number:
+        description: Optional numeric build number (defaults to this workflow run number)
+        required: false
+        type: string
+
+concurrency:
+  group: tvos-testflight
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  archive-and-upload:
+    name: Archive and upload Mather TV
+    runs-on: macos-15
+    timeout-minutes: 60
+    environment: testflight-release
+    env:
+      RELEASE_VERSION: ${{ inputs.version }}
+      RELEASE_BUILD_NUMBER: ${{ inputs.build_number || github.run_number }}
+      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+      APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+      APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app
+
+      - name: Validate release inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version must use numeric major.minor.patch format." >&2
+            exit 1
+          fi
+          if [[ ! "$RELEASE_BUILD_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Build number must be a positive integer." >&2
+            exit 1
+          fi
+          for name in APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_KEY_ID APP_STORE_CONNECT_PRIVATE_KEY; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing required secret: $name" >&2
+              exit 1
+            fi
+          done
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate project
+        run: xcodegen generate
+
+      - name: Configure App Store Connect key
+        shell: bash
+        run: |
+          set -euo pipefail
+          key_path="$RUNNER_TEMP/AuthKey_${APP_STORE_CONNECT_KEY_ID}.p8"
+          key_content="${APP_STORE_CONNECT_PRIVATE_KEY//\\n/$'\n'}"
+          printf '%s\n' "$key_content" > "$key_path"
+          chmod 600 "$key_path"
+          echo "ASC_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+
+      - name: Archive Mather TV
+        shell: bash
+        run: |
+          set -euo pipefail
+          xcodebuild archive \
+            -project Mather.xcodeproj \
+            -scheme MatherTV \
+            -destination "generic/platform=tvOS" \
+            -archivePath "$RUNNER_TEMP/MatherTV.xcarchive" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
+            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID" \
+            DEVELOPMENT_TEAM=J3387FUR8X \
+            CODE_SIGN_STYLE=Automatic \
+            MARKETING_VERSION="$RELEASE_VERSION" \
+            CURRENT_PROJECT_VERSION="$RELEASE_BUILD_NUMBER"
+
+      - name: Upload to TestFlight
+        shell: bash
+        run: |
+          set -euo pipefail
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/MatherTV.xcarchive" \
+            -exportPath "$RUNNER_TEMP/MatherTV-export" \
+            -exportOptionsPlist ci_scripts/ExportOptions-tvOS.plist \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
+            -authenticationKeyID "$APP_STORE_CONNECT_KEY_ID" \
+            -authenticationKeyIssuerID "$APP_STORE_CONNECT_ISSUER_ID"
+
+      - name: Publish workflow summary
+        if: success()
+        shell: bash
+        run: |
+          {
+            echo "## Mather TV uploaded"
+            echo
+            echo "- Version: $RELEASE_VERSION"
+            echo "- Build: $RELEASE_BUILD_NUMBER"
+            echo "- Platform: tvOS"
+            echo
+            echo "App Store Connect will process the build before it appears in TestFlight."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AppTV/AngleArcadeTVView.swift
+++ b/AppTV/AngleArcadeTVView.swift
@@ -19,30 +19,31 @@ struct AngleArcadeTVView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 22) {
-            header
+        ZStack {
+            MatherTVBackdrop()
 
-            AngleArcadeFieldView(
-                target: target,
-                prediction: prediction,
-                firedShot: firedShot
-            )
-            .frame(height: 314)
-            .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 28, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 28, style: .continuous)
-                    .stroke(Color.white.opacity(0.14), lineWidth: 2)
-            )
+            VStack(alignment: .leading, spacing: 28) {
+                header
 
-            controls
+                AngleArcadeFieldView(
+                    target: target,
+                    prediction: prediction,
+                    firedShot: firedShot
+                )
+                .frame(maxWidth: .infinity)
+                .frame(height: 520)
+                .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 30, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 30, style: .continuous)
+                        .stroke(Color.white.opacity(0.14), lineWidth: 2)
+                )
+
+                controls
+            }
+            .frame(maxWidth: 1680, maxHeight: .infinity, alignment: .topLeading)
+            .padding(.horizontal, 90)
+            .padding(.vertical, 66)
         }
-        .padding(34)
-        .frame(width: 790, height: 604, alignment: .topLeading)
-        .background(Color(red: 0.05, green: 0.11, blue: 0.16).opacity(0.82), in: RoundedRectangle(cornerRadius: 30, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 30, style: .continuous)
-                .stroke(Color(red: 0.55, green: 0.88, blue: 1.0).opacity(0.24), lineWidth: 2)
-        )
         .onAppear {
             focusedAction = .fire
         }
@@ -57,11 +58,11 @@ struct AngleArcadeTVView: View {
         HStack(alignment: .top, spacing: 24) {
             VStack(alignment: .leading, spacing: 10) {
                 Text("Angle Arcade")
-                    .font(.system(size: 46, weight: .bold, design: .rounded))
+                    .font(.system(size: 70, weight: .bold, design: .rounded))
                     .foregroundStyle(.white)
 
                 Text(target.title)
-                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                    .font(.system(size: 30, weight: .semibold, design: .rounded))
                     .foregroundStyle(Color(red: 0.55, green: 0.88, blue: 1.0))
             }
 
@@ -71,11 +72,11 @@ struct AngleArcadeTVView: View {
                 ForEach(targets.indices, id: \.self) { index in
                     Circle()
                         .fill(index == targetIndex ? Color(red: 1.0, green: 0.76, blue: 0.30) : Color.white.opacity(0.28))
-                        .frame(width: 18, height: 18)
+                        .frame(width: 20, height: 20)
                         .accessibilityHidden(true)
                 }
             }
-            .padding(.top, 14)
+            .padding(.top, 20)
         }
     }
 
@@ -91,8 +92,8 @@ struct AngleArcadeTVView: View {
                 primaryAction()
             } label: {
                 Label(firedShot == nil ? "Fire" : "Replay", systemImage: firedShot == nil ? "paperplane.fill" : "arrow.clockwise")
-                    .font(.system(size: 25, weight: .bold, design: .rounded))
-                    .frame(width: 156, height: 74)
+                    .font(.system(size: 28, weight: .bold, design: .rounded))
+                    .frame(width: 220, height: 92)
             }
             .buttonStyle(.borderedProminent)
             .focused($focusedAction, equals: .fire)

--- a/AppTV/AngleArcadeTVView.swift
+++ b/AppTV/AngleArcadeTVView.swift
@@ -228,8 +228,14 @@ private struct AngleArcadeFieldView: View {
         color: Color,
         dashed: Bool
     ) {
-        let mapped = points.map { screenPoint($0, origin: origin, scale: scale) }
-            .filter { $0.x <= size.width + 20 && $0.y >= -20 && $0.y <= size.height + 20 }
+        let screenPoints: [CGPoint] = points.map { point in
+            screenPoint(point, origin: origin, scale: scale)
+        }
+        let mapped: [CGPoint] = screenPoints.filter { point in
+            point.x <= size.width + 20
+                && point.y >= -20
+                && point.y <= size.height + 20
+        }
         guard mapped.count > 1 else { return }
 
         var path = Path()

--- a/AppTV/MatherTVRootView.swift
+++ b/AppTV/MatherTVRootView.swift
@@ -2,68 +2,89 @@ import SwiftUI
 
 struct MatherTVRootView: View {
     @FocusState private var focusedAction: MatherTVAction.ID?
-    @State private var selectedAction = MatherTVAction.angle
+    @State private var activeGame: MatherTVAction?
+    @State private var lastFocusedAction = MatherTVAction.memory
 
     private let actions = MatherTVAction.allCases
 
     var body: some View {
+        Group {
+            if let activeGame {
+                gameView(for: activeGame)
+                    .id(activeGame.id)
+                    .overlay(alignment: .top) {
+                        Label("Menu  ·  All games", systemImage: "chevron.backward")
+                            .font(.system(size: 22, weight: .bold, design: .rounded))
+                            .foregroundStyle(.white.opacity(0.68))
+                            .padding(.horizontal, 22)
+                            .padding(.vertical, 13)
+                            .background(.black.opacity(0.26), in: Capsule())
+                            .padding(.top, 28)
+                            .accessibilityHidden(true)
+                    }
+                    .onExitCommand {
+                        exitGame(activeGame)
+                    }
+            } else {
+                launcher
+            }
+        }
+        .onAppear {
+            focusLauncher()
+        }
+    }
+
+    private var launcher: some View {
         ZStack {
             MatherTVBackdrop()
 
-            VStack(alignment: .leading, spacing: 42) {
+            VStack(alignment: .leading, spacing: 46) {
                 header
 
-                HStack(alignment: .center, spacing: 34) {
-                    actionMenu
-                    selectedActionPanel
+                HStack(spacing: 30) {
+                    ForEach(actions) { action in
+                        Button {
+                            openGame(action)
+                        } label: {
+                            MatherTVGameCard(
+                                action: action,
+                                isFocused: focusedAction == action.id
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .focused($focusedAction, equals: action.id)
+                        .accessibilityLabel(action.title)
+                        .accessibilityHint(action.accessibilityHint)
+                        .accessibilityIdentifier("tv-mode-\(action.id)")
+                    }
                 }
+
+                Label("Swipe to choose, then press select to play.", systemImage: "hand.tap.fill")
+                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.white.opacity(0.66))
             }
-            .frame(maxWidth: 1480, alignment: .leading)
-            .padding(.horizontal, 92)
+            .frame(maxWidth: 1680, maxHeight: .infinity, alignment: .topLeading)
+            .padding(.horizontal, 90)
             .padding(.vertical, 76)
-        }
-        .onAppear {
-            focusedAction = selectedAction.id
         }
     }
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("Mather TV Lab")
+            Text("Choose a game")
                 .font(.system(size: 72, weight: .bold, design: .rounded))
                 .foregroundStyle(.white)
 
-            Text("A couch-ready shell for focus/select math play.")
+            Text("One game at a time. Press Menu anytime to come back here.")
                 .font(.system(size: 30, weight: .medium, design: .rounded))
                 .foregroundStyle(.white.opacity(0.76))
         }
         .accessibilityElement(children: .combine)
     }
 
-    private var actionMenu: some View {
-        VStack(spacing: 24) {
-            ForEach(actions) { action in
-                Button {
-                    selectedAction = action
-                } label: {
-                    MatherTVActionRow(
-                        action: action,
-                        isFocused: focusedAction == action.id,
-                        isSelected: selectedAction == action
-                    )
-                }
-                .buttonStyle(.plain)
-                .focused($focusedAction, equals: action.id)
-                .accessibilityHint(action.accessibilityHint)
-                .accessibilityIdentifier("tv-mode-\(action.id)")
-            }
-        }
-        .frame(width: 560)
-    }
-
     @ViewBuilder
-    private var selectedActionPanel: some View {
-        switch selectedAction {
+    private func gameView(for action: MatherTVAction) -> some View {
+        switch action {
         case .memory:
             MemoryGalleryTVView()
         case .angle:
@@ -72,61 +93,64 @@ struct MatherTVRootView: View {
             SumSprintPartyTVView()
         }
     }
+
+    private func openGame(_ action: MatherTVAction) {
+        lastFocusedAction = action
+        focusedAction = nil
+        activeGame = action
+    }
+
+    private func exitGame(_ action: MatherTVAction) {
+        lastFocusedAction = action
+        activeGame = nil
+        focusLauncher()
+    }
+
+    private func focusLauncher() {
+        guard activeGame == nil else { return }
+        Task { @MainActor in
+            focusedAction = lastFocusedAction.id
+        }
+    }
 }
 
-private struct MatherTVActionRow: View {
+private struct MatherTVGameCard: View {
     let action: MatherTVAction
     let isFocused: Bool
-    let isSelected: Bool
 
     var body: some View {
-        HStack(spacing: 22) {
+        VStack(alignment: .leading, spacing: 24) {
             Image(systemName: action.symbolName)
-                .font(.system(size: 42, weight: .bold))
-                .frame(width: 70, height: 70)
+                .font(.system(size: 58, weight: .bold))
+                .frame(width: 96, height: 96)
                 .foregroundStyle(isFocused ? Color(red: 0.09, green: 0.13, blue: 0.19) : .white)
-                .background(iconBackground, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .background(isFocused ? .white : .white.opacity(0.12), in: RoundedRectangle(cornerRadius: 24, style: .continuous))
 
-            VStack(alignment: .leading, spacing: 8) {
-                Text(action.title)
-                    .font(.system(size: 32, weight: .bold, design: .rounded))
-                    .foregroundStyle(isFocused ? Color(red: 0.07, green: 0.10, blue: 0.16) : .white)
+            Text(action.title)
+                .font(.system(size: 36, weight: .bold, design: .rounded))
+                .foregroundStyle(isFocused ? Color(red: 0.07, green: 0.10, blue: 0.16) : .white)
+                .lineLimit(2)
 
-                Text(action.subtitle)
-                    .font(.system(size: 21, weight: .medium, design: .rounded))
-                    .foregroundStyle(isFocused ? Color(red: 0.15, green: 0.20, blue: 0.29) : .white.opacity(0.65))
-                    .lineLimit(2)
-            }
+            Text(action.subtitle)
+                .font(.system(size: 24, weight: .medium, design: .rounded))
+                .foregroundStyle(isFocused ? Color(red: 0.15, green: 0.20, blue: 0.29) : .white.opacity(0.68))
 
             Spacer(minLength: 0)
+
+            Label("Play", systemImage: "play.fill")
+                .font(.system(size: 23, weight: .bold, design: .rounded))
+                .foregroundStyle(isFocused ? Color(red: 0.08, green: 0.28, blue: 0.39) : .white.opacity(0.72))
         }
-        .padding(24)
-        .frame(width: 560, height: 132)
-        .background(rowBackground, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
-        .overlay(rowStroke)
-        .scaleEffect(isFocused ? 1.055 : 1.0)
-        .shadow(color: .black.opacity(isFocused ? 0.35 : 0.16), radius: isFocused ? 24 : 10, x: 0, y: isFocused ? 18 : 8)
+        .padding(32)
+        .frame(width: 500, height: 390, alignment: .topLeading)
+        .background(isFocused ? .white : .white.opacity(0.08), in: RoundedRectangle(cornerRadius: 32, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 32, style: .continuous)
+                .stroke(isFocused ? Color(red: 0.55, green: 0.88, blue: 1.0) : .white.opacity(0.14), lineWidth: isFocused ? 4 : 2)
+        )
+        .scaleEffect(isFocused ? 1.045 : 1.0)
+        .shadow(color: .black.opacity(isFocused ? 0.36 : 0.16), radius: isFocused ? 28 : 10, x: 0, y: isFocused ? 18 : 8)
         .animation(.spring(response: 0.28, dampingFraction: 0.78), value: isFocused)
-        .animation(.easeInOut(duration: 0.18), value: isSelected)
-    }
-
-    private var iconBackground: some ShapeStyle {
-        isFocused ? .white : .white.opacity(0.12)
-    }
-
-    private var rowBackground: some ShapeStyle {
-        if isFocused {
-            return AnyShapeStyle(.white)
-        }
-        if isSelected {
-            return AnyShapeStyle(Color(red: 0.10, green: 0.32, blue: 0.42).opacity(0.74))
-        }
-        return AnyShapeStyle(.white.opacity(0.08))
-    }
-
-    private var rowStroke: some View {
-        RoundedRectangle(cornerRadius: 28, style: .continuous)
-            .stroke(isSelected ? Color(red: 0.55, green: 0.88, blue: 1.0).opacity(0.78) : .white.opacity(0.12), lineWidth: 2)
     }
 }
 
@@ -188,9 +212,9 @@ private enum MatherTVAction: String, CaseIterable, Identifiable {
 
     var accessibilityHint: String {
         switch self {
-        case .memory: "Selects the Memory Gallery picture matching game."
-        case .angle: "Selects the Angle Arcade prototype."
-        case .sprint: "Selects the Sum Sprint Party answer game."
+        case .memory: "Opens the Memory Gallery picture matching game."
+        case .angle: "Opens the Angle Arcade aiming game."
+        case .sprint: "Opens the Sum Sprint Party answer game."
         }
     }
 }

--- a/ci_scripts/ExportOptions-tvOS.plist
+++ b/ci_scripts/ExportOptions-tvOS.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>destination</key>
+	<string>upload</string>
+	<key>manageAppVersionAndBuildNumber</key>
+	<false/>
+	<key>method</key>
+	<string>app-store-connect</string>
+	<key>signingStyle</key>
+	<string>automatic</string>
+	<key>stripSwiftSymbols</key>
+	<true/>
+	<key>teamID</key>
+	<string>J3387FUR8X</string>
+	<key>uploadSymbols</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## What changed

- Replaced the split launcher/game layout with a dedicated TV launcher and a single mounted full-screen game.
- Restores launcher focus to the last-played game when the Menu button is pressed.
- Expanded Angle Arcade to the full tvOS safe area and added consistent in-game Menu guidance.
- Added a tvOS simulator build to the main CI workflow.
- Added a guarded, manually dispatched `tvOS TestFlight` workflow that archives and uploads `MatherTV` with automatic signing and the existing App Store Connect API secrets.

## Why

The previous root view kept the launcher interactive while rendering a game beside it. That leaked focus between navigation and gameplay and cropped the game UI. The repository also had TestFlight feedback/polling automation, but no GitHub Actions path that archived and uploaded the tvOS scheme.

## Impact

Apple TV users now choose one activity and play it full-screen. Pressing Menu returns to the launcher. After this PR merges, maintainers can dispatch `tvOS TestFlight` with a semantic version such as `2.6.94`; its run number is used as the default build number.

## Validation

- Apple TV 4K (3rd generation), tvOS 26.5 simulator: launcher, all three games, gameplay Select actions, and Menu return flow.
- `xcodebuild build -scheme MatherTV -destination 'generic/platform=tvOS Simulator' CODE_SIGNING_ALLOWED=NO`
- `actionlint` for the changed GitHub Actions workflows.
- `plutil -lint ci_scripts/ExportOptions-tvOS.plist`
- `xcodegen generate` followed by a clean generated-project diff.
- `git diff --check`